### PR TITLE
Add Serialize to CreatureExport / NeuronExport / SynapseExport (#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-30.md
+++ b/docs/pr-summary-30.md
@@ -1,0 +1,45 @@
+## Summary
+Adds symmetric `Serialize` support to `CreatureExport`, `NeuronExport`, and
+`SynapseExport` so parsed networks (or those constructed in Rust) can be
+written back out to the canonical TypeScript `CreatureExport` JSON shape.
+The existing `#[serde(rename = "...")]` attributes (`semanticVersion`,
+`forwardOnly`, `fromUUID`, `toUUID`, `type`) apply symmetrically on output.
+
+Adds 1:1 inverse helpers:
+- `squash_name_from(SquashType) -> &'static str` — inverse of `parse_squash_name`.
+- `synapse_type_name_from(SynapseType) -> Option<&'static str>` — inverse of `parse_synapse_type`.
+
+Also adds convenience wrappers `creature_to_json` / `creature_to_json_pretty`
+for the canonical serialisation path, and derives `Clone` / `PartialEq` on
+the three structs to support round-trip equality assertions.
+
+Unblocks snapshot diffing, cache priming, and the topology-export work in #22.
+
+Closes #30.
+
+## Evidence
+Backend/library change — no UI to screenshot. Verified by unit/integration
+tests (see Test Plan below) and a clean `./quality.sh` run covering fmt,
+clippy `-D warnings`, workspace tests, `cargo deny`, and `cargo doc -D warnings`.
+
+## Test Plan
+Added `neat-core/tests/creature/roundtrip.rs` with 7 new tests:
+
+- `parse_serialise_parse_preserves_all_fields` — parse the shared minimal
+  fixture, serialise, re-parse, and assert field-by-field equality.
+- `serialisation_is_deterministic_byte_identical` — two serialisations of
+  the same `CreatureExport` produce byte-identical JSON (compact and pretty).
+- `minimal_one_input_one_output_one_synapse_roundtrips` — edge case:
+  1 input, 1 output, 1 synapse, no hidden, no optional fields.
+- `camelcase_field_names_are_symmetric_on_output` — asserts the serialised
+  output uses `semanticVersion`, `forwardOnly`, `fromUUID`, `toUUID`, and
+  `type`, and that the result re-parses to an equal value.
+- `every_squash_variant_roundtrips_through_name_helpers` — for every
+  `SquashType` variant, `parse_squash_name(squash_name_from(v)) == Ok(v)`.
+- `every_synapse_variant_roundtrips_through_name_helpers` — for every
+  `SynapseType` variant, `parse_synapse_type(synapse_type_name_from(v)) == v`.
+- `optional_fields_absent_when_none` — `None` optional fields are omitted
+  from the JSON (matching the TypeScript "optional field" convention) and
+  still round-trip cleanly.
+
+All existing tests continue to pass; `./quality.sh` passes cleanly.

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -1,12 +1,30 @@
-//! Creature JSON deserialisation for NEAT-AI neural networks.
+//! Creature JSON (de)serialisation for NEAT-AI neural networks.
 //!
 //! This module provides Rust structs matching the TypeScript `CreatureExport`,
 //! `NeuronExport`, and `SynapseExport` interfaces, along with conversion to
 //! `CompiledNetwork` for efficient activation.
 //!
-//! Issue #1965 - Implement creature JSON deserialisation in Rust.
+//! The structs derive both [`serde::Deserialize`] and [`serde::Serialize`], so
+//! a parsed creature can be written back out to the same JSON shape. Round
+//! tripping — `parse -> serialise -> parse` — preserves every field, and two
+//! serialisations of the same `CreatureExport` produce byte-identical JSON
+//! (serde emits fields in declaration order).
+//!
+//! The `#[serde(rename = "...")]` attributes (`semanticVersion`, `forwardOnly`,
+//! `fromUUID`, `toUUID`, `type`) apply symmetrically on both input and output,
+//! so the canonical TypeScript camelCase shape is preserved.
+//!
+//! Optional string fields are skipped when `None` to match the TypeScript
+//! "optional field" convention (absent key rather than explicit `null`).
+//!
+//! The inverse helpers [`squash_name_from`] and [`synapse_type_name_from`]
+//! provide a 1:1 inverse of [`parse_squash_name`] and [`parse_synapse_type`]
+//! respectively, for callers constructing `NeuronExport` / `SynapseExport`
+//! values in Rust from enum variants.
+//!
+//! Issues: #1965 (initial deserialisation), #30 (symmetric serialisation).
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::network::{CompiledNetwork, NeuronData, SynapseData};
@@ -14,7 +32,7 @@ use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
 
 /// Top-level creature export format matching the TypeScript `CreatureExport` interface.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CreatureExport {
     /// Number of input neurons.
     pub input: usize,
@@ -25,7 +43,7 @@ pub struct CreatureExport {
     /// List of synapses connecting neurons.
     pub synapses: Vec<SynapseExport>,
     /// Optional semantic version string.
-    #[serde(rename = "semanticVersion")]
+    #[serde(rename = "semanticVersion", skip_serializing_if = "Option::is_none")]
     pub semantic_version: Option<String>,
     /// When true, training rows are independent (no recurrent / feedback state).
     #[serde(rename = "forwardOnly", default)]
@@ -33,7 +51,7 @@ pub struct CreatureExport {
 }
 
 /// Neuron export format matching the TypeScript `NeuronExport` interface.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct NeuronExport {
     /// Neuron type: "hidden", "output", or "constant".
     #[serde(rename = "type")]
@@ -43,11 +61,12 @@ pub struct NeuronExport {
     /// Bias value for the neuron.
     pub bias: f64,
     /// Activation function name (e.g. "TANH", "ReLU"). Defaults to IDENTITY.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub squash: Option<String>,
 }
 
 /// Synapse export format matching the TypeScript `SynapseExport` interface.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SynapseExport {
     /// UUID of the source neuron (e.g. "input-0" for input neurons).
     #[serde(rename = "fromUUID")]
@@ -58,7 +77,7 @@ pub struct SynapseExport {
     /// Connection weight.
     pub weight: f64,
     /// Optional synapse type: "positive", "negative", or "condition".
-    #[serde(rename = "type")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub synapse_type: Option<String>,
 }
 
@@ -123,9 +142,93 @@ pub fn parse_synapse_type(type_str: Option<&str>) -> SynapseType {
     }
 }
 
+/// Canonical activation name for a [`SquashType`].
+///
+/// This is the 1:1 inverse of [`parse_squash_name`]: for every variant `v`,
+/// `parse_squash_name(squash_name_from(v)) == Ok(v)` holds. Where
+/// [`parse_squash_name`] accepts aliases (e.g. `"ReLU"` and `"RELU"` both map
+/// to [`SquashType::Relu`]), this function returns the canonical variant used
+/// by the TypeScript emitter.
+///
+/// Use this when populating [`NeuronExport::squash`] from a Rust
+/// [`SquashType`] before serialising back to JSON.
+pub fn squash_name_from(ty: SquashType) -> &'static str {
+    match ty {
+        SquashType::Identity => "IDENTITY",
+        SquashType::Relu => "RELU",
+        SquashType::Relu6 => "ReLU6",
+        SquashType::LeakyRelu => "LeakyReLU",
+        SquashType::Selu => "SELU",
+        SquashType::Elu => "ELU",
+        SquashType::Logistic => "LOGISTIC",
+        SquashType::Tanh => "TANH",
+        SquashType::HardTanh => "HARD_TANH",
+        SquashType::Softsign => "SOFTSIGN",
+        SquashType::Softplus => "Softplus",
+        SquashType::Swish => "Swish",
+        SquashType::Mish => "Mish",
+        SquashType::Gelu => "GELU",
+        SquashType::Sine => "SINE",
+        SquashType::Cosine => "Cosine",
+        SquashType::Tan => "TAN",
+        SquashType::ArcTan => "ArcTan",
+        SquashType::Gaussian => "GAUSSIAN",
+        SquashType::BentIdentity => "BENT_IDENTITY",
+        SquashType::BipolarSigmoid => "BIPOLAR_SIGMOID",
+        SquashType::Bipolar => "BIPOLAR",
+        SquashType::Step => "STEP",
+        SquashType::Complement => "COMPLEMENT",
+        SquashType::Absolute => "ABSOLUTE",
+        SquashType::Square => "SQUARE",
+        SquashType::Cube => "Cube",
+        SquashType::Sqrt => "SQRT",
+        SquashType::StdInverse => "StdInverse",
+        SquashType::Exponential => "Exponential",
+        SquashType::LogSigmoid => "LogSigmoid",
+        SquashType::Isru => "ISRU",
+        SquashType::Minimum => "MINIMUM",
+        SquashType::Maximum => "MAXIMUM",
+        SquashType::If => "IF",
+        SquashType::Hypotenuse => "HYPOT",
+        SquashType::HypotenuseV2 => "HYPOTv2",
+        SquashType::Mean => "MEAN",
+    }
+}
+
+/// Canonical JSON type string for a [`SynapseType`].
+///
+/// Inverse of [`parse_synapse_type`]: returns `None` for
+/// [`SynapseType::Standard`] (omitted in the JSON export by convention) and
+/// the canonical lowercase TypeScript names for the other variants.
+/// For every variant `v`, `parse_synapse_type(synapse_type_name_from(v)) == v`
+/// holds.
+pub fn synapse_type_name_from(ty: SynapseType) -> Option<&'static str> {
+    match ty {
+        SynapseType::Standard => None,
+        SynapseType::Condition => Some("condition"),
+        SynapseType::Negative => Some("negative"),
+        SynapseType::Positive => Some("positive"),
+    }
+}
+
 /// Parse a creature JSON string into a `CreatureExport` struct.
 pub fn parse_creature_json(json: &str) -> Result<CreatureExport, String> {
     serde_json::from_str(json).map_err(|e| format!("Failed to parse creature JSON: {e}"))
+}
+
+/// Serialise a [`CreatureExport`] to canonical JSON text.
+///
+/// Output is deterministic: fields are emitted in struct declaration order,
+/// so two calls with the same input produce byte-identical output. This is
+/// the symmetric counterpart to [`parse_creature_json`].
+pub fn creature_to_json(creature: &CreatureExport) -> Result<String, String> {
+    serde_json::to_string(creature).map_err(|e| format!("Failed to serialise creature JSON: {e}"))
+}
+
+/// Pretty-printed variant of [`creature_to_json`].
+pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, String> {
+    serde_json::to_string_pretty(creature)
+        .map_err(|e| format!("Failed to serialise creature JSON: {e}"))
 }
 
 /// Convert a `CreatureExport` into a `CompiledNetwork` for activation.

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -34,8 +34,9 @@ pub mod unsquash;
 
 // Re-export key types for convenience
 pub use creature::{
-    CreatureExport, NeuronExport, SynapseExport, compile_creature, parse_creature_json,
-    parse_squash_name, parse_synapse_type,
+    CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
+    creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
+    squash_name_from, synapse_type_name_from,
 };
 pub use network::{CompiledNetwork, NeuronData, SynapseData};
 pub use pc_inference::PredictiveCodingEngine;

