### PR TITLE
Verify wasm bundle release is downloadable after publish (#48)

### DIFF
--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -44,3 +44,22 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "wasm_activation bundle for ${GITHUB_SHA::7}" \
             --notes "Auto-built wasm_activation/pkg for commit ${GITHUB_SHA}."
+
+      # Issue #48 — re-download the asset we just published and prove it
+      # extracts cleanly with all four files NEAT-AI's build.sh checks for
+      # and a wasm blob above the 128 KiB stub-detection threshold. Catches
+      # silent `gh release create` upload regressions in NEAT-AI-core CI
+      # rather than leaving downstream NEAT-AI bump-deps PRs to fail.
+      - name: Verify published bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="wasm-bundle-${GITHUB_SHA}"
+          verify_dir="$(mktemp -d)"
+          gh release download "$tag" \
+            --pattern 'wasm_activation-pkg.tar.gz' \
+            --dir "$verify_dir"
+          chmod +x scripts/verify-wasm-bundle.sh
+          ./scripts/verify-wasm-bundle.sh \
+            --archive "$verify_dir/wasm_activation-pkg.tar.gz" \
+            --rev "${GITHUB_SHA}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-48.md
+++ b/docs/pr-summary-48.md
@@ -1,0 +1,50 @@
+## Summary
+
+Add a post-publish verification step to `wasm-bundle.yml` so a silent
+`gh release create` upload regression is caught in NEAT-AI-core CI rather
+than discovered when a downstream NEAT-AI bump-deps PR fails on `build.sh`.
+
+A new `scripts/verify-wasm-bundle.sh` re-downloads the just-published
+asset, extracts it, and asserts the same invariants NEAT-AI's `build.sh`
+checks for: top-level `pkg/`, four required files, and a
+`wasm_activation_bg.wasm` blob above the 128 KiB stub-detection threshold.
+When `--rev` is supplied, the embedded `neat_core_rev.txt` must also match,
+proving the asset attached to the tag corresponds to that tag's commit SHA.
+
+Closes #48.
+
+## Evidence
+
+CLI / workflow change — no UI to screenshot. Verification logic is exercised
+by 16 new bats cases against synthetic fixture archives (good case plus
+multiple failure modes: missing files, undersized wasm, malformed archive,
+mismatched rev, layout without top-level `pkg/`).
+
+```mermaid
+flowchart LR
+    A[Build wasm bundle] --> B[gh release create]
+    B --> C[gh release download<br/>same tag]
+    C --> D[verify-wasm-bundle.sh]
+    D -->|pass| E[Workflow green]
+    D -->|fail| F[Workflow red — surface broken release immediately]
+```
+
+Per-tool runs:
+
+- `bats tests/scripts` → 39/39 pass (16 new + 23 existing).
+- `shellcheck` clean on `scripts/verify-wasm-bundle.sh`.
+- `./quality.sh` → all checks pass.
+
+## Test Plan
+
+- Added `tests/scripts/verify_wasm_bundle.bats` with 16 cases covering:
+  - usage / unknown options / missing `--archive` / non-existent archive
+  - happy path (well-formed bundle accepted)
+  - each required file missing → fails (incl. `wasm_activation_bg.wasm.d.ts`)
+  - undersized wasm rejected; exact 128 KiB threshold accepted
+  - `--min-size-bytes` override; non-integer rejected
+  - `--rev` mismatch fails; match passes; absent `neat_core_rev.txt` tolerated
+  - malformed (non-gzip) archive rejected
+  - archive without top-level `pkg/` rejected
+- Existing `build_wasm_bundle.bats` continues to pass — file list and size
+  threshold semantics stay aligned with the verifier.

--- a/scripts/verify-wasm-bundle.sh
+++ b/scripts/verify-wasm-bundle.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# verify-wasm-bundle.sh — Post-publish integrity check for the per-commit
+# wasm_activation bundle (Issue #48).
+#
+# Used by .github/workflows/wasm-bundle.yml after `gh release create` to
+# re-download the just-published asset and prove the upload actually worked
+# end-to-end. A silent upload regression (gh exits 0 but the asset is
+# missing/truncated) would otherwise only surface when a downstream NEAT-AI
+# bump-deps run fails on `build.sh` — far from the source of the breakage.
+#
+# Behaviour:
+#   1. Extract the supplied tarball into a scratch directory.
+#   2. Assert the archive unpacks to a top-level `pkg/` (matches
+#      build-wasm-bundle.sh's layout and NEAT-AI's import paths).
+#   3. Assert all four files NEAT-AI's `build.sh` validates are present:
+#        - wasm_activation.js
+#        - wasm_activation_bg.wasm
+#        - wasm_activation.d.ts
+#        - wasm_activation_bg.wasm.d.ts
+#   4. Assert wasm_activation_bg.wasm is at least --min-size-bytes (default
+#      131072 / 128 KiB — the same MIN_WASM_BYTES stub-detection threshold
+#      used by NEAT-AI's build.sh).
+#   5. If --rev <SHA> is supplied AND neat_core_rev.txt is present, assert
+#      they match (ensures the asset attached to the release tag corresponds
+#      to the tag's commit SHA).
+#
+# Exits non-zero on any failure so the workflow surfaces a broken release
+# immediately instead of leaving downstream consumers to discover it.
+
+set -euo pipefail
+
+# 128 KiB — mirrors NEAT-AI build.sh MIN_WASM_BYTES.
+DEFAULT_MIN_WASM_BYTES=131072
+
+ARCHIVE=""
+EXPECTED_REV=""
+MIN_WASM_BYTES="$DEFAULT_MIN_WASM_BYTES"
+
+usage() {
+  cat <<EOF
+Usage: verify-wasm-bundle.sh --archive <path> [options]
+
+Verifies the integrity of a published wasm_activation bundle tarball.
+
+Options:
+  --archive <path>       Path to the wasm_activation-pkg.tar.gz to verify.
+                         Required.
+  --rev <SHA>            Expected commit SHA. When supplied, the embedded
+                         neat_core_rev.txt (if present) must match.
+  --min-size-bytes <N>   Minimum acceptable wasm_activation_bg.wasm size,
+                         in bytes (default: ${DEFAULT_MIN_WASM_BYTES}).
+  -h, --help             Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive)
+      [[ $# -ge 2 ]] || { echo "error: --archive requires a value" >&2; exit 2; }
+      ARCHIVE="$2"
+      shift 2
+      ;;
+    --rev)
+      [[ $# -ge 2 ]] || { echo "error: --rev requires a value" >&2; exit 2; }
+      EXPECTED_REV="$2"
+      shift 2
+      ;;
+    --min-size-bytes)
+      [[ $# -ge 2 ]] || { echo "error: --min-size-bytes requires a value" >&2; exit 2; }
+      MIN_WASM_BYTES="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$ARCHIVE" ]]; then
+  echo "error: --archive is required" >&2
+  exit 2
+fi
+
+if [[ ! -f "$ARCHIVE" ]]; then
+  echo "error: archive not found: $ARCHIVE" >&2
+  exit 1
+fi
+
+if ! [[ "$MIN_WASM_BYTES" =~ ^[0-9]+$ ]]; then
+  echo "error: --min-size-bytes must be a non-negative integer (got '$MIN_WASM_BYTES')" >&2
+  exit 2
+fi
+
+EXTRACT_DIR="$(mktemp -d)"
+trap 'rm -rf "$EXTRACT_DIR"' EXIT
+
+if ! tar -xzf "$ARCHIVE" -C "$EXTRACT_DIR"; then
+  echo "error: failed to extract archive: $ARCHIVE" >&2
+  exit 1
+fi
+
+PKG_DIR="$EXTRACT_DIR/pkg"
+if [[ ! -d "$PKG_DIR" ]]; then
+  echo "error: archive does not contain a top-level pkg/ directory" >&2
+  exit 1
+fi
+
+# Same file list NEAT-AI's build.sh validates — keep these two in lock-step.
+REQUIRED_FILES=(
+  "wasm_activation.js"
+  "wasm_activation_bg.wasm"
+  "wasm_activation.d.ts"
+  "wasm_activation_bg.wasm.d.ts"
+)
+
+for required in "${REQUIRED_FILES[@]}"; do
+  if [[ ! -f "$PKG_DIR/$required" ]]; then
+    echo "error: required file missing from bundle: pkg/$required" >&2
+    exit 1
+  fi
+done
+
+WASM_FILE="$PKG_DIR/wasm_activation_bg.wasm"
+WASM_SIZE=$(wc -c <"$WASM_FILE" | tr -d ' ')
+echo "wasm_activation_bg.wasm size: ${WASM_SIZE} bytes (threshold ${MIN_WASM_BYTES})"
+if (( WASM_SIZE < MIN_WASM_BYTES )); then
+  echo "error: wasm_activation_bg.wasm is below the minimum size threshold (${WASM_SIZE} < ${MIN_WASM_BYTES} bytes)" >&2
+  exit 1
+fi
+
+REV_FILE="$PKG_DIR/neat_core_rev.txt"
+if [[ -n "$EXPECTED_REV" && -f "$REV_FILE" ]]; then
+  EMBEDDED_REV="$(tr -d '[:space:]' <"$REV_FILE")"
+  if [[ "$EMBEDDED_REV" != "$EXPECTED_REV" ]]; then
+    echo "error: neat_core_rev.txt rev '${EMBEDDED_REV}' does not match expected '${EXPECTED_REV}'" >&2
+    exit 1
+  fi
+  echo "neat_core_rev.txt matches expected rev: ${EXPECTED_REV}"
+fi
+
+echo "✅ Bundle verified OK: $ARCHIVE"

--- a/tests/scripts/verify_wasm_bundle.bats
+++ b/tests/scripts/verify_wasm_bundle.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Tests for scripts/verify-wasm-bundle.sh — post-publish verification gate
+# (Issue #48). The verifier downloads (or, in tests, is handed) the published
+# wasm_activation-pkg.tar.gz, asserts the archive extracts cleanly, contains
+# the four files NEAT-AI's build.sh checks for, and that
+# wasm_activation_bg.wasm clears the 128 KiB stub-detection threshold.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/verify-wasm-bundle.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_DIR="$(mktemp -d)"
+  PKG_DIR="$TMP_DIR/pkg"
+  mkdir -p "$PKG_DIR"
+  export TMP_DIR PKG_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Build a fake pkg/ tree that the verifier should accept. Optional first arg
+# is the wasm blob size in bytes (default 200000 — comfortably above the
+# 128 KiB threshold). Optional second arg is the rev string written into
+# neat_core_rev.txt (default "deadbeef"). Tarballs the result to
+# $TMP_DIR/bundle.tar.gz.
+make_good_bundle() {
+  local wasm_bytes="${1:-200000}"
+  local rev="${2:-deadbeef}"
+  : >"$PKG_DIR/wasm_activation.js"
+  : >"$PKG_DIR/wasm_activation.d.ts"
+  : >"$PKG_DIR/wasm_activation_bg.wasm.d.ts"
+  dd if=/dev/zero of="$PKG_DIR/wasm_activation_bg.wasm" \
+    bs=1 count="$wasm_bytes" status=none
+  printf '%s\n' "$rev" >"$PKG_DIR/neat_core_rev.txt"
+  tar -czf "$TMP_DIR/bundle.tar.gz" -C "$TMP_DIR" pkg
+}
+
+@test "shows usage with --help" {
+  run "$SCRIPT_UNDER_TEST" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--archive"* ]]
+}
+
+@test "rejects unknown options" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "fails when --archive is missing" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--archive"* ]]
+}
+
+@test "fails when archive file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/missing.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "accepts a well-formed bundle" {
+  make_good_bundle
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verified"* ]] || [[ "$output" == *"OK"* ]]
+}
+
+@test "fails when wasm_activation.js is missing" {
+  make_good_bundle
+  # Rebuild without the .js file.
+  rm "$PKG_DIR/wasm_activation.js"
+  tar -czf "$TMP_DIR/bundle.tar.gz" -C "$TMP_DIR" pkg
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"wasm_activation.js"* ]]
+}
+
+@test "fails when wasm_activation_bg.wasm.d.ts is missing" {
+  make_good_bundle
+  rm "$PKG_DIR/wasm_activation_bg.wasm.d.ts"
+  tar -czf "$TMP_DIR/bundle.tar.gz" -C "$TMP_DIR" pkg
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"wasm_activation_bg.wasm.d.ts"* ]]
+}
+
+@test "fails when wasm blob is below 128 KiB threshold" {
+  # 100 KB — below the 128 KiB (131072 bytes) stub-detection threshold.
+  make_good_bundle 102400
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"below"* ]] || [[ "$output" == *"size"* ]]
+}
+
+@test "passes at exactly the 128 KiB threshold" {
+  make_good_bundle 131072
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -eq 0 ]
+}
+
+@test "honours --min-size-bytes override" {
+  make_good_bundle 50000
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz" --min-size-bytes 40000
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects non-integer --min-size-bytes" {
+  make_good_bundle
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz" --min-size-bytes abc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"min-size-bytes"* ]]
+}
+
+@test "fails when --rev does not match neat_core_rev.txt" {
+  make_good_bundle 200000 "abc1234"
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz" --rev "deadbeef"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rev"* ]]
+}
+
+@test "passes when --rev matches neat_core_rev.txt" {
+  make_good_bundle 200000 "abc1234"
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz" --rev "abc1234"
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when neat_core_rev.txt is absent and --rev not supplied" {
+  make_good_bundle
+  rm "$PKG_DIR/neat_core_rev.txt"
+  tar -czf "$TMP_DIR/bundle.tar.gz" -C "$TMP_DIR" pkg
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails on a malformed (non-gzip) archive" {
+  printf 'not a tar archive' >"$TMP_DIR/bundle.tar.gz"
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when archive lacks a top-level pkg/ directory" {
+  : >"$PKG_DIR/wasm_activation.js"
+  : >"$PKG_DIR/wasm_activation.d.ts"
+  : >"$PKG_DIR/wasm_activation_bg.wasm.d.ts"
+  dd if=/dev/zero of="$PKG_DIR/wasm_activation_bg.wasm" bs=1 count=200000 status=none
+  # Pack the *contents* of pkg/ at the archive root rather than the pkg/ dir.
+  tar -czf "$TMP_DIR/bundle.tar.gz" -C "$PKG_DIR" .
+  run "$SCRIPT_UNDER_TEST" --archive "$TMP_DIR/bundle.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pkg"* ]]
+}


