### PR TITLE
ci: add actionlint CI lint gate for GitHub Actions workflows (#96)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,58 @@
+name: Actionlint
+
+# Issue #96 — CI lint gate for GitHub Actions workflows.
+#
+# Runs the upstream actionlint binary (rhysd/actionlint) on every push to
+# Develop and every pull request so workflow regressions fail the build.
+#
+# Install pattern mirrors gitleaks.yml (Issue #99) and the wasm-pack pinned
+# install (Issue #78): download a version-pinned release tarball and verify
+# its SHA-256 before executing the binary. Avoids the supply-chain risk of
+# floating Marketplace actions and keeps third-party `uses:` entries pinned
+# to commit SHAs (Issue #77).
+
+on:
+  push:
+    branches: [Develop]
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Install actionlint CLI from a version-pinned release tarball with
+      # SHA-256 verification. Bump ACTIONLINT_VERSION + ACTIONLINT_SHA256
+      # together — the SHA-256 is the sha256sum of the linux_amd64 .tar.gz
+      # asset on the corresponding GitHub release page.
+      - name: Install actionlint CLI
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          # sha256 of actionlint_1.7.12_linux_amd64.tar.gz from
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${asset}"
+          curl --proto '=https' --tlsv1.2 -fsSL -o "$asset" "$url"
+          echo "${ACTIONLINT_SHA256}  ${asset}" | sha256sum -c -
+          tar -xzf "$asset" actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          rm -f "$asset" actionlint
+          actionlint -version
+
+      - name: Run actionlint
+        # `-ignore 'SC2016'` suppresses a false positive from actionlint's
+        # bundled shellcheck integration on intentional single-quoted echo
+        # strings inside heredocs (e.g. upgrade-dependencies.yml). All other
+        # shellcheck diagnostics still fail the build.
+        run: |
+          set -euo pipefail
+          actionlint -no-color -ignore 'SC2016'

--- a/docs/archive/pr-summaries/pr-summary-96.md
+++ b/docs/archive/pr-summaries/pr-summary-96.md
@@ -1,0 +1,82 @@
+## Summary
+
+Adds a CI lint gate that runs `actionlint` against every GitHub Actions
+workflow on every push to `Develop` and every pull request, so workflow
+regressions fail the build. Closes #96.
+
+The issue body claimed there were no workflows under `.github/workflows/`,
+which is no longer accurate (the directory already contains seven
+workflows). The substantive finding — that `actionlint` is never invoked
+in CI — was correct and is what this PR fixes.
+
+The new workflow installs the upstream `rhysd/actionlint` CLI from a
+version-pinned release tarball with SHA-256 verification, mirroring the
+hardened install pattern already used in `gitleaks.yml` (Issue #99) and
+`wasm-bundle.yml` (Issue #78). The third-party `actions/checkout` ref is
+pinned to a 40-character commit SHA, consistent with the SHA-pinning
+policy from Issue #77.
+
+A single `-ignore 'SC2016'` suppression filters a false-positive from
+actionlint's bundled shellcheck integration on intentional single-quoted
+echo strings inside the `upgrade-dependencies.yml` heredoc. All other
+actionlint and shellcheck diagnostics still fail the build.
+
+## Evidence
+
+This is a CI-only change with no UI surface. Behaviour is verified by
+running `actionlint` locally against the repository's seven existing
+workflow files plus the newly added one — exit code 0, no diagnostics:
+
+```text
+$ actionlint -no-color -ignore 'SC2016' .github/workflows/*.yml
+$ echo $?
+0
+```
+
+Pipeline shape after this PR:
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CI[CI workflow]
+    PR --> ML[Markdown Lint]
+    PR --> GL[Gitleaks]
+    PR --> SEC[Security]
+    PR --> AL[Actionlint *new*]
+    AL -->|fail| Block[Block merge]
+    AL -->|pass| Allow[Allow merge]
+```
+
+## Test Plan
+
+- Added `tests/scripts/actionlint_workflow.bats` (7 tests) which
+  asserts on observable outcomes:
+  - workflow file exists and parses as YAML,
+  - triggers on `pull_request` and on pushes to `Develop`,
+  - has an `actionlint` job that actually invokes the `actionlint`
+    binary (not just installs it),
+  - third-party `uses:` entries are SHA-pinned (Issue #77 policy),
+  - install step pins both a semver `ACTIONLINT_VERSION` and a
+    64-hex `ACTIONLINT_SHA256` env var, and runs `sha256sum -c`,
+  - if `actionlint` is installed locally, the workflows on disk
+    actually pass it (behavioural sanity gate, skipped if missing).
+- All seven new tests pass locally with `bats tests/scripts/actionlint_workflow.bats`.
+- The existing `workflow_sha_pinning.bats` still passes for the new
+  workflow's `uses:` entries.
+
+## Pre-existing failures (out of scope)
+
+`./quality.sh` reports five pre-existing bats failures unrelated to this
+PR:
+
+- `ci_workflow_quarantine.bats` tests 31, 32, 33, 37 — concern `ci.yml`
+  bypassing the `bump-deps.sh` quarantine; not touched by this PR.
+- `workflow_sha_pinning.bats` test 78 — `upgrade-dependencies.yml` pins
+  `taiki-e/install-action@v2` to a floating tag; not touched by this PR.
+
+Verified these failures are present on `milestone/audit-issues` without
+this PR's changes applied. They require their own issues to address.
+
+## Deno regression avoided
+
+No Deno markers in this repo (Rust workspace), so the rule does not
+apply.

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# Tests for the actionlint GitHub Actions linter workflow (Issue #96).
+#
+# Asserts on observable outcomes:
+#   - the workflow YAML file exists and parses,
+#   - it triggers on pull_request and on pushes to Develop,
+#   - it actually runs the `actionlint` binary,
+#   - third-party actions are SHA-pinned (consistent with Issue #77),
+#   - the install step pins both version and SHA-256 (supply-chain hygiene
+#     mirroring gitleaks.yml from Issue #99 and wasm-pack from Issue #78),
+#   - if `actionlint` is installed locally, it passes against the current
+#     workflows on disk (behavioural sanity check).
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/actionlint.yml"
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "actionlint workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "actionlint workflow is valid YAML" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "actionlint workflow triggers on PRs and on pushes to Develop" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+# YAML parses bare 'on:' as boolean True in some loaders; tolerate both.
+triggers = data.get("on") or data.get(True)
+assert triggers is not None, data
+assert "pull_request" in triggers, triggers
+push = triggers.get("push") or {}
+branches = push.get("branches") or []
+assert "Develop" in branches, branches
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "actionlint workflow exposes a job that runs the actionlint binary" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+jobs = data["jobs"]
+# Single job with a recognisable name, e.g. "actionlint".
+assert "actionlint" in jobs, list(jobs)
+job = jobs["actionlint"]
+assert job["runs-on"] == "ubuntu-latest", job
+steps = job["steps"]
+runs = [s.get("run", "") for s in steps]
+# A step must actually invoke the actionlint binary (not just install it).
+assert any(
+    "actionlint" in r
+    and "curl" not in r
+    and "tar" not in r
+    and "sha256sum" not in r
+    and "install -m" not in r
+    for r in runs
+), runs
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "actionlint workflow pins third-party actions to commit SHAs" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+sha_re = re.compile(r"^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$")
+for step in data["jobs"]["actionlint"]["steps"]:
+    uses = step.get("uses")
+    if uses is None:
+        continue
+    assert sha_re.match(uses), f"action not SHA-pinned: {uses}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "actionlint workflow pins both version and SHA-256 for the CLI install" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["actionlint"]["steps"]
+install = [
+    s for s in steps
+    if isinstance(s.get("name"), str) and "install" in s["name"].lower()
+    and "actionlint" in s["name"].lower()
+]
+assert install, "Install actionlint step missing"
+step = install[0]
+env = step.get("env", {}) or {}
+# A pinned version env var and a sha256 env var must both be present.
+keys = {k.upper(): v for k, v in env.items()}
+version = keys.get("ACTIONLINT_VERSION") or keys.get("VERSION")
+sha256 = keys.get("ACTIONLINT_SHA256") or keys.get("SHA256")
+assert version, f"version env var missing: {env}"
+assert re.match(r"^\d+\.\d+\.\d+$", str(version)), version
+assert sha256, f"sha256 env var missing: {env}"
+assert re.match(r"^[0-9a-f]{64}$", str(sha256)), sha256
+# The run script must invoke sha256sum -c to verify the downloaded asset.
+run_script = step.get("run", "")
+assert "sha256sum" in run_script and "-c" in run_script, run_script
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Behavioural sanity check: if actionlint is installed locally, the workflows
+# in this repo must actually pass it. Skipped on machines without actionlint
+# so unit tests stay portable.
+@test "actionlint passes against the current workflows on disk" {
+  if ! command -v actionlint &>/dev/null; then
+    skip "actionlint not installed locally"
+  fi
+  cd "$REPO_ROOT"
+  # SC2016 is an intentional pattern in upgrade-dependencies.yml (literal echo
+  # strings inside a heredoc); the workflow ignores it via -ignore, so mirror
+  # that here for the local sanity check.
+  run actionlint -no-color -ignore 'SC2016' .github/workflows/actionlint.yml .github/workflows/ci.yml .github/workflows/gitleaks.yml .github/workflows/markdown-lint.yml .github/workflows/security.yml .github/workflows/semgrep.yml .github/workflows/upgrade-dependencies.yml .github/workflows/wasm-bundle.yml
+  echo "$output"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Adds a CI lint gate that runs `actionlint` against every GitHub Actions
workflow on every push to `Develop` and every pull request, so workflow
regressions fail the build. Closes #96.

The issue body claimed there were no workflows under `.github/workflows/`,
which is no longer accurate (the directory already contains seven
workflows). The substantive finding — that `actionlint` is never invoked
in CI — was correct and is what this PR fixes.

The new workflow installs the upstream `rhysd/actionlint` CLI from a
version-pinned release tarball with SHA-256 verification, mirroring the
hardened install pattern already used in `gitleaks.yml` (#99) and
`wasm-bundle.yml` (#78). The third-party `actions/checkout` ref is
SHA-pinned per the #77 policy.

A single `-ignore 'SC2016'` suppression filters a false-positive from
actionlint's bundled shellcheck integration on intentional single-quoted
echo strings inside `upgrade-dependencies.yml`. All other actionlint and
shellcheck diagnostics still fail the build.

## Evidence

CI-only change with no UI surface. Verified locally:

```text
$ actionlint -no-color -ignore 'SC2016' .github/workflows/*.yml
$ echo $?
0
```

```mermaid
flowchart LR
    PR[Pull Request] --> CI[CI workflow]
    PR --> ML[Markdown Lint]
    PR --> GL[Gitleaks]
    PR --> AL[Actionlint *new*]
    AL -->|fail| Block[Block merge]
    AL -->|pass| Allow[Allow merge]
```

## Test Plan

- Added `tests/scripts/actionlint_workflow.bats` with 7 behavioural tests
  covering workflow existence, valid YAML, triggers, job invocation of
  the binary, SHA-pinning of `uses:`, pinned `ACTIONLINT_VERSION` +
  `ACTIONLINT_SHA256` with `sha256sum -c` verification, and a local
  sanity gate that runs actionlint when installed.
- All seven tests pass locally.
- Existing `workflow_sha_pinning.bats` still passes for the new file.

## Pre-existing failures (out of scope)

`./quality.sh` reports five pre-existing bats failures already present
on `milestone/audit-issues` without this PR (concerning `ci.yml`
quarantine bypass and `upgrade-dependencies.yml` pinning
`taiki-e/install-action@v2`). They require their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)