--- a/neat-core/tests/creature/main.rs
+++ b/neat-core/tests/creature/main.rs
@@ -4,3 +4,4 @@
 mod common;
 
 mod compile_smoke;
+mod roundtrip;

--- a/neat-core/tests/creature/roundtrip.rs
+++ b/neat-core/tests/creature/roundtrip.rs
@@ -1,0 +1,230 @@
+//! Round-trip tests for `CreatureExport` / `NeuronExport` / `SynapseExport`
+//! serialisation — issue #30.
+//!
+//! These tests exercise the public `parse_creature_json` / `creature_to_json`
+//! contract: parsing a fixture, serialising it back, and re-parsing the
+//! result must preserve every field. They also verify deterministic output
+//! and the 1:1 inverse mapping for every `SquashType` / `SynapseType` variant.
+
+use neat_core::{
+    CreatureExport, NeuronExport, SynapseExport, creature_to_json, creature_to_json_pretty,
+    parse_creature_json, parse_squash_name, parse_synapse_type, squash_name_from,
+    synapse_type_name_from,
+};
+use neat_core::{SquashType, SynapseType};
+
+fn all_squash_variants() -> &'static [SquashType] {
+    &[
+        SquashType::Identity,
+        SquashType::Relu,
+        SquashType::Relu6,
+        SquashType::LeakyRelu,
+        SquashType::Selu,
+        SquashType::Elu,
+        SquashType::Logistic,
+        SquashType::Tanh,
+        SquashType::HardTanh,
+        SquashType::Softsign,
+        SquashType::Softplus,
+        SquashType::Swish,
+        SquashType::Mish,
+        SquashType::Gelu,
+        SquashType::Sine,
+        SquashType::Cosine,
+        SquashType::Tan,
+        SquashType::ArcTan,
+        SquashType::Gaussian,
+        SquashType::BentIdentity,
+        SquashType::BipolarSigmoid,
+        SquashType::Bipolar,
+        SquashType::Step,
+        SquashType::Complement,
+        SquashType::Absolute,
+        SquashType::Square,
+        SquashType::Cube,
+        SquashType::Sqrt,
+        SquashType::StdInverse,
+        SquashType::Exponential,
+        SquashType::LogSigmoid,
+        SquashType::Isru,
+        SquashType::Minimum,
+        SquashType::Maximum,
+        SquashType::If,
+        SquashType::Hypotenuse,
+        SquashType::HypotenuseV2,
+        SquashType::Mean,
+    ]
+}
+
+fn all_synapse_variants() -> &'static [SynapseType] {
+    &[
+        SynapseType::Standard,
+        SynapseType::Condition,
+        SynapseType::Negative,
+        SynapseType::Positive,
+    ]
+}
+
+fn assert_creature_equal(a: &CreatureExport, b: &CreatureExport) {
+    assert_eq!(a.input, b.input, "input mismatch");
+    assert_eq!(a.output, b.output, "output mismatch");
+    assert_eq!(
+        a.semantic_version, b.semantic_version,
+        "semantic_version mismatch"
+    );
+    assert_eq!(a.forward_only, b.forward_only, "forward_only mismatch");
+    assert_eq!(a.neurons.len(), b.neurons.len(), "neuron count mismatch");
+    for (i, (na, nb)) in a.neurons.iter().zip(b.neurons.iter()).enumerate() {
+        assert_eq!(na.neuron_type, nb.neuron_type, "neuron {i} type");
+        assert_eq!(na.uuid, nb.uuid, "neuron {i} uuid");
+        assert_eq!(na.bias, nb.bias, "neuron {i} bias");
+        assert_eq!(na.squash, nb.squash, "neuron {i} squash");
+    }
+    assert_eq!(a.synapses.len(), b.synapses.len(), "synapse count mismatch");
+    for (i, (sa, sb)) in a.synapses.iter().zip(b.synapses.iter()).enumerate() {
+        assert_eq!(sa.from_uuid, sb.from_uuid, "synapse {i} fromUUID");
+        assert_eq!(sa.to_uuid, sb.to_uuid, "synapse {i} toUUID");
+        assert_eq!(sa.weight, sb.weight, "synapse {i} weight");
+        assert_eq!(sa.synapse_type, sb.synapse_type, "synapse {i} type");
+    }
+}
+
+#[test]
+fn parse_serialise_parse_preserves_all_fields() {
+    let creature = parse_creature_json(crate::common::minimal_creature_json()).expect("parse");
+    let serialised = creature_to_json(&creature).expect("serialise");
+    let reparsed = parse_creature_json(&serialised).expect("re-parse");
+    assert_creature_equal(&creature, &reparsed);
+}
+
+#[test]
+fn serialisation_is_deterministic_byte_identical() {
+    let creature = parse_creature_json(crate::common::minimal_creature_json()).expect("parse");
+    let a = creature_to_json(&creature).expect("serialise a");
+    let b = creature_to_json(&creature).expect("serialise b");
+    assert_eq!(a, b, "two serialisations must be byte-identical");
+
+    let pretty_a = creature_to_json_pretty(&creature).expect("pretty a");
+    let pretty_b = creature_to_json_pretty(&creature).expect("pretty b");
+    assert_eq!(
+        pretty_a, pretty_b,
+        "pretty serialisations must also be byte-identical"
+    );
+}
+
+#[test]
+fn minimal_one_input_one_output_one_synapse_roundtrips() {
+    let json = r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.25, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.5}
+        ]
+    }"#;
+    let creature = parse_creature_json(json).expect("parse minimal");
+    assert_eq!(creature.input, 1);
+    assert_eq!(creature.output, 1);
+    assert_eq!(creature.neurons.len(), 1);
+    assert_eq!(creature.synapses.len(), 1);
+    assert!(creature.synapses[0].synapse_type.is_none());
+
+    let serialised = creature_to_json(&creature).expect("serialise");
+    let reparsed = parse_creature_json(&serialised).expect("re-parse");
+    assert_creature_equal(&creature, &reparsed);
+}
+
+#[test]
+fn camelcase_field_names_are_symmetric_on_output() {
+    let creature = CreatureExport {
+        input: 1,
+        output: 1,
+        neurons: vec![NeuronExport {
+            neuron_type: "output".to_string(),
+            uuid: "output-0".to_string(),
+            bias: 0.0,
+            squash: Some("IDENTITY".to_string()),
+        }],
+        synapses: vec![SynapseExport {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: Some("condition".to_string()),
+        }],
+        semantic_version: Some("1.2.3".to_string()),
+        forward_only: true,
+    };
+
+    let serialised = creature_to_json(&creature).expect("serialise");
+    // Assert on the canonical TypeScript camelCase field names.
+    assert!(serialised.contains("\"semanticVersion\":\"1.2.3\""));
+    assert!(serialised.contains("\"forwardOnly\":true"));
+    assert!(serialised.contains("\"fromUUID\":\"input-0\""));
+    assert!(serialised.contains("\"toUUID\":\"output-0\""));
+    assert!(serialised.contains("\"type\":\"condition\""));
+    assert!(serialised.contains("\"type\":\"output\""));
+
+    let reparsed = parse_creature_json(&serialised).expect("re-parse");
+    assert_creature_equal(&creature, &reparsed);
+}
+
+#[test]
+fn every_squash_variant_roundtrips_through_name_helpers() {
+    for &variant in all_squash_variants() {
+        let name = squash_name_from(variant);
+        let parsed = parse_squash_name(name)
+            .unwrap_or_else(|e| panic!("parse_squash_name({name:?}) failed for {variant:?}: {e}"));
+        assert_eq!(
+            parsed, variant,
+            "parse_squash_name(squash_name_from({variant:?})) != {variant:?}"
+        );
+    }
+}
+
+#[test]
+fn every_synapse_variant_roundtrips_through_name_helpers() {
+    for &variant in all_synapse_variants() {
+        let name = synapse_type_name_from(variant);
+        let parsed = parse_synapse_type(name);
+        assert_eq!(
+            parsed, variant,
+            "parse_synapse_type(synapse_type_name_from({variant:?})) != {variant:?}"
+        );
+    }
+}
+
+#[test]
+fn optional_fields_absent_when_none() {
+    // A creature with no semanticVersion and no synapse types should not
+    // emit those keys at all — matches the TypeScript "optional field"
+    // convention and avoids explicit `null` values in the canonical JSON.
+    let creature = CreatureExport {
+        input: 1,
+        output: 1,
+        neurons: vec![NeuronExport {
+            neuron_type: "output".to_string(),
+            uuid: "output-0".to_string(),
+            bias: 0.0,
+            squash: None,
+        }],
+        synapses: vec![SynapseExport {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }],
+        semantic_version: None,
+        forward_only: false,
+    };
+
+    let serialised = creature_to_json(&creature).expect("serialise");
+    assert!(!serialised.contains("semanticVersion"));
+    assert!(!serialised.contains("\"squash\""));
+    // The only "type" field that remains is the neuron type.
+    assert_eq!(serialised.matches("\"type\"").count(), 1);
+
+    let reparsed = parse_creature_json(&serialised).expect("re-parse");
+    assert_creature_equal(&creature, &reparsed);
+}