### PR DESCRIPTION
## Summary

Add a post-publish verification step to `wasm-bundle.yml` so a silent
`gh release create` upload regression is caught in NEAT-AI-core CI rather
than discovered when a downstream NEAT-AI bump-deps PR fails on `build.sh`.

A new `scripts/verify-wasm-bundle.sh` re-downloads the just-published
asset, extracts it, and asserts the same invariants NEAT-AI's `build.sh`
checks for: top-level `pkg/`, four required files, and a
`wasm_activation_bg.wasm` blob above the 128 KiB stub-detection threshold.
When `--rev` is supplied, the embedded `neat_core_rev.txt` must also match,
proving the asset attached to the tag corresponds to that tag's commit SHA.

Closes #48.

## Evidence

CLI / workflow change — no UI to screenshot. Verification logic is exercised
by 16 new bats cases against synthetic fixture archives (good case plus
multiple failure modes: missing files, undersized wasm, malformed archive,
mismatched rev, layout without top-level `pkg/`).

```mermaid
flowchart LR
    A[Build wasm bundle] --> B[gh release create]
    B --> C[gh release download<br/>same tag]
    C --> D[verify-wasm-bundle.sh]
    D -->|pass| E[Workflow green]
    D -->|fail| F[Workflow red — surface broken release immediately]
```

Per-tool runs:

- `bats tests/scripts` → 39/39 pass (16 new + 23 existing).
- `shellcheck` clean on `scripts/verify-wasm-bundle.sh`.
- `./quality.sh` → all checks pass.

## Test Plan

- Added `tests/scripts/verify_wasm_bundle.bats` with 16 cases covering:
  - usage / unknown options / missing `--archive` / non-existent archive
  - happy path (well-formed bundle accepted)
  - each required file missing → fails (incl. `wasm_activation_bg.wasm.d.ts`)
  - undersized wasm rejected; exact 128 KiB threshold accepted
  - `--min-size-bytes` override; non-integer rejected
  - `--rev` mismatch fails; match passes; absent `neat_core_rev.txt` tolerated
  - malformed (non-gzip) archive rejected
  - archive without top-level `pkg/` rejected
- Existing `build_wasm_bundle.bats` continues to pass — file list and size
  threshold semantics stay aligned with the verifier.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-48 -->