### PR TITLE
Add Semgrep SAST scanning workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,19 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - run: semgrep ci --config p/default
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-4.md
+++ b/docs/pr-summary-4.md
@@ -1,0 +1,38 @@
+## Summary
+
+Added `.github/workflows/semgrep.yml` to enable Semgrep SAST (static
+application security testing) on every pull request. The workflow runs
+the `semgrep ci --config p/default` ruleset inside the official
+`semgrep/semgrep` container and uses the `SEMGREP_APP_TOKEN` secret when
+present. Closes #4.
+
+## Evidence
+
+This is a CI-only change — there is no UI or runtime behaviour to
+screenshot. Verification:
+
+- `./quality.sh < /dev/null` — passes cleanly (rustfmt, clippy,
+  shellcheck, codespell, cargo deny, cargo audit, full workspace tests,
+  doc build, release build).
+- The new workflow file is valid YAML matching the template in the
+  issue and follows the same `actions/checkout@v4` and least-privilege
+  `contents: read` pattern used by the existing
+  `.github/workflows/security.yml`.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> Trigger[on: pull_request]
+    Trigger --> Job[semgrep job]
+    Job --> Container[semgrep/semgrep container]
+    Container --> Scan[semgrep ci --config p/default]
+    Scan --> Result{Findings?}
+    Result -- yes --> Fail[PR check fails]
+    Result -- no --> Pass[PR check passes]
+```
+
+## Test Plan
+
+- [x] `./quality.sh < /dev/null` passes locally.
+- [x] Workflow YAML matches the template from issue #4.
+- [ ] After merge, confirm the `Semgrep` check runs on the next pull
+      request.


### PR DESCRIPTION
## Summary

Added `.github/workflows/semgrep.yml` to enable Semgrep SAST (static
application security testing) on every pull request. The workflow runs
the `semgrep ci --config p/default` ruleset inside the official
`semgrep/semgrep` container and uses the `SEMGREP_APP_TOKEN` secret when
present. Closes #4.

## Evidence

This is a CI-only change — there is no UI or runtime behaviour to
screenshot. Verification:

- `./quality.sh < /dev/null` — passes cleanly (rustfmt, clippy,
  shellcheck, codespell, cargo deny, cargo audit, full workspace tests,
  doc build, release build).
- The new workflow file is valid YAML matching the template in the
  issue and follows the same `actions/checkout@v4` and least-privilege
  `contents: read` pattern used by the existing
  `.github/workflows/security.yml`.

```mermaid
flowchart LR
    PR[Pull Request] --> Trigger[on: pull_request]
    Trigger --> Job[semgrep job]
    Job --> Container[semgrep/semgrep container]
    Container --> Scan[semgrep ci --config p/default]
    Scan --> Result{Findings?}
    Result -- yes --> Fail[PR check fails]
    Result -- no --> Pass[PR check passes]
```

## Test Plan

- [x] `./quality.sh < /dev/null` passes locally.
- [x] Workflow YAML matches the template from issue #4.
- [ ] After merge, confirm the `Semgrep` check runs on the next pull
      request.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-4 -->