### PR TITLE
Add wasm-bundle.yml CI workflow with per-commit Release publishing

### DIFF
--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -1,0 +1,46 @@
+# Issue #37 — Build the wasm_activation bundle on every push to Develop and
+# publish a per-commit GitHub Release so NEAT-AI can pin neatCore.rev to any
+# historical Develop SHA. One Release per commit keeps artefacts immutable
+# and addressable by SHA.
+
+name: Publish wasm_activation bundle
+
+on:
+  push:
+    branches: [Develop]
+
+permissions:
+  contents: write   # required by `gh release create`
+
+jobs:
+  publish:
+    name: Build and publish wasm_activation bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build wasm_activation bundle
+        run: |
+          chmod +x scripts/build-wasm-bundle.sh
+          ./scripts/build-wasm-bundle.sh \
+            --rev "${GITHUB_SHA}" \
+            --out wasm_activation-pkg.tar.gz
+
+      - name: Publish per-commit Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="wasm-bundle-${GITHUB_SHA}"
+          gh release create "$tag" wasm_activation-pkg.tar.gz \
+            --target "$GITHUB_SHA" \
+            --title "wasm_activation bundle for ${GITHUB_SHA::7}" \
+            --notes "Auto-built wasm_activation/pkg for commit ${GITHUB_SHA}."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-37.md
+++ b/docs/pr-summary-37.md
@@ -1,0 +1,42 @@
+## Summary
+
+Adds a CI workflow that builds the `wasm_activation` bundle on every push to `Develop` and publishes it as an immutable per-commit GitHub Release, so NEAT-AI can pin `neatCore.rev` to any historical SHA. Closes #37.
+
+The build/packaging logic lives in `scripts/build-wasm-bundle.sh` so it is unit-testable via bats — the workflow is a thin invocation around it. The script enforces a minimum `wasm_activation_bg.wasm` size (default 100 KB) so a stub build never gets published, and embeds the SHA in `pkg/neat_core_rev.txt` for downstream integrity checks in NEAT-AI's `build.sh`.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    A[push to Develop] --> B[wasm-bundle.yml]
+    B --> C[build-wasm-bundle.sh]
+    C --> D{wasm size<br/>&gt;= 100 KB?}
+    D -- no --> X[fail clean,<br/>no release]
+    D -- yes --> E[tar pkg/ +<br/>neat_core_rev.txt]
+    E --> F[gh release create<br/>wasm-bundle-&lt;sha&gt;]
+    F --> G[NEAT-AI pulls per rev]
+```
+
+## Evidence
+
+This is a CI/automation change — no UI to screenshot. Verified locally via:
+
+- **bats tests** (`tests/scripts/build_wasm_bundle.bats`, 11 cases, all green) cover argument parsing, size threshold, missing pkg dir, missing wasm-pack outputs, the embedded `neat_core_rev.txt`, and the produced tarball layout.
+- **shellcheck** clean on the new script.
+- **codespell** clean.
+
+The workflow itself is exercised end-to-end the first time it runs against `Develop` post-merge — that is the only place the real `wasm-pack` toolchain is available without bloating CI on every PR. The contract surfaced by the script (size floor, pkg layout, `neat_core_rev.txt`) is fully covered by the bats suite.
+
+### Acceptance criteria mapping
+
+- [x] **Workflow runs on every push to Develop, publishes `wasm-bundle-<sha>` Release with `wasm_activation-pkg.tar.gz`** — `.github/workflows/wasm-bundle.yml`.
+- [x] **`gh release download` works for any historical Develop commit** — one Release per commit, tag pattern `wasm-bundle-<full SHA>` avoids collisions with semver tags.
+- [x] **`pkg/wasm_activation.d.ts` is a strict superset of NEAT-AI's vendored copy** — the build is a straight `wasm-pack build neat-core --target web --out-name wasm_activation`, which emits the canonical `.d.ts` for all `#[wasm_bindgen]` exports added in #36.
+- [x] **`wasm_activation_bg.wasm` is non-trivially sized** — script rejects builds below the configurable byte threshold (default 100 KB, matching the stub size called out in the issue).
+- [x] **Workflow fails cleanly without publishing on `wasm-pack` failure or undersized WASM** — `set -euo pipefail` propagates `wasm-pack`'s exit code; size check exits non-zero before the tar is written; `gh release create` only runs if the previous step succeeded.
+
+## Test Plan
+
+- Added `tests/scripts/build_wasm_bundle.bats` — 11 cases covering happy path, every error branch, and the threshold boundary.
+- Existing `tests/scripts/bump_deps.bats` continues to pass (23 total bats cases green).
+- `shellcheck` and `codespell` clean across the repo.

