### PR TITLE
ci(gitleaks): migrate off Node 20 gitleaks-action to pinned CLI binary

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,14 @@
 name: Gitleaks
 
+# Issue #99 — migrated off the Node-based `gitleaks/gitleaks-action@v2.3.9`,
+# which declares `using: node20` and triggered the GitHub-hosted runner
+# Node 20 deprecation warning (Node 20 auto-upgrades to Node 24 on
+# 2026-06-02; full removal 2026-09-16). Upstream has not shipped a Node
+# 22/24 release of the action, so we install the gitleaks CLI binary
+# directly with SHA-256 verification (mirrors the wasm-pack pinned-install
+# pattern from Issue #78). The CLI is MIT-licensed and free, so dropping
+# the action also drops the GITLEAKS_LICENSE requirement.
+
 on:
   pull_request:
     branches: ["*"]
@@ -15,8 +24,38 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      # gitleaks/gitleaks-action@v2.3.9
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+
+      # Install the gitleaks CLI from a version-pinned release tarball with
+      # SHA-256 verification. Bump GITLEAKS_VERSION + GITLEAKS_SHA256
+      # together — the SHA-256 is the sha256sum of the .tar.gz asset on
+      # the corresponding GitHub release page.
+      - name: Install gitleaks CLI
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: "8.30.1"
+          # sha256 of gitleaks_8.30.1_linux_x64.tar.gz from
+          # https://github.com/gitleaks/gitleaks/releases/tag/v8.30.1
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
+          curl --proto '=https' --tlsv1.2 -fsSL -o "$asset" "$url"
+          echo "${GITLEAKS_SHA256}  ${asset}" | sha256sum -c -
+          tar -xzf "$asset" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f "$asset" gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: |
+          set -euo pipefail
+          # --redact: never print matched secrets in CI logs.
+          # --verbose: show one line per finding.
+          # --no-banner: cleaner log output.
+          # Exit code is non-zero when leaks are found, failing the job.
+          gitleaks detect \
+            --source . \
+            --config .gitleaks.toml \
+            --redact \
+            --verbose \
+            --no-banner

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,8 +13,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2 — Issue #97/#99: bumped off Node 20 (EOL 2026-09-16).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # actions/setup-node@v6.4.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/docs/archive/pr-summaries/pr-summary-99.md
+++ b/docs/archive/pr-summaries/pr-summary-99.md
@@ -1,0 +1,98 @@
+## Summary
+
+Migrated the `Gitleaks` workflow off the Node-based
+`gitleaks/gitleaks-action@v2.3.9` — whose `action.yml` declares
+`using: node20` and triggered the GitHub-hosted runner Node 20
+deprecation warning — onto the upstream gitleaks CLI binary installed
+from a SHA-256-pinned release tarball. Upstream has not shipped a
+Node 22/24 release of the action, so direct installation is the only
+safe migration. Mirrors the wasm-pack pinned-install pattern from
+Issue #78. Also drops the `GITLEAKS_LICENSE` requirement (the CLI is
+MIT-licensed and free; only the org-mode action required a licence).
+
+Picked up an Issue #97 leftover at the same time: `markdown-lint.yml`
+still used the deprecated `actions/checkout@v4.3.1` (Node 20) SHA.
+Bumped it to `actions/checkout@v6.0.2` so the deprecation regression
+test stays green.
+
+Closes #99.
+
+### Deno regression avoided
+
+This is a Rust repo, not a Deno repo. No Node-only tooling was
+introduced — the migration *removes* a Node-based action and replaces
+it with a Go binary invoked from a `run:` step.
+
+## Evidence
+
+This is a CI-only change with no UI to screenshot. Verified via the
+new regression test (`tests/scripts/gitleaks_pinned_install.bats`,
+6 cases) plus the updated denylist in
+`tests/scripts/workflow_sha_pinning.bats`.
+
+```mermaid
+flowchart LR
+    A[checkout @ v6.0.2] --> B[Install gitleaks CLI<br/>v8.30.1 + sha256 verify]
+    B --> C[gitleaks detect --source . --redact]
+    style B fill:#cfc
+    style C fill:#cfc
+```
+
+Before — `gitleaks/gitleaks-action@v2.3.9` (Node 20, EOL 2026-09-16,
+requires `GITLEAKS_LICENSE`):
+
+```yaml
+- uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+```
+
+After — pinned CLI install, no Node runtime, no licence:
+
+```yaml
+- name: Install gitleaks CLI
+  env:
+    GITLEAKS_VERSION: "8.30.1"
+    GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+  run: |
+    set -euo pipefail
+    asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+    url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
+    curl --proto '=https' --tlsv1.2 -fsSL -o "$asset" "$url"
+    echo "${GITLEAKS_SHA256}  ${asset}" | sha256sum -c -
+    tar -xzf "$asset" gitleaks
+    sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+    rm -f "$asset" gitleaks
+    gitleaks version
+- name: Run gitleaks
+  run: gitleaks detect --source . --config .gitleaks.toml --redact --verbose --no-banner
+```
+
+## Test Plan
+
+- **Added** `tests/scripts/gitleaks_pinned_install.bats` — 6 cases
+  asserting `gitleaks.yml` no longer references the Node-based action,
+  installs from a version-pinned release URL, verifies the tarball
+  with `sha256sum -c`, declares `GITLEAKS_SHA256` (64 hex) and
+  `GITLEAKS_VERSION` (semver) env vars, and invokes the gitleaks CLI.
+  All six fail against the old workflow and pass against the new one
+  (TDD red → green).
+- **Extended** `tests/scripts/workflow_sha_pinning.bats` denylist with
+  the Node 20 `gitleaks-action` SHA so the deprecated pin cannot be
+  re-introduced.
+- **Generalised** the deprecation test name from
+  *"no workflow uses actions/checkout pinned to a deprecated Node
+  runtime"* to *"no workflow uses an action pinned to a deprecated
+  Node runtime"* — the underlying logic was always action-agnostic.
+- **Bumped** `markdown-lint.yml` checkout from `v4.3.1` (Node 20) to
+  `v6.0.2` (Node 24) so the deprecation test passes cleanly.
+
+## Pre-existing test failure not addressed here
+
+`workflow_sha_pinning.bats::every action in every workflow is pinned
+to a 40-char commit SHA` still fails because `upgrade-dependencies.yml`
+line 30 uses `taiki-e/install-action@v2` (a floating major tag). This
+predates Issue #99 and is a separate supply-chain concern (SHA pinning,
+not Node deprecation). Tracked in follow-up issue
+[stSoftwareAU/NEAT-AI-core#104](https://github.com/stSoftwareAU/NEAT-AI-core/issues/104).

--- a/tests/scripts/gitleaks_pinned_install.bats
+++ b/tests/scripts/gitleaks_pinned_install.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# Tests for Issue #99 — gitleaks must run from a pinned upstream CLI tarball
+# with SHA-256 verification rather than the Node-based gitleaks-action.
+#
+# Why this matters: gitleaks/gitleaks-action@v2.3.9 declares
+# `using: node20` in its action.yml. Node 20 is scheduled for automatic
+# upgrade to Node 24 on GitHub-hosted runners on 2026-06-02 and full
+# removal on 2026-09-16. Upstream has not shipped a Node 22/24 release of
+# the action, so the safe migration is to install the gitleaks CLI binary
+# directly (mirrors the wasm-pack pinned-install pattern from Issue #78).
+# This also drops the GITLEAKS_LICENSE requirement, which the action
+# imposed on organisations but the CLI does not.
+#
+# These are "what" tests — they assert on the YAML the runner will
+# execute, not on commentary or surrounding prose.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WF="${REPO_ROOT}/.github/workflows/gitleaks.yml"
+}
+
+# Strip YAML comments so the assertions can't be defeated by leaving the
+# original `uses: gitleaks/gitleaks-action@…` line behind as a comment.
+strip_comments() {
+  sed -E 's/[[:space:]]*#.*$//' "$1"
+}
+
+@test "gitleaks.yml does not use the Node-based gitleaks-action" {
+  [ -f "$WF" ]
+  stripped="$(strip_comments "$WF")"
+  if printf '%s\n' "$stripped" | grep -E 'gitleaks/gitleaks-action@' >/dev/null; then
+    printf 'Node-based gitleaks-action still referenced in gitleaks.yml:\n%s\n' \
+      "$(printf '%s\n' "$stripped" | grep -nE 'gitleaks/gitleaks-action@')" >&2
+    return 1
+  fi
+}
+
+@test "gitleaks.yml installs gitleaks from a version-pinned release URL" {
+  [ -f "$WF" ]
+  # Require a download from the gitleaks release archive at a specific tag
+  # (either a literal vX.Y.Z or a v${GITLEAKS_VERSION} env expansion — the
+  # version itself is asserted by a sibling test).
+  run grep -E 'github\.com/gitleaks/gitleaks/releases/download/v(\$\{?GITLEAKS_VERSION\}?|[0-9]+\.[0-9]+\.[0-9]+)/' "$WF"
+  [ "$status" -eq 0 ]
+}
+
+@test "gitleaks.yml verifies the gitleaks tarball with sha256sum -c" {
+  [ -f "$WF" ]
+  run grep -E 'sha256sum[[:space:]]+-c' "$WF"
+  [ "$status" -eq 0 ]
+}
+
+@test "gitleaks.yml declares a 64-hex GITLEAKS_SHA256 env var" {
+  [ -f "$WF" ]
+  run grep -E 'GITLEAKS_SHA256:[[:space:]]*"?[0-9a-f]{64}"?' "$WF"
+  [ "$status" -eq 0 ]
+}
+
+@test "gitleaks.yml declares a semver GITLEAKS_VERSION env var" {
+  [ -f "$WF" ]
+  run grep -E 'GITLEAKS_VERSION:[[:space:]]*"?[0-9]+\.[0-9]+\.[0-9]+"?' "$WF"
+  [ "$status" -eq 0 ]
+}
+
+@test "gitleaks.yml invokes the gitleaks CLI" {
+  [ -f "$WF" ]
+  # Either `./gitleaks detect …` (binary extracted to CWD) or
+  # `gitleaks detect …` (binary on PATH). Both are acceptable.
+  run grep -E '(\./)?gitleaks[[:space:]]+(detect|dir|git)' "$WF"
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/workflow_sha_pinning.bats
+++ b/tests/scripts/workflow_sha_pinning.bats
@@ -114,11 +114,11 @@ PY
   [ "$status" -eq 0 ]
 }
 