### PR DESCRIPTION
## Summary
Adds symmetric `Serialize` support to `CreatureExport`, `NeuronExport`, and
`SynapseExport` so parsed networks (or those constructed in Rust) can be
written back out to the canonical TypeScript `CreatureExport` JSON shape.
The existing `#[serde(rename = "...")]` attributes (`semanticVersion`,
`forwardOnly`, `fromUUID`, `toUUID`, `type`) apply symmetrically on output.

Adds 1:1 inverse helpers:
- `squash_name_from(SquashType) -> &'static str` — inverse of `parse_squash_name`.
- `synapse_type_name_from(SynapseType) -> Option<&'static str>` — inverse of `parse_synapse_type`.

Also adds convenience wrappers `creature_to_json` / `creature_to_json_pretty`
for the canonical serialisation path, and derives `Clone` / `PartialEq` on
the three structs to support round-trip equality assertions.

Unblocks snapshot diffing, cache priming, and the topology-export work in #22.

Closes #30.

## Evidence
Backend/library change — no UI to screenshot. Verified by unit/integration
tests (see Test Plan below) and a clean `./quality.sh` run covering fmt,
clippy `-D warnings`, workspace tests, `cargo deny`, and `cargo doc -D warnings`.

## Test Plan
Added `neat-core/tests/creature/roundtrip.rs` with 7 new tests:

- `parse_serialise_parse_preserves_all_fields` — parse the shared minimal
  fixture, serialise, re-parse, and assert field-by-field equality.
- `serialisation_is_deterministic_byte_identical` — two serialisations of
  the same `CreatureExport` produce byte-identical JSON (compact and pretty).
- `minimal_one_input_one_output_one_synapse_roundtrips` — edge case:
  1 input, 1 output, 1 synapse, no hidden, no optional fields.
- `camelcase_field_names_are_symmetric_on_output` — asserts the serialised
  output uses `semanticVersion`, `forwardOnly`, `fromUUID`, `toUUID`, and
  `type`, and that the result re-parses to an equal value.
- `every_squash_variant_roundtrips_through_name_helpers` — for every
  `SquashType` variant, `parse_squash_name(squash_name_from(v)) == Ok(v)`.
- `every_synapse_variant_roundtrips_through_name_helpers` — for every
  `SynapseType` variant, `parse_synapse_type(synapse_type_name_from(v)) == v`.
- `optional_fields_absent_when_none` — `None` optional fields are omitted
  from the JSON (matching the TypeScript "optional field" convention) and
  still round-trip cleanly.

All existing tests continue to pass; `./quality.sh` passes cleanly.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-30 -->