### PR TITLE
Add CompiledNetwork topology export (DOT/JSON) (#22)

### DIFF
--- a/docs/pr-summary-22.md
+++ b/docs/pr-summary-22.md
@@ -1,0 +1,27 @@
+## Summary
+Adds a deterministic, pure-data topology export for `CompiledNetwork` — DOT (Graphviz) and a minimal topology JSON — so networks can be inspected and visualised externally without pulling a GUI stack into `neat-core`. Closes #22.
+
+New module `neat-core/src/topology_export.rs` provides:
+
+- `CompiledNetwork::to_dot(num_outputs) -> String` — emits a `digraph CompiledNetwork { ... }` with one node per neuron (labelled with index, kind, squash function and bias) and one edge per synapse (labelled with weight and synapse type). Shapes encode node kind (`ellipse` for inputs, `box` for hidden, `doublecircle` for outputs, `diamond` for constants).
+- `CompiledNetwork::to_topology_json(num_outputs) -> String` — emits pretty-printed JSON with `num_inputs`, `num_outputs`, `num_neurons`, and ordered `nodes`/`synapses` arrays.
+- `NodeKind` enum, `squash_name`, `synapse_type_name`, and the free `to_dot`/`to_topology_json` functions, all re-exported from `lib.rs`.
+
+Output is deterministic: nodes are emitted in ascending index order, synapses in storage order (grouped by target neuron then by per-target compilation order), and weights are formatted with fixed six-decimal-place precision.
+
+`num_outputs` is passed in because `CompiledNetwork` does not itself record the output count — outputs are the last `num_outputs` neurons by construction.
+
+## Evidence
+This is a CLI/library change with no web interface. Evidence is test-based:
+
+- `cargo test --workspace --lib --tests --all-features` — all tests pass (13 new + 397 existing).
+- `./quality.sh` — passes cleanly (fmt, clippy `-D warnings`, check, tests, rustdoc `-D warnings`, release build).
+- Module-level rustdoc includes a runnable usage example (verified by the doc-test build).
+
+## Test Plan
+New integration tests in `neat-core/tests/topology_export.rs`:
+
+- **Happy path (DOT)** — valid `digraph` header/footer, one node per neuron, input/hidden/output kinds labelled, activation names labelled, one edge per synapse, weights and synapse types in edge labels.
+- **Happy path (JSON)** — round-trips through `serde_json::from_str`, reports correct `num_inputs`/`num_outputs`/`num_neurons`, node kinds and squash names match, bias present for non-inputs and absent for inputs, synapse from/to/type correct.
+- **Edge case** — minimal single-input → single-output network exports cleanly to both formats.
+- **Determinism** — two calls on the same network return byte-identical output for both DOT and JSON; re-compiling the same creature JSON and exporting produces byte-identical output across both formats.

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod simd;
 pub mod squash;
 pub mod synapse_type;
 pub mod topological_backprop;
+pub mod topology_export;
 pub mod topology_ops;
 pub mod training_bin_stream;
 pub mod training_data;
@@ -67,6 +68,7 @@ pub use topological_backprop::{
     NeuronType, PropagateInput, PropagateOutcome, PropagateOutput, StandardOutcome, SynapseDelta,
     SynapseInput, propagate_topological_loop,
 };
+pub use topology_export::{NodeKind, squash_name, synapse_type_name, to_dot, to_topology_json};
 pub use topology_ops::{
     BACKWARD_CONNECTION, DUPLICATE_CONNECTION, SELF_CONNECTION, SORT_ERROR_FROM, SORT_ERROR_TO,
     STRUCTURAL_BIAS_NOT_FINITE, STRUCTURAL_CONSTANT_HAS_INWARD, STRUCTURAL_HIDDEN_NO_INWARD,

--- a/neat-core/src/topology_export.rs
+++ b/neat-core/src/topology_export.rs
@@ -1,0 +1,328 @@
+//! Deterministic topology export from [`CompiledNetwork`] (Issue #22).
+//!
+//! This module provides pure-data exports — DOT (Graphviz) and a minimal
+//! topology JSON — suitable for external tooling (Graphviz renderers, web
+//! viewers, snapshot diffs) without pulling a GUI stack into `neat-core`.
+//!
+//! Output is deterministic for identical input: nodes are emitted in ascending
+//! index order, synapses in the order they are stored on the network (which is
+//! itself deterministic — compilation groups by target neuron and preserves
+//! per-target synapse order), and weights are formatted with a fixed
+//! precision. Two exports of the same network produce byte-identical output.
+//!
+//! # Example
+//!
+//! ```
+//! use neat_core::{compile_creature, parse_creature_json};
+//!
+//! let json = r#"{
+//!     "input": 1,
+//!     "output": 1,
+//!     "neurons": [
+//!         {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+//!     ],
+//!     "synapses": [
+//!         {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+//!     ],
+//!     "forwardOnly": true
+//! }"#;
+//! let creature = parse_creature_json(json).unwrap();
+//! let network = compile_creature(&creature).unwrap();
+//!
+//! let dot = network.to_dot(creature.output);
+//! assert!(dot.starts_with("digraph "));
+//!
+//! let topology = network.to_topology_json(creature.output);
+//! assert!(topology.contains("\"num_inputs\""));
+//! ```
+
+use std::fmt::Write;
+
+use serde::Serialize;
+
+use crate::network::CompiledNetwork;
+use crate::squash::SquashType;
+use crate::synapse_type::SynapseType;
+
+/// Node classification used by topology exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    /// Input neuron (index `0..num_inputs`).
+    Input,
+    /// Hidden (non-output, non-constant) neuron.
+    Hidden,
+    /// Output neuron (last `num_outputs` neurons).
+    Output,
+    /// Constant neuron (no inward connections).
+    Constant,
+}
+
+impl NodeKind {
+    /// Lowercase identifier used in DOT labels and JSON exports.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NodeKind::Input => "input",
+            NodeKind::Hidden => "hidden",
+            NodeKind::Output => "output",
+            NodeKind::Constant => "constant",
+        }
+    }
+}
+
+/// Classify a neuron by its absolute index in the compiled network.
+fn classify(network: &CompiledNetwork, index: usize, num_outputs: usize) -> NodeKind {
+    if index < network.num_inputs {
+        return NodeKind::Input;
+    }
+    let neuron = &network.neurons[index - network.num_inputs];
+    if neuron.is_constant {
+        return NodeKind::Constant;
+    }
+    let output_start = network.num_neurons.saturating_sub(num_outputs);
+    if index >= output_start {
+        NodeKind::Output
+    } else {
+        NodeKind::Hidden
+    }
+}
+
+/// Canonical name for a squash (activation) function.
+///
+/// Names match those accepted by [`crate::creature::parse_squash_name`], so a
+/// JSON export round-trips through the TypeScript contract where possible.
+pub fn squash_name(ty: SquashType) -> &'static str {
+    match ty {
+        SquashType::Identity => "IDENTITY",
+        SquashType::Relu => "RELU",
+        SquashType::Relu6 => "ReLU6",
+        SquashType::LeakyRelu => "LeakyReLU",
+        SquashType::Selu => "SELU",
+        SquashType::Elu => "ELU",
+        SquashType::Logistic => "LOGISTIC",
+        SquashType::Tanh => "TANH",
+        SquashType::HardTanh => "HARD_TANH",
+        SquashType::Softsign => "SOFTSIGN",
+        SquashType::Softplus => "Softplus",
+        SquashType::Swish => "Swish",
+        SquashType::Mish => "Mish",
+        SquashType::Gelu => "GELU",
+        SquashType::Sine => "SINE",
+        SquashType::Cosine => "Cosine",
+        SquashType::Tan => "TAN",
+        SquashType::ArcTan => "ArcTan",
+        SquashType::Gaussian => "GAUSSIAN",
+        SquashType::BentIdentity => "BENT_IDENTITY",
+        SquashType::BipolarSigmoid => "BIPOLAR_SIGMOID",
+        SquashType::Bipolar => "BIPOLAR",
+        SquashType::Step => "STEP",
+        SquashType::Complement => "COMPLEMENT",
+        SquashType::Absolute => "ABSOLUTE",
+        SquashType::Square => "SQUARE",
+        SquashType::Cube => "Cube",
+        SquashType::Sqrt => "SQRT",
+        SquashType::StdInverse => "StdInverse",
+        SquashType::Exponential => "Exponential",
+        SquashType::LogSigmoid => "LogSigmoid",
+        SquashType::Isru => "ISRU",
+        SquashType::Minimum => "MINIMUM",
+        SquashType::Maximum => "MAXIMUM",
+        SquashType::If => "IF",
+        SquashType::Hypotenuse => "HYPOT",
+        SquashType::HypotenuseV2 => "HYPOTv2",
+        SquashType::Mean => "MEAN",
+    }
+}
+
+/// Canonical name for a synapse type.
+pub fn synapse_type_name(ty: SynapseType) -> &'static str {
+    match ty {
+        SynapseType::Standard => "Standard",
+        SynapseType::Condition => "Condition",
+        SynapseType::Negative => "Negative",
+        SynapseType::Positive => "Positive",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON export
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct NodeRecord {
+    index: usize,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bias: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    squash: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct SynapseRecord {
+    from: u32,
+    to: u32,
+    weight: f32,
+    #[serde(rename = "type")]
+    synapse_type: &'static str,
+}
+
+#[derive(Serialize)]
+struct TopologyExport {
+    num_inputs: usize,
+    num_outputs: usize,
+    num_neurons: usize,
+    nodes: Vec<NodeRecord>,
+    synapses: Vec<SynapseRecord>,
+}
+
+/// Build a deterministic JSON topology description.
+///
+/// The returned string is pretty-printed JSON using `serde_json`'s default
+/// formatter. Nodes are listed in ascending index order; synapses are listed
+/// in network storage order (grouped by target neuron, then by per-target
+/// compilation order). See the module docs for the determinism contract.
+pub fn to_topology_json(network: &CompiledNetwork, num_outputs: usize) -> String {
+    let mut nodes = Vec::with_capacity(network.num_neurons);
+
+    for i in 0..network.num_inputs {
+        nodes.push(NodeRecord {
+            index: i,
+            kind: NodeKind::Input.as_str(),
+            bias: None,
+            squash: None,
+        });
+    }
+
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let index = network.num_inputs + offset;
+        let kind = classify(network, index, num_outputs);
+        let squash = SquashType::from(neuron.squash_type);
+        nodes.push(NodeRecord {
+            index,
+            kind: kind.as_str(),
+            bias: Some(neuron.bias),
+            squash: Some(squash_name(squash)),
+        });
+    }
+
+    let mut synapses = Vec::with_capacity(network.synapses.len());
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let to_index = (network.num_inputs + offset) as u32;
+        let start = neuron.start_synapse as usize;
+        let end = start + neuron.num_synapses as usize;
+        for synapse in &network.synapses[start..end] {
+            let synapse_type = SynapseType::from(synapse.synapse_type);
+            synapses.push(SynapseRecord {
+                from: synapse.from_index,
+                to: to_index,
+                weight: synapse.weight,
+                synapse_type: synapse_type_name(synapse_type),
+            });
+        }
+    }
+
+    let export = TopologyExport {
+        num_inputs: network.num_inputs,
+        num_outputs,
+        num_neurons: network.num_neurons,
+        nodes,
+        synapses,
+    };
+
+    // `serde_json` serialises struct fields in declaration order, so this is
+    // deterministic. `to_string_pretty` is stable across calls for the same
+    // input.
+    serde_json::to_string_pretty(&export).expect("TopologyExport is always serialisable to JSON")
+}
+
+// ---------------------------------------------------------------------------
+// DOT export
+// ---------------------------------------------------------------------------
+
+/// Emit a deterministic DOT (Graphviz) representation of the network.
+///
+/// Node shape convention:
+/// - inputs: `ellipse`
+/// - hidden: `box`
+/// - outputs: `doublecircle`
+/// - constants: `diamond`
+///
+/// Each edge is labelled with `"<weight> <SynapseType>"` where `<weight>` is
+/// formatted with six-decimal-place precision for stable output.
+pub fn to_dot(network: &CompiledNetwork, num_outputs: usize) -> String {
+    // Pre-allocate a reasonable buffer to avoid intermediate reallocations —
+    // roughly 64 bytes per node + 48 bytes per edge.
+    let mut out =
+        String::with_capacity(64 + network.num_neurons * 64 + network.synapses.len() * 48);
+
+    out.push_str("digraph CompiledNetwork {\n");
+    out.push_str("  rankdir=LR;\n");
+
+    // Node declarations in ascending index order.
+    for i in 0..network.num_inputs {
+        writeln!(out, "  n{i} [label=\"n{i}\\ninput\", shape=ellipse];",).unwrap();
+    }
+
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let index = network.num_inputs + offset;
+        let kind = classify(network, index, num_outputs);
+        let shape = match kind {
+            NodeKind::Input => "ellipse",
+            NodeKind::Hidden => "box",
+            NodeKind::Output => "doublecircle",
+            NodeKind::Constant => "diamond",
+        };
+        let squash = squash_name(SquashType::from(neuron.squash_type));
+        let kind_label = kind.as_str();
+        let bias = neuron.bias;
+        writeln!(
+            out,
+            "  n{index} [label=\"n{index}\\n{kind_label}\\n{squash}\\nbias={bias:.6}\", shape={shape}];",
+        )
+        .unwrap();
+    }
+
+    // Edges in storage order.
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let to_index = network.num_inputs + offset;
+        let start = neuron.start_synapse as usize;
+        let end = start + neuron.num_synapses as usize;
+        for synapse in &network.synapses[start..end] {
+            let from_index = synapse.from_index as usize;
+            let weight = synapse.weight;
+            let synapse_type = synapse_type_name(SynapseType::from(synapse.synapse_type));
+            writeln!(
+                out,
+                "  n{from_index} -> n{to_index} [label=\"{weight:.6} {synapse_type}\"];",
+            )
+            .unwrap();
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Methods on CompiledNetwork
+// ---------------------------------------------------------------------------
+
+impl CompiledNetwork {
+    /// Export this network as a DOT (Graphviz) string.
+    ///
+    /// See [`to_dot`] for format details and determinism guarantees.
+    ///
+    /// `num_outputs` is required because [`CompiledNetwork`] itself does not
+    /// record the output count — outputs are the last `num_outputs` neurons
+    /// by construction.
+    pub fn to_dot(&self, num_outputs: usize) -> String {
+        to_dot(self, num_outputs)
+    }
+
+    /// Export this network as a topology JSON string.
+    ///
+    /// See [`to_topology_json`] for format details and determinism guarantees.
+    pub fn to_topology_json(&self, num_outputs: usize) -> String {
+        to_topology_json(self, num_outputs)
+    }
+}

--- a/neat-core/tests/topology_export.rs
+++ b/neat-core/tests/topology_export.rs
@@ -1,0 +1,278 @@
+//! Tests for CompiledNetwork topology export (DOT / JSON).
+//!
+//! Issue #22 — machine-readable topology export for debugging and visualisation.
+
+use neat_core::{compile_creature, parse_creature_json};
+
+/// A small network with two inputs, one hidden neuron, and one output neuron.
+/// Weights and biases are chosen so the resulting strings are easy to inspect.
+fn small_network_json() -> &'static str {
+    r#"{
+        "input": 2,
+        "output": 1,
+        "neurons": [
+            {"type": "hidden", "uuid": "hidden-1", "bias": 0.25, "squash": "TANH"},
+            {"type": "output", "uuid": "output-0", "bias": -0.5, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "hidden-1", "weight": 1.0},
+            {"fromUUID": "input-1", "toUUID": "hidden-1", "weight": 0.5},
+            {"fromUUID": "hidden-1", "toUUID": "output-0", "weight": 1.5}
+        ],
+        "forwardOnly": true
+    }"#
+}
+
+/// The minimal possible non-trivial network: a single input feeding a single
+/// output through one synapse.
+fn minimal_network_json() -> &'static str {
+    r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+        ],
+        "forwardOnly": true
+    }"#
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn to_dot_emits_valid_digraph_header() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(
+        dot.starts_with("digraph "),
+        "DOT output must begin with `digraph`, got: {dot}"
+    );
+    assert!(
+        dot.trim_end().ends_with('}'),
+        "DOT output must close with `}}`"
+    );
+}
+
+#[test]
+fn to_dot_contains_node_for_every_neuron() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    // Two inputs + one hidden + one output = 4 nodes declared as `n0`..`n3`.
+    for i in 0..network.num_neurons {
+        let needle = format!("n{i} ");
+        assert!(
+            dot.contains(&needle),
+            "DOT output is missing node declaration `n{i}`:\n{dot}"
+        );
+    }
+}
+
+#[test]
+fn to_dot_classifies_nodes_as_input_hidden_output() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(dot.contains("input"), "DOT output should label input nodes");
+    assert!(
+        dot.contains("hidden"),
+        "DOT output should label hidden nodes"
+    );
+    assert!(
+        dot.contains("output"),
+        "DOT output should label output nodes"
+    );
+}
+
+#[test]
+fn to_dot_labels_activation_function_for_non_inputs() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(
+        dot.contains("TANH"),
+        "hidden neuron squash should be labelled"
+    );
+    assert!(
+        dot.contains("IDENTITY"),
+        "output neuron squash should be labelled"
+    );
+}
+
+#[test]
+fn to_dot_declares_one_edge_per_synapse() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    let edge_count = dot.matches(" -> ").count();
+    assert_eq!(
+        edge_count,
+        network.synapses.len(),
+        "DOT edge count must match synapse count"
+    );
+}
+
+#[test]
+fn to_dot_edges_include_weight_and_type() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    // Each of the three synapse weights should appear in the DOT output.
+    for expected in ["1.000000", "0.500000", "1.500000"] {
+        assert!(
+            dot.contains(expected),
+            "DOT output is missing expected weight `{expected}`:\n{dot}"
+        );
+    }
+    assert!(
+        dot.contains("Standard"),
+        "DOT output should label synapse type"
+    );
+}
+
+#[test]
+fn to_topology_json_round_trips_as_valid_json() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let json = network.to_topology_json(creature.output);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("to_topology_json output must be valid JSON");
+
+    assert_eq!(parsed["num_inputs"], 2);
+    assert_eq!(parsed["num_outputs"], 1);
+    assert_eq!(parsed["num_neurons"], 4);
+
+    let nodes = parsed["nodes"].as_array().expect("nodes must be an array");
+    assert_eq!(nodes.len(), 4, "node count must match num_neurons");
+
+    assert_eq!(nodes[0]["kind"], "input");
+    assert_eq!(nodes[1]["kind"], "input");
+    assert_eq!(nodes[2]["kind"], "hidden");
+    assert_eq!(nodes[2]["squash"], "TANH");
+    assert_eq!(nodes[3]["kind"], "output");
+    assert_eq!(nodes[3]["squash"], "IDENTITY");
+
+    let synapses = parsed["synapses"]
+        .as_array()
+        .expect("synapses must be an array");
+    assert_eq!(synapses.len(), 3);
+
+    // First synapse: input-0 -> hidden-1 with weight 1.0, type Standard.
+    assert_eq!(synapses[0]["from"], 0);
+    assert_eq!(synapses[0]["to"], 2);
+    assert_eq!(synapses[0]["type"], "Standard");
+}
+
+#[test]
+fn to_topology_json_includes_bias_for_non_input_nodes() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let json = network.to_topology_json(creature.output);
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let nodes = parsed["nodes"].as_array().unwrap();
+
+    // Inputs should not expose a bias (they have none).
+    assert!(nodes[0].get("bias").is_none());
+    // Hidden neuron bias 0.25 and output neuron bias -0.5 should be present.
+    assert!((nodes[2]["bias"].as_f64().unwrap() - 0.25).abs() < 1e-6);
+    assert!((nodes[3]["bias"].as_f64().unwrap() + 0.5).abs() < 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Edge case: minimal network
+// ---------------------------------------------------------------------------
+
+#[test]
+fn minimal_network_exports_to_dot_cleanly() {
+    let creature = parse_creature_json(minimal_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(dot.starts_with("digraph "));
+    assert_eq!(
+        dot.matches(" -> ").count(),
+        1,
+        "minimal network has one edge"
+    );
+    assert!(dot.contains("n0"));
+    assert!(dot.contains("n1"));
+    assert!(dot.contains("input"));
+    assert!(dot.contains("output"));
+}
+
+#[test]
+fn minimal_network_exports_to_topology_json_cleanly() {
+    let creature = parse_creature_json(minimal_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let json = network.to_topology_json(creature.output);
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["num_inputs"], 1);
+    assert_eq!(parsed["num_outputs"], 1);
+    assert_eq!(parsed["num_neurons"], 2);
+    assert_eq!(parsed["nodes"].as_array().unwrap().len(), 2);
+    assert_eq!(parsed["synapses"].as_array().unwrap().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn to_dot_is_deterministic_across_calls() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+
+    let a = network.to_dot(creature.output);
+    let b = network.to_dot(creature.output);
+
+    assert_eq!(
+        a, b,
+        "to_dot must return byte-identical output for identical input"
+    );
+}
+
+#[test]
+fn to_topology_json_is_deterministic_across_calls() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+
+    let a = network.to_topology_json(creature.output);
+    let b = network.to_topology_json(creature.output);
+
+    assert_eq!(
+        a, b,
+        "to_topology_json must return byte-identical output for identical input"
+    );
+}
+
+#[test]
+fn to_dot_is_deterministic_across_fresh_compiles() {
+    // Recompile the same creature JSON twice and confirm both exports match byte-for-byte.
+    let creature_a = parse_creature_json(small_network_json()).unwrap();
+    let creature_b = parse_creature_json(small_network_json()).unwrap();
+    let network_a = compile_creature(&creature_a).unwrap();
+    let network_b = compile_creature(&creature_b).unwrap();
+
+    assert_eq!(
+        network_a.to_dot(creature_a.output),
+        network_b.to_dot(creature_b.output)
+    );
+    assert_eq!(
+        network_a.to_topology_json(creature_a.output),
+        network_b.to_topology_json(creature_b.output)
+    );
+}


### PR DESCRIPTION
## Summary
Adds a deterministic, pure-data topology export for `CompiledNetwork` — DOT (Graphviz) and a minimal topology JSON — so networks can be inspected and visualised externally without pulling a GUI stack into `neat-core`. Closes #22.

New module `neat-core/src/topology_export.rs` provides:

- `CompiledNetwork::to_dot(num_outputs) -> String` — emits a `digraph CompiledNetwork { ... }` with one node per neuron (labelled with index, kind, squash function and bias) and one edge per synapse (labelled with weight and synapse type). Shapes encode node kind (`ellipse` for inputs, `box` for hidden, `doublecircle` for outputs, `diamond` for constants).
- `CompiledNetwork::to_topology_json(num_outputs) -> String` — emits pretty-printed JSON with `num_inputs`, `num_outputs`, `num_neurons`, and ordered `nodes`/`synapses` arrays.
- `NodeKind` enum, `squash_name`, `synapse_type_name`, and the free `to_dot`/`to_topology_json` functions, all re-exported from `lib.rs`.

Output is deterministic: nodes are emitted in ascending index order, synapses in storage order (grouped by target neuron then by per-target compilation order), and weights are formatted with fixed six-decimal-place precision.

`num_outputs` is passed in because `CompiledNetwork` does not itself record the output count — outputs are the last `num_outputs` neurons by construction.

## Evidence
This is a CLI/library change with no web interface. Evidence is test-based:

- `cargo test --workspace --lib --tests --all-features` — all tests pass (13 new + 397 existing).
- `./quality.sh` — passes cleanly (fmt, clippy `-D warnings`, check, tests, rustdoc `-D warnings`, release build).
- Module-level rustdoc includes a runnable usage example (verified by the doc-test build).

## Test Plan
New integration tests in `neat-core/tests/topology_export.rs`:

- **Happy path (DOT)** — valid `digraph` header/footer, one node per neuron, input/hidden/output kinds labelled, activation names labelled, one edge per synapse, weights and synapse types in edge labels.
- **Happy path (JSON)** — round-trips through `serde_json::from_str`, reports correct `num_inputs`/`num_outputs`/`num_neurons`, node kinds and squash names match, bias present for non-inputs and absent for inputs, synapse from/to/type correct.
- **Edge case** — minimal single-input → single-output network exports cleanly to both formats.
- **Determinism** — two calls on the same network return byte-identical output for both DOT and JSON; re-compiling the same creature JSON and exporting produces byte-identical output across both formats.



## Milestone
This PR is part of the **Research 23 Apr** milestone and targets the `milestone/research-23-apr` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-22 -->