### PR TITLE
ci: bump actions/checkout to v6.0.2 (node24) — Closes #97

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -129,8 +129,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -184,8 +184,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -250,8 +250,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -305,8 +305,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,8 +11,8 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       # gitleaks/gitleaks-action@v2.3.9

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,8 +13,8 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: semgrep ci --config p/default
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: Develop
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain (with wasm32 target)
         # dtolnay/rust-toolchain@stable

--- a/docs/archive/pr-summaries/pr-summary-97.md
+++ b/docs/archive/pr-summaries/pr-summary-97.md
@@ -1,0 +1,36 @@
+## Summary
+
+Bumped `actions/checkout` from the deprecated v4.3.1 pin (SHA `34e114876b…`, runs on Node 20, EOL on GitHub-hosted runners 2026-09-16) to v6.0.2 (SHA `de0fac2e45…`, runs on Node 24) across every workflow in `.github/workflows/`. Added a regression test that denylists the deprecated SHA so a future revert is caught at quality-check time. Closes #97.
+
+## Evidence
+
+Backend/CI-only change — no UI to screenshot.
+
+- `actions/checkout@v6.0.2` runtime confirmed as `node24` via the GitHub API:
+  `gh api "repos/actions/checkout/contents/action.yml?ref=v6.0.2"` → `using: node24`.
+- Every workflow under `.github/workflows/` now references the new SHA:
+
+  ```
+  $ grep -rn "actions/checkout@" .github/workflows/
+  ci.yml, markdown-lint.yml, gitleaks.yml, wasm-bundle.yml,
+  security.yml, upgrade-dependencies.yml, semgrep.yml
+  → all pinned to @de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+  ```
+
+- Regression test (`tests/scripts/workflow_sha_pinning.bats`, new test "no workflow uses actions/checkout pinned to a deprecated Node runtime") was verified to **fail** against the pre-fix workflows and **pass** after the bump.
+
+```mermaid
+flowchart LR
+    A["v4.3.1<br/>SHA 34e11487…<br/>node20 (EOL 2026-09-16)"] -->|Issue #97 bump| B["v6.0.2<br/>SHA de0fac2e…<br/>node24"]
+    B --> C["Regression test<br/>denylists 34e11487…"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/workflow_sha_pinning.bats::"no workflow uses actions/checkout pinned to a deprecated Node runtime"` — parses each workflow YAML and asserts no `uses:` ref ends with the deprecated SHA. Maintains a denylist keyed by SHA so future Node-runtime EOLs (e.g. node22) can be appended.
+- Updated the existing `"SHA-pin regex rejects floating tags and branch refs"` test's positive example from the now-deprecated SHA to the new v6.0.2 SHA.
+- `./quality.sh < /dev/null` passes the new test and shows the same 5 pre-existing failures as the milestone base branch (unrelated `cargo upgrade` quarantine checks in `ci.yml` and a pre-existing unpinned `taiki-e/install-action@v2` in `upgrade-dependencies.yml`) — no new failures introduced.
+
+## Out of scope
+
+- The pre-existing unpinned `taiki-e/install-action@v2` in `upgrade-dependencies.yml` and the `ci.yml` bare `cargo upgrade`/`cargo update` failures are tracked separately under the `github-actions-audit` milestone.

