### PR TITLE
Milestone: Research 23 Apr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-11.md
+++ b/docs/pr-summary-11.md
@@ -1,0 +1,23 @@
+## Summary
+Lifted the `Clone` derive on `CompiledNetwork` and the batch-4-way regression tests from the unmerged `makefaster` branch (PR #2) into the milestone branch. Cloning the compiled network lets native tools (e.g. the NEAT-AI scorer) pin one network per worker thread for forward-only batch scoring, so each thread owns its own activation/hint/trace buffers. Closes #11.
+
+## Changes
+- Added a brief doc comment and `#[derive(Clone)]` to `CompiledNetwork` in `neat-core/src/network.rs`.
+- Added a `#[cfg(test)] mod tests` block at the end of `neat-core/src/network.rs` with seven scenarios validating `activate_and_trace_batch_4way` against the single-record `activate_and_trace`.
+
+## Evidence
+Backend/library change only — no web interface to screenshot. Verified via:
+- `cargo test --workspace` (all tests pass, including the seven new ones)
+- `./quality.sh` (rustfmt, clippy, cargo-deny, tests, docs, release build all pass)
+
+## Test Plan
+New tests added to `neat-core/src/network.rs`:
+- `test_batch_4way_matches_single_relu` — Standard squash (ReLU hidden + Identity output).
+- `test_batch_4way_matches_single_tanh_logistic` — TANH + LOGISTIC squash.
+- `test_batch_4way_minimum_aggregate` — MINIMUM aggregate (`squash_type = 32`).
+- `test_batch_4way_maximum_aggregate` — MAXIMUM aggregate (`squash_type = 33`).
+- `test_batch_4way_if_aggregate` — IF aggregate (`squash_type = 34`) with condition / positive / negative synapse types.
+- `test_batch_4way_constant_neuron` — Constant neuron (`is_constant: true`) passed through identity.
+- `test_batch_4way_multi_layer` — 2-hidden-layer ReLU network with an identity output.
+
+Each test runs four inputs through both the single-record `activate_and_trace` and the batch `activate_and_trace_batch_4way`, then asserts every f32 in the batch result lies within `1e-5` of the corresponding single-record result. Tests call the public API and assert on observable outputs — no source-text inspection.

--- a/docs/pr-summary-12.md
+++ b/docs/pr-summary-12.md
@@ -1,0 +1,22 @@
+## Summary
+Carried over `simd_native.rs` from the `makefaster` branch to add native SIMD fast paths for multi-record weighted sums:
+
+- **x86_64**: AVX2 + FMA (`_mm256_fmadd_ps`) for 8-wide; FMA + SSE (`_mm_fmadd_ps`) for 4-wide.
+- **aarch64**: NEON (`vfmaq_f32` over two `float32x4` lanes) for 8-wide; single `float32x4` for 4-wide.
+- Runtime feature detection (`is_x86_feature_detected!` / `is_aarch64_feature_detected!`) gates every `unsafe` path; scalar fallback otherwise.
+
+`simd.rs` no longer carries the scalar fallback bodies for `weighted_sum_simd_4records` / `weighted_sum_simd_8records` — it re-exports them from `simd_native`. The `simd128`/wasm path is unchanged.
+
+Closes #12.
+
+## Evidence
+Pure backend SIMD code — no UI to screenshot.
+
+- `cargo test --workspace` passes (all 126 tests, incl. 2 new in `simd_native`).
+- `./quality.sh` passes: rustfmt, clippy (`-D warnings`), cargo-deny, tests, docs, release build.
+- Tests compare native dispatcher output to the bundled scalar reference using exact equality on small inputs that fit FMA equivalence.
+
+## Test Plan
+- `simd::simd_native::tests::native_8_matches_scalar_small` — dispatcher output matches scalar for 8 records.
+- `simd::simd_native::tests::native_4_matches_scalar_small` — dispatcher output matches scalar for 4 records.
+- All existing `simd` and workspace tests continue to pass.

--- a/docs/pr-summary-13.md
+++ b/docs/pr-summary-13.md
@@ -1,0 +1,65 @@
+## Summary
+
+Added tunable I/O modes to `training_bin_stream` so the NEAT-AI scorer can A/B
+between the existing pipelined double-buffer reader and a simpler sequential
+reader at run time — no rebuild required. Closes #13.
+
+Carried over from the unmerged `makefaster` branch (PR #2):
+
+- `TrainingReadMode { PipelinedDoubleBuffer, SingleBufferSequential }` —
+  `Default` is `PipelinedDoubleBuffer`.
+- `training_read_tuning_from_env(record_bytes)` — reads
+  `NEAT_SCORER_IO_MODE` (case-insensitive `single`/`double`, default `double`)
+  and `NEAT_SCORER_READ_BYTES` (decimal `usize`, default 2 MiB, clamped to
+  `[record_bytes.max(1), 64 MiB]`).
+- `io_backend_label(mode)` — stable telemetry string. On `wasm32` always
+  `"sequential_chunked_file_read"`; on native `"pipelined_double_buffer"` or
+  `"single_buffer_sequential"`.
+- `for_each_read_chunk_with_mode` — primary native entry point; ignores the
+  `mode` on `wasm32`.
+- `for_each_read_chunk` is now a thin wrapper that delegates with
+  `PipelinedDoubleBuffer` (the legacy `NEAT_TRAINING_READ_SEQUENTIAL` escape
+  hatch from issue #25 is still honoured for backwards compatibility).
+- The private `for_each_read_chunk_sequential` is shared between the
+  `SingleBufferSequential` path and `wasm32`; `for_each_read_chunk_native`
+  renamed to `for_each_read_chunk_native_double`.
+- Module doc comment updated to describe both modes and the new env vars.
+
+## Evidence
+
+Backend/library change — no UI. Verification via tests and quality gate:
+
+- `cargo test -p neat-core --lib training_bin_stream` — 19 passed, 0 failed.
+- `./quality.sh` — green (fmt, clippy `-D warnings`, deny, tests, doc, release
+  build).
+- `cargo build -p neat-core --target wasm32-unknown-unknown` — compiles
+  cleanly; the `mode` argument is suppressed with `let _ = mode;` on
+  `wasm32` so the warning-free build is preserved.
+
+## Test Plan
+
+Added to `neat_core::training_bin_stream::tests`:
+
+- `both_modes_agree_on_multi_file_corpus` — multi-file fixture spanning a
+  chunk boundary; asserts the two modes produce byte-identical output via the
+  new `run_files(mode)` helper.
+- `both_modes_handle_empty_files` — empty-files coverage for both modes.
+- `zero_read_buf_len_is_rejected_in_both_modes` — the existing
+  `"read_buf_len must be positive"` error path still fires under
+  `for_each_read_chunk_with_mode` for both modes.
+- `training_read_mode_default_is_pipelined_double_buffer` — verifies the
+  documented default.
+- `io_backend_label_native_reflects_mode` — stable telemetry strings.
+- `training_read_tuning_defaults_without_env` — no env vars → pipelined +
+  default 2 MiB.
+- `training_read_tuning_parses_modes_case_insensitively` — `single`/`SINGLE`/
+  `Single`/`double`/`DOUBLE`/unknown all map correctly.
+- `training_read_tuning_clamps_read_bytes` — below lower bound, above upper
+  bound, within-bounds pass-through, and unparsable fallback to
+  `DEFAULT_READ_BYTES`.
+- `training_read_tuning_handles_zero_record_bytes` — `record_bytes = 0`
+  clamps up to 1.
+
+All pre-existing tests in the module are retained (including the issue #25
+teardown race regression and the legacy `SEQUENTIAL_ENV` coverage) and
+continue to pass.

--- a/docs/pr-summary-21.md
+++ b/docs/pr-summary-21.md
@@ -1,0 +1,18 @@
+## Summary
+Research-only PR documenting a feature-by-feature comparison between the MIT-licensed [Ikaruga/NEAT-AI](https://github.com/Ikaruga/NEAT-AI) Rust project and `neat-core` (Apache-2.0). Adds `docs/research/ikaruga-neat-ai-comparison.md` covering genome/mutation, speciation, population management, feed-forward evaluation, topology visualisation, GPU (Burn/WGPU), serialisation, emulator bridge, and fitness — each classified as already present / owned by parent repo / out of scope / worth adopting, with licence-compatibility note (MIT → Apache-2.0 inbound). Closes #21.
+
+Two adoption candidates identified:
+- **Topology export (DOT/JSON)** — already tracked by existing open issue #22; no new issue filed.
+- **`CreatureExport` round-trip JSON (`Serialize` derive)** — new follow-up issue #30 filed and linked from the document.
+
+No code changes to `neat-core` itself; `./quality.sh` run as a sanity check and passes.
+
+## Evidence
+No UI or performance change — this is a research document. The only artefact is `docs/research/ikaruga-neat-ai-comparison.md`. Validation: `./quality.sh < /dev/null` runs fmt, clippy, workspace tests, doc build, release build, and `cargo deny` — all pass unchanged.
+
+## Test Plan
+- [x] `./quality.sh < /dev/null` passes (existing test suite unchanged).
+- [x] `docs/research/ikaruga-neat-ai-comparison.md` exists and covers every feature area listed in issue #21.
+- [x] Each candidate has a classification + one-paragraph justification.
+- [x] Each "adopt" candidate has a linked issue (#22 existing, #30 new).
+- [x] Licence-compatibility note included (MIT inbound → Apache-2.0).

--- a/docs/pr-summary-22.md
+++ b/docs/pr-summary-22.md
@@ -1,0 +1,27 @@
+## Summary
+Adds a deterministic, pure-data topology export for `CompiledNetwork` — DOT (Graphviz) and a minimal topology JSON — so networks can be inspected and visualised externally without pulling a GUI stack into `neat-core`. Closes #22.
+
+New module `neat-core/src/topology_export.rs` provides:
+
+- `CompiledNetwork::to_dot(num_outputs) -> String` — emits a `digraph CompiledNetwork { ... }` with one node per neuron (labelled with index, kind, squash function and bias) and one edge per synapse (labelled with weight and synapse type). Shapes encode node kind (`ellipse` for inputs, `box` for hidden, `doublecircle` for outputs, `diamond` for constants).
+- `CompiledNetwork::to_topology_json(num_outputs) -> String` — emits pretty-printed JSON with `num_inputs`, `num_outputs`, `num_neurons`, and ordered `nodes`/`synapses` arrays.
+- `NodeKind` enum, `squash_name`, `synapse_type_name`, and the free `to_dot`/`to_topology_json` functions, all re-exported from `lib.rs`.
+
+Output is deterministic: nodes are emitted in ascending index order, synapses in storage order (grouped by target neuron then by per-target compilation order), and weights are formatted with fixed six-decimal-place precision.
+
+`num_outputs` is passed in because `CompiledNetwork` does not itself record the output count — outputs are the last `num_outputs` neurons by construction.
+
+## Evidence
+This is a CLI/library change with no web interface. Evidence is test-based:
+
+- `cargo test --workspace --lib --tests --all-features` — all tests pass (13 new + 397 existing).
+- `./quality.sh` — passes cleanly (fmt, clippy `-D warnings`, check, tests, rustdoc `-D warnings`, release build).
+- Module-level rustdoc includes a runnable usage example (verified by the doc-test build).
+
+## Test Plan
+New integration tests in `neat-core/tests/topology_export.rs`:
+
+- **Happy path (DOT)** — valid `digraph` header/footer, one node per neuron, input/hidden/output kinds labelled, activation names labelled, one edge per synapse, weights and synapse types in edge labels.
+- **Happy path (JSON)** — round-trips through `serde_json::from_str`, reports correct `num_inputs`/`num_outputs`/`num_neurons`, node kinds and squash names match, bias present for non-inputs and absent for inputs, synapse from/to/type correct.
+- **Edge case** — minimal single-input → single-output network exports cleanly to both formats.
+- **Determinism** — two calls on the same network return byte-identical output for both DOT and JSON; re-compiling the same creature JSON and exporting produces byte-identical output across both formats.

--- a/docs/research/ikaruga-neat-ai-comparison.md
+++ b/docs/research/ikaruga-neat-ai-comparison.md
@@ -1,0 +1,149 @@
+# Ikaruga/NEAT-AI vs `neat-core`: feature comparison and adoption candidates
+
+**Research issue:** [#21](https://github.com/stSoftwareAU/NEAT-AI-core/issues/21) (part of #20)
+**Upstream project:** [Ikaruga/NEAT-AI](https://github.com/Ikaruga/NEAT-AI) — pure-Rust NEAT for retro games (BizHawk + MAME), ~5,143 lines, **MIT-licensed**, WIP.
+**This crate:** [`neat-core`](https://github.com/stSoftwareAU/NEAT-AI-core) — shared native Rust library for the NEAT-AI ecosystem, **Apache-2.0**.
+
+## Licence compatibility
+
+Ikaruga/NEAT-AI is **MIT**; `neat-core` is **Apache-2.0**. MIT is permissive and compatible with Apache-2.0 for **inbound** adaptation: code or ideas may be ported into `neat-core` provided the upstream copyright notice and MIT licence text are preserved for any verbatim transcriptions (e.g., in a `NOTICE` or header). Paraphrased re-implementations of published techniques (speciation, tournament selection, innovation numbers) do not require attribution but we will cite Ikaruga as the inspiration where we directly mirror its structure.
+
+No code from Ikaruga/NEAT-AI has been transcribed into this repository as of the date of this research. Any future port that copies non-trivial fragments must carry the MIT notice.
+
+## Scope reminder
+
+`neat-core` is intentionally narrow: it provides the **compute kernels** (compiled forward pass, topological backprop, SIMD accumulation, loss functions, safe-zone clamping, streaming training-data I/O, topology validation, predictive coding). Evolutionary operators — mutation, crossover, speciation, the generation loop — live upstream in the **NEAT-AI** Deno/TypeScript repository, not here. The comparison below classifies each Ikaruga feature against that scope boundary.
+
+## Upstream inventory (Ikaruga/NEAT-AI, `bizhawk-neat` variant)
+
+| File | Approx. LOC | Purpose |
+|------|------------:|---------|
+| `src/neat/genome.rs` | 547 | `NodeGene`, `ConnectionGene`, `Genome`; 3 mutation operators; 4 activation functions; serde on all structs; global innovation counter. |
+| `src/neat/species.rs` | 304 | Compatibility distance, adjusted fitness (`fitness / species_size`), stagnation counter with top-2 elitism. |
+| `src/neat/population.rs` | 381 | Tournament selection, crossover + mutation paths, interspecies mating, offspring-per-species allocation. |
+| `src/neat/config.rs` | — | `NeatConfig` with ~15 tuning knobs; JSON persistence (`from_file`/`to_file`). |
+| `src/network/neural_net.rs` | 301 | Feed-forward via topological sort + cycle skip; `BatchEvaluator` present but sequential; Burn tensors imported but unused. |
+| `src/visualization/network_view.rs` | 855 | Live `egui`/`eframe` renderer against `Arc<RwLock<VisualizationState>>`; no DOT/JSON export; not headless. |
+| `src/emulator/connection.rs` | 558 | TCP bridge to Lua scripts running inside BizHawk/MAME. |
+| `src/game/fitness.rs` | 579 | Per-game scoring. |
+| `lua/bizhawk_bridge.lua` | — | In-emulator bridge script. |
+| **Cargo deps of note** | | `burn = "0.16"` (wgpu), `egui`/`eframe = "0.29"`, `tokio = "1"`, `serde`, `rand`, `thiserror`, `tracing`. |
+
+The `mame-neat` sibling crate mirrors this layout against MAME.
+
+## `neat-core` inventory (relevant modules)
+
+| Module | Role |
+|--------|------|
+| `squash` | **38 activation variants** (Identity, ReLU, ReLU6, LeakyReLU, SELU, ELU, Logistic, Tanh, HardTanh, Softsign, Softplus, Swish, Mish, GELU, Sine, Cosine, Tan, ArcTan, Gaussian, BentIdentity, BipolarSigmoid, Bipolar, Step, Complement, Absolute, Square, Cube, Sqrt, StdInverse, Exponential, LogSigmoid, ISRU, Minimum, Maximum, If, Hypotenuse, HypotenuseV2, Mean). |
+| `creature` | `CreatureExport` / `NeuronExport` / `SynapseExport` — **`Deserialize` only** (no `Serialize`), plus `compile_creature` to `CompiledNetwork`. |
+| `network` | `CompiledNetwork`, `NeuronData`, `SynapseData` — compiled forward-pass evaluator. |
+| `topological_backprop` | Topologically ordered backprop loop (lifted from `wasm_activation` per #9). |
+| `topology_ops` | Cycle detection, reverse topological order, structural validation, batch validation. |
+| `accumulate`, `simd`, `simd_native` | 4-way and 8-way SIMD multi-record weighted-sum / bias accumulation; AVX2/FMA on x86_64 and NEON on aarch64 (#12). |
+| `loss` | MSE/MAE/MAPE/MSLE/cross-entropy/hinge packed-batch reducers + `mse_mean_record`. |
+| `pc_inference` / `pc_learning` | Predictive-coding inference engine and learning rule. |
+| `training_bin_stream` | Chunked double-buffered `.bin` scan API with env-tunable modes (#13). |
+| `training_data` | `.bin` reader / iterator / seeking record reader. |
+| `training_state` | Persistent per-neuron / per-synapse state for online training. |
+| `safe_zone` | Range-clamping for unbounded activations. |
+| `score_scan`, `elastic_distribution`, `fused_error`, `error`, `derivative`, `range`, `unsquash` | Supporting numerics. |
+
+Source footprint: ~15,100 LOC across `neat-core/src/`. No evolutionary operator code is present — by design.
+
+## Feature-by-feature comparison
+
+Each row below covers one feature area. Classification legend:
+
+- ✅ **already present** in `neat-core`
+- 🌐 **owned by parent NEAT-AI** (Deno/TypeScript repo)
+- ⛔ **out of scope** for `neat-core`
+- 🎯 **worth adopting** (with priority + effort)
+
+### 1. Genome representation and mutation operators — 🌐 parent repo
+
+Ikaruga models genomes as `HashMap<NodeId, NodeGene>` + `HashMap<InnovationId, ConnectionGene>`, with a global innovation counter and three mutation operators (weight perturb/replace, add-connection with DFS cycle check, add-node by splitting a connection). `neat-core` contains no `Genome` type and no mutation operators — genome state lives in the TypeScript `Creature` type in the NEAT-AI repo, which is already richer (UUID-based neurons, condition/positive/negative synapse types, constant neurons, aggregate activations). `neat-core`'s responsibility ends at **compiling** a creature (via `compile_creature`) and **validating** its topology (`validate_structural_integrity`, `validate_topology`). Adopting Rust-side mutation here would duplicate the source of truth and is explicitly out of this crate's scope.
+
+### 2. Speciation (distance, fitness sharing, stagnation) — 🌐 parent repo
+
+Ikaruga implements compatibility distance with three coefficients (excess, disjoint, weight), fitness sharing via `adjusted_fitness = fitness / species_size`, and a stagnation counter with top-2 preservation. The parent NEAT-AI repo already provides speciation at the population level; `neat-core` does not see populations. Nothing to adopt here.
+
+### 3. Population management, tournament selection, crossover, generation loop — 🌐 parent repo
+
+Ikaruga's `population.rs` (381 LOC) runs the evolution loop including tournament selection, elitism, interspecies mating, and re-speciation. Again, this is parent-repo territory. `neat-core` does not hold population state.
+
+### 4. Config struct with JSON persistence — 🌐 parent repo / partially ✅
+
+Ikaruga's `NeatConfig` persists ~15 evolutionary knobs via serde JSON. `neat-core`'s only config-shaped input is `TrainingDataConfig` for the binary streaming reader, already present and tested. Evolutionary hyper-parameters belong in the parent repo, where the generation loop reads them.
+
+### 5. Neural-network feed-forward evaluation — ✅ already present (and richer)
+
+Ikaruga computes a topological order with DFS + cycle skip and iterates nodes sequentially applying one of **four** activation functions (Sigmoid, Tanh, ReLU, Linear). `neat-core` provides:
+
+- `CompiledNetwork` with pre-compiled evaluation order and **38** activation variants — a strict superset.
+- `topological_backprop` for training, which Ikaruga lacks entirely (Ikaruga is inference-only).
+- SIMD 4-way / 8-way batch accumulation across records (AVX2/FMA + NEON).
+- Predictive-coding inference (`PredictiveCodingEngine`) — novel vs Ikaruga.
+- Aggregate activations (MIN/MAX/IF/HYPOT/MEAN) for conditional branching inside a network — not present in Ikaruga.
+
+Ikaruga's `BatchEvaluator` imports `burn::tensor` but the batched path is still sequential `inputs.iter().map(…)`. Nothing to port.
+
+### 6. Topology visualisation — 🎯 worth adopting (data-only export, not the GUI)
+
+Ikaruga ships an 855-line `network_view.rs` built on `egui`/`eframe`, live-coupled to `Arc<RwLock<VisualizationState>>`. It is **not headless** and does **not export** DOT, JSON, or any other machine-readable graph format. `neat-core` has **no export path** today.
+
+The useful capability to pull forward is **deterministic topology export** (DOT and/or topology JSON) from `CompiledNetwork`, so downstream tools (Graphviz, web viewers, snapshot diffs) can render networks without linking a GUI stack into `neat-core`. The live `egui` renderer itself is out of scope — any interactive viewer belongs in [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore) or a sibling tool.
+
+- **Priority:** medium.
+- **Effort:** small (1 PR, ~300 LOC + tests).
+- **Tracked by:** existing open issue [#22 — Add CompiledNetwork topology export (DOT/JSON) for debugging and visualisation](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22). **No new issue needed.**
+
+### 7. GPU acceleration (Burn + WGPU) — ⛔ out of scope
+
+Ikaruga declares `burn = "0.16"` with WGPU, but `neural_net.rs` openly admits the GPU path is unimplemented (`"For now, we'll use the simple network evaluation"`). Even the aspirational use-case — batched forward-pass for a single population generation — does not fit `neat-core`'s constraints: this crate must build on `wasm32-unknown-unknown` for the NEAT-AI WASM path, and pulling Burn + WGPU would break that. The SIMD native path (#12) plus the chunked streaming reader (#13) already give `neat-core` a competitive CPU throughput story. GPU experimentation belongs in a separate crate or in the NEAT-AI-Discovery repository, not here.
+
+No adoption. Record as **explicitly rejected** to avoid re-litigating.
+
+### 8. Serialisation format — 🎯 worth adopting (round-trip JSON on `CreatureExport`)
+
+Ikaruga derives both `Serialize` and `Deserialize` on its `Genome`, enabling full round-trip JSON persistence. `neat-core`'s `CreatureExport` currently derives **only** `Deserialize` — networks can be loaded but not written back out. For the topology-export work in #22, and for snapshot diffing, cache priming, and WASM bridging, a symmetric serialise path is worth adding. The JSON shape is fixed by the TypeScript `CreatureExport` contract, so there is no schema design required — only matching `Serialize` derives, `#[serde(rename = …)]` attributes, and a deterministic field ordering test.
+
+- **Priority:** medium.
+- **Effort:** small (~150 LOC + tests: round-trip, deterministic field order, numerical precision on f64 weights).
+- **Issue:** new follow-up issue created per this research.
+
+### 9. Emulator bridge / environment interface (TCP + Lua) — ⛔ out of scope
+
+Ikaruga's `connection.rs` (558 LOC) plus two Lua scripts wire a BizHawk or MAME instance over TCP to feed screen pixels in and button presses out. This is entirely application-specific and has no place in a shared compute library. The parent NEAT-AI repo defines its own environment abstraction; game-specific drivers belong there or in an example crate.
+
+No adoption.
+
+### 10. Fitness evaluation — 🌐 parent repo / ⛔ out of scope for `neat-core`
+
+Ikaruga's `fitness.rs` (579 LOC) encodes per-game scoring heuristics. Fitness is defined at the application layer, not in a compute crate.
+
+## Summary table
+
+| # | Feature area | Ikaruga | `neat-core` | Classification | Follow-up |
+|---|---|---|---|---|---|
+| 1 | Genome + 3 mutation ops | `genome.rs` 547 LOC | — | 🌐 parent repo | — |
+| 2 | Speciation | `species.rs` 304 LOC | — | 🌐 parent repo | — |
+| 3 | Population, tournament, crossover | `population.rs` 381 LOC | — | 🌐 parent repo | — |
+| 4 | NeatConfig JSON | `config.rs` | `TrainingDataConfig` only | 🌐 parent repo | — |
+| 5 | Feed-forward evaluation | 4 activations, no SIMD, no backprop | 38 activations + backprop + SIMD + PC | ✅ already richer | — |
+| 6 | Topology visualisation | 855-LOC egui GUI, no export | no export path | 🎯 adopt (data-only export) | [#22](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22) (existing) |
+| 7 | GPU (Burn + WGPU) | declared, unused | — | ⛔ out of scope (breaks WASM) | — |
+| 8 | Genome JSON round-trip | `Serialize` + `Deserialize` | `Deserialize` only | 🎯 adopt | [#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30) |
+| 9 | Emulator TCP + Lua bridge | 558 LOC + Lua scripts | — | ⛔ out of scope | — |
+| 10 | Fitness scoring | 579 LOC per game | — | ⛔ out of scope | — |
+
+## Adoption candidates (prioritised)
+
+1. **CompiledNetwork topology export (DOT / topology JSON)** — medium priority, small effort. Already scoped in open issue **[#22](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22)**. No new issue needed.
+2. **`CreatureExport` round-trip JSON (`Serialize` on all three export types)** — medium priority, small effort. Tracked by follow-up issue **[#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30)** raised alongside this document.
+
+Everything else is either already covered more completely by `neat-core`, owned by the parent NEAT-AI repo, or deliberately outside this crate's scope.
+
+## Attribution
+
+This document summarises the public source of [Ikaruga/NEAT-AI](https://github.com/Ikaruga/NEAT-AI) (MIT, © contributors). No code was transcribed; file names, approximate line counts, dependency versions, and high-level designs were read from the upstream repository.

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod simd;
 pub mod squash;
 pub mod synapse_type;
 pub mod topological_backprop;
+pub mod topology_export;
 pub mod topology_ops;
 pub mod training_bin_stream;
 pub mod training_data;
@@ -67,6 +68,7 @@ pub use topological_backprop::{
     NeuronType, PropagateInput, PropagateOutcome, PropagateOutput, StandardOutcome, SynapseDelta,
     SynapseInput, propagate_topological_loop,
 };
+pub use topology_export::{NodeKind, squash_name, synapse_type_name, to_dot, to_topology_json};
 pub use topology_ops::{
     BACKWARD_CONNECTION, DUPLICATE_CONNECTION, SELF_CONNECTION, SORT_ERROR_FROM, SORT_ERROR_TO,
     STRUCTURAL_BIAS_NOT_FINITE, STRUCTURAL_CONSTANT_HAS_INWARD, STRUCTURAL_HIDDEN_NO_INWARD,

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -45,6 +45,9 @@ pub struct SynapseData {
 
 /// Compiled network data structure
 ///
+/// `Clone` is supported so native tools (for example the NEAT-AI scorer) can run
+/// forward-only batch scoring on multiple threads, each with its own activation buffers.
+///
 /// Format (Issue #1125 - updated to support aggregate functions):
 /// - Header: [num_neurons: u32, num_inputs: u32]
 /// - Neuron data: For each neuron after inputs:
@@ -59,6 +62,7 @@ pub struct SynapseData {
 ///
 /// This compact format minimises memory access and enables efficient iteration.
 /// Issue #1175 - Uses typed structs for better cache locality and compiler optimisation.
+#[derive(Clone)]
 pub struct CompiledNetwork {
     /// Total number of neurons (including input)
     pub num_neurons: usize,
@@ -1578,5 +1582,371 @@ impl CompiledNetwork {
             trace.push(neuron_idx as f32);
             trace.push(0.0f32);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to build a CompiledNetwork directly for testing
+    fn make_network(
+        num_inputs: usize,
+        neurons: Vec<NeuronData>,
+        synapses: Vec<SynapseData>,
+    ) -> CompiledNetwork {
+        let num_neurons = num_inputs + neurons.len();
+        let num_non_inputs = neurons.len();
+        let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+        CompiledNetwork {
+            num_neurons,
+            num_inputs,
+            neurons,
+            synapses,
+            activations: vec![0.0; num_neurons],
+            hint_values_buffer: vec![0.0; num_non_inputs],
+            trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        }
+    }
+
+    fn make_synapse(from_index: u32, weight: f32) -> SynapseData {
+        SynapseData {
+            weight,
+            from_index,
+            synapse_type: 0,
+            _padding: [0; 3],
+        }
+    }
+
+    fn make_synapse_typed(from_index: u32, weight: f32, synapse_type: u8) -> SynapseData {
+        SynapseData {
+            weight,
+            from_index,
+            synapse_type,
+            _padding: [0; 3],
+        }
+    }
+
+    /// Split the packed batch_4way output into its four records using the length header.
+    fn split_batch_records(batch_result: &[f32]) -> [&[f32]; 4] {
+        let len0 = batch_result[0] as usize;
+        let len1 = batch_result[1] as usize;
+        let len2 = batch_result[2] as usize;
+        let len3 = batch_result[3] as usize;
+        let start0 = 4;
+        let start1 = start0 + len0;
+        let start2 = start1 + len1;
+        let start3 = start2 + len2;
+        [
+            &batch_result[start0..start0 + len0],
+            &batch_result[start1..start1 + len1],
+            &batch_result[start2..start2 + len2],
+            &batch_result[start3..start3 + len3],
+        ]
+    }
+
+    fn assert_records_match(single_results: &[Vec<f32>], batch_records: &[&[f32]; 4]) {
+        for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
+            assert_eq!(
+                single.len(),
+                batch.len(),
+                "Record {i}: length mismatch (single={}, batch={})",
+                single.len(),
+                batch.len()
+            );
+            for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
+                assert!(
+                    (s - b).abs() < 1e-5,
+                    "Record {i}, element {j}: single={s}, batch={b}"
+                );
+            }
+        }
+    }
+
+    /// Test that batch 4-way matches single-record activate_and_trace for standard squash (ReLU)
+    #[test]
+    fn test_batch_4way_matches_single_relu() {
+        // Network: 2 inputs, 1 hidden (ReLU), 1 output (Identity)
+        let synapses = vec![
+            make_synapse(0, 0.5),  // hidden <- input0
+            make_synapse(1, -0.3), // hidden <- input1
+            make_synapse(2, 1.0),  // output <- hidden
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 0.1,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 1, // ReLU
+                is_constant: false,
+            },
+            NeuronData {
+                bias: -0.2,
+                start_synapse: 2,
+                num_synapses: 1,
+                squash_type: 0, // Identity
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[0.5, -1.0], &[-2.0, 3.0], &[0.0, 0.0]];
+
+        // Run single-record activate_and_trace for each
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        // Run batch 4-way
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed_input: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed_input, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with TANH and LOGISTIC squash functions
+    #[test]
+    fn test_batch_4way_matches_single_tanh_logistic() {
+        let synapses = vec![
+            make_synapse(0, 1.0),
+            make_synapse(1, 0.5),
+            make_synapse(2, -0.7),
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 0.0,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 7, // TANH
+                is_constant: false,
+            },
+            NeuronData {
+                bias: 0.5,
+                start_synapse: 2,
+                num_synapses: 1,
+                squash_type: 6, // LOGISTIC
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 0.5], &[-1.0, 2.0], &[0.3, -0.3], &[2.0, -1.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with MINIMUM aggregate function
+    #[test]
+    fn test_batch_4way_minimum_aggregate() {
+        // 2 inputs -> 1 MINIMUM neuron (output)
+        let synapses = vec![make_synapse(0, 1.0), make_synapse(1, 1.0)];
+        let neurons = vec![NeuronData {
+            bias: 0.0,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: 32, // MINIMUM
+            is_constant: false,
+        }];
+
+        let inputs: [&[f32]; 4] = [
+            &[3.0, 1.0],  // min = 1.0
+            &[-1.0, 2.0], // min = -1.0
+            &[5.0, 5.0],  // min = 5.0
+            &[0.0, -3.0], // min = -3.0
+        ];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with MAXIMUM aggregate function
+    #[test]
+    fn test_batch_4way_maximum_aggregate() {
+        let synapses = vec![make_synapse(0, 1.0), make_synapse(1, 1.0)];
+        let neurons = vec![NeuronData {
+            bias: 0.5,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: 33, // MAXIMUM
+            is_constant: false,
+        }];
+
+        let inputs: [&[f32]; 4] = [&[3.0, 1.0], &[-1.0, 2.0], &[5.0, 5.0], &[0.0, -3.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with IF aggregate function
+    #[test]
+    fn test_batch_4way_if_aggregate() {
+        // 3 inputs -> 1 IF neuron
+        // synapse0: condition, synapse1: positive, synapse2: negative
+        let synapses = vec![
+            make_synapse_typed(0, 1.0, 1), // condition
+            make_synapse_typed(1, 1.0, 3), // positive
+            make_synapse_typed(2, 1.0, 2), // negative
+        ];
+        let neurons = vec![NeuronData {
+            bias: 0.0,
+            start_synapse: 0,
+            num_synapses: 3,
+            squash_type: 34, // IF
+            is_constant: false,
+        }];
+
+        let inputs: [&[f32]; 4] = [
+            &[1.0, 5.0, 10.0],  // condition>0 -> positive=5.0
+            &[-1.0, 5.0, 10.0], // condition<=0 -> negative=10.0
+            &[0.5, 3.0, 7.0],   // condition>0 -> positive=3.0
+            &[-2.0, 3.0, 7.0],  // condition<=0 -> negative=7.0
+        ];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(3, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(3, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 3, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with constant neurons
+    #[test]
+    fn test_batch_4way_constant_neuron() {
+        let synapses = vec![
+            make_synapse(2, 1.0), // output <- constant
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 42.0,
+                start_synapse: 0,
+                num_synapses: 0,
+                squash_type: 0,
+                is_constant: true,
+            },
+            NeuronData {
+                bias: 0.0,
+                start_synapse: 0,
+                num_synapses: 1,
+                squash_type: 0, // Identity
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[3.0, 4.0], &[5.0, 6.0], &[7.0, 8.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
+    }
+
+    /// Test batch 4-way with a deeper network (multiple layers)
+    #[test]
+    fn test_batch_4way_multi_layer() {
+        // 2 inputs -> 2 hidden (ReLU) -> 1 output (Identity)
+        let synapses = vec![
+            // Hidden 0 (idx 2): from input 0 and 1
+            make_synapse(0, 0.5),
+            make_synapse(1, 0.3),
+            // Hidden 1 (idx 3): from input 0 and 1
+            make_synapse(0, -0.4),
+            make_synapse(1, 0.6),
+            // Output (idx 4): from hidden 0 and hidden 1
+            make_synapse(2, 1.0),
+            make_synapse(3, -0.5),
+        ];
+        let neurons = vec![
+            NeuronData {
+                bias: 0.1,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 1, // ReLU
+                is_constant: false,
+            },
+            NeuronData {
+                bias: -0.1,
+                start_synapse: 2,
+                num_synapses: 2,
+                squash_type: 1, // ReLU
+                is_constant: false,
+            },
+            NeuronData {
+                bias: 0.0,
+                start_synapse: 4,
+                num_synapses: 2,
+                squash_type: 0, // Identity
+                is_constant: false,
+            },
+        ];
+
+        let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[-1.0, 0.5], &[3.0, -2.0], &[0.0, 0.0]];
+
+        let mut single_results = Vec::new();
+        for input in &inputs {
+            let mut net = make_network(2, neurons.clone(), synapses.clone());
+            let result = net.activate_and_trace(input, 1);
+            single_results.push(result);
+        }
+
+        let net = make_network(2, neurons.clone(), synapses.clone());
+        let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
+        let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
+
+        let batch_records = split_batch_records(&batch_result);
+        assert_records_match(&single_results, &batch_records);
     }
 }

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -11,6 +11,8 @@
 //!   perform multiply and add in a single instruction with better precision.
 //! - **Multi-record batching**: Processes the same neuron across 4 or 8 input records
 //!   in parallel, amortising weight loads across records.
+//! - **Native (`not(wasm32)`)**: `simd_native.rs` uses **AVX2** (8-wide) and **FMA+SSE** (4-wide)
+//!   on `x86_64`, **NEON** on `aarch64`; otherwise scalar (same numerics as the old fallback).
 //! - **SIMD aggregate helpers**: `weighted_sum_of_squares_simd` for Hypotenuse
 //!   and `weighted_sum_for_mean_simd` for Mean activation functions.
 
@@ -449,75 +451,14 @@ pub fn weighted_sum_simd_8records(
     )
 }
 
-/// Scalar fallback for non-WASM targets (for testing)
+// Native (non-wasm32) multi-record helpers now live in `simd_native.rs` and use
+// AVX2/FMA on x86_64, NEON on aarch64, falling back to scalar elsewhere.
 #[cfg(not(target_arch = "wasm32"))]
-#[inline]
-#[allow(clippy::too_many_arguments)]
-pub fn weighted_sum_simd_8records(
-    synapses: &[SynapseData],
-    act0: &[f32],
-    act1: &[f32],
-    act2: &[f32],
-    act3: &[f32],
-    act4: &[f32],
-    act5: &[f32],
-    act6: &[f32],
-    act7: &[f32],
-    start: usize,
-    end: usize,
-    bias: f32,
-) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
-    let mut sum0 = bias;
-    let mut sum1 = bias;
-    let mut sum2 = bias;
-    let mut sum3 = bias;
-    let mut sum4 = bias;
-    let mut sum5 = bias;
-    let mut sum6 = bias;
-    let mut sum7 = bias;
-    for synapse in synapses.iter().take(end).skip(start) {
-        let from = synapse.from_index as usize;
-        let w = synapse.weight;
-        sum0 += act0[from] * w;
-        sum1 += act1[from] * w;
-        sum2 += act2[from] * w;
-        sum3 += act3[from] * w;
-        sum4 += act4[from] * w;
-        sum5 += act5[from] * w;
-        sum6 += act6[from] * w;
-        sum7 += act7[from] * w;
-    }
-    (sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7)
-}
+#[path = "simd_native.rs"]
+mod simd_native;
 
-/// Scalar fallback for non-WASM targets (for testing)
 #[cfg(not(target_arch = "wasm32"))]
-#[inline]
-#[allow(clippy::too_many_arguments)]
-pub fn weighted_sum_simd_4records(
-    synapses: &[SynapseData],
-    act0: &[f32],
-    act1: &[f32],
-    act2: &[f32],
-    act3: &[f32],
-    start: usize,
-    end: usize,
-    bias: f32,
-) -> (f32, f32, f32, f32) {
-    let mut sum0 = bias;
-    let mut sum1 = bias;
-    let mut sum2 = bias;
-    let mut sum3 = bias;
-    for synapse in synapses.iter().take(end).skip(start) {
-        let from = synapse.from_index as usize;
-        let w = synapse.weight;
-        sum0 += act0[from] * w;
-        sum1 += act1[from] * w;
-        sum2 += act2[from] * w;
-        sum3 += act3[from] * w;
-    }
-    (sum0, sum1, sum2, sum3)
-}
+pub use simd_native::{weighted_sum_simd_4records, weighted_sum_simd_8records};
 
 /// Scalar fallback for non-WASM targets (for testing)
 #[cfg(not(target_arch = "wasm32"))]

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -1,0 +1,391 @@
+//! Native SIMD fast paths for multi-record weighted sums (Issue #1202 / #1209 on native hosts).
+//!
+//! `wasm32` uses `simd128` in `simd.rs`. Here **`x86_64`** uses **AVX2** (`__m256` + FMA) for
+//! 8-wide and **FMA + SSE** for 4-wide; **`aarch64`** uses **NEON** (`float32x4` pairs for 8-wide).
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use crate::network::SynapseData;
+
+#[inline]
+fn weighted_sum_simd_8records_scalar(
+    synapses: &[SynapseData],
+    act0: &[f32],
+    act1: &[f32],
+    act2: &[f32],
+    act3: &[f32],
+    act4: &[f32],
+    act5: &[f32],
+    act6: &[f32],
+    act7: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
+    let mut sum0 = bias;
+    let mut sum1 = bias;
+    let mut sum2 = bias;
+    let mut sum3 = bias;
+    let mut sum4 = bias;
+    let mut sum5 = bias;
+    let mut sum6 = bias;
+    let mut sum7 = bias;
+    for synapse in synapses.iter().take(end).skip(start) {
+        let from = synapse.from_index as usize;
+        let w = synapse.weight;
+        sum0 += act0[from] * w;
+        sum1 += act1[from] * w;
+        sum2 += act2[from] * w;
+        sum3 += act3[from] * w;
+        sum4 += act4[from] * w;
+        sum5 += act5[from] * w;
+        sum6 += act6[from] * w;
+        sum7 += act7[from] * w;
+    }
+    (sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7)
+}
+
+#[inline]
+fn weighted_sum_simd_4records_scalar(
+    synapses: &[SynapseData],
+    act0: &[f32],
+    act1: &[f32],
+    act2: &[f32],
+    act3: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> (f32, f32, f32, f32) {
+    let mut sum0 = bias;
+    let mut sum1 = bias;
+    let mut sum2 = bias;
+    let mut sum3 = bias;
+    for synapse in synapses.iter().take(end).skip(start) {
+        let from = synapse.from_index as usize;
+        let w = synapse.weight;
+        sum0 += act0[from] * w;
+        sum1 += act1[from] * w;
+        sum2 += act2[from] * w;
+        sum3 += act3[from] * w;
+    }
+    (sum0, sum1, sum2, sum3)
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use super::SynapseData;
+    use core::arch::x86_64::*;
+
+    /// # Safety
+    /// Caller must ensure AVX2 is enabled (`is_x86_feature_detected!("avx2")`).
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub unsafe fn weighted_sum_simd_8records_avx2(
+        synapses: &[SynapseData],
+        act0: &[f32],
+        act1: &[f32],
+        act2: &[f32],
+        act3: &[f32],
+        act4: &[f32],
+        act5: &[f32],
+        act6: &[f32],
+        act7: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
+        let mut acc = _mm256_set1_ps(bias);
+        for i in start..end {
+            let synapse = synapses.get_unchecked(i);
+            let from = synapse.from_index as usize;
+            let w = synapse.weight;
+            let acts = _mm256_set_ps(
+                *act7.get_unchecked(from),
+                *act6.get_unchecked(from),
+                *act5.get_unchecked(from),
+                *act4.get_unchecked(from),
+                *act3.get_unchecked(from),
+                *act2.get_unchecked(from),
+                *act1.get_unchecked(from),
+                *act0.get_unchecked(from),
+            );
+            let ws = _mm256_set1_ps(w);
+            acc = _mm256_fmadd_ps(ws, acts, acc);
+        }
+        let mut out = [0.0_f32; 8];
+        _mm256_storeu_ps(out.as_mut_ptr(), acc);
+        (
+            out[0], out[1], out[2], out[3], out[4], out[5], out[6], out[7],
+        )
+    }
+
+    /// # Safety
+    /// Caller must ensure FMA is enabled (`is_x86_feature_detected!("fma")`).
+    #[target_feature(enable = "fma")]
+    #[inline]
+    pub unsafe fn weighted_sum_simd_4records_fma(
+        synapses: &[SynapseData],
+        act0: &[f32],
+        act1: &[f32],
+        act2: &[f32],
+        act3: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> (f32, f32, f32, f32) {
+        let mut acc = _mm_set1_ps(bias);
+        for i in start..end {
+            let synapse = synapses.get_unchecked(i);
+            let from = synapse.from_index as usize;
+            let w = synapse.weight;
+            let acts = _mm_set_ps(
+                *act3.get_unchecked(from),
+                *act2.get_unchecked(from),
+                *act1.get_unchecked(from),
+                *act0.get_unchecked(from),
+            );
+            let ws = _mm_set1_ps(w);
+            acc = _mm_fmadd_ps(ws, acts, acc);
+        }
+        let mut out = [0.0_f32; 4];
+        _mm_storeu_ps(out.as_mut_ptr(), acc);
+        (out[0], out[1], out[2], out[3])
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64 {
+    use super::SynapseData;
+    use core::arch::aarch64::*;
+
+    /// # Safety
+    /// Caller must ensure NEON is available (typical on aarch64-apple-darwin / linux-aarch64).
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub unsafe fn weighted_sum_simd_8records_neon(
+        synapses: &[SynapseData],
+        act0: &[f32],
+        act1: &[f32],
+        act2: &[f32],
+        act3: &[f32],
+        act4: &[f32],
+        act5: &[f32],
+        act6: &[f32],
+        act7: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
+        let mut acc03 = vdupq_n_f32(bias);
+        let mut acc47 = vdupq_n_f32(bias);
+        let mut lane03 = [0.0_f32; 4];
+        let mut lane47 = [0.0_f32; 4];
+        for i in start..end {
+            let synapse = synapses.get_unchecked(i);
+            let from = synapse.from_index as usize;
+            let w = synapse.weight;
+            lane03[0] = *act0.get_unchecked(from);
+            lane03[1] = *act1.get_unchecked(from);
+            lane03[2] = *act2.get_unchecked(from);
+            lane03[3] = *act3.get_unchecked(from);
+            lane47[0] = *act4.get_unchecked(from);
+            lane47[1] = *act5.get_unchecked(from);
+            lane47[2] = *act6.get_unchecked(from);
+            lane47[3] = *act7.get_unchecked(from);
+            let acts03 = vld1q_f32(lane03.as_ptr());
+            let acts47 = vld1q_f32(lane47.as_ptr());
+            let vw = vdupq_n_f32(w);
+            acc03 = vfmaq_f32(acc03, vw, acts03);
+            acc47 = vfmaq_f32(acc47, vw, acts47);
+        }
+        let mut o03 = [0.0_f32; 4];
+        let mut o47 = [0.0_f32; 4];
+        vst1q_f32(o03.as_mut_ptr(), acc03);
+        vst1q_f32(o47.as_mut_ptr(), acc47);
+        (
+            o03[0], o03[1], o03[2], o03[3], o47[0], o47[1], o47[2], o47[3],
+        )
+    }
+
+    /// # Safety
+    /// Caller must ensure NEON is available.
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub unsafe fn weighted_sum_simd_4records_neon(
+        synapses: &[SynapseData],
+        act0: &[f32],
+        act1: &[f32],
+        act2: &[f32],
+        act3: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> (f32, f32, f32, f32) {
+        let mut acc = vdupq_n_f32(bias);
+        let mut lane = [0.0_f32; 4];
+        for i in start..end {
+            let synapse = synapses.get_unchecked(i);
+            let from = synapse.from_index as usize;
+            let w = synapse.weight;
+            lane[0] = *act0.get_unchecked(from);
+            lane[1] = *act1.get_unchecked(from);
+            lane[2] = *act2.get_unchecked(from);
+            lane[3] = *act3.get_unchecked(from);
+            let acts = vld1q_f32(lane.as_ptr());
+            let vw = vdupq_n_f32(w);
+            acc = vfmaq_f32(acc, vw, acts);
+        }
+        let mut out = [0.0_f32; 4];
+        vst1q_f32(out.as_mut_ptr(), acc);
+        (out[0], out[1], out[2], out[3])
+    }
+}
+
+/// 8-record weighted sum: AVX2+FMA on x86_64, NEON on aarch64, else scalar.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn weighted_sum_simd_8records(
+    synapses: &[SynapseData],
+    act0: &[f32],
+    act1: &[f32],
+    act2: &[f32],
+    act3: &[f32],
+    act4: &[f32],
+    act5: &[f32],
+    act6: &[f32],
+    act7: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
+    let count = end.saturating_sub(start);
+    if count == 0 {
+        return (bias, bias, bias, bias, bias, bias, bias, bias);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            return unsafe {
+                x86::weighted_sum_simd_8records_avx2(
+                    synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
+                )
+            };
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            return unsafe {
+                aarch64::weighted_sum_simd_8records_neon(
+                    synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
+                )
+            };
+        }
+    }
+
+    weighted_sum_simd_8records_scalar(
+        synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
+    )
+}
+
+/// 4-record weighted sum: FMA+SSE on x86_64, NEON on aarch64, else scalar.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn weighted_sum_simd_4records(
+    synapses: &[SynapseData],
+    act0: &[f32],
+    act1: &[f32],
+    act2: &[f32],
+    act3: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> (f32, f32, f32, f32) {
+    let count = end.saturating_sub(start);
+    if count == 0 {
+        return (bias, bias, bias, bias);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("fma") {
+            return unsafe {
+                x86::weighted_sum_simd_4records_fma(
+                    synapses, act0, act1, act2, act3, start, end, bias,
+                )
+            };
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            return unsafe {
+                aarch64::weighted_sum_simd_4records_neon(
+                    synapses, act0, act1, act2, act3, start, end, bias,
+                )
+            };
+        }
+    }
+
+    weighted_sum_simd_4records_scalar(synapses, act0, act1, act2, act3, start, end, bias)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::SynapseData;
+
+    fn synapse(from: u32, weight: f32) -> SynapseData {
+        SynapseData {
+            weight,
+            from_index: from,
+            synapse_type: 0,
+            _padding: [0; 3],
+        }
+    }
+
+    #[test]
+    fn native_8_matches_scalar_small() {
+        let syn = [synapse(0, 1.0), synapse(1, 2.0)];
+        let act0 = vec![1.0_f32, 2.0];
+        let act1 = vec![0.5_f32, 1.0];
+        let act2 = vec![2.0_f32, 0.0];
+        let act3 = vec![1.0_f32, 1.0];
+        let act4 = vec![0.0_f32, 3.0];
+        let act5 = vec![1.0_f32, 0.5];
+        let act6 = vec![1.5_f32, 1.5];
+        let act7 = vec![-1.0_f32, 2.0];
+        let s = weighted_sum_simd_8records_scalar(
+            &syn, &act0, &act1, &act2, &act3, &act4, &act5, &act6, &act7, 0, 2, 0.25,
+        );
+        let n = weighted_sum_simd_8records(
+            &syn, &act0, &act1, &act2, &act3, &act4, &act5, &act6, &act7, 0, 2, 0.25,
+        );
+        assert_eq!(n.0, s.0);
+        assert_eq!(n.1, s.1);
+        assert_eq!(n.2, s.2);
+        assert_eq!(n.3, s.3);
+        assert_eq!(n.4, s.4);
+        assert_eq!(n.5, s.5);
+        assert_eq!(n.6, s.6);
+        assert_eq!(n.7, s.7);
+    }
+
+    #[test]
+    fn native_4_matches_scalar_small() {
+        let syn = [synapse(0, 0.5), synapse(2, 1.5)];
+        let a0 = vec![1.0_f32, 0.0, 3.0];
+        let a1 = vec![2.0_f32, 1.0, 0.0];
+        let a2 = vec![0.0_f32, 1.0, 4.0];
+        let a3 = vec![1.0_f32, 2.0, 0.5];
+        let s = weighted_sum_simd_4records_scalar(&syn, &a0, &a1, &a2, &a3, 0, 2, -1.0);
+        let n = weighted_sum_simd_4records(&syn, &a0, &a1, &a2, &a3, 0, 2, -1.0);
+        assert_eq!(n.0, s.0);
+        assert_eq!(n.1, s.1);
+        assert_eq!(n.2, s.2);
+        assert_eq!(n.3, s.3);
+    }
+}

--- a/neat-core/src/topology_export.rs
+++ b/neat-core/src/topology_export.rs
@@ -1,0 +1,328 @@
+//! Deterministic topology export from [`CompiledNetwork`] (Issue #22).
+//!
+//! This module provides pure-data exports — DOT (Graphviz) and a minimal
+//! topology JSON — suitable for external tooling (Graphviz renderers, web
+//! viewers, snapshot diffs) without pulling a GUI stack into `neat-core`.
+//!
+//! Output is deterministic for identical input: nodes are emitted in ascending
+//! index order, synapses in the order they are stored on the network (which is
+//! itself deterministic — compilation groups by target neuron and preserves
+//! per-target synapse order), and weights are formatted with a fixed
+//! precision. Two exports of the same network produce byte-identical output.
+//!
+//! # Example
+//!
+//! ```
+//! use neat_core::{compile_creature, parse_creature_json};
+//!
+//! let json = r#"{
+//!     "input": 1,
+//!     "output": 1,
+//!     "neurons": [
+//!         {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+//!     ],
+//!     "synapses": [
+//!         {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+//!     ],
+//!     "forwardOnly": true
+//! }"#;
+//! let creature = parse_creature_json(json).unwrap();
+//! let network = compile_creature(&creature).unwrap();
+//!
+//! let dot = network.to_dot(creature.output);
+//! assert!(dot.starts_with("digraph "));
+//!
+//! let topology = network.to_topology_json(creature.output);
+//! assert!(topology.contains("\"num_inputs\""));
+//! ```
+
+use std::fmt::Write;
+
+use serde::Serialize;
+
+use crate::network::CompiledNetwork;
+use crate::squash::SquashType;
+use crate::synapse_type::SynapseType;
+
+/// Node classification used by topology exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    /// Input neuron (index `0..num_inputs`).
+    Input,
+    /// Hidden (non-output, non-constant) neuron.
+    Hidden,
+    /// Output neuron (last `num_outputs` neurons).
+    Output,
+    /// Constant neuron (no inward connections).
+    Constant,
+}
+
+impl NodeKind {
+    /// Lowercase identifier used in DOT labels and JSON exports.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NodeKind::Input => "input",
+            NodeKind::Hidden => "hidden",
+            NodeKind::Output => "output",
+            NodeKind::Constant => "constant",
+        }
+    }
+}
+
+/// Classify a neuron by its absolute index in the compiled network.
+fn classify(network: &CompiledNetwork, index: usize, num_outputs: usize) -> NodeKind {
+    if index < network.num_inputs {
+        return NodeKind::Input;
+    }
+    let neuron = &network.neurons[index - network.num_inputs];
+    if neuron.is_constant {
+        return NodeKind::Constant;
+    }
+    let output_start = network.num_neurons.saturating_sub(num_outputs);
+    if index >= output_start {
+        NodeKind::Output
+    } else {
+        NodeKind::Hidden
+    }
+}
+
+/// Canonical name for a squash (activation) function.
+///
+/// Names match those accepted by [`crate::creature::parse_squash_name`], so a
+/// JSON export round-trips through the TypeScript contract where possible.
+pub fn squash_name(ty: SquashType) -> &'static str {
+    match ty {
+        SquashType::Identity => "IDENTITY",
+        SquashType::Relu => "RELU",
+        SquashType::Relu6 => "ReLU6",
+        SquashType::LeakyRelu => "LeakyReLU",
+        SquashType::Selu => "SELU",
+        SquashType::Elu => "ELU",
+        SquashType::Logistic => "LOGISTIC",
+        SquashType::Tanh => "TANH",
+        SquashType::HardTanh => "HARD_TANH",
+        SquashType::Softsign => "SOFTSIGN",
+        SquashType::Softplus => "Softplus",
+        SquashType::Swish => "Swish",
+        SquashType::Mish => "Mish",
+        SquashType::Gelu => "GELU",
+        SquashType::Sine => "SINE",
+        SquashType::Cosine => "Cosine",
+        SquashType::Tan => "TAN",
+        SquashType::ArcTan => "ArcTan",
+        SquashType::Gaussian => "GAUSSIAN",
+        SquashType::BentIdentity => "BENT_IDENTITY",
+        SquashType::BipolarSigmoid => "BIPOLAR_SIGMOID",
+        SquashType::Bipolar => "BIPOLAR",
+        SquashType::Step => "STEP",
+        SquashType::Complement => "COMPLEMENT",
+        SquashType::Absolute => "ABSOLUTE",
+        SquashType::Square => "SQUARE",
+        SquashType::Cube => "Cube",
+        SquashType::Sqrt => "SQRT",
+        SquashType::StdInverse => "StdInverse",
+        SquashType::Exponential => "Exponential",
+        SquashType::LogSigmoid => "LogSigmoid",
+        SquashType::Isru => "ISRU",
+        SquashType::Minimum => "MINIMUM",
+        SquashType::Maximum => "MAXIMUM",
+        SquashType::If => "IF",
+        SquashType::Hypotenuse => "HYPOT",
+        SquashType::HypotenuseV2 => "HYPOTv2",
+        SquashType::Mean => "MEAN",
+    }
+}
+
+/// Canonical name for a synapse type.
+pub fn synapse_type_name(ty: SynapseType) -> &'static str {
+    match ty {
+        SynapseType::Standard => "Standard",
+        SynapseType::Condition => "Condition",
+        SynapseType::Negative => "Negative",
+        SynapseType::Positive => "Positive",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON export
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct NodeRecord {
+    index: usize,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bias: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    squash: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct SynapseRecord {
+    from: u32,
+    to: u32,
+    weight: f32,
+    #[serde(rename = "type")]
+    synapse_type: &'static str,
+}
+
+#[derive(Serialize)]
+struct TopologyExport {
+    num_inputs: usize,
+    num_outputs: usize,
+    num_neurons: usize,
+    nodes: Vec<NodeRecord>,
+    synapses: Vec<SynapseRecord>,
+}
+
+/// Build a deterministic JSON topology description.
+///
+/// The returned string is pretty-printed JSON using `serde_json`'s default
+/// formatter. Nodes are listed in ascending index order; synapses are listed
+/// in network storage order (grouped by target neuron, then by per-target
+/// compilation order). See the module docs for the determinism contract.
+pub fn to_topology_json(network: &CompiledNetwork, num_outputs: usize) -> String {
+    let mut nodes = Vec::with_capacity(network.num_neurons);
+
+    for i in 0..network.num_inputs {
+        nodes.push(NodeRecord {
+            index: i,
+            kind: NodeKind::Input.as_str(),
+            bias: None,
+            squash: None,
+        });
+    }
+
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let index = network.num_inputs + offset;
+        let kind = classify(network, index, num_outputs);
+        let squash = SquashType::from(neuron.squash_type);
+        nodes.push(NodeRecord {
+            index,
+            kind: kind.as_str(),
+            bias: Some(neuron.bias),
+            squash: Some(squash_name(squash)),
+        });
+    }
+
+    let mut synapses = Vec::with_capacity(network.synapses.len());
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let to_index = (network.num_inputs + offset) as u32;
+        let start = neuron.start_synapse as usize;
+        let end = start + neuron.num_synapses as usize;
+        for synapse in &network.synapses[start..end] {
+            let synapse_type = SynapseType::from(synapse.synapse_type);
+            synapses.push(SynapseRecord {
+                from: synapse.from_index,
+                to: to_index,
+                weight: synapse.weight,
+                synapse_type: synapse_type_name(synapse_type),
+            });
+        }
+    }
+
+    let export = TopologyExport {
+        num_inputs: network.num_inputs,
+        num_outputs,
+        num_neurons: network.num_neurons,
+        nodes,
+        synapses,
+    };
+
+    // `serde_json` serialises struct fields in declaration order, so this is
+    // deterministic. `to_string_pretty` is stable across calls for the same
+    // input.
+    serde_json::to_string_pretty(&export).expect("TopologyExport is always serialisable to JSON")
+}
+
+// ---------------------------------------------------------------------------
+// DOT export
+// ---------------------------------------------------------------------------
+
+/// Emit a deterministic DOT (Graphviz) representation of the network.
+///
+/// Node shape convention:
+/// - inputs: `ellipse`
+/// - hidden: `box`
+/// - outputs: `doublecircle`
+/// - constants: `diamond`
+///
+/// Each edge is labelled with `"<weight> <SynapseType>"` where `<weight>` is
+/// formatted with six-decimal-place precision for stable output.
+pub fn to_dot(network: &CompiledNetwork, num_outputs: usize) -> String {
+    // Pre-allocate a reasonable buffer to avoid intermediate reallocations —
+    // roughly 64 bytes per node + 48 bytes per edge.
+    let mut out =
+        String::with_capacity(64 + network.num_neurons * 64 + network.synapses.len() * 48);
+
+    out.push_str("digraph CompiledNetwork {\n");
+    out.push_str("  rankdir=LR;\n");
+
+    // Node declarations in ascending index order.
+    for i in 0..network.num_inputs {
+        writeln!(out, "  n{i} [label=\"n{i}\\ninput\", shape=ellipse];",).unwrap();
+    }
+
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let index = network.num_inputs + offset;
+        let kind = classify(network, index, num_outputs);
+        let shape = match kind {
+            NodeKind::Input => "ellipse",
+            NodeKind::Hidden => "box",
+            NodeKind::Output => "doublecircle",
+            NodeKind::Constant => "diamond",
+        };
+        let squash = squash_name(SquashType::from(neuron.squash_type));
+        let kind_label = kind.as_str();
+        let bias = neuron.bias;
+        writeln!(
+            out,
+            "  n{index} [label=\"n{index}\\n{kind_label}\\n{squash}\\nbias={bias:.6}\", shape={shape}];",
+        )
+        .unwrap();
+    }
+
+    // Edges in storage order.
+    for (offset, neuron) in network.neurons.iter().enumerate() {
+        let to_index = network.num_inputs + offset;
+        let start = neuron.start_synapse as usize;
+        let end = start + neuron.num_synapses as usize;
+        for synapse in &network.synapses[start..end] {
+            let from_index = synapse.from_index as usize;
+            let weight = synapse.weight;
+            let synapse_type = synapse_type_name(SynapseType::from(synapse.synapse_type));
+            writeln!(
+                out,
+                "  n{from_index} -> n{to_index} [label=\"{weight:.6} {synapse_type}\"];",
+            )
+            .unwrap();
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Methods on CompiledNetwork
+// ---------------------------------------------------------------------------
+
+impl CompiledNetwork {
+    /// Export this network as a DOT (Graphviz) string.
+    ///
+    /// See [`to_dot`] for format details and determinism guarantees.
+    ///
+    /// `num_outputs` is required because [`CompiledNetwork`] itself does not
+    /// record the output count — outputs are the last `num_outputs` neurons
+    /// by construction.
+    pub fn to_dot(&self, num_outputs: usize) -> String {
+        to_dot(self, num_outputs)
+    }
+
+    /// Export this network as a topology JSON string.
+    ///
+    /// See [`to_topology_json`] for format details and determinism guarantees.
+    pub fn to_topology_json(&self, num_outputs: usize) -> String {
+        to_topology_json(self, num_outputs)
+    }
+}

--- a/neat-core/src/training_bin_stream.rs
+++ b/neat-core/src/training_bin_stream.rs
@@ -3,19 +3,40 @@
 //! [`for_each_read_chunk`] is the **only** scan entry point used for production-sized
 //! forward passes: callers append each chunk to a staging buffer and unpack records.
 //!
-//! - **Native (`not(wasm32)`):** pipelined double-buffer reads (reader thread + ping-pong
-//!   `Vec<u8>`) so the main thread can overlap disk I/O with `f32` unpack + network work.
-//! - **`wasm32-unknown-unknown`:** sequential `File::read` into one buffer (no threads,
-//!   no mmap). Same callback contract as native — one mental model, target-specific
-//!   implementation only.
+//! ## Read modes (native only)
 //!
-//! ## Sequential escape hatch (issue #25)
+//! On native hosts, two read strategies are available via [`TrainingReadMode`]:
 //!
-//! On native hosts, setting the environment variable `NEAT_TRAINING_READ_SEQUENTIAL=1`
-//! (accepted values: `1`, `true`, `yes`, `on`, case-insensitive) selects the same
-//! sequential `File::read` loop used on `wasm32`. This avoids the pipelined reader
-//! entirely — handy for downstream consumers who hit teardown races while the
-//! pipelined path is under investigation.
+//! - [`TrainingReadMode::PipelinedDoubleBuffer`] *(default)* — a background reader
+//!   thread fills ping-pong `Vec<u8>` buffers so the consumer can overlap disk I/O
+//!   with `f32` unpack + network work.
+//! - [`TrainingReadMode::SingleBufferSequential`] — a single-threaded `File::read`
+//!   loop into one buffer. Simpler teardown semantics and the only available mode
+//!   on `wasm32-unknown-unknown`.
+//!
+//! Both modes invoke the same `on_chunk` callback and produce byte-identical output
+//! for a given corpus, so callers can A/B the two without any code changes.
+//!
+//! ## Env-driven tuning
+//!
+//! [`training_read_tuning_from_env`] lets downstream tools (e.g. NEAT-AI-scorer)
+//! pick the read mode and read-buffer size at run time — no rebuild required:
+//!
+//! - `NEAT_SCORER_IO_MODE` — case-insensitive `single` or `double` (default
+//!   `double`). Unknown values fall back to the pipelined default.
+//! - `NEAT_SCORER_READ_BYTES` — decimal `usize`, default 2 MiB, clamped to
+//!   `[record_bytes.max(1), 64 MiB]`.
+//!
+//! [`io_backend_label`] returns a stable telemetry string for the selected mode
+//! (always `"sequential_chunked_file_read"` on `wasm32`).
+//!
+//! ## Legacy sequential escape hatch (issue #25)
+//!
+//! The older `NEAT_TRAINING_READ_SEQUENTIAL` env var (accepted values: `1`,
+//! `true`, `yes`, `on`, case-insensitive) is still honoured by
+//! [`for_each_read_chunk`] for backwards compatibility. New callers should use
+//! [`for_each_read_chunk_with_mode`] and [`training_read_tuning_from_env`] to
+//! select the mode explicitly.
 
 use std::fs::File;
 use std::io::Read;
@@ -25,18 +46,133 @@ use std::path::PathBuf;
 /// single-threaded read path even on native targets.
 pub const SEQUENTIAL_ENV: &str = "NEAT_TRAINING_READ_SEQUENTIAL";
 
-/// Read every byte from `bin_files` in order, invoking `on_chunk` for each read segment.
+/// Env var selecting the native read mode: `single` or `double`
+/// (case-insensitive). Unknown values fall back to the pipelined default.
+pub const IO_MODE_ENV: &str = "NEAT_SCORER_IO_MODE";
+
+/// Env var selecting the read buffer size in bytes (decimal `usize`). Clamped
+/// to `[record_bytes.max(1), 64 MiB]`.
+pub const READ_BYTES_ENV: &str = "NEAT_SCORER_READ_BYTES";
+
+/// Default read buffer length (2 MiB) when [`READ_BYTES_ENV`] is unset.
+pub const DEFAULT_READ_BYTES: usize = 2 * 1024 * 1024;
+
+/// Upper clamp for the read buffer length (64 MiB).
+pub const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
+
+/// Selects the native chunk-read strategy.
 ///
-/// `read_buf_len` should be at least one record (`>= record_bytes`); callers typically
-/// use ~2 MiB rounded down to a whole number of records.
+/// Ignored on `wasm32`, where the sequential `File::read` loop is the only
+/// available strategy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TrainingReadMode {
+    /// Background reader thread + ping-pong `Vec<u8>` buffers. Default.
+    #[default]
+    PipelinedDoubleBuffer,
+    /// Single-threaded `File::read` loop into one buffer.
+    SingleBufferSequential,
+}
+
+/// Reads [`IO_MODE_ENV`] and [`READ_BYTES_ENV`] and returns the selected mode
+/// and read buffer length.
 ///
-/// On native targets, reads are pipelined with a background thread unless the
-/// [`SEQUENTIAL_ENV`] env var forces the sequential path. On `wasm32`, reads
-/// are always sequential and as large as `read_buf_len` allows — still chunked
-/// so you never load an entire shard into memory at once.
+/// - `NEAT_SCORER_IO_MODE` is parsed case-insensitively:
+///   - `single` → [`TrainingReadMode::SingleBufferSequential`]
+///   - `double` or unset or any unknown value →
+///     [`TrainingReadMode::PipelinedDoubleBuffer`]
+/// - `NEAT_SCORER_READ_BYTES` is parsed as decimal `usize` and clamped to
+///   `[record_bytes.max(1), 64 MiB]`. Unset or unparsable values fall back to
+///   the default 2 MiB, also clamped.
+pub fn training_read_tuning_from_env(record_bytes: usize) -> (TrainingReadMode, usize) {
+    let mode = match std::env::var(IO_MODE_ENV) {
+        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "single" => TrainingReadMode::SingleBufferSequential,
+            _ => TrainingReadMode::PipelinedDoubleBuffer,
+        },
+        Err(_) => TrainingReadMode::PipelinedDoubleBuffer,
+    };
+
+    let requested = std::env::var(READ_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_READ_BYTES);
+
+    let lower = record_bytes.max(1);
+    let upper = MAX_READ_BYTES.max(lower);
+    let read_bytes = requested.clamp(lower, upper);
+
+    (mode, read_bytes)
+}
+
+/// Stable telemetry label for the chosen read backend.
+///
+/// On `wasm32` the returned label is always `"sequential_chunked_file_read"`
+/// regardless of the input mode (there is only one backend on that target).
+pub fn io_backend_label(mode: TrainingReadMode) -> &'static str {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = mode;
+        "sequential_chunked_file_read"
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        match mode {
+            TrainingReadMode::PipelinedDoubleBuffer => "pipelined_double_buffer",
+            TrainingReadMode::SingleBufferSequential => "single_buffer_sequential",
+        }
+    }
+}
+
+/// Read every byte from `bin_files` in order, invoking `on_chunk` for each read
+/// segment. Thin wrapper that delegates to [`for_each_read_chunk_with_mode`]
+/// using [`TrainingReadMode::PipelinedDoubleBuffer`].
+///
+/// For backwards compatibility, setting the legacy [`SEQUENTIAL_ENV`] env var
+/// to a truthy value forces [`TrainingReadMode::SingleBufferSequential`] even
+/// through this entry point. New callers should prefer
+/// [`for_each_read_chunk_with_mode`] for explicit selection.
 pub fn for_each_read_chunk<F>(
     bin_files: &[PathBuf],
     read_buf_len: usize,
+    on_chunk: F,
+) -> Result<(), String>
+where
+    F: FnMut(&[u8]) -> Result<(), String>,
+{
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let mode = if sequential_env_requested() {
+            TrainingReadMode::SingleBufferSequential
+        } else {
+            TrainingReadMode::PipelinedDoubleBuffer
+        };
+        for_each_read_chunk_with_mode(bin_files, read_buf_len, mode, on_chunk)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        for_each_read_chunk_with_mode(
+            bin_files,
+            read_buf_len,
+            TrainingReadMode::PipelinedDoubleBuffer,
+            on_chunk,
+        )
+    }
+}
+
+/// Primary native entry point: reads every byte from `bin_files` in order using
+/// the requested [`TrainingReadMode`].
+///
+/// `read_buf_len` should be at least one record (`>= record_bytes`); callers
+/// typically pass ~2 MiB rounded down to a whole number of records. A value of
+/// `0` is rejected with an error.
+///
+/// On `wasm32` the `mode` argument is ignored — a sequential `File::read` loop
+/// is used regardless.
+pub fn for_each_read_chunk_with_mode<F>(
+    bin_files: &[PathBuf],
+    read_buf_len: usize,
+    mode: TrainingReadMode,
     on_chunk: F,
 ) -> Result<(), String>
 where
@@ -48,19 +184,24 @@ where
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        if sequential_env_requested() {
-            return for_each_read_chunk_sequential(bin_files, read_buf_len, on_chunk);
+        match mode {
+            TrainingReadMode::PipelinedDoubleBuffer => {
+                for_each_read_chunk_native_double(bin_files, read_buf_len, on_chunk)
+            }
+            TrainingReadMode::SingleBufferSequential => {
+                for_each_read_chunk_sequential(bin_files, read_buf_len, on_chunk)
+            }
         }
-        for_each_read_chunk_native(bin_files, read_buf_len, on_chunk)
     }
 
     #[cfg(target_arch = "wasm32")]
     {
+        let _ = mode;
         for_each_read_chunk_sequential(bin_files, read_buf_len, on_chunk)
     }
 }
 
-/// Returns true if the sequential escape hatch is selected via env var.
+/// Returns true if the legacy sequential escape hatch is selected via env var.
 #[cfg(not(target_arch = "wasm32"))]
 fn sequential_env_requested() -> bool {
     match std::env::var(SEQUENTIAL_ENV) {
@@ -73,7 +214,7 @@ fn sequential_env_requested() -> bool {
 }
 
 /// Sequential read loop — shared between the wasm32 target and the native
-/// escape hatch. Same observable contract as the pipelined path.
+/// single-buffer mode. Same observable contract as the pipelined path.
 fn for_each_read_chunk_sequential<F>(
     bin_files: &[PathBuf],
     read_buf_len: usize,
@@ -108,7 +249,7 @@ where
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn for_each_read_chunk_native<F>(
+fn for_each_read_chunk_native_double<F>(
     bin_files: &[PathBuf],
     read_buf_len: usize,
     mut on_chunk: F,
@@ -265,6 +406,18 @@ mod tests {
         files
     }
 
+    /// Run a fixture through `for_each_read_chunk_with_mode` and return the
+    /// concatenated bytes seen by the callback.
+    fn run_files(files: &[PathBuf], read_buf_len: usize, mode: TrainingReadMode) -> Vec<u8> {
+        let mut acc = Vec::new();
+        for_each_read_chunk_with_mode(files, read_buf_len, mode, |c| {
+            acc.extend_from_slice(c);
+            Ok(())
+        })
+        .expect("for_each_read_chunk_with_mode succeeded");
+        acc
+    }
+
     #[test]
     fn for_each_read_chunk_concatenates_files() -> Result<(), String> {
         let dir = TempDir::new().map_err(|e| e.to_string())?;
@@ -276,6 +429,58 @@ mod tests {
         })?;
         assert_eq!(acc, vec![1, 2, 3, 4, 5, 6]);
         Ok(())
+    }
+
+    /// Both read modes must produce identical byte streams for the same
+    /// multi-file corpus that spans a chunk boundary.
+    #[test]
+    fn both_modes_agree_on_multi_file_corpus() -> Result<(), String> {
+        let dir = TempDir::new().map_err(|e| e.to_string())?;
+        // Varying shard sizes so at least one read straddles a chunk boundary
+        // relative to `read_buf_len = 7`.
+        let shards: Vec<Vec<u8>> = (0..5)
+            .map(|i| (0..(13 * (i + 1))).map(|b| b as u8).collect())
+            .collect();
+        let expected_total: usize = shards.iter().map(|s| s.len()).sum();
+        let files = write_bins(dir.path(), &shards);
+
+        let double = run_files(&files, 7, TrainingReadMode::PipelinedDoubleBuffer);
+        let single = run_files(&files, 7, TrainingReadMode::SingleBufferSequential);
+
+        assert_eq!(double.len(), expected_total);
+        assert_eq!(
+            double, single,
+            "double- and single-buffer output must match"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn both_modes_handle_empty_files() -> Result<(), String> {
+        let dir = TempDir::new().map_err(|e| e.to_string())?;
+        let files = write_bins(dir.path(), &[vec![], vec![], vec![]]);
+
+        let double = run_files(&files, 16, TrainingReadMode::PipelinedDoubleBuffer);
+        let single = run_files(&files, 16, TrainingReadMode::SingleBufferSequential);
+
+        assert!(double.is_empty());
+        assert!(single.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn zero_read_buf_len_is_rejected_in_both_modes() {
+        for mode in [
+            TrainingReadMode::PipelinedDoubleBuffer,
+            TrainingReadMode::SingleBufferSequential,
+        ] {
+            let err = for_each_read_chunk_with_mode(&[], 0, mode, |_| Ok(()))
+                .expect_err("expected error");
+            assert!(
+                err.contains("read_buf_len"),
+                "mode {mode:?} must reject read_buf_len=0 with the existing error string, got: {err}"
+            );
+        }
     }
 
     /// Regression for issue #25: a slow `on_chunk` must NOT cause the pipelined
@@ -480,5 +685,139 @@ mod tests {
 
         assert_eq!(pipelined_bytes, sequential_bytes);
         Ok(())
+    }
+
+    // ---- TrainingReadMode / tuning helper / label coverage ----
+
+    #[test]
+    fn training_read_mode_default_is_pipelined_double_buffer() {
+        assert_eq!(
+            TrainingReadMode::default(),
+            TrainingReadMode::PipelinedDoubleBuffer
+        );
+    }
+
+    #[test]
+    fn io_backend_label_native_reflects_mode() {
+        assert_eq!(
+            io_backend_label(TrainingReadMode::PipelinedDoubleBuffer),
+            "pipelined_double_buffer"
+        );
+        assert_eq!(
+            io_backend_label(TrainingReadMode::SingleBufferSequential),
+            "single_buffer_sequential"
+        );
+    }
+
+    #[test]
+    fn training_read_tuning_defaults_without_env() -> Result<(), String> {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: serialised via ENV_LOCK.
+        unsafe {
+            std::env::remove_var(IO_MODE_ENV);
+            std::env::remove_var(READ_BYTES_ENV);
+        }
+
+        let (mode, bytes) = training_read_tuning_from_env(32);
+        assert_eq!(mode, TrainingReadMode::PipelinedDoubleBuffer);
+        assert_eq!(bytes, DEFAULT_READ_BYTES);
+        Ok(())
+    }
+
+    #[test]
+    fn training_read_tuning_parses_modes_case_insensitively() {
+        for (val, expected) in [
+            ("single", TrainingReadMode::SingleBufferSequential),
+            ("SINGLE", TrainingReadMode::SingleBufferSequential),
+            ("Single", TrainingReadMode::SingleBufferSequential),
+            ("double", TrainingReadMode::PipelinedDoubleBuffer),
+            ("DOUBLE", TrainingReadMode::PipelinedDoubleBuffer),
+            ("nonsense", TrainingReadMode::PipelinedDoubleBuffer),
+        ] {
+            let _guard = ENV_LOCK.lock().unwrap();
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe {
+                std::env::set_var(IO_MODE_ENV, val);
+                std::env::remove_var(READ_BYTES_ENV);
+            }
+            let (mode, _) = training_read_tuning_from_env(1);
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe { std::env::remove_var(IO_MODE_ENV) };
+            assert_eq!(mode, expected, "value {val:?} should map to {expected:?}");
+        }
+    }
+
+    #[test]
+    fn training_read_tuning_clamps_read_bytes() {
+        // Below lower bound → clamped up to record_bytes.
+        {
+            let _guard = ENV_LOCK.lock().unwrap();
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe {
+                std::env::set_var(READ_BYTES_ENV, "1");
+                std::env::remove_var(IO_MODE_ENV);
+            }
+            let (_, bytes) = training_read_tuning_from_env(128);
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe { std::env::remove_var(READ_BYTES_ENV) };
+            assert_eq!(bytes, 128);
+        }
+
+        // Above upper bound → clamped down to MAX_READ_BYTES.
+        {
+            let _guard = ENV_LOCK.lock().unwrap();
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe {
+                std::env::set_var(READ_BYTES_ENV, "9999999999");
+                std::env::remove_var(IO_MODE_ENV);
+            }
+            let (_, bytes) = training_read_tuning_from_env(32);
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe { std::env::remove_var(READ_BYTES_ENV) };
+            assert_eq!(bytes, MAX_READ_BYTES);
+        }
+
+        // Within bounds → passed through verbatim.
+        {
+            let _guard = ENV_LOCK.lock().unwrap();
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe {
+                std::env::set_var(READ_BYTES_ENV, "131072");
+                std::env::remove_var(IO_MODE_ENV);
+            }
+            let (_, bytes) = training_read_tuning_from_env(64);
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe { std::env::remove_var(READ_BYTES_ENV) };
+            assert_eq!(bytes, 131_072);
+        }
+
+        // Unparsable → falls back to DEFAULT_READ_BYTES (and clamp).
+        {
+            let _guard = ENV_LOCK.lock().unwrap();
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe {
+                std::env::set_var(READ_BYTES_ENV, "not-a-number");
+                std::env::remove_var(IO_MODE_ENV);
+            }
+            let (_, bytes) = training_read_tuning_from_env(64);
+            // SAFETY: serialised via ENV_LOCK.
+            unsafe { std::env::remove_var(READ_BYTES_ENV) };
+            assert_eq!(bytes, DEFAULT_READ_BYTES);
+        }
+    }
+
+    #[test]
+    fn training_read_tuning_handles_zero_record_bytes() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: serialised via ENV_LOCK.
+        unsafe {
+            std::env::set_var(READ_BYTES_ENV, "1");
+            std::env::remove_var(IO_MODE_ENV);
+        }
+        let (_, bytes) = training_read_tuning_from_env(0);
+        // SAFETY: serialised via ENV_LOCK.
+        unsafe { std::env::remove_var(READ_BYTES_ENV) };
+        // record_bytes=0 is clamped up to 1 so bytes must be at least 1.
+        assert!(bytes >= 1);
     }
 }

--- a/neat-core/tests/topology_export.rs
+++ b/neat-core/tests/topology_export.rs
@@ -1,0 +1,278 @@
+//! Tests for CompiledNetwork topology export (DOT / JSON).
+//!
+//! Issue #22 — machine-readable topology export for debugging and visualisation.
+
+use neat_core::{compile_creature, parse_creature_json};
+
+/// A small network with two inputs, one hidden neuron, and one output neuron.
+/// Weights and biases are chosen so the resulting strings are easy to inspect.
+fn small_network_json() -> &'static str {
+    r#"{
+        "input": 2,
+        "output": 1,
+        "neurons": [
+            {"type": "hidden", "uuid": "hidden-1", "bias": 0.25, "squash": "TANH"},
+            {"type": "output", "uuid": "output-0", "bias": -0.5, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "hidden-1", "weight": 1.0},
+            {"fromUUID": "input-1", "toUUID": "hidden-1", "weight": 0.5},
+            {"fromUUID": "hidden-1", "toUUID": "output-0", "weight": 1.5}
+        ],
+        "forwardOnly": true
+    }"#
+}
+
+/// The minimal possible non-trivial network: a single input feeding a single
+/// output through one synapse.
+fn minimal_network_json() -> &'static str {
+    r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+        ],
+        "forwardOnly": true
+    }"#
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn to_dot_emits_valid_digraph_header() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(
+        dot.starts_with("digraph "),
+        "DOT output must begin with `digraph`, got: {dot}"
+    );
+    assert!(
+        dot.trim_end().ends_with('}'),
+        "DOT output must close with `}}`"
+    );
+}
+
+#[test]
+fn to_dot_contains_node_for_every_neuron() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    // Two inputs + one hidden + one output = 4 nodes declared as `n0`..`n3`.
+    for i in 0..network.num_neurons {
+        let needle = format!("n{i} ");
+        assert!(
+            dot.contains(&needle),
+            "DOT output is missing node declaration `n{i}`:\n{dot}"
+        );
+    }
+}
+
+#[test]
+fn to_dot_classifies_nodes_as_input_hidden_output() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(dot.contains("input"), "DOT output should label input nodes");
+    assert!(
+        dot.contains("hidden"),
+        "DOT output should label hidden nodes"
+    );
+    assert!(
+        dot.contains("output"),
+        "DOT output should label output nodes"
+    );
+}
+
+#[test]
+fn to_dot_labels_activation_function_for_non_inputs() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(
+        dot.contains("TANH"),
+        "hidden neuron squash should be labelled"
+    );
+    assert!(
+        dot.contains("IDENTITY"),
+        "output neuron squash should be labelled"
+    );
+}
+
+#[test]
+fn to_dot_declares_one_edge_per_synapse() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    let edge_count = dot.matches(" -> ").count();
+    assert_eq!(
+        edge_count,
+        network.synapses.len(),
+        "DOT edge count must match synapse count"
+    );
+}
+
+#[test]
+fn to_dot_edges_include_weight_and_type() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    // Each of the three synapse weights should appear in the DOT output.
+    for expected in ["1.000000", "0.500000", "1.500000"] {
+        assert!(
+            dot.contains(expected),
+            "DOT output is missing expected weight `{expected}`:\n{dot}"
+        );
+    }
+    assert!(
+        dot.contains("Standard"),
+        "DOT output should label synapse type"
+    );
+}
+
+#[test]
+fn to_topology_json_round_trips_as_valid_json() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let json = network.to_topology_json(creature.output);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("to_topology_json output must be valid JSON");
+
+    assert_eq!(parsed["num_inputs"], 2);
+    assert_eq!(parsed["num_outputs"], 1);
+    assert_eq!(parsed["num_neurons"], 4);
+
+    let nodes = parsed["nodes"].as_array().expect("nodes must be an array");
+    assert_eq!(nodes.len(), 4, "node count must match num_neurons");
+
+    assert_eq!(nodes[0]["kind"], "input");
+    assert_eq!(nodes[1]["kind"], "input");
+    assert_eq!(nodes[2]["kind"], "hidden");
+    assert_eq!(nodes[2]["squash"], "TANH");
+    assert_eq!(nodes[3]["kind"], "output");
+    assert_eq!(nodes[3]["squash"], "IDENTITY");
+
+    let synapses = parsed["synapses"]
+        .as_array()
+        .expect("synapses must be an array");
+    assert_eq!(synapses.len(), 3);
+
+    // First synapse: input-0 -> hidden-1 with weight 1.0, type Standard.
+    assert_eq!(synapses[0]["from"], 0);
+    assert_eq!(synapses[0]["to"], 2);
+    assert_eq!(synapses[0]["type"], "Standard");
+}
+
+#[test]
+fn to_topology_json_includes_bias_for_non_input_nodes() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let json = network.to_topology_json(creature.output);
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let nodes = parsed["nodes"].as_array().unwrap();
+
+    // Inputs should not expose a bias (they have none).
+    assert!(nodes[0].get("bias").is_none());
+    // Hidden neuron bias 0.25 and output neuron bias -0.5 should be present.
+    assert!((nodes[2]["bias"].as_f64().unwrap() - 0.25).abs() < 1e-6);
+    assert!((nodes[3]["bias"].as_f64().unwrap() + 0.5).abs() < 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Edge case: minimal network
+// ---------------------------------------------------------------------------
+
+#[test]
+fn minimal_network_exports_to_dot_cleanly() {
+    let creature = parse_creature_json(minimal_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let dot = network.to_dot(creature.output);
+
+    assert!(dot.starts_with("digraph "));
+    assert_eq!(
+        dot.matches(" -> ").count(),
+        1,
+        "minimal network has one edge"
+    );
+    assert!(dot.contains("n0"));
+    assert!(dot.contains("n1"));
+    assert!(dot.contains("input"));
+    assert!(dot.contains("output"));
+}
+
+#[test]
+fn minimal_network_exports_to_topology_json_cleanly() {
+    let creature = parse_creature_json(minimal_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+    let json = network.to_topology_json(creature.output);
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["num_inputs"], 1);
+    assert_eq!(parsed["num_outputs"], 1);
+    assert_eq!(parsed["num_neurons"], 2);
+    assert_eq!(parsed["nodes"].as_array().unwrap().len(), 2);
+    assert_eq!(parsed["synapses"].as_array().unwrap().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn to_dot_is_deterministic_across_calls() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+
+    let a = network.to_dot(creature.output);
+    let b = network.to_dot(creature.output);
+
+    assert_eq!(
+        a, b,
+        "to_dot must return byte-identical output for identical input"
+    );
+}
+
+#[test]
+fn to_topology_json_is_deterministic_across_calls() {
+    let creature = parse_creature_json(small_network_json()).unwrap();
+    let network = compile_creature(&creature).unwrap();
+
+    let a = network.to_topology_json(creature.output);
+    let b = network.to_topology_json(creature.output);
+
+    assert_eq!(
+        a, b,
+        "to_topology_json must return byte-identical output for identical input"
+    );
+}
+
+#[test]
+fn to_dot_is_deterministic_across_fresh_compiles() {
+    // Recompile the same creature JSON twice and confirm both exports match byte-for-byte.
+    let creature_a = parse_creature_json(small_network_json()).unwrap();
+    let creature_b = parse_creature_json(small_network_json()).unwrap();
+    let network_a = compile_creature(&creature_a).unwrap();
+    let network_b = compile_creature(&creature_b).unwrap();
+
+    assert_eq!(
+        network_a.to_dot(creature_a.output),
+        network_b.to_dot(creature_b.output)
+    );
+    assert_eq!(
+        network_a.to_topology_json(creature_a.output),
+        network_b.to_topology_json(creature_b.output)
+    );
+}


### PR DESCRIPTION
## Milestone: Research 23 Apr

This PR merges the completed milestone branch into Develop.
Closes #33

### Issues addressed
- #22: Add CompiledNetwork topology export (DOT/JSON) for debugging and visualisation
- #21: Research: compare Ikaruga/NEAT-AI with neat-core and document adoption candidates
- #13: Add tunable I/O modes to training_bin_stream (TrainingReadMode, env-driven tuning)
- #12: Add native SIMD fast paths (AVX2/FMA on x86_64, NEON on aarch64) for multi-record weighted sums
- #11: Make CompiledNetwork Clone-able and add tests for activate_and_trace_batch_4way

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.