### PR TITLE
Expose CompiledNetwork::to_dot and to_topology_json via wasm-bindgen (#43)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-43.md
+++ b/docs/pr-summary-43.md
@@ -1,0 +1,33 @@
+## Summary
+
+Added the `#[wasm_bindgen]` annotation to the `impl CompiledNetwork` block in `neat-core/src/topology_export.rs` (gated to `wasm32`), so `to_dot(num_outputs)` and `to_topology_json(num_outputs)` are exposed as methods on the `CompiledNetwork` JS class in `wasm_activation/pkg/wasm_activation.{js,d.ts}`. This unblocks NEAT-AI issue #2417, which delegates all topology formatting to core. Closes #43.
+
+The change mirrors the established pattern used for `activate` / `activate_view` / `reset_state` in `neat-core/src/network.rs` — a single `#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]` on the impl block, no per-method annotation required.
+
+## Evidence
+
+Backend-only change (no UI, no performance work). Verified by:
+
+1. `wasm-pack build neat-core --target web --out-name wasm_activation --out-dir wasm_activation/pkg` succeeds, and the generated `wasm_activation.d.ts` contains:
+   ```
+   to_dot(num_outputs: number): string;
+   to_topology_json(num_outputs: number): string;
+   ```
+   plus the matching `compilednetwork_to_dot` / `compilednetwork_to_topology_json` raw exports in `InitOutput`.
+2. `./quality.sh` is green (fmt, clippy, deny, doc, full workspace tests including the 13 existing `topology_export` tests and the 9 `wasm_bindgen_surface` tests).
+3. Native build is unaffected — the impl block remains a plain Rust impl when the `wasm32` cfg is inactive.
+
+```mermaid
+flowchart LR
+  A[CompiledNetwork::to_dot/to_topology_json] -->|cfg_attr wasm32 wasm_bindgen| B[wasm-pack build]
+  B --> C[wasm_activation.d.ts<br/>to_dot / to_topology_json methods]
+  C --> D[NEAT-AI TS wrapper<br/>issue #2417]
+```
+
+## Test Plan
+
+- Added two regression tests to `neat-core/tests/wasm_bindgen_surface.rs`:
+  - `to_dot_method_callable_on_compiled_network` — invokes `CompiledNetwork::to_dot(1)` on a minimal serialised network and asserts the DOT digraph header/footer.
+  - `to_topology_json_method_callable_on_compiled_network` — invokes `to_topology_json(1)` and asserts the JSON parses with the expected `num_inputs` / `num_outputs` / `num_neurons` values.
+- Existing `neat-core/tests/topology_export.rs` (13 tests) continues to pass — the impl-block annotation does not change native behaviour.
+- Manually verified the wasm bundle: `wasm-pack build` and `grep -E "to_dot|to_topology_json" neat-core/wasm_activation/pkg/wasm_activation.d.ts` shows the methods on the `CompiledNetwork` class.

--- a/neat-core/src/topology_export.rs
+++ b/neat-core/src/topology_export.rs
@@ -40,6 +40,9 @@ use std::fmt::Write;
 
 use serde::Serialize;
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
 use crate::network::CompiledNetwork;
 use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
@@ -306,7 +309,14 @@ pub fn to_dot(network: &CompiledNetwork, num_outputs: usize) -> String {
 // ---------------------------------------------------------------------------
 // Methods on CompiledNetwork
 // ---------------------------------------------------------------------------
+//
+// Issue #43 — annotate the impl block with `#[wasm_bindgen]` on `wasm32`
+// targets so `to_dot` and `to_topology_json` appear as methods on the
+// `CompiledNetwork` JS class in `wasm_activation/pkg/wasm_activation.{js,d.ts}`,
+// mirroring the pattern used for `activate` / `activate_view` / `reset_state`
+// in `network.rs`. NEAT-AI's TypeScript wrapper depends on these exports.
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl CompiledNetwork {
     /// Export this network as a DOT (Graphviz) string.
     ///

--- a/neat-core/tests/wasm_bindgen_surface.rs
+++ b/neat-core/tests/wasm_bindgen_surface.rs
@@ -81,6 +81,32 @@ fn activate_view_matches_activate() {
 }
 
 #[test]
+fn to_dot_method_callable_on_compiled_network() {
+    // Issue #43 — `to_dot` must remain accessible as a `CompiledNetwork`
+    // method on native (and via `#[wasm_bindgen]` on wasm32). This guards
+    // that the bindgen impl block does not regress the native surface.
+    let bytes = minimal_network_bytes();
+    let net = CompiledNetwork::new(&bytes).expect("parse");
+    let dot = net.to_dot(1);
+    assert!(dot.starts_with("digraph "));
+    assert!(dot.trim_end().ends_with('}'));
+}
+
+#[test]
+fn to_topology_json_method_callable_on_compiled_network() {
+    // Issue #43 — `to_topology_json` must remain accessible as a
+    // `CompiledNetwork` method on native (and via `#[wasm_bindgen]` on wasm32).
+    let bytes = minimal_network_bytes();
+    let net = CompiledNetwork::new(&bytes).expect("parse");
+    let json = net.to_topology_json(1);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("to_topology_json output must be valid JSON");
+    assert_eq!(parsed["num_inputs"], 1);
+    assert_eq!(parsed["num_outputs"], 1);
+    assert_eq!(parsed["num_neurons"], 2);
+}
+
+#[test]
 fn reset_state_clears_non_input_activations() {
     let bytes = minimal_network_bytes();
     let mut net = CompiledNetwork::new(&bytes).expect("parse");


### PR DESCRIPTION
## Summary

Added the `#[wasm_bindgen]` annotation to the `impl CompiledNetwork` block in `neat-core/src/topology_export.rs` (gated to `wasm32`), so `to_dot(num_outputs)` and `to_topology_json(num_outputs)` are exposed as methods on the `CompiledNetwork` JS class in `wasm_activation/pkg/wasm_activation.{js,d.ts}`. This unblocks NEAT-AI issue #2417, which delegates all topology formatting to core. Closes #43.

The change mirrors the established pattern used for `activate` / `activate_view` / `reset_state` in `neat-core/src/network.rs` — a single `#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]` on the impl block, no per-method annotation required.

## Evidence

Backend-only change (no UI, no performance work). Verified by:

1. `wasm-pack build neat-core --target web --out-name wasm_activation --out-dir wasm_activation/pkg` succeeds, and the generated `wasm_activation.d.ts` contains:
   ```
   to_dot(num_outputs: number): string;
   to_topology_json(num_outputs: number): string;
   ```
   plus the matching `compilednetwork_to_dot` / `compilednetwork_to_topology_json` raw exports in `InitOutput`.
2. `./quality.sh` is green (fmt, clippy, deny, doc, full workspace tests including the 13 existing `topology_export` tests and the 9 `wasm_bindgen_surface` tests).
3. Native build is unaffected — the impl block remains a plain Rust impl when the `wasm32` cfg is inactive.

```mermaid
flowchart LR
  A[CompiledNetwork::to_dot/to_topology_json] -->|cfg_attr wasm32 wasm_bindgen| B[wasm-pack build]
  B --> C[wasm_activation.d.ts<br/>to_dot / to_topology_json methods]
  C --> D[NEAT-AI TS wrapper<br/>issue #2417]
```

## Test Plan

- Added two regression tests to `neat-core/tests/wasm_bindgen_surface.rs`:
  - `to_dot_method_callable_on_compiled_network` — invokes `CompiledNetwork::to_dot(1)` on a minimal serialised network and asserts the DOT digraph header/footer.
  - `to_topology_json_method_callable_on_compiled_network` — invokes `to_topology_json(1)` and asserts the JSON parses with the expected `num_inputs` / `num_outputs` / `num_neurons` values.
- Existing `neat-core/tests/topology_export.rs` (13 tests) continues to pass — the impl-block annotation does not change native behaviour.
- Manually verified the wasm bundle: `wasm-pack build` and `grep -E "to_dot|to_topology_json" neat-core/wasm_activation/pkg/wasm_activation.d.ts` shows the methods on the `CompiledNetwork` class.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-43 -->