### PR TITLE
docs: add canonical Related Repositories section to README (#18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,39 @@ cargo test --workspace
 ./quality.sh
 ```
 
+## Related Repositories
+
+The NEAT-AI project is split across seven public repositories. Each focuses on one concern and composes with the others as shown below.
+
+| Repository | Role |
+|------------|------|
+| [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI) | Primary Deno/TypeScript neural-network engine (evolution, training, WASM activation). |
+| [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) | Shared native Rust library (`neat-core`) with numerics, topology helpers, and the chunked `.bin` training stream. |
+| [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) | Rust discovery module invoked by NEAT-AI via Deno FFI to search architectures and hyper-parameters. |
+| [NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot) | Creature/genome snapshot format and fixtures produced by NEAT-AI and consumed by downstream tools. |
+| [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) | Production forward-only scoring application built on `neat-core` via a path dependency. |
+| [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore) | Visualiser for creatures that reads NEAT-AI-Snapshot data. |
+| [NEAT-AI-Examples](https://github.com/stSoftwareAU/NEAT-AI-Examples) | Worked examples and tutorials that depend on NEAT-AI. |
+
+### Dependency graph
+
+```mermaid
+graph TD
+    Core[NEAT-AI-core<br/>Rust shared lib]
+    Main[NEAT-AI<br/>Deno/TypeScript engine]
+    Discovery[NEAT-AI-Discovery<br/>Rust, via Deno FFI]
+    Snapshot[NEAT-AI-Snapshot<br/>creature data]
+    Scorer[NEAT-AI-scorer<br/>Rust scorer app]
+    Explore[NEAT-AI-Explore<br/>visualiser]
+    Examples[NEAT-AI-Examples<br/>tutorials]
+
+    Main -->|Deno FFI| Discovery
+    Main -->|produces| Snapshot
+    Scorer -->|path dependency| Core
+    Explore -->|reads| Snapshot
+    Examples -->|depends on| Main
+```
+
 ## License
 
 Apache-2.0 — see `LICENSE`.

--- a/docs/pr-summary-18.md
+++ b/docs/pr-summary-18.md
@@ -1,0 +1,13 @@
+## Summary
+Added a canonical `## Related Repositories` section to the NEAT-AI-core README listing all seven public NEAT-AI-* repositories, their one-line roles, and a Mermaid dependency diagram. The same block will be reused verbatim in the other NEAT-AI-* READMEs so the cross-repo description stays consistent. Closes #18.
+
+## Evidence
+Documentation-only change — no UI or runtime behaviour affected.
+
+- `./quality.sh < /dev/null` passes cleanly (fmt, clippy, tests, doc, deny, release build).
+- Rendered Mermaid graph shows the dependency arrows: NEAT-AI → NEAT-AI-Discovery (Deno FFI), NEAT-AI → NEAT-AI-Snapshot (produces), NEAT-AI-scorer → NEAT-AI-core (path dep), NEAT-AI-Explore → NEAT-AI-Snapshot (reads), NEAT-AI-Examples → NEAT-AI (depends on).
+
+## Test Plan
+- [x] `./quality.sh` passes.
+- [x] README renders the new `## Related Repositories` section with all 7 repos, links, and Mermaid diagram.
+- [x] Canonical block posted as a comment on issue #18 for verbatim reuse by sibling sub-issues.


### PR DESCRIPTION
## Summary
Added a canonical `## Related Repositories` section to the NEAT-AI-core README listing all seven public NEAT-AI-* repositories, their one-line roles, and a Mermaid dependency diagram. The same block will be reused verbatim in the other NEAT-AI-* READMEs so the cross-repo description stays consistent. Closes #18.

## Evidence
Documentation-only change — no UI or runtime behaviour affected.

- `./quality.sh < /dev/null` passes cleanly (fmt, clippy, tests, doc, deny, release build).
- Rendered Mermaid graph shows the dependency arrows: NEAT-AI → NEAT-AI-Discovery (Deno FFI), NEAT-AI → NEAT-AI-Snapshot (produces), NEAT-AI-scorer → NEAT-AI-core (path dep), NEAT-AI-Explore → NEAT-AI-Snapshot (reads), NEAT-AI-Examples → NEAT-AI (depends on).

## Test Plan
- [x] `./quality.sh` passes.
- [x] README renders the new `## Related Repositories` section with all 7 repos, links, and Mermaid diagram.
- [x] Canonical block posted as a comment on issue #18 for verbatim reuse by sibling sub-issues.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-18 -->