### PR TITLE
feat(loss): add categorical_error_sum_batch_packed (Issue #88)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-if"
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neat-core"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "serde",
  "serde_json",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.26"
+version = "0.1.27"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/archive/pr-summaries/pr-summary-88.md
+++ b/docs/archive/pr-summaries/pr-summary-88.md
@@ -59,7 +59,7 @@ New tests in `neat-core/src/loss.rs` (covers acceptance criteria one-to-one):
 
 Run locally:
 
-```
+```bash
 cargo test -p neat-core --lib loss::tests::categorical
 RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
 ```

--- a/docs/archive/pr-summaries/pr-summary-88.md
+++ b/docs/archive/pr-summaries/pr-summary-88.md
@@ -1,0 +1,65 @@
+## Summary
+
+Adds `categorical_error_sum_batch_packed` to `neat-core/src/loss.rs` and
+re-exports it from the crate root. This is the seventh and final built-in
+NEAT-AI cost function the native scorer needs (see
+stSoftwareAU/NEAT-AI-scorer#119) — it mirrors the TypeScript
+`CategoricalError` (argmax misclassification rate) and returns the count of
+misclassified records, matching the `[inputs..., targets...]` packed-record
+signature used by the existing `mse_/mae_/cross_entropy_/mape_/msle_/hinge_`
+helpers so the scorer can dispatch all seven costs through a single
+trait/enum. Closes #88.
+
+Behaviour highlights:
+
+- Per-record argmax comparison with first-index tie-breaking (matches the
+  TS `a > b` convention on both target and output sides).
+- Empty record set or `input_size + num_outputs == 0` returns `0.0`; a
+  zero `num_outputs` also returns `0.0` (degenerate — no class to predict).
+- Intentionally non-differentiable: this is a scoring / early-stop metric,
+  not a gradient source.
+
+## Evidence
+
+Backend-only change — no UI to screenshot. Verified via `cargo test`,
+`cargo clippy -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc`.
+All 5 new tests pass alongside the existing suite.
+
+```mermaid
+flowchart LR
+    R[packed records<br/>inputs + targets] --> A[network.activate_into]
+    A --> O[outputs]
+    O --> AM1[argmax outputs]
+    R --> AM2[argmax targets]
+    AM1 --> CMP{equal?}
+    AM2 --> CMP
+    CMP -->|yes| Z[+0]
+    CMP -->|no| ONE[+1]
+    Z --> SUM[sum]
+    ONE --> SUM
+```
+
+## Test Plan
+
+New tests in `neat-core/src/loss.rs` (covers acceptance criteria one-to-one):
+
+- `categorical_error_perfect_prediction_returns_zero` — three records where
+  the target argmax matches the output argmax → `0.0`.
+- `categorical_error_all_wrong_returns_record_count` — three records where
+  every target argmax disagrees with the output argmax → `3.0`.
+- `categorical_error_empty_input_returns_zero` — empty records, degenerate
+  `input_size + num_outputs == 0`, and `num_outputs == 0` all return `0.0`.
+- `categorical_error_ties_resolve_to_first_index` — three records share
+  the 3-way-tied output `[1.0, 1.0, 1.0]`; tied targets verify first-index
+  argmax on both target and output sides matches the TS reference.
+- `categorical_error_mixed_batch_matches_reference` — six handcrafted
+  records with annotated argmax expectations summing to `3.0`; also
+  checks `forward_only=false` yields the same count on a stateless
+  feed-forward creature.
+
+Run locally:
+
+```
+cargo test -p neat-core --lib loss::tests::categorical
+RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
+```

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.121"
+wasm-bindgen = "0.2.122"
 
 [dev-dependencies]
 tempfile = "3"

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -64,8 +64,9 @@ pub use elastic_distribution::distribute_elastic_error;
 pub use error::{apply_calculate_error, apply_calculate_error_batch_4way};
 pub use fused_error::apply_fused_error_distribution;
 pub use loss::{
-    cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
-    mape_sum_batch_packed, mse_mean_record, mse_sum_batch_packed, msle_sum_batch_packed,
+    categorical_error_sum_batch_packed, cross_entropy_sum_batch_packed, hinge_sum_batch_packed,
+    mae_sum_batch_packed, mape_sum_batch_packed, mse_mean_record, mse_sum_batch_packed,
+    msle_sum_batch_packed,
 };
 pub use range::{apply_get_range, apply_limit_range, apply_validate_range};
 pub use safe_zone::{apply_safe_zone_adjustment, apply_safe_zone_adjustment_batch};

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -2087,6 +2087,98 @@ pub fn hinge_sum_batch_packed(
     sum_error
 }
 
+/// Fused activate + Categorical Error (argmax misclassification) for batch scoring.
+///
+/// Reference TypeScript: `NEAT-AI/src/costs/CategoricalError.ts`. For each
+/// record, this compares the index of the largest target value (the true
+/// class) with the index of the largest output value (the predicted class).
+/// Each record contributes `0` for a correct prediction or `1` for an
+/// incorrect one. The returned sum is therefore the **count of
+/// misclassified records**; divide by `record_count` to obtain the mean
+/// error rate (`1 - accuracy`).
+///
+/// Ties resolve to the first index (standard argmax convention) on both the
+/// target and output sides, matching the TS reference.
+///
+/// This metric is intentionally **non-differentiable** — it is intended as a
+/// scoring / early-stop signal, not a gradient source.
+///
+/// # Arguments
+/// * `network` - The compiled network to activate
+/// * `records` - Packed array of `[inputs..., targets...]` records
+/// * `input_size` - Number of inputs per record
+/// * `num_outputs` - Number of outputs per record
+/// * `forward_only` - If true, skip reset_state() (for forward-only networks)
+///
+/// # Returns
+/// Count of misclassified records (divide by record count for mean error
+/// rate). Returns `0.0` when the record set is empty or `input_size +
+/// num_outputs == 0`.
+///
+/// Issue stSoftwareAU/NEAT-AI-core#88 — extend native scorer with the last
+/// remaining built-in NEAT-AI cost function.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn categorical_error_sum_batch_packed(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    forward_only: bool,
+) -> f64 {
+    let values_per_record = input_size + num_outputs;
+    if values_per_record == 0 {
+        return 0.0;
+    }
+    let num_records = records.len() / values_per_record;
+    if num_records == 0 || num_outputs == 0 {
+        return 0.0;
+    }
+
+    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
+    let mut misclassified: f64 = 0.0;
+
+    for record_idx in 0..num_records {
+        if !forward_only {
+            network.reset_state();
+        }
+
+        let base = record_idx * values_per_record;
+        let input_start = base;
+        let input_end = base + input_size;
+        let target_start = input_end;
+
+        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
+
+        // Argmax with first-index tie-breaking — matches the TS reference
+        // (`a > b` so equal values keep the earlier index).
+        let mut target_argmax: usize = 0;
+        let mut target_best: f32 = records[target_start];
+        for j in 1..num_outputs {
+            let v = records[target_start + j];
+            if v > target_best {
+                target_best = v;
+                target_argmax = j;
+            }
+        }
+
+        let mut output_argmax: usize = 0;
+        let mut output_best: f32 = outputs[0];
+        for j in 1..num_outputs {
+            let v = outputs[j];
+            if v > output_best {
+                output_best = v;
+                output_argmax = j;
+            }
+        }
+
+        if target_argmax != output_argmax {
+            misclassified += 1.0;
+        }
+    }
+
+    misclassified
+}
+
 /// Non-fused recurrent-path MSE for `forwardOnly: false` networks.
 ///
 /// Activates the network **once per record**, resetting hidden activations