--- a/scripts/build-wasm-bundle.sh
+++ b/scripts/build-wasm-bundle.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# build-wasm-bundle.sh — Build wasm_activation/pkg via wasm-pack and tarball
+# it for per-commit publication (Issue #37).
+#
+# Used by .github/workflows/wasm-bundle.yml. Kept as a standalone script so
+# the build/packaging contract is unit-testable via bats without spinning up
+# a runner.
+#
+# Behaviour:
+#   1. Run `wasm-pack build neat-core --target web --out-name wasm_activation
+#      --out-dir wasm_activation/pkg` (skipped when --pkg-dir is supplied).
+#   2. Verify `wasm_activation_bg.wasm` exceeds the configured byte threshold
+#      (defaults to 100 KB) so a stub build does not get published.
+#   3. Embed the commit SHA in `pkg/neat_core_rev.txt` for downstream
+#      integrity checks (NEAT-AI's `build.sh`).
+#   4. Tar+gzip the `pkg/` directory so the resulting archive unpacks to a
+#      `pkg/` subfolder, matching NEAT-AI's existing import paths.
+#
+# Exits non-zero (without producing a tarball) on any failure so the workflow
+# never publishes an incomplete or undersized bundle.
+
+set -euo pipefail
+
+DEFAULT_MIN_WASM_BYTES=102400
+REV="${GITHUB_SHA:-}"
+OUT_TAR="wasm_activation-pkg.tar.gz"
+MIN_WASM_BYTES="$DEFAULT_MIN_WASM_BYTES"
+PKG_DIR=""
+SKIP_BUILD=0
+
+usage() {
+  cat <<EOF
+Usage: build-wasm-bundle.sh [options]
+
+Builds the wasm_activation bundle and packages pkg/ as a tarball.
+
+Options:
+  --rev <SHA>              Commit SHA to embed in neat_core_rev.txt.
+                           Defaults to \$GITHUB_SHA if set.
+  --out <path>             Output tarball path
+                           (default: wasm_activation-pkg.tar.gz).
+  --min-size-bytes <N>     Minimum acceptable wasm_activation_bg.wasm size,
+                           in bytes (default: ${DEFAULT_MIN_WASM_BYTES}).
+  --pkg-dir <path>         Use a pre-built pkg/ directory instead of running
+                           wasm-pack. Implies --skip-build (used by tests).
+  --skip-build             Skip wasm-pack invocation. Requires --pkg-dir.
+  -h, --help               Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rev)
+      [[ $# -ge 2 ]] || { echo "error: --rev requires a value" >&2; exit 2; }
+      REV="$2"
+      shift 2
+      ;;
+    --out)
+      [[ $# -ge 2 ]] || { echo "error: --out requires a value" >&2; exit 2; }
+      OUT_TAR="$2"
+      shift 2
+      ;;
+    --min-size-bytes)
+      [[ $# -ge 2 ]] || { echo "error: --min-size-bytes requires a value" >&2; exit 2; }
+      MIN_WASM_BYTES="$2"
+      shift 2
+      ;;
+    --pkg-dir)
+      [[ $# -ge 2 ]] || { echo "error: --pkg-dir requires a value" >&2; exit 2; }
+      PKG_DIR="$2"
+      SKIP_BUILD=1
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$REV" ]]; then
+  echo "error: --rev (or GITHUB_SHA) is required" >&2
+  exit 2
+fi
+
+if ! [[ "$MIN_WASM_BYTES" =~ ^[0-9]+$ ]]; then
+  echo "error: --min-size-bytes must be a non-negative integer (got '$MIN_WASM_BYTES')" >&2
+  exit 2
+fi
+
+if [[ "$SKIP_BUILD" -eq 1 && -z "$PKG_DIR" ]]; then
+  echo "error: --skip-build requires --pkg-dir" >&2
+  exit 2
+fi
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  if ! command -v wasm-pack >/dev/null 2>&1; then
+    echo "error: wasm-pack is required on PATH" >&2
+    exit 1
+  fi
+  PKG_DIR="neat-core/wasm_activation/pkg"
+  rm -rf "neat-core/wasm_activation"
+  echo "🛠️  Running wasm-pack build (target=web, out-name=wasm_activation)"
+  wasm-pack build neat-core \
+    --target web \
+    --out-name wasm_activation \
+    --out-dir wasm_activation/pkg
+fi
+
+if [[ ! -d "$PKG_DIR" ]]; then
+  echo "error: pkg directory '$PKG_DIR' not found" >&2
+  exit 1
+fi
+
+WASM_FILE="$PKG_DIR/wasm_activation_bg.wasm"
+DTS_FILE="$PKG_DIR/wasm_activation.d.ts"
+JS_FILE="$PKG_DIR/wasm_activation.js"
+
+for required in "$WASM_FILE" "$DTS_FILE" "$JS_FILE"; do
+  if [[ ! -f "$required" ]]; then
+    echo "error: expected wasm-pack output missing: $required" >&2
+    exit 1
+  fi
+done
+
+WASM_SIZE=$(wc -c <"$WASM_FILE" | tr -d ' ')
+echo "wasm_activation_bg.wasm size: ${WASM_SIZE} bytes (threshold ${MIN_WASM_BYTES})"
+if (( WASM_SIZE < MIN_WASM_BYTES )); then
+  echo "error: wasm_activation_bg.wasm is below the minimum size threshold (${WASM_SIZE} < ${MIN_WASM_BYTES} bytes)" >&2
+  exit 1
+fi
+
+printf '%s\n' "$REV" >"$PKG_DIR/neat_core_rev.txt"
+
+PARENT_DIR="$(cd "$(dirname "$PKG_DIR")" && pwd)"
+PKG_BASE="$(basename "$PKG_DIR")"
+
+# Resolve OUT_TAR to an absolute path so the -C below does not move it.
+case "$OUT_TAR" in
+  /*) OUT_ABS="$OUT_TAR" ;;
+  *)  OUT_ABS="$PWD/$OUT_TAR" ;;
+esac
+
+tar -czf "$OUT_ABS" -C "$PARENT_DIR" "$PKG_BASE"
+
+ARCHIVE_SIZE=$(wc -c <"$OUT_ABS" | tr -d ' ')
+echo "✅ Built bundle: $OUT_ABS (${ARCHIVE_SIZE} bytes, rev=${REV})"

--- a/tests/scripts/build_wasm_bundle.bats
+++ b/tests/scripts/build_wasm_bundle.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# Tests for scripts/build-wasm-bundle.sh — wasm_activation packaging gate
+# (Issue #37). Verifies argument parsing, the size threshold, the embedded
+# rev marker, and that the produced archive unpacks to a `pkg/` subfolder.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/build-wasm-bundle.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_DIR="$(mktemp -d)"
+  PKG_DIR="$TMP_DIR/pkg"
+  mkdir -p "$PKG_DIR"
+  export TMP_DIR PKG_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Build a fake pkg/ that satisfies the script's structural checks. The wasm
+# blob is sized via the first arg (bytes).
+populate_fake_pkg() {
+  local wasm_bytes="${1:-200000}"
+  : >"$PKG_DIR/wasm_activation.js"
+  : >"$PKG_DIR/wasm_activation.d.ts"
+  dd if=/dev/zero of="$PKG_DIR/wasm_activation_bg.wasm" \
+    bs=1 count="$wasm_bytes" status=none
+}
+
+@test "shows usage with --help" {
+  run "$SCRIPT_UNDER_TEST" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--rev"* ]]
+  [[ "$output" == *"--min-size-bytes"* ]]
+}
+
+@test "rejects unknown options" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "rejects non-integer --min-size-bytes" {
+  populate_fake_pkg
+  run "$SCRIPT_UNDER_TEST" \
+    --rev deadbeef --pkg-dir "$PKG_DIR" \
+    --out "$TMP_DIR/out.tar.gz" \
+    --min-size-bytes abc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"min-size-bytes"* ]]
+}
+
+@test "requires --rev when GITHUB_SHA is unset" {
+  populate_fake_pkg
+  run env -u GITHUB_SHA "$SCRIPT_UNDER_TEST" \
+    --pkg-dir "$PKG_DIR" --out "$TMP_DIR/out.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--rev"* ]]
+}
+
+@test "uses GITHUB_SHA env when --rev not provided" {
+  populate_fake_pkg
+  GITHUB_SHA=cafef00d run "$SCRIPT_UNDER_TEST" \
+    --pkg-dir "$PKG_DIR" --out "$TMP_DIR/out.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$PKG_DIR/neat_core_rev.txt" ]
+  [ "$(cat "$PKG_DIR/neat_core_rev.txt")" = "cafef00d" ]
+}
+
+@test "fails when wasm size is below threshold" {
+  # 50 KB blob, threshold 100 KB — must fail.
+  populate_fake_pkg 51200
+  run "$SCRIPT_UNDER_TEST" \
+    --rev deadbeef --pkg-dir "$PKG_DIR" \
+    --out "$TMP_DIR/out.tar.gz" \
+    --min-size-bytes 102400
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"below the minimum size threshold"* ]]
+  [ ! -f "$TMP_DIR/out.tar.gz" ]
+}
+
+@test "fails when pkg directory does not exist" {
+  run "$SCRIPT_UNDER_TEST" \
+    --rev deadbeef --pkg-dir "$TMP_DIR/missing-pkg" \
+    --out "$TMP_DIR/out.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "fails when wasm-pack output files are missing" {
+  # Only a directory exists; required files absent.
+  run "$SCRIPT_UNDER_TEST" \
+    --rev deadbeef --pkg-dir "$PKG_DIR" \
+    --out "$TMP_DIR/out.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "produces a tarball that unpacks to pkg/ subfolder with required files" {
+  populate_fake_pkg 200000
+  run "$SCRIPT_UNDER_TEST" \
+    --rev "abc1234" --pkg-dir "$PKG_DIR" \
+    --out "$TMP_DIR/out.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/out.tar.gz" ]
+
+  EXTRACT_DIR="$TMP_DIR/extracted"
+  mkdir -p "$EXTRACT_DIR"
+  tar -xzf "$TMP_DIR/out.tar.gz" -C "$EXTRACT_DIR"
+
+  [ -d "$EXTRACT_DIR/pkg" ]
+  [ -f "$EXTRACT_DIR/pkg/wasm_activation_bg.wasm" ]
+  [ -f "$EXTRACT_DIR/pkg/wasm_activation.d.ts" ]
+  [ -f "$EXTRACT_DIR/pkg/wasm_activation.js" ]
+  [ -f "$EXTRACT_DIR/pkg/neat_core_rev.txt" ]
+  [ "$(cat "$EXTRACT_DIR/pkg/neat_core_rev.txt")" = "abc1234" ]
+}
+
+@test "passes with exact threshold match" {
+  populate_fake_pkg 102400
+  run "$SCRIPT_UNDER_TEST" \
+    --rev deadbeef --pkg-dir "$PKG_DIR" \
+    --out "$TMP_DIR/out.tar.gz" \
+    --min-size-bytes 102400
+  [ "$status" -eq 0 ]
+}
+
+@test "--skip-build without --pkg-dir is rejected" {
+  run "$SCRIPT_UNDER_TEST" --rev deadbeef --skip-build
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--pkg-dir"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a CI workflow that builds the `wasm_activation` bundle on every push to `Develop` and publishes it as an immutable per-commit GitHub Release, so NEAT-AI can pin `neatCore.rev` to any historical SHA. Closes #37.

The build/packaging logic lives in `scripts/build-wasm-bundle.sh` so it is unit-testable via bats — the workflow is a thin invocation around it. The script enforces a minimum `wasm_activation_bg.wasm` size (default 100 KB) so a stub build never gets published, and embeds the SHA in `pkg/neat_core_rev.txt` for downstream integrity checks in NEAT-AI's `build.sh`.

### Architecture

```mermaid
flowchart LR
    A[push to Develop] --> B[wasm-bundle.yml]
    B --> C[build-wasm-bundle.sh]
    C --> D{wasm size<br/>&gt;= 100 KB?}
    D -- no --> X[fail clean,<br/>no release]
    D -- yes --> E[tar pkg/ +<br/>neat_core_rev.txt]
    E --> F[gh release create<br/>wasm-bundle-&lt;sha&gt;]
    F --> G[NEAT-AI pulls per rev]
```

## Evidence

This is a CI/automation change — no UI to screenshot. Verified locally via:

- **bats tests** (`tests/scripts/build_wasm_bundle.bats`, 11 cases, all green) cover argument parsing, size threshold, missing pkg dir, missing wasm-pack outputs, the embedded `neat_core_rev.txt`, and the produced tarball layout.
- **shellcheck** clean on the new script.
- **codespell** clean.

The workflow itself is exercised end-to-end the first time it runs against `Develop` post-merge — that is the only place the real `wasm-pack` toolchain is available without bloating CI on every PR. The contract surfaced by the script (size floor, pkg layout, `neat_core_rev.txt`) is fully covered by the bats suite.

### Acceptance criteria mapping

- [x] **Workflow runs on every push to Develop, publishes `wasm-bundle-<sha>` Release with `wasm_activation-pkg.tar.gz`** — `.github/workflows/wasm-bundle.yml`.
- [x] **`gh release download` works for any historical Develop commit** — one Release per commit, tag pattern `wasm-bundle-<full SHA>` avoids collisions with semver tags.
- [x] **`pkg/wasm_activation.d.ts` is a strict superset of NEAT-AI's vendored copy** — the build is a straight `wasm-pack build neat-core --target web --out-name wasm_activation`, which emits the canonical `.d.ts` for all `#[wasm_bindgen]` exports added in #36.
- [x] **`wasm_activation_bg.wasm` is non-trivially sized** — script rejects builds below the configurable byte threshold (default 100 KB, matching the stub size called out in the issue).
- [x] **Workflow fails cleanly without publishing on `wasm-pack` failure or undersized WASM** — `set -euo pipefail` propagates `wasm-pack`'s exit code; size check exits non-zero before the tar is written; `gh release create` only runs if the previous step succeeded.

## Test Plan

- Added `tests/scripts/build_wasm_bundle.bats` — 11 cases covering happy path, every error branch, and the threshold boundary.
- Existing `tests/scripts/bump_deps.bats` continues to pass (23 total bats cases green).
- `shellcheck` and `codespell` clean across the repo.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-37 -->