--- a/tests/scripts/workflow_sha_pinning.bats
+++ b/tests/scripts/workflow_sha_pinning.bats
@@ -114,6 +114,46 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #97 regression: actions/checkout pins must not point at SHAs whose
+# runtime is the deprecated Node.js 20 (EOL 2026-09-16). Maintain a denylist
+# of known-deprecated commits and assert no workflow uses them. New entries
+# go here whenever a Node-runtime EOL is announced.
+@test "no workflow uses actions/checkout pinned to a deprecated Node runtime" {
+  run python3 - <<PY
+import glob, os, re, sys
+
+workflows_dir = "$WORKFLOWS_DIR"
+# SHA -> reason. Add deprecated runtime SHAs here as Node versions reach EOL.
+DEPRECATED = {
+    # actions/checkout@v4.3.1 — runs on Node 20 (EOL on GitHub-hosted
+    # runners 2026-09-16). Bumped to v6.0.2 (Node 24) for Issue #97.
+    "34e114876b0b11c390a56381ad16ebd13914f8d5": "actions/checkout@v4.3.1 (node20, EOL 2026-09-16)",
+}
+uses_re = re.compile(r"uses:\s*([^\s#]+)")
+
+failures = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        for lineno, line in enumerate(fh, 1):
+            m = uses_re.search(line)
+            if not m:
+                continue
+            ref = m.group(1)
+            if "@" not in ref:
+                continue
+            sha = ref.rsplit("@", 1)[1]
+            if sha in DEPRECATED:
+                failures.append(
+                    f"{os.path.basename(path)}:{lineno}: {ref} -> {DEPRECATED[sha]}"
+                )
+
+if failures:
+    sys.stderr.write("Deprecated-runtime action SHAs in use:\n  " + "\n  ".join(failures) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
 # Behavioural sanity check: the regex actually rejects a known-bad ref. If
 # someone weakens the regex this test catches it.
 @test "SHA-pin regex rejects floating tags and branch refs" {
@@ -131,7 +171,7 @@ for ref in bad:
     assert not sha_re.match(ref), f"regex incorrectly accepted {ref}"
 
 good = [
-    "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+    "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
     "denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282",
 ]
 for ref in good:


### PR DESCRIPTION
## Summary

Bumped `actions/checkout` from the deprecated v4.3.1 pin (SHA `34e114876b…`, runs on Node 20, EOL on GitHub-hosted runners 2026-09-16) to v6.0.2 (SHA `de0fac2e45…`, runs on Node 24) across every workflow in `.github/workflows/`. Added a regression test that denylists the deprecated SHA so a future revert is caught at quality-check time. Closes #97.

## Evidence

Backend/CI-only change — no UI to screenshot.

- `actions/checkout@v6.0.2` runtime confirmed as `node24` via the GitHub API:
  `gh api "repos/actions/checkout/contents/action.yml?ref=v6.0.2"` → `using: node24`.
- Every workflow under `.github/workflows/` now references the new SHA:

  ```
  $ grep -rn "actions/checkout@" .github/workflows/
  ci.yml, markdown-lint.yml, gitleaks.yml, wasm-bundle.yml,
  security.yml, upgrade-dependencies.yml, semgrep.yml
  → all pinned to @de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
  ```

- Regression test (`tests/scripts/workflow_sha_pinning.bats`, new test "no workflow uses actions/checkout pinned to a deprecated Node runtime") was verified to **fail** against the pre-fix workflows and **pass** after the bump.

```mermaid
flowchart LR
    A["v4.3.1<br/>SHA 34e11487…<br/>node20 (EOL 2026-09-16)"] -->|Issue #97 bump| B["v6.0.2<br/>SHA de0fac2e…<br/>node24"]
    B --> C["Regression test<br/>denylists 34e11487…"]
```

## Test Plan

- Added `tests/scripts/workflow_sha_pinning.bats::"no workflow uses actions/checkout pinned to a deprecated Node runtime"` — parses each workflow YAML and asserts no `uses:` ref ends with the deprecated SHA. Maintains a denylist keyed by SHA so future Node-runtime EOLs (e.g. node22) can be appended.
- Updated the existing `"SHA-pin regex rejects floating tags and branch refs"` test's positive example from the now-deprecated SHA to the new v6.0.2 SHA.
- `./quality.sh < /dev/null` passes the new test and shows the same 5 pre-existing failures as the milestone base branch (unrelated `cargo upgrade` quarantine checks in `ci.yml` and a pre-existing unpinned `taiki-e/install-action@v2` in `upgrade-dependencies.yml`) — no new failures introduced.

## Out of scope

- The pre-existing unpinned `taiki-e/install-action@v2` in `upgrade-dependencies.yml` and the `ci.yml` bare `cargo upgrade`/`cargo update` failures are tracked separately under the `github-actions-audit` milestone.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-97 -->