### PR TITLE
ci: complete Cargo Security Audit workflow (rustsec/audit-check)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,16 @@ jobs:
         with:
           tool: cargo-audit
 
-      - name: Run RustSec audit
+      # Primary audit: rustsec/audit-check@v2 annotates PRs with RustSec advisories.
+      # It wraps the `cargo audit` CLI (cargo-audit) and reports vulnerabilities inline.
+      - name: Run RustSec audit (rustsec/audit-check)
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Fallback: run `cargo audit` directly so the job fails even if the action
+      # cannot post annotations (e.g. permission edge cases on forked PRs).
+      - name: Run cargo audit (fallback)
         run: cargo audit
 
       - name: Dependency review (GitHub Advisory / license diff on PR)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-5.md
+++ b/docs/pr-summary-5.md
@@ -1,0 +1,18 @@
+## Summary
+Completed the Cargo Security Audit workflow by adding the `rustsec/audit-check@v2` action to `.github/workflows/security.yml`. The reusable security workflow now runs the official RustSec action (which annotates PRs with advisories) as the primary audit, with the existing manual `cargo audit` run retained as a fallback that still fails the job if the action cannot post annotations (e.g. forked PR permission edge cases). Closes #5.
+
+## Evidence
+Backend/CI-only change — no UI. The workflow change was verified by diff review:
+
+- The three detection patterns called out by VibeCoding workflow sync are now all present in `.github/workflows/security.yml`:
+  - `cargo audit` — fallback step and comment references
+  - `cargo-audit` — `taiki-e/install-action` `tool:` entry plus the step name
+  - `rustsec/audit-check` — new `uses: rustsec/audit-check@v2` step
+
+YAML structure was eyeballed against the existing (valid) workflow; no structural changes were made beyond inserting a new step before the fallback.
+
+## Test Plan
+- [x] `.github/workflows/security.yml` contains `rustsec/audit-check@v2` as a step.
+- [x] The existing `cargo audit` invocation is retained so the job still fails on vulnerabilities even if the action cannot post annotations.
+- [x] `cargo-audit` is still installed via `taiki-e/install-action@v2`.
+- [ ] On the first PR after merge, confirm the new step reports green and that RustSec annotations appear on the PR if any advisories match.


### PR DESCRIPTION
## Summary
Completed the Cargo Security Audit workflow by adding the `rustsec/audit-check@v2` action to `.github/workflows/security.yml`. The reusable security workflow now runs the official RustSec action (which annotates PRs with advisories) as the primary audit, with the existing manual `cargo audit` run retained as a fallback that still fails the job if the action cannot post annotations (e.g. forked PR permission edge cases). Closes #5.

## Evidence
Backend/CI-only change — no UI. The workflow change was verified by diff review:

- The three detection patterns called out by VibeCoding workflow sync are now all present in `.github/workflows/security.yml`:
  - `cargo audit` — fallback step and comment references
  - `cargo-audit` — `taiki-e/install-action` `tool:` entry plus the step name
  - `rustsec/audit-check` — new `uses: rustsec/audit-check@v2` step

YAML structure was eyeballed against the existing (valid) workflow; no structural changes were made beyond inserting a new step before the fallback.

## Test Plan
- [x] `.github/workflows/security.yml` contains `rustsec/audit-check@v2` as a step.
- [x] The existing `cargo audit` invocation is retained so the job still fails on vulnerabilities even if the action cannot post annotations.
- [x] `cargo-audit` is still installed via `taiki-e/install-action@v2`.
- [ ] On the first PR after merge, confirm the new step reports green and that RustSec annotations appear on the PR if any advisories match.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-5 -->