### PR TITLE
🟢 Add `repository` metadata to Cargo.toml workspace package (Issue #113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -132,9 +132,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "memchr"
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 version = "0.1.30"
 edition = "2024"
 license = "Apache-2.0"
+repository = "https://github.com/stSoftwareAU/NEAT-AI-core"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-113.md
+++ b/docs/archive/pr-summaries/pr-summary-113.md
@@ -1,0 +1,37 @@
+# Add `repository` metadata to Cargo workspace package (Issue #113)
+
+## Summary
+
+Completed the standard Rust API Guidelines (C-METADATA) metadata set by adding a
+`repository` field to the shared `[workspace.package]` table in the root
+`Cargo.toml`, and inheriting it in `neat-core/Cargo.toml` via
+`repository.workspace = true` (alongside the existing
+`version`/`edition`/`license` inheritances). Consumers, `cargo doc`, registry
+pages, and supply-chain provenance tooling can now mechanically locate the
+upstream source from the manifest. Closes #113.
+
+## Evidence
+
+Backend/manifest change — no web interface to screenshot. Verified by a new
+"what" test that asserts on the observable Cargo metadata (the `CARGO_PKG_*`
+values Cargo resolves from the manifest, including workspace inheritance):
+
+```
+running 2 tests
+test core_metadata_set_is_complete ... ok
+test repository_metadata_points_at_upstream_source ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+The three pre-existing `quality.sh` failures (BATS 31–33, concerning
+`ci.yml`/`bump-deps.sh`) are unrelated to this change — they reproduce on the
+clean base tree before any edit.
+
+## Test Plan
+
+- Added `neat-core/tests/package_metadata.rs`:
+  - `repository_metadata_points_at_upstream_source` — asserts
+    `CARGO_PKG_REPOSITORY` equals the upstream GitHub URL.
+  - `core_metadata_set_is_complete` — asserts `description`, `license`
+    (`Apache-2.0`) and `repository` are all present (C-METADATA completeness).

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "neat-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Shared computation library for NEAT-AI neural network operations. Optional wasm-bindgen on wasm32 only."
 
 [lints]

--- a/neat-core/tests/package_metadata.rs
+++ b/neat-core/tests/package_metadata.rs
@@ -1,0 +1,23 @@
+//! Issue #113 — verify the crate exposes complete C-METADATA metadata.
+//!
+//! Cargo populates `CARGO_PKG_*` environment variables from the resolved
+//! manifest (including workspace inheritance) at compile time. Asserting on
+//! them checks the observable outcome — what a registry, `cargo doc`, or a
+//! supply-chain provenance tool would read — rather than how the manifest is
+//! written.
+
+#[test]
+fn repository_metadata_points_at_upstream_source() {
+    assert_eq!(
+        env!("CARGO_PKG_REPOSITORY"),
+        "https://github.com/stSoftwareAU/NEAT-AI-core",
+    );
+}
+
+#[test]
+fn core_metadata_set_is_complete() {
+    // C-METADATA: description, license and repository must all be present.
+    assert!(!env!("CARGO_PKG_DESCRIPTION").is_empty());
+    assert_eq!(env!("CARGO_PKG_LICENSE"), "Apache-2.0");
+    assert!(!env!("CARGO_PKG_REPOSITORY").is_empty());
+}


### PR DESCRIPTION
# Add `repository` metadata to Cargo workspace package (Issue #113)

## Summary

Completed the standard Rust API Guidelines (C-METADATA) metadata set by adding a
`repository` field to the shared `[workspace.package]` table in the root
`Cargo.toml`, and inheriting it in `neat-core/Cargo.toml` via
`repository.workspace = true` (alongside the existing
`version`/`edition`/`license` inheritances). Consumers, `cargo doc`, registry
pages, and supply-chain provenance tooling can now mechanically locate the
upstream source from the manifest. Closes #113.

## Evidence

Backend/manifest change — no web interface to screenshot. Verified by a new
"what" test that asserts on the observable Cargo metadata (the `CARGO_PKG_*`
values Cargo resolves from the manifest, including workspace inheritance):

```
running 2 tests
test core_metadata_set_is_complete ... ok
test repository_metadata_points_at_upstream_source ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The three pre-existing `quality.sh` failures (BATS 31–33, concerning
`ci.yml`/`bump-deps.sh`) are unrelated to this change — they reproduce on the
clean base tree before any edit.

## Test Plan

- Added `neat-core/tests/package_metadata.rs`:
  - `repository_metadata_points_at_upstream_source` — asserts
    `CARGO_PKG_REPOSITORY` equals the upstream GitHub URL.
  - `core_metadata_set_is_complete` — asserts `description`, `license`
    (`Apache-2.0`) and `repository` are all present (C-METADATA completeness).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpwks03p-f95c78`<!-- vibe-worker-issue-113 -->