### PR TITLE
docs: document cross-repo propagation flow (#47)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,71 @@ graph TD
     Examples -->|depends on| Main
 ```
 
+## Propagation to downstream repositories
+
+Once an enhancement merges to `Develop` here, it flows automatically to the
+next pull request raised in either consumer repository — no manual SHA bump
+is required. The two consumer paths differ in mechanism but share the same
+Vibe Coder hook (`bump-deps.sh` runs before `quality.sh` on every PR).
+
+### NEAT-AI (Deno + WASM consumer)
+
+- On every push to `Develop`, [`.github/workflows/wasm-bundle.yml`](.github/workflows/wasm-bundle.yml)
+  builds `wasm_activation-pkg.tar.gz` and publishes a per-commit GitHub
+  Release tagged `wasm-bundle-<SHA>`.
+- NEAT-AI's `bump-deps.sh` invokes `./build.sh`, which downloads the matching
+  bundle and updates `deno.json`'s `neatCore.rev` field in lock-step.
+- A fresh PR in NEAT-AI is therefore sufficient to pick up the latest
+  `Develop` of NEAT-AI-core.
+
+### NEAT-AI-scorer (Rust + path dependency)
+
+- NEAT-AI-scorer's CI uses `actions/checkout` to clone
+  `stSoftwareAU/NEAT-AI-core@Develop` into the workspace on every PR.
+- `rust_scorer/Cargo.toml`'s `path = "../../NEAT-AI-core/neat-core"` resolves
+  against that fresh clone, so the next PR build always compiles against the
+  current tip of `Develop`.
+- No SHA pin or release artefact is involved on this path.
+
+### End-to-end flow
+
+```mermaid
+sequenceDiagram
+    actor Dev as Maintainer
+    participant Core as NEAT-AI-core/Develop
+    participant CI as wasm-bundle.yml
+    participant Rel as GitHub Release<br/>wasm-bundle-{SHA}
+    participant Main as NEAT-AI PR
+    participant Scorer as NEAT-AI-scorer PR
+
+    Dev->>Core: merge enhancement
+    Core->>CI: push to Develop
+    CI->>Rel: build & publish wasm_activation-pkg.tar.gz
+    Dev->>Main: open PR
+    Main->>Rel: bump-deps.sh -> build.sh download
+    Note over Main: deno.json neatCore.rev advances
+    Dev->>Scorer: open PR
+    Scorer->>Core: actions/checkout @Develop
+    Note over Scorer: path dep resolves fresh clone
+```
+
+### Wiring reference
+
+| Consumer | Trigger | Script / workflow |
+|----------|---------|-------------------|
+| NEAT-AI-core | push to `Develop` | [`.github/workflows/wasm-bundle.yml`](.github/workflows/wasm-bundle.yml) |
+| NEAT-AI | PR opened (Vibe Coder hook) | `NEAT-AI/bump-deps.sh` → `NEAT-AI/build.sh` |
+| NEAT-AI-scorer | PR opened (CI) | `NEAT-AI-scorer/.github/workflows/ci.yml` (`actions/checkout` of `NEAT-AI-core@Develop`) |
+
+### Race window
+
+`wasm-bundle.yml` typically takes ~30–60 seconds to build and publish the
+release after a merge to `Develop`. PRs raised in NEAT-AI inside that
+window may transiently fail the bundle download in `build.sh` because the
+release tag for the latest `Develop` SHA does not yet exist. Re-run the
+PR's checks once the bundle workflow has completed, or wait a minute
+before opening the PR.
+
 ## License
 
 Apache-2.0 — see `LICENSE`.

--- a/docs/pr-summary-47.md
+++ b/docs/pr-summary-47.md
@@ -1,0 +1,47 @@
+## Summary
+
+Documents the end-to-end propagation flow from `NEAT-AI-core/Develop` to the
+two consumer repositories (NEAT-AI and NEAT-AI-scorer), so a maintainer can
+see at a glance that an enhancement merged here flows automatically to the
+next downstream PR. Adds a new `Propagation to downstream repositories`
+section to `README.md` covering both consumer paths, a Mermaid sequence
+diagram, a wiring reference table, and a note on the `wasm-bundle.yml` race
+window. Closes #47.
+
+## Evidence
+
+Documentation-only change. The new section is rendered from `README.md`
+and visible on the repository landing page after merge. The Mermaid
+sequence diagram below is the same block that appears in the README:
+
+```mermaid
+sequenceDiagram
+    actor Dev as Maintainer
+    participant Core as NEAT-AI-core/Develop
+    participant CI as wasm-bundle.yml
+    participant Rel as GitHub Release<br/>wasm-bundle-{SHA}
+    participant Main as NEAT-AI PR
+    participant Scorer as NEAT-AI-scorer PR
+
+    Dev->>Core: merge enhancement
+    Core->>CI: push to Develop
+    CI->>Rel: build & publish wasm_activation-pkg.tar.gz
+    Dev->>Main: open PR
+    Main->>Rel: bump-deps.sh -> build.sh download
+    Note over Main: deno.json neatCore.rev advances
+    Dev->>Scorer: open PR
+    Scorer->>Core: actions/checkout @Develop
+    Note over Scorer: path dep resolves fresh clone
+```
+
+`./quality.sh` passes cleanly (fmt, clippy, deny, tests, doc, release
+build) — no code paths changed.
+
+## Test Plan
+
+- No new unit tests: README.md change only.
+- Verified `./quality.sh < /dev/null` passes end-to-end on the modified
+  tree (all existing workspace tests green).
+- Manually checked README rendering for the new section, the Mermaid
+  block, the wiring table, and the race-window note against the issue
+  acceptance criteria.


### PR DESCRIPTION
## Summary

Documents the end-to-end propagation flow from `NEAT-AI-core/Develop` to the
two consumer repositories (NEAT-AI and NEAT-AI-scorer), so a maintainer can
see at a glance that an enhancement merged here flows automatically to the
next downstream PR. Adds a new `Propagation to downstream repositories`
section to `README.md` covering both consumer paths, a Mermaid sequence
diagram, a wiring reference table, and a note on the `wasm-bundle.yml` race
window. Closes #47.

## Evidence

Documentation-only change. The new section is rendered from `README.md`
and visible on the repository landing page after merge. The Mermaid
sequence diagram below is the same block that appears in the README:

```mermaid
sequenceDiagram
    actor Dev as Maintainer
    participant Core as NEAT-AI-core/Develop
    participant CI as wasm-bundle.yml
    participant Rel as GitHub Release<br/>wasm-bundle-{SHA}
    participant Main as NEAT-AI PR
    participant Scorer as NEAT-AI-scorer PR

    Dev->>Core: merge enhancement
    Core->>CI: push to Develop
    CI->>Rel: build & publish wasm_activation-pkg.tar.gz
    Dev->>Main: open PR
    Main->>Rel: bump-deps.sh -> build.sh download
    Note over Main: deno.json neatCore.rev advances
    Dev->>Scorer: open PR
    Scorer->>Core: actions/checkout @Develop
    Note over Scorer: path dep resolves fresh clone
```

`./quality.sh` passes cleanly (fmt, clippy, deny, tests, doc, release
build) — no code paths changed.

## Test Plan

- No new unit tests: README.md change only.
- Verified `./quality.sh < /dev/null` passes end-to-end on the modified
  tree (all existing workspace tests green).
- Manually checked README rendering for the new section, the Mermaid
  block, the wiring table, and the race-window note against the issue
  acceptance criteria.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-47 -->