### PR TITLE
🟠 Script injection via github.head_ref in CI 'run:' blocks (Issue #79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Pull latest changes
-        run: git pull origin ${{ github.head_ref }}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git pull origin "$HEAD_REF"
 
       - name: Fetch base branch
         run: |
@@ -105,13 +107,15 @@ jobs:
           cargo outdated -R || true
 
       - name: Commit version and dependency changes
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "No changes after version bump / dependency upgrade"
           else
             git commit -m "chore: auto-increment versions for changed projects"
-            git push origin ${{ github.head_ref }}
+            git push origin "$HEAD_REF"
           fi
 
   auto-format:
@@ -156,13 +160,15 @@ jobs:
 
       - name: Commit rustfmt if needed
         id: fmt_commit
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if ! git diff --quiet; then
             git add -A
             git commit -m "chore: apply rustfmt fixes"
-            git push origin ${{ github.head_ref }}
+            git push origin "$HEAD_REF"
             echo "pushed=true" >> "$GITHUB_OUTPUT"
           else
             echo "pushed=false" >> "$GITHUB_OUTPUT"
@@ -186,7 +192,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull latest changes
-        run: git pull origin ${{ github.head_ref }}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git pull origin "$HEAD_REF"
 
       - name: Free up runner disk space
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,9 @@ jobs:
           fetch-depth: 0
 
       - name: Pull latest (after version/dependency bot commits)
-        run: git pull --ff-only origin "${{ github.head_ref }}" || true
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git pull --ff-only origin "$HEAD_REF" || true
 
       - name: Install Rust toolchain
         # dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-79.md
+++ b/docs/pr-summary-79.md
@@ -1,0 +1,71 @@
+# Script-injection hardening for `github.head_ref` in CI workflows
+
+## Summary
+
+Closes #79. Eliminated direct interpolation of `${{ github.head_ref }}` into
+every `run:` shell block under `.github/workflows/`. Each affected step now
+binds `github.head_ref` to a step-level `env:` variable (`HEAD_REF`) and the
+shell references it via `"$HEAD_REF"`, so any shell metacharacters smuggled
+into a branch name are inert parameter-expansion text rather than template
+substitution that the shell would evaluate.
+
+The fix follows the GitHub Security Lab guidance on untrusted input in
+GitHub Actions and matches the pattern recommended in the issue.
+
+## Affected call sites
+
+| File | Step | Before | After |
+| --- | --- | --- | --- |
+| `.github/workflows/ci.yml` | `version-increment` → Pull latest changes | `git pull origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git pull origin "$HEAD_REF"` |
+| `.github/workflows/ci.yml` | `version-increment` → Commit version and dependency changes | `git push origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git push origin "$HEAD_REF"` |
+| `.github/workflows/ci.yml` | `auto-format` → Commit rustfmt if needed | `git push origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git push origin "$HEAD_REF"` |
+| `.github/workflows/ci.yml` | `quality` → Pull latest changes | `git pull origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git pull origin "$HEAD_REF"` |
+| `.github/workflows/security.yml` | `security` → Pull latest | `git pull --ff-only origin "${{ github.head_ref }}" \|\| true` | `env: HEAD_REF`, `git pull --ff-only origin "$HEAD_REF" \|\| true` |
+
+Remaining `${{ github.head_ref }}` references inside `with:` blocks of
+`actions/checkout` are passed as action inputs (not shell), so they are
+safe and were left in place.
+
+## Evidence
+
+Added a regression bats test
+(`tests/scripts/workflow_script_injection.bats`) that parses every workflow
+under `.github/workflows/` and fails if any `run:` body matches a tainted
+context expression (`github.head_ref`, `github.event.pull_request.*`,
+`github.event.issue.*`, `github.event.comment.body`,
+`github.event.review.body`, `github.event.commits.*`,
+`github.event.workflow_run.head_branch`). A second test pins the
+detector regex against known-bad and known-safe snippets so a future
+weakening of the detector is caught.
+
+Before the fix, `bats tests/scripts/workflow_script_injection.bats`
+reported:
+
+```text
+not ok 1 no run: block interpolates tainted github contexts directly
+```
+
+After the fix:
+
+```text
+ok 1 no run: block interpolates tainted github contexts directly
+ok 2 tainted-context detector regex catches known-bad patterns
+```
+
+```mermaid
+flowchart LR
+    A[PR branch name<br/>'evil$(curl ...|bash)'] --> B{run: body}
+    B -->|Before: template substitution| C[Shell evaluates<br/>command substitution<br/>= RCE on runner]
+    B -->|After: env-var binding| D["$HEAD_REF<br/>= literal string<br/>= safe"]
+```
+
+## Test plan
+
+- New: `tests/scripts/workflow_script_injection.bats` — both tests pass.
+- Existing bats suites (`workflow_sha_pinning.bats`,
+  `ci_workflow_quarantine.bats`, etc.) were unaffected; the failures
+  visible in those suites pre-date this change (verified by stashing the
+  PR diff and re-running the suite).
+- `python3` YAML parse of both modified workflow files succeeds.
+- `shellcheck` and `codespell` clean on the new bats file and the
+  modified workflows.

--- a/tests/scripts/workflow_script_injection.bats
+++ b/tests/scripts/workflow_script_injection.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# Tests that GitHub Actions workflows do not interpolate attacker-controlled
+# context expressions directly into `run:` shell blocks (Issue #79).
+#
+# Rationale: contexts such as `github.head_ref`, `github.event.pull_request.*`,
+# `github.event.issue.*`, `github.event.comment.*`, `github.event.review.*`,
+# `github.event.commits.*`, and `github.event.workflow_run.*` are populated
+# from user-controlled input (branch names, PR titles/bodies, etc.).
+# `git check-ref-format` permits shell metacharacters such as `$`, `;`, `(`,
+# `)`, backtick, `&`, `|`, `"`, `'`, `<`, and `>` in branch names, so any
+# `${{ ... }}` expansion of these contexts inside a `run:` body lets the
+# branch name escape the surrounding shell command and execute arbitrary
+# code on the runner — see
+# https://securitylab.github.com/research/github-actions-untrusted-input/.
+#
+# The accepted mitigation is to bind the tainted context to an `env:` value
+# on the step, then reference the resulting shell variable from `run:`.
+# Shell parameter expansion makes metacharacters inert.
+#
+# These are "what" tests: they parse the YAML and assert on observable
+# outcomes (the contents of each step's `run:` body and `env:` map), not
+# on source-text heuristics.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "no run: block interpolates tainted github contexts directly" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import glob, os, re, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+
+# Contexts that come from outside the trust boundary. Branch names, PR
+# titles/bodies, issue bodies, comments, commit messages, and workflow_run
+# event payloads are all user-controlled.
+tainted_re = re.compile(
+    r"\$\{\{\s*github\.(?:"
+    r"head_ref"
+    r"|event\.pull_request\.(?:title|body|head\.ref|head\.label|head\.repo\.[A-Za-z_.]+)"
+    r"|event\.issue\.(?:title|body)"
+    r"|event\.comment\.body"
+    r"|event\.review\.body"
+    r"|event\.commits\.[^}]*"
+    r"|event\.workflow_run\.head_branch"
+    r")\s*\}\}"
+)
+
+failures = []
+files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
+assert files, f"no workflow files found in {workflows_dir}"
+
+for path in files:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    jobs = (data.get("jobs") or {}) if isinstance(data, dict) else {}
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for idx, step in enumerate(job.get("steps", []) or []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            m = tainted_re.search(run)
+            if m:
+                failures.append(
+                    f"{os.path.basename(path)} job={job_name} "
+                    f"step[{idx}]={step.get('name', '<unnamed>')!r} "
+                    f"tainted={m.group(0)}"
+                )
+
+if failures:
+    sys.stderr.write(
+        "Tainted github context interpolated into run: block(s):\n  "
+        + "\n  ".join(failures)
+        + "\n\nBind the context to an `env:` value on the step and reference\n"
+        + "the resulting shell variable from `run:` instead.\n"
+    )
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "tainted-context detector regex catches known-bad patterns" {
+  run python3 - <<'PY'
+import re
+
+tainted_re = re.compile(
+    r"\$\{\{\s*github\.(?:"
+    r"head_ref"
+    r"|event\.pull_request\.(?:title|body|head\.ref|head\.label|head\.repo\.[A-Za-z_.]+)"
+    r"|event\.issue\.(?:title|body)"
+    r"|event\.comment\.body"
+    r"|event\.review\.body"
+    r"|event\.commits\.[^}]*"
+    r"|event\.workflow_run\.head_branch"
+    r")\s*\}\}"
+)
+
+bad = [
+    "git pull origin ${{ github.head_ref }}",
+    'git pull --ff-only origin "${{ github.head_ref }}" || true',
+    "echo ${{ github.event.pull_request.title }}",
+    "echo ${{ github.event.issue.body }}",
+    "echo ${{ github.event.workflow_run.head_branch }}",
+]
+for snippet in bad:
+    assert tainted_re.search(snippet), f"regex failed to catch: {snippet}"
+
+# Safe patterns: env-var binding (the mitigation) and contexts that are not
+# user-controlled (e.g. github.ref_name on push to a protected branch is
+# still untrusted in general, but github.repository / github.sha are not).
+safe = [
+    'echo "$HEAD_REF"',
+    "echo ${{ github.repository }}",
+    "echo ${{ github.sha }}",
+    "echo ${{ secrets.GITHUB_TOKEN }}",
+]
+for snippet in safe:
+    assert not tainted_re.search(snippet), f"regex falsely flagged: {snippet}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Script-injection hardening for `github.head_ref` in CI workflows

## Summary

Closes #79. Eliminated direct interpolation of `${{ github.head_ref }}` into
every `run:` shell block under `.github/workflows/`. Each affected step now
binds `github.head_ref` to a step-level `env:` variable (`HEAD_REF`) and the
shell references it via `"$HEAD_REF"`, so any shell metacharacters smuggled
into a branch name are inert parameter-expansion text rather than template
substitution that the shell would evaluate.

The fix follows the GitHub Security Lab guidance on untrusted input in
GitHub Actions and matches the pattern recommended in the issue.

## Affected call sites

| File | Step | Before | After |
| --- | --- | --- | --- |
| `.github/workflows/ci.yml` | `version-increment` → Pull latest changes | `git pull origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git pull origin "$HEAD_REF"` |
| `.github/workflows/ci.yml` | `version-increment` → Commit version and dependency changes | `git push origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git push origin "$HEAD_REF"` |
| `.github/workflows/ci.yml` | `auto-format` → Commit rustfmt if needed | `git push origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git push origin "$HEAD_REF"` |
| `.github/workflows/ci.yml` | `quality` → Pull latest changes | `git pull origin ${{ github.head_ref }}` | `env: HEAD_REF`, `git pull origin "$HEAD_REF"` |
| `.github/workflows/security.yml` | `security` → Pull latest | `git pull --ff-only origin "${{ github.head_ref }}" \|\| true` | `env: HEAD_REF`, `git pull --ff-only origin "$HEAD_REF" \|\| true` |

Remaining `${{ github.head_ref }}` references inside `with:` blocks of
`actions/checkout` are passed as action inputs (not shell), so they are
safe and were left in place.

## Evidence

Added a regression bats test
(`tests/scripts/workflow_script_injection.bats`) that parses every workflow
under `.github/workflows/` and fails if any `run:` body matches a tainted
context expression (`github.head_ref`, `github.event.pull_request.*`,
`github.event.issue.*`, `github.event.comment.body`,
`github.event.review.body`, `github.event.commits.*`,
`github.event.workflow_run.head_branch`). A second test pins the
detector regex against known-bad and known-safe snippets so a future
weakening of the detector is caught.

Before the fix, `bats tests/scripts/workflow_script_injection.bats`
reported:

```text
not ok 1 no run: block interpolates tainted github contexts directly
```

After the fix:

```text
ok 1 no run: block interpolates tainted github contexts directly
ok 2 tainted-context detector regex catches known-bad patterns
```

```mermaid
flowchart LR
    A[PR branch name<br/>'evil$(curl ...|bash)'] --> B{run: body}
    B -->|Before: template substitution| C[Shell evaluates<br/>command substitution<br/>= RCE on runner]
    B -->|After: env-var binding| D["$HEAD_REF<br/>= literal string<br/>= safe"]
```

## Test plan

- New: `tests/scripts/workflow_script_injection.bats` — both tests pass.
- Existing bats suites (`workflow_sha_pinning.bats`,
  `ci_workflow_quarantine.bats`, etc.) were unaffected; the failures
  visible in those suites pre-date this change (verified by stashing the
  PR diff and re-running the suite).
- `python3` YAML parse of both modified workflow files succeeds.
- `shellcheck` and `codespell` clean on the new bats file and the
  modified workflows.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-79 -->