### PR TITLE
Make CompiledNetwork Clone-able and add activate_and_trace_batch_4way tests

### DIFF
--- a/docs/pr-summary-11.md
+++ b/docs/pr-summary-11.md
@@ -1,0 +1,23 @@
+## Summary
+Lifted the `Clone` derive on `CompiledNetwork` and the batch-4-way regression tests from the unmerged `makefaster` branch (PR #2) into the milestone branch. Cloning the compiled network lets native tools (e.g. the NEAT-AI scorer) pin one network per worker thread for forward-only batch scoring, so each thread owns its own activation/hint/trace buffers. Closes #11.
+
+## Changes
+- Added a brief doc comment and `#[derive(Clone)]` to `CompiledNetwork` in `neat-core/src/network.rs`.
+- Added a `#[cfg(test)] mod tests` block at the end of `neat-core/src/network.rs` with seven scenarios validating `activate_and_trace_batch_4way` against the single-record `activate_and_trace`.
+
+## Evidence
+Backend/library change only — no web interface to screenshot. Verified via:
+- `cargo test --workspace` (all tests pass, including the seven new ones)
+- `./quality.sh` (rustfmt, clippy, cargo-deny, tests, docs, release build all pass)
+
+## Test Plan
+New tests added to `neat-core/src/network.rs`:
+- `test_batch_4way_matches_single_relu` — Standard squash (ReLU hidden + Identity output).
+- `test_batch_4way_matches_single_tanh_logistic` — TANH + LOGISTIC squash.
+- `test_batch_4way_minimum_aggregate` — MINIMUM aggregate (`squash_type = 32`).
+- `test_batch_4way_maximum_aggregate` — MAXIMUM aggregate (`squash_type = 33`).
+- `test_batch_4way_if_aggregate` — IF aggregate (`squash_type = 34`) with condition / positive / negative synapse types.
+- `test_batch_4way_constant_neuron` — Constant neuron (`is_constant: true`) passed through identity.
+- `test_batch_4way_multi_layer` — 2-hidden-layer ReLU network with an identity output.
+
+Each test runs four inputs through both the single-record `activate_and_trace` and the batch `activate_and_trace_batch_4way`, then asserts every f32 in the batch result lies within `1e-5` of the corresponding single-record result. Tests call the public API and assert on observable outputs — no source-text inspection.

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -45,6 +45,9 @@ pub struct SynapseData {
 
 /// Compiled network data structure
 ///
+/// `Clone` is supported so native tools (for example the NEAT-AI scorer) can run
+/// forward-only batch scoring on multiple threads, each with its own activation buffers.
+///
 /// Format (Issue #1125 - updated to support aggregate functions):
 /// - Header: [num_neurons: u32, num_inputs: u32]
 /// - Neuron data: For each neuron after inputs:
@@ -59,6 +62,7 @@ pub struct SynapseData {
 ///
 /// This compact format minimises memory access and enables efficient iteration.
 /// Issue #1175 - Uses typed structs for better cache locality and compiler optimisation.
+#[derive(Clone)]
 pub struct CompiledNetwork {
     /// Total number of neurons (including input)
     pub num_neurons: usize,
@@ -1578,5 +1582,371 @@ impl CompiledNetwork {
             trace.push(neuron_idx as f32);
             trace.push(0.0f32);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to build a CompiledNetwork directly for testing
+    fn make_network(
+        num_inputs: usize,
+        neurons: Vec<NeuronData>,
+        synapses: Vec<SynapseData>,
+    ) -> CompiledNetwork {
+        let num_neurons = num_inputs + neurons.len();
+        let num_non_inputs = neurons.len();
+        let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+        CompiledNetwork {
+            num_neurons,
+            num_inputs,
+            neurons,
+            synapses,
+            activations: vec![0.0; num_neurons],
+            hint_values_buffer: vec![0.0; num_non_inputs],
+            trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        }
+    }
+
+    fn make_synapse(from_index: u32, weight: f32) -> SynapseData {
+        SynapseData {
+            weight,
+            from_index,
+            synapse_type: 0,
+            _padding: [0; 3],
+        }
+    }
+
+    fn make_synapse_typed(from_index: u32, weight: f32, synapse_type: u8) -> SynapseData {
+        SynapseData {
+            weight,
+            from_index,
+            synapse_type,
+            _padding: [0; 3],
+        }
+    }
+
+    /// Split the packed batch_4way output into its four records using the length header.
+    fn split_batch_records(batch_result: &[f32]) -> [&[f32]; 4] {
+        let len0 = batch_result[0] as usize;
+        let len1 = batch_result[1] as usize;
+        let len2 = batch_result[2] as usize;
+        let len3 = batch_result[3] as usize;
+        let start0 = 4;
+        let start1 = start0 + len0;
+        let start2 = start1 + len1;
+        let start3 = start2 + len2;
+        [
+            &batch_result[start0..start0 + len0],
+            &batch_result[start1..start1 + len1],
+            &batch_result[start2..start2 + len2],
+            &batch_result[start3..start3 + len3],
+        ]
+    }
+
+    fn assert_records_match(single_results: &[Vec<f32>], batch_records: &[&[f32]; 4]) {
+        for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
+            assert_eq!(
+                single.len(),
+                batch.len(),
+                "Record {i}: length mismatch (single={}, batch={})",
+                single.len(),
+                batch.len()
+            );
+            for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
+                assert!(
+                    (s - b).abs() < 1e-5,
+                    "Record {i}, element {j}: single={s}, batch={b}"
+                );
+            }
+        }
+    }
+
+    /// Test that batch 4-way matches single-record activate_and_trace for standard squash (ReLU)
+    #[test]
+    fn test_batch_4way_matches_single_relu() {
+        // Network: 2 inputs, 1 hidden (ReLU), 1 output (Identity)
+        let synapses = vec![
+            make_synapse(0, 0.5),  // hidden <- input0
+            make_synapse(1, -0.3), // hidden <- input1
+            make_synapse(2, 1.0),  // output <- hidden
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 0.1,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 1, // ReLU
+                is_constant: false,
+            },
+            NeuronData {
+                bias: -0.2,
+                start_synapse: 2,
+                num_synapses: 1,
+                squash_type: 0, // Identity
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[0.5, -1.0], &[-2.0, 3.0], &[0.0, 0.0]];
+
+        // Run single-record activate_and_trace for each
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        // Run batch 4-way
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed_input: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed_input, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with TANH and LOGISTIC squash functions
+    #[test]
+    fn test_batch_4way_matches_single_tanh_logistic() {
+        let synapses = vec![
+            make_synapse(0, 1.0),
+            make_synapse(1, 0.5),
+            make_synapse(2, -0.7),
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 0.0,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 7, // TANH
+                is_constant: false,
+            },
+            NeuronData {
+                bias: 0.5,
+                start_synapse: 2,
+                num_synapses: 1,
+                squash_type: 6, // LOGISTIC
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 0.5], &[-1.0, 2.0], &[0.3, -0.3], &[2.0, -1.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with MINIMUM aggregate function
+    #[test]
+    fn test_batch_4way_minimum_aggregate() {
+        // 2 inputs -> 1 MINIMUM neuron (output)
+        let synapses = vec![make_synapse(0, 1.0), make_synapse(1, 1.0)];
+        let neurons = vec![NeuronData {
+            bias: 0.0,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: 32, // MINIMUM
+            is_constant: false,
+        }];
+
+        let inputs: [&[f32]; 4] = [
+            &[3.0, 1.0],  // min = 1.0
+            &[-1.0, 2.0], // min = -1.0
+            &[5.0, 5.0],  // min = 5.0
+            &[0.0, -3.0], // min = -3.0
+        ];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with MAXIMUM aggregate function
+    #[test]
+    fn test_batch_4way_maximum_aggregate() {
+        let synapses = vec![make_synapse(0, 1.0), make_synapse(1, 1.0)];
+        let neurons = vec![NeuronData {
+            bias: 0.5,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: 33, // MAXIMUM
+            is_constant: false,
+        }];
+
+        let inputs: [&[f32]; 4] = [&[3.0, 1.0], &[-1.0, 2.0], &[5.0, 5.0], &[0.0, -3.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with IF aggregate function
+    #[test]
+    fn test_batch_4way_if_aggregate() {
+        // 3 inputs -> 1 IF neuron
+        // synapse0: condition, synapse1: positive, synapse2: negative
+        let synapses = vec![
+            make_synapse_typed(0, 1.0, 1), // condition
+            make_synapse_typed(1, 1.0, 3), // positive
+            make_synapse_typed(2, 1.0, 2), // negative
+        ];
+        let neurons = vec![NeuronData {
+            bias: 0.0,
+            start_synapse: 0,
+            num_synapses: 3,
+            squash_type: 34, // IF
+            is_constant: false,
+        }];
+
+        let inputs: [&[f32]; 4] = [
+            &[1.0, 5.0, 10.0],  // condition>0 -> positive=5.0
+            &[-1.0, 5.0, 10.0], // condition<=0 -> negative=10.0
+            &[0.5, 3.0, 7.0],   // condition>0 -> positive=3.0
+            &[-2.0, 3.0, 7.0],  // condition<=0 -> negative=7.0
+        ];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(3, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(3, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 3, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with constant neurons
+    #[test]
+    fn test_batch_4way_constant_neuron() {
+        let synapses = vec![
+            make_synapse(2, 1.0), // output <- constant
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 42.0,
+                start_synapse: 0,
+                num_synapses: 0,
+                squash_type: 0,
+                is_constant: true,
+            },
+            NeuronData {
+                bias: 0.0,
+                start_synapse: 0,
+                num_synapses: 1,
+                squash_type: 0, // Identity
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[3.0, 4.0], &[5.0, 6.0], &[7.0, 8.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with a deeper network (multiple layers)
+    #[test]
+    fn test_batch_4way_multi_layer() {
+        // 2 inputs -> 2 hidden (ReLU) -> 1 output (Identity)
+        let synapses = vec![
+            // Hidden 0 (idx 2): from input 0 and 1
+            make_synapse(0, 0.5),
+            make_synapse(1, 0.3),
+            // Hidden 1 (idx 3): from input 0 and 1
+            make_synapse(0, -0.4),
+            make_synapse(1, 0.6),
+            // Output (idx 4): from hidden 0 and hidden 1
+            make_synapse(2, 1.0),
+            make_synapse(3, -0.5),
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 0.1,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 1, // ReLU
+                is_constant: false,
+            },
+            NeuronData {
+                bias: -0.1,
+                start_synapse: 2,
+                num_synapses: 2,
+                squash_type: 1, // ReLU
+                is_constant: false,
+            },
+            NeuronData {
+                bias: 0.0,
+                start_synapse: 4,
+                num_synapses: 2,
+                squash_type: 0, // Identity
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[-1.0, 0.5], &[3.0, -2.0], &[0.0, 0.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
     }
 }


### PR DESCRIPTION
## Summary
Lifted the `Clone` derive on `CompiledNetwork` and the batch-4-way regression tests from the unmerged `makefaster` branch (PR #2) into the milestone branch. Cloning the compiled network lets native tools (e.g. the NEAT-AI scorer) pin one network per worker thread for forward-only batch scoring, so each thread owns its own activation/hint/trace buffers. Closes #11.

## Changes
- Added a brief doc comment and `#[derive(Clone)]` to `CompiledNetwork` in `neat-core/src/network.rs`.
- Added a `#[cfg(test)] mod tests` block at the end of `neat-core/src/network.rs` with seven scenarios validating `activate_and_trace_batch_4way` against the single-record `activate_and_trace`.

## Evidence
Backend/library change only — no web interface to screenshot. Verified via:
- `cargo test --workspace` (all tests pass, including the seven new ones)
- `./quality.sh` (rustfmt, clippy, cargo-deny, tests, docs, release build all pass)

## Test Plan
New tests added to `neat-core/src/network.rs`:
- `test_batch_4way_matches_single_relu` — Standard squash (ReLU hidden + Identity output).
- `test_batch_4way_matches_single_tanh_logistic` — TANH + LOGISTIC squash.
- `test_batch_4way_minimum_aggregate` — MINIMUM aggregate (`squash_type = 32`).
- `test_batch_4way_maximum_aggregate` — MAXIMUM aggregate (`squash_type = 33`).
- `test_batch_4way_if_aggregate` — IF aggregate (`squash_type = 34`) with condition / positive / negative synapse types.
- `test_batch_4way_constant_neuron` — Constant neuron (`is_constant: true`) passed through identity.
- `test_batch_4way_multi_layer` — 2-hidden-layer ReLU network with an identity output.

Each test runs four inputs through both the single-record `activate_and_trace` and the batch `activate_and_trace_batch_4way`, then asserts every f32 in the batch result lies within `1e-5` of the corresponding single-record result. Tests call the public API and assert on observable outputs — no source-text inspection.



## Milestone
This PR is part of the **Research 23 Apr** milestone and targets the `milestone/research-23-apr` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-11 -->