@@ -2255,5 +2347,152 @@ mod tests {
 
         // Zero input_size + zero num_outputs — degenerate, also 0.0.
         assert_eq!(mse_mean_record(&mut network, &records, 0, 0), 0.0);
+    }
+
+    // ----- categorical_error_sum_batch_packed (issue #88) -----
+    //
+    // 2-input / 3-output linear creature used to test argmax classification.
+    // All outputs use IDENTITY so we can hand-roll exact activations:
+    //   output-0 = 1.0 * in0 + 0.0 * in1
+    //   output-1 = 0.0 * in0 + 1.0 * in1
+    //   output-2 = 0.5 * in0 + 0.5 * in1
+    //
+    // Sample activations:
+    //   (1, 0) -> [1.0, 0.0, 0.5]   argmax = 0
+    //   (0, 1) -> [0.0, 1.0, 0.5]   argmax = 1
+    //   (2, 1) -> [2.0, 1.0, 1.5]   argmax = 0
+    //   (1, 1) -> [1.0, 1.0, 1.0]   argmax = 0 (3-way tie, first wins)
+    fn three_class_creature_json() -> &'static str {
+        r#"{
+            "input": 2,
+            "output": 3,
+            "neurons": [
+                {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"},
+                {"type": "output", "uuid": "output-1", "bias": 0.0, "squash": "IDENTITY"},
+                {"type": "output", "uuid": "output-2", "bias": 0.0, "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0},
+                {"fromUUID": "input-1", "toUUID": "output-0", "weight": 0.0},
+                {"fromUUID": "input-0", "toUUID": "output-1", "weight": 0.0},
+                {"fromUUID": "input-1", "toUUID": "output-1", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "output-2", "weight": 0.5},
+                {"fromUUID": "input-1", "toUUID": "output-2", "weight": 0.5}
+            ],
+            "forwardOnly": true
+        }"#
+    }
+
+    #[test]
+    fn categorical_error_perfect_prediction_returns_zero() {
+        let creature = parse_creature_json(three_class_creature_json()).expect("parse");
+        let mut network = compile_creature(&creature).expect("compile");
+
+        // Each record's target argmax matches the output argmax above.
+        #[rustfmt::skip]
+        let records: Vec<f32> = vec![
+            1.0, 0.0, /* target */ 1.0, 0.0, 0.0, // out argmax 0, tgt argmax 0
+            0.0, 1.0, /* target */ 0.0, 1.0, 0.0, // out argmax 1, tgt argmax 1
+            2.0, 1.0, /* target */ 1.0, 0.0, 0.0, // out argmax 0, tgt argmax 0
+        ];
+
+        let err = categorical_error_sum_batch_packed(&mut network, &records, 2, 3, true);
+        assert_eq!(err, 0.0);
+    }
+
+    #[test]
+    fn categorical_error_all_wrong_returns_record_count() {
+        let creature = parse_creature_json(three_class_creature_json()).expect("parse");
+        let mut network = compile_creature(&creature).expect("compile");
+
+        // Every record's target argmax disagrees with the output argmax.
+        #[rustfmt::skip]
+        let records: Vec<f32> = vec![
+            1.0, 0.0, /* target */ 0.0, 1.0, 0.0, // out argmax 0, tgt argmax 1
+            0.0, 1.0, /* target */ 1.0, 0.0, 0.0, // out argmax 1, tgt argmax 0
+            2.0, 1.0, /* target */ 0.0, 0.0, 1.0, // out argmax 0, tgt argmax 2
+        ];
+
+        let err = categorical_error_sum_batch_packed(&mut network, &records, 2, 3, true);
+        assert_eq!(err, 3.0);
+    }
+
+    #[test]
+    fn categorical_error_empty_input_returns_zero() {
+        let creature = parse_creature_json(three_class_creature_json()).expect("parse");
+        let mut network = compile_creature(&creature).expect("compile");
+
+        // Empty record set.
+        let empty: Vec<f32> = Vec::new();
+        assert_eq!(
+            categorical_error_sum_batch_packed(&mut network, &empty, 2, 3, true),
+            0.0
+        );
+
+        // Degenerate input_size + num_outputs == 0.
+        assert_eq!(
+            categorical_error_sum_batch_packed(&mut network, &empty, 0, 0, true),
+            0.0
+        );
+
+        // Degenerate num_outputs == 0 with non-empty input_size.
+        assert_eq!(
+            categorical_error_sum_batch_packed(&mut network, &empty, 2, 0, true),
+            0.0
+        );
+    }
+
+    #[test]
+    fn categorical_error_ties_resolve_to_first_index() {
+        let creature = parse_creature_json(three_class_creature_json()).expect("parse");
+        let mut network = compile_creature(&creature).expect("compile");
+
+        // Input (1, 1) -> outputs [1.0, 1.0, 1.0]: 3-way tie, argmax = 0.
+        // Record 1: target [0.5, 0.5, 0.4] -> tgt argmax = 0 (first wins) -> correct.
+        // Record 2: target [0.4, 0.5, 0.5] -> tgt argmax = 1 (first of tied
+        //           1 and 2) -> mismatch with output argmax 0 -> 1 error.
+        // Record 3: target [0.5, 0.4, 0.5] -> tgt argmax = 0 (first of tied
+        //           0 and 2) -> correct.
+        #[rustfmt::skip]
+        let records: Vec<f32> = vec![
+            1.0, 1.0, /* target */ 0.5, 0.5, 0.4,
+            1.0, 1.0, /* target */ 0.4, 0.5, 0.5,
+            1.0, 1.0, /* target */ 0.5, 0.4, 0.5,
+        ];
+
+        let err = categorical_error_sum_batch_packed(&mut network, &records, 2, 3, true);
+        assert_eq!(err, 1.0);
+    }
+
+    #[test]
+    fn categorical_error_mixed_batch_matches_reference() {
+        let creature = parse_creature_json(three_class_creature_json()).expect("parse");
+        let mut network = compile_creature(&creature).expect("compile");
+
+        // Hand-crafted mixed batch — annotate each row with the expected
+        // output argmax (from the linear creature above) and target argmax,
+        // then the per-record contribution (0 correct, 1 wrong).
+        #[rustfmt::skip]
+        let records: Vec<f32> = vec![
+            // in0, in1, t0, t1, t2 | out argmax | tgt argmax | err
+            1.0, 0.0,  1.0, 0.0, 0.0, //     0          0         0
+            0.0, 1.0,  1.0, 0.0, 0.0, //     1          0         1
+            2.0, 1.0,  0.0, 0.0, 1.0, //     0          2         1
+            0.0, 2.0,  0.0, 1.0, 0.0, //     1          1         0
+            1.0, 1.0,  0.5, 0.4, 0.4, //     0 (tie)    0 (tie)   0
+            1.0, 0.0,  0.0, 1.0, 0.0, //     0          1         1
+        ];
+        // Total errors expected = 3.
+
+        let err = categorical_error_sum_batch_packed(&mut network, &records, 2, 3, true);
+        assert_eq!(err, 3.0);
+
+        // The forward_only=false path takes the same record loop with an
+        // additional reset_state() — for this stateless feed-forward
+        // creature it must produce the same count.
+        let mut net_recurrent = compile_creature(&creature).expect("compile");
+        let err_recurrent =
+            categorical_error_sum_batch_packed(&mut net_recurrent, &records, 2, 3, false);
+        assert_eq!(err_recurrent, 3.0);
     }
 }


