### PR TITLE
🟡 Third-party GitHub Actions pinned to floating tags instead of 40-char SHAs (Issue #77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.0
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -49,10 +50,12 @@ jobs:
           git fetch origin Develop:Develop || git fetch origin develop:develop || true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Install cargo-edit and cargo-outdated
-        uses: taiki-e/install-action@v2
+        # taiki-e/install-action@v2.79.2
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d
         with:
           tool: cargo-edit,cargo-outdated
 
@@ -122,7 +125,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.0
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -142,7 +146,8 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           components: rustfmt, clippy
 
@@ -173,7 +178,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.0
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -193,17 +199,20 @@ jobs:
           df -h /
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           components: rustfmt, clippy
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        # Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           workspaces: ". -> target"
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        # taiki-e/install-action@v2.79.2
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d
         with:
           tool: cargo-deny
 
@@ -233,7 +242,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.0
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -264,7 +274,8 @@ jobs:
           exit "$exit_code"
 
       - name: Run codespell
-        uses: codespell-project/actions-codespell@v2
+        # codespell-project/actions-codespell@v2.2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579
         with:
           check_filenames: true
           check_hidden: true
@@ -286,13 +297,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.0
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Check for required files
         run: |

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,10 +11,12 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      # gitleaks/gitleaks-action@v2.3.9
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -26,17 +27,20 @@ jobs:
         run: git pull --ff-only origin "${{ github.head_ref }}" || true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        # taiki-e/install-action@v2.79.2
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d
         with:
           tool: cargo-audit
 
       # Primary audit: rustsec/audit-check@v2 annotates PRs with RustSec advisories.
       # It wraps the `cargo audit` CLI (cargo-audit) and reports vulnerabilities inline.
       - name: Run RustSec audit (rustsec/audit-check)
-        uses: rustsec/audit-check@v2
+        # rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,6 +51,7 @@ jobs:
 
       - name: Dependency review (GitHub Advisory / license diff on PR)
         if: ${{ inputs.include-dependency-review && github.event_name == 'pull_request' }}
-        uses: actions/dependency-review-action@v4
+        # actions/dependency-review-action@v4.9.0
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,8 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4.1.1
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - run: semgrep ci --config p/default
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,13 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: Develop
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Install cargo-edit
         run: cargo install cargo-edit
@@ -66,7 +68,8 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        # peter-evans/create-pull-request@v7.0.11
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/upgrade-dependencies

--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -18,10 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install Rust toolchain (with wasm32 target)
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: wasm32-unknown-unknown
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-77.md
+++ b/docs/pr-summary-77.md
@@ -1,0 +1,71 @@
+## Summary
+
+Pinned every third-party GitHub Action across all CI workflows to a
+40-character commit SHA, matching the pattern already used in
+`.github/workflows/markdown-lint.yml`. Floating refs such as
+`@v4`, `@v2`, or branch refs like `@stable` were a supply-chain risk:
+a compromised maintainer account or a malicious release on any of the
+referenced actions would have run inside our workflows with secrets
+such as `ACTIONS_PUSH`, `GITHUB_TOKEN`, `GITLEAKS_LICENSE`, and
+`SEMGREP_APP_TOKEN` available in `process.env`. Closes #77.
+
+The human-readable version is preserved as a trailing comment on each
+pinned step so Dependabot can still bump the pin and reviewers can see
+which release is in use.
+
+## Evidence
+
+Bug-fix / CI-config change with no UI to screenshot. Evidence is the
+new bats test suite plus the YAML diffs themselves.
+
+### Workflow pinning flow
+
+```mermaid
+flowchart LR
+    A[Floating tag<br/>e.g. @stable, @v2] -->|mutable| B[Maintainer compromise<br/>or malicious release]
+    B --> C[Workflow runs<br/>attacker code]
+    C --> D[Secrets leak<br/>ACTIONS_PUSH, GITHUB_TOKEN, …]
+
+    E[40-char commit SHA<br/>+ # version comment] -->|immutable| F[Workflow runs<br/>known-good code]
+    F --> G[Secrets remain safe]
+```
+
+### Actions pinned (and the SHA chosen)
+
+| Action | New SHA | Release |
+| --- | --- | --- |
+| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
+| `dtolnay/rust-toolchain` | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable |
+| `taiki-e/install-action` | `213ccc1a076163c093f914550b94feb90fab916d` | v2.79.2 |
+| `Swatinem/rust-cache` | `c19371144df3bb44fab255c43d04cbc2ab54d1c4` | v2.9.1 |
+| `codespell-project/actions-codespell` | `8f01853be192eb0f849a5c7d721450e7a467c579` | v2.2 |
+| `rustsec/audit-check` | `69366f33c96575abad1ee0dba8212993eecbe998` | v2.0.0 |
+| `actions/dependency-review-action` | `2031cfc080254a8a887f58cffee85186f0e49e48` | v4.9.0 |
+| `peter-evans/create-pull-request` | `22a9089034f40e5a961c8808d113e2c98fb63676` | v7.0.11 |
+| `gitleaks/gitleaks-action` | `ff98106e4c7b2bc287b24eaf42907196329070c7` | v2.3.9 |
+
+Six workflow files updated:
+`ci.yml`, `security.yml`, `upgrade-dependencies.yml`, `gitleaks.yml`,
+`wasm-bundle.yml`, `semgrep.yml`. The reusable workflow call
+`uses: ./.github/workflows/security.yml` in `ci.yml` is local and
+correctly left as-is.
+
+## Test Plan
+
+- Added `tests/scripts/workflow_sha_pinning.bats` with three "what"
+  tests:
+  - `every action in every workflow is pinned to a 40-char commit SHA`
+    — parses every `*.yml` under `.github/workflows/`, walks the
+    `jobs[*].steps[*].uses` and job-level `uses:` keys, and fails if
+    any external `uses:` does not match `^.+@[0-9a-f]{40}$`. Local
+    reusable workflows (`./…`) are exempt.
+  - `every SHA-pinned action has a version comment alongside it` —
+    confirms each pinned step has either a trailing `#` comment or a
+    nearby `#` comment within the step block so Dependabot and human
+    reviewers can read the version.
+  - `SHA-pin regex rejects floating tags and branch refs` —
+    behavioural sanity check that the regex actually rejects
+    `@v4`, `@v4.1.1`, `@stable`, etc. and accepts real 40-char SHAs.
+- All 51 bats tests pass (`bats tests/scripts/`).
+- `./quality.sh` passes cleanly (cargo fmt, clippy, deny, tests, doc,
+  release build all green).

--- a/tests/scripts/workflow_sha_pinning.bats
+++ b/tests/scripts/workflow_sha_pinning.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Tests for SHA-pinning of GitHub Actions across every workflow (Issue #77).
+#
+# Rationale: floating tags such as `@v4`, `@v2`, or branch refs like `@stable`
+# are mutable. A compromised maintainer account or supply-chain attack on the
+# action's release pipeline can re-point them at malicious code, which would
+# then execute with our workflow secrets (ACTIONS_PUSH, GITHUB_TOKEN,
+# GITLEAKS_LICENSE, SEMGREP_APP_TOKEN). Pinning every `uses:` to a 40-char
+# commit SHA — the pattern already used in markdown-lint.yml — removes that
+# attack surface.
+#
+# These are "what" tests: they parse the YAML and assert on observable
+# outcomes (the `uses:` ref shape), not on source-text heuristics.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+# Helper: assert every uses: in every workflow under WORKFLOWS_DIR is pinned
+# to a 40-char hex SHA. Local reusable workflows (./.github/workflows/*.yml)
+# are exempt because they live in this repo.
+@test "every action in every workflow is pinned to a 40-char commit SHA" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, re, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+sha_re = re.compile(r"^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$")
+local_re = re.compile(r"^\./")
+
+failures = []
+files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
+assert files, f"no workflow files found in {workflows_dir}"
+
+for path in files:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    jobs = data.get("jobs", {}) or {}
+    for job_name, job in jobs.items():
+        # Reusable workflow call (uses at the job level) — only flag if external.
+        job_uses = job.get("uses") if isinstance(job, dict) else None
+        if job_uses and not local_re.match(job_uses):
+            if not sha_re.match(job_uses):
+                failures.append(f"{os.path.basename(path)} job={job_name} uses={job_uses}")
+        for step in (job.get("steps", []) or []) if isinstance(job, dict) else []:
+            uses = step.get("uses")
+            if uses is None:
+                continue
+            if local_re.match(uses):
+                continue
+            if not sha_re.match(uses):
+                failures.append(f"{os.path.basename(path)} job={job_name} uses={uses}")
+
+if failures:
+    sys.stderr.write("Unpinned actions:\n  " + "\n  ".join(failures) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Every external uses: line should be followed (in the raw YAML) by an
+# adjacent human-readable version comment so Dependabot / reviewers can see
+# which release the SHA corresponds to. Pattern matches markdown-lint.yml.
+@test "every SHA-pinned action has a version comment alongside it" {
+  run python3 - <<PY
+import glob, os, re, sys
+
+workflows_dir = "$WORKFLOWS_DIR"
+uses_re = re.compile(r"^(\s*)(?:-\s*)?uses:\s*([^\s#]+)(?:\s*#\s*(.+))?\s*$")
+sha_at_re = re.compile(r"@[0-9a-f]{40}$")
+
+failures = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        lines = fh.readlines()
+    for i, line in enumerate(lines):
+        m = uses_re.match(line)
+        if not m:
+            continue
+        ref = m.group(2)
+        inline_comment = m.group(3)
+        if ref.startswith("./"):
+            continue
+        if not sha_at_re.search(ref):
+            continue
+        # Need a version annotation: either inline trailing comment on the
+        # uses: line, or a # comment somewhere within the current step block
+        # (scan backwards until we hit another step boundary or the job).
+        if inline_comment:
+            continue
+        found = False
+        for j in range(i - 1, max(-1, i - 6), -1):
+            prev_raw = lines[j]
+            prev = prev_raw.strip()
+            if prev.startswith("#"):
+                found = True
+                break
+            # Step boundary: a bare "-" item (new step) two or more lines back
+            # OR a job-level key. Stop scanning.
+            if j < i - 1 and prev.lstrip().startswith("- "):
+                break
+            if prev == "":
+                break
+        if not found:
+            failures.append(f"{os.path.basename(path)}:{i + 1}: missing version comment for {ref}")
+
+if failures:
+    sys.stderr.write("Missing version comments:\n  " + "\n  ".join(failures) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Behavioural sanity check: the regex actually rejects a known-bad ref. If
+# someone weakens the regex this test catches it.
+@test "SHA-pin regex rejects floating tags and branch refs" {
+  run python3 - <<PY
+import re
+sha_re = re.compile(r"^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$")
+bad = [
+    "actions/checkout@v4",
+    "actions/checkout@v4.1.1",
+    "dtolnay/rust-toolchain@stable",
+    "taiki-e/install-action@v2",
+    "Swatinem/rust-cache@v2",
+]
+for ref in bad:
+    assert not sha_re.match(ref), f"regex incorrectly accepted {ref}"
+
+good = [
+    "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+    "denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282",
+]
+for ref in good:
+    assert sha_re.match(ref), f"regex incorrectly rejected {ref}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Pinned every third-party GitHub Action across all CI workflows to a
40-character commit SHA, matching the pattern already used in
`.github/workflows/markdown-lint.yml`. Floating refs such as
`@v4`, `@v2`, or branch refs like `@stable` were a supply-chain risk:
a compromised maintainer account or a malicious release on any of the
referenced actions would have run inside our workflows with secrets
such as `ACTIONS_PUSH`, `GITHUB_TOKEN`, `GITLEAKS_LICENSE`, and
`SEMGREP_APP_TOKEN` available in `process.env`. Closes #77.

The human-readable version is preserved as a trailing comment on each
pinned step so Dependabot can still bump the pin and reviewers can see
which release is in use.

## Evidence

Bug-fix / CI-config change with no UI to screenshot. Evidence is the
new bats test suite plus the YAML diffs themselves.

### Workflow pinning flow

```mermaid
flowchart LR
    A[Floating tag<br/>e.g. @stable, @v2] -->|mutable| B[Maintainer compromise<br/>or malicious release]
    B --> C[Workflow runs<br/>attacker code]
    C --> D[Secrets leak<br/>ACTIONS_PUSH, GITHUB_TOKEN, …]

    E[40-char commit SHA<br/>+ # version comment] -->|immutable| F[Workflow runs<br/>known-good code]
    F --> G[Secrets remain safe]
```

### Actions pinned (and the SHA chosen)

| Action | New SHA | Release |
| --- | --- | --- |
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `dtolnay/rust-toolchain` | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable |
| `taiki-e/install-action` | `213ccc1a076163c093f914550b94feb90fab916d` | v2.79.2 |
| `Swatinem/rust-cache` | `c19371144df3bb44fab255c43d04cbc2ab54d1c4` | v2.9.1 |
| `codespell-project/actions-codespell` | `8f01853be192eb0f849a5c7d721450e7a467c579` | v2.2 |
| `rustsec/audit-check` | `69366f33c96575abad1ee0dba8212993eecbe998` | v2.0.0 |
| `actions/dependency-review-action` | `2031cfc080254a8a887f58cffee85186f0e49e48` | v4.9.0 |
| `peter-evans/create-pull-request` | `22a9089034f40e5a961c8808d113e2c98fb63676` | v7.0.11 |
| `gitleaks/gitleaks-action` | `ff98106e4c7b2bc287b24eaf42907196329070c7` | v2.3.9 |

Six workflow files updated:
`ci.yml`, `security.yml`, `upgrade-dependencies.yml`, `gitleaks.yml`,
`wasm-bundle.yml`, `semgrep.yml`. The reusable workflow call
`uses: ./.github/workflows/security.yml` in `ci.yml` is local and
correctly left as-is.

## Test Plan

- Added `tests/scripts/workflow_sha_pinning.bats` with three "what"
  tests:
  - `every action in every workflow is pinned to a 40-char commit SHA`
    — parses every `*.yml` under `.github/workflows/`, walks the
    `jobs[*].steps[*].uses` and job-level `uses:` keys, and fails if
    any external `uses:` does not match `^.+@[0-9a-f]{40}$`. Local
    reusable workflows (`./…`) are exempt.
  - `every SHA-pinned action has a version comment alongside it` —
    confirms each pinned step has either a trailing `#` comment or a
    nearby `#` comment within the step block so Dependabot and human
    reviewers can read the version.
  - `SHA-pin regex rejects floating tags and branch refs` —
    behavioural sanity check that the regex actually rejects
    `@v4`, `@v4.1.1`, `@stable`, etc. and accepts real 40-char SHAs.
- All 51 bats tests pass (`bats tests/scripts/`).
- `./quality.sh` passes cleanly (cargo fmt, clippy, deny, tests, doc,
  release build all green).



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-77 -->