-# Issue #97 regression: actions/checkout pins must not point at SHAs whose
+# Issue #97 / #99 regression: action pins must not point at SHAs whose
 # runtime is the deprecated Node.js 20 (EOL 2026-09-16). Maintain a denylist
 # of known-deprecated commits and assert no workflow uses them. New entries
 # go here whenever a Node-runtime EOL is announced.
-@test "no workflow uses actions/checkout pinned to a deprecated Node runtime" {
+@test "no workflow uses an action pinned to a deprecated Node runtime" {
   run python3 - <<PY
 import glob, os, re, sys
 
@@ -128,6 +128,11 @@ DEPRECATED = {
     # actions/checkout@v4.3.1 — runs on Node 20 (EOL on GitHub-hosted
     # runners 2026-09-16). Bumped to v6.0.2 (Node 24) for Issue #97.
     "34e114876b0b11c390a56381ad16ebd13914f8d5": "actions/checkout@v4.3.1 (node20, EOL 2026-09-16)",
+    # gitleaks/gitleaks-action@v2.3.9 — runs on Node 20 (action.yml declares
+    # using node20) and upstream has not shipped a Node 22/24 release.
+    # Issue #99 replaced this with a direct CLI install in gitleaks.yml so
+    # the workflow has no Node runtime at all.
+    "ff98106e4c7b2bc287b24eaf42907196329070c7": "gitleaks/gitleaks-action@v2.3.9 (node20, EOL 2026-09-16)",
 }
 uses_re = re.compile(r"uses:\s*([^\s#]+)")
 


### PR DESCRIPTION
## Summary

Migrated the `Gitleaks` workflow off the Node-based
`gitleaks/gitleaks-action@v2.3.9` — whose `action.yml` declares
`using: node20` and triggered the GitHub-hosted runner Node 20
deprecation warning — onto the upstream gitleaks CLI binary installed
from a SHA-256-pinned release tarball. Upstream has not shipped a
Node 22/24 release of the action, so direct installation is the only
safe migration. Mirrors the wasm-pack pinned-install pattern from
Issue #78. Also drops the `GITLEAKS_LICENSE` requirement (the CLI is
MIT-licensed and free; only the org-mode action required a licence).

Picked up an Issue #97 leftover at the same time: `markdown-lint.yml`
still used the deprecated `actions/checkout@v4.3.1` (Node 20) SHA.
Bumped it to `actions/checkout@v6.0.2` so the deprecation regression
test stays green.

Closes #99.

### Deno regression avoided

This is a Rust repo, not a Deno repo. No Node-only tooling was
introduced — the migration *removes* a Node-based action and replaces
it with a Go binary invoked from a `run:` step.

## Evidence

This is a CI-only change with no UI to screenshot. Verified via the
new regression test (`tests/scripts/gitleaks_pinned_install.bats`,
6 cases) plus the updated denylist in
`tests/scripts/workflow_sha_pinning.bats`.

```mermaid
flowchart LR
    A[checkout @ v6.0.2] --> B[Install gitleaks CLI<br/>v8.30.1 + sha256 verify]
    B --> C[gitleaks detect --source . --redact]
    style B fill:#cfc
    style C fill:#cfc
```

Before — `gitleaks/gitleaks-action@v2.3.9` (Node 20, EOL 2026-09-16,
requires `GITLEAKS_LICENSE`):

```yaml
- uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
```

After — pinned CLI install, no Node runtime, no licence:

```yaml
- name: Install gitleaks CLI
  env:
    GITLEAKS_VERSION: "8.30.1"
    GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
  run: |
    set -euo pipefail
    asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
    url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
    curl --proto '=https' --tlsv1.2 -fsSL -o "$asset" "$url"
    echo "${GITLEAKS_SHA256}  ${asset}" | sha256sum -c -
    tar -xzf "$asset" gitleaks
    sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
    rm -f "$asset" gitleaks
    gitleaks version
- name: Run gitleaks
  run: gitleaks detect --source . --config .gitleaks.toml --redact --verbose --no-banner
```

## Test Plan

- **Added** `tests/scripts/gitleaks_pinned_install.bats` — 6 cases
  asserting `gitleaks.yml` no longer references the Node-based action,
  installs from a version-pinned release URL, verifies the tarball
  with `sha256sum -c`, declares `GITLEAKS_SHA256` (64 hex) and
  `GITLEAKS_VERSION` (semver) env vars, and invokes the gitleaks CLI.
  All six fail against the old workflow and pass against the new one
  (TDD red → green).
- **Extended** `tests/scripts/workflow_sha_pinning.bats` denylist with
  the Node 20 `gitleaks-action` SHA so the deprecated pin cannot be
  re-introduced.
- **Generalised** the deprecation test name from
  *"no workflow uses actions/checkout pinned to a deprecated Node
  runtime"* to *"no workflow uses an action pinned to a deprecated
  Node runtime"* — the underlying logic was always action-agnostic.
- **Bumped** `markdown-lint.yml` checkout from `v4.3.1` (Node 20) to
  `v6.0.2` (Node 24) so the deprecation test passes cleanly.

## Pre-existing test failure not addressed here

`workflow_sha_pinning.bats::every action in every workflow is pinned
to a 40-char commit SHA` still fails because `upgrade-dependencies.yml`
line 30 uses `taiki-e/install-action@v2` (a floating major tag). This
predates Issue #99 and is a separate supply-chain concern (SHA pinning,
not Node deprecation). Tracked in follow-up issue
[stSoftwareAU/NEAT-AI-core#104](https://github.com/stSoftwareAU/NEAT-AI-core/issues/104).



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-99 -->