### PR TITLE
ci(security): bump dependency-review-action to v5.0.0 (node24)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Dependency review (GitHub Advisory / license diff on PR)
         if: ${{ inputs.include-dependency-review && github.event_name == 'pull_request' }}
-        # actions/dependency-review-action@v4.9.0
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        # actions/dependency-review-action@v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
         with:
           comment-summary-in-pr: always

--- a/docs/archive/pr-summaries/pr-summary-100.md
+++ b/docs/archive/pr-summaries/pr-summary-100.md
@@ -1,0 +1,26 @@
+## Summary
+
+Bumped `actions/dependency-review-action` from v4.9.0 (node20, runtime EOL 2026-09-16) to v5.0.0 (node24) in `.github/workflows/security.yml`, and added the deprecated v4.9.0 SHA to the Node-runtime denylist in `tests/scripts/workflow_sha_pinning.bats` so the regression cannot reappear. Closes #100.
+
+The v4.9.0 release `action.yml` declares `using: 'node20'`; v5.0.0 declares `using: 'node24'` and requires Actions Runner v2.327.1+ (already available on GitHub-hosted runners).
+
+## Evidence
+
+CLI-only change — no UI to screenshot. Runtime declarations verified directly against the upstream `action.yml` files at each pinned SHA:
+
+- `2031cfc080254a8a887f58cffee85186f0e49e48` (v4.9.0) → `using: 'node20'` (deprecated)
+- `a1d282b36b6f3519aa1f3fc636f609c47dddb294` (v5.0.0) → `using: 'node24'` (current)
+
+```mermaid
+flowchart LR
+    Old["security.yml<br/>actions/dependency-review-action@v4.9.0<br/>2031cfc... (node20, EOL 2026-09-16)"]
+    New["security.yml<br/>actions/dependency-review-action@v5.0.0<br/>a1d282b... (node24)"]
+    Denylist["workflow_sha_pinning.bats<br/>DEPRECATED denylist<br/>(regression guard)"]
+    Old -->|"bump"| New
+    Old -.->|"added to"| Denylist
+```
+
+## Test Plan
+
+- `tests/scripts/workflow_sha_pinning.bats` — `no workflow uses an action pinned to a deprecated Node runtime` now also rejects the v4.9.0 SHA `2031cfc080254a8a887f58cffee85186f0e49e48`. The test passes with the bumped workflow and would fail if a future change re-introduced the old SHA.
+- Pre-existing failures in `quality.sh` (tests 31, 32, 33, 37, 78) are on the base branch and unrelated to this change — none reference `dependency-review-action`.

--- a/tests/scripts/workflow_sha_pinning.bats
+++ b/tests/scripts/workflow_sha_pinning.bats
@@ -133,6 +133,9 @@ DEPRECATED = {
     # Issue #99 replaced this with a direct CLI install in gitleaks.yml so
     # the workflow has no Node runtime at all.
     "ff98106e4c7b2bc287b24eaf42907196329070c7": "gitleaks/gitleaks-action@v2.3.9 (node20, EOL 2026-09-16)",
+    # actions/dependency-review-action@v4.9.0 — runs on Node 20 (action.yml
+    # declares using node20). Bumped to v5.0.0 (Node 24) for Issue #100.
+    "2031cfc080254a8a887f58cffee85186f0e49e48": "actions/dependency-review-action@v4.9.0 (node20, EOL 2026-09-16)",
 }
 uses_re = re.compile(r"uses:\s*([^\s#]+)")
 


### PR DESCRIPTION
## Summary

Bumped `actions/dependency-review-action` from v4.9.0 (node20, runtime EOL 2026-09-16) to v5.0.0 (node24) in `.github/workflows/security.yml`, and added the deprecated v4.9.0 SHA to the Node-runtime denylist in `tests/scripts/workflow_sha_pinning.bats` so the regression cannot reappear. Closes #100.

The v4.9.0 release `action.yml` declares `using: 'node20'`; v5.0.0 declares `using: 'node24'` and requires Actions Runner v2.327.1+ (already available on GitHub-hosted runners).

## Evidence

CLI-only change — no UI to screenshot. Runtime declarations verified directly against the upstream `action.yml` files at each pinned SHA:

- `2031cfc080254a8a887f58cffee85186f0e49e48` (v4.9.0) → `using: 'node20'` (deprecated)
- `a1d282b36b6f3519aa1f3fc636f609c47dddb294` (v5.0.0) → `using: 'node24'` (current)

```mermaid
flowchart LR
    Old["security.yml<br/>actions/dependency-review-action@v4.9.0<br/>2031cfc... (node20, EOL 2026-09-16)"]
    New["security.yml<br/>actions/dependency-review-action@v5.0.0<br/>a1d282b... (node24)"]
    Denylist["workflow_sha_pinning.bats<br/>DEPRECATED denylist<br/>(regression guard)"]
    Old -->|"bump"| New
    Old -.->|"added to"| Denylist
```

## Test Plan

- `tests/scripts/workflow_sha_pinning.bats` — `no workflow uses an action pinned to a deprecated Node runtime` now also rejects the v4.9.0 SHA `2031cfc080254a8a887f58cffee85186f0e49e48`. The test passes with the bumped workflow and would fail if a future change re-introduced the old SHA.
- Pre-existing failures in `quality.sh` (tests 31, 32, 33, 37, 78) are on the base branch and unrelated to this change — none reference `dependency-review-action`.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-100 -->