### PR DESCRIPTION
## Summary

Adds `categorical_error_sum_batch_packed` to `neat-core/src/loss.rs` and
re-exports it from the crate root. This is the seventh and final built-in
NEAT-AI cost function the native scorer needs (see
stSoftwareAU/NEAT-AI-scorer#119) — it mirrors the TypeScript
`CategoricalError` (argmax misclassification rate) and returns the count of
misclassified records, matching the `[inputs..., targets...]` packed-record
signature used by the existing `mse_/mae_/cross_entropy_/mape_/msle_/hinge_`
helpers so the scorer can dispatch all seven costs through a single
trait/enum. Closes #88.

Behaviour highlights:

- Per-record argmax comparison with first-index tie-breaking (matches the
  TS `a > b` convention on both target and output sides).
- Empty record set or `input_size + num_outputs == 0` returns `0.0`; a
  zero `num_outputs` also returns `0.0` (degenerate — no class to predict).
- Intentionally non-differentiable: this is a scoring / early-stop metric,
  not a gradient source.

## Evidence

Backend-only change — no UI to screenshot. Verified via `cargo test`,
`cargo clippy -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc`.
All 5 new tests pass alongside the existing suite.

```mermaid
flowchart LR
    R[packed records<br/>inputs + targets] --> A[network.activate_into]
    A --> O[outputs]
    O --> AM1[argmax outputs]
    R --> AM2[argmax targets]
    AM1 --> CMP{equal?}
    AM2 --> CMP
    CMP -->|yes| Z[+0]
    CMP -->|no| ONE[+1]
    Z --> SUM[sum]
    ONE --> SUM
```

## Test Plan

New tests in `neat-core/src/loss.rs` (covers acceptance criteria one-to-one):

- `categorical_error_perfect_prediction_returns_zero` — three records where
  the target argmax matches the output argmax → `0.0`.
- `categorical_error_all_wrong_returns_record_count` — three records where
  every target argmax disagrees with the output argmax → `3.0`.
- `categorical_error_empty_input_returns_zero` — empty records, degenerate
  `input_size + num_outputs == 0`, and `num_outputs == 0` all return `0.0`.
- `categorical_error_ties_resolve_to_first_index` — three records share
  the 3-way-tied output `[1.0, 1.0, 1.0]`; tied targets verify first-index
  argmax on both target and output sides matches the TS reference.
- `categorical_error_mixed_batch_matches_reference` — six handcrafted
  records with annotated argmax expectations summing to `3.0`; also
  checks `forward_only=false` yields the same count on a stateless
  feed-forward creature.

Run locally:

```
cargo test -p neat-core --lib loss::tests::categorical
RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
```