### PR TITLE
Add /// doc comments to public squash/range constants (Issue #114)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.31"
+version = "0.1.32"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-114.md
+++ b/docs/archive/pr-summaries/pr-summary-114.md
@@ -1,0 +1,50 @@
+# PR Summary — Issue #114
+
+## Summary
+
+Several `pub const` items in the public `squash` and `range` modules carried
+only ordinary `//` line comments, which rustdoc ignores, so they rendered in
+`cargo doc` with no explanation. This change promotes those comments to `///`
+rustdoc doc comments and adds one-line summaries where none existed. It also
+adds a `///` summary to the public `apply_limit_range_f64` function.
+
+Items documented:
+
+- `src/squash.rs`: `SELU_ALPHA`, `SELU_LAMBDA`, `GELU_COEFF`, `SQRT_2_OVER_PI`,
+  `LEAKY_RELU_ALPHA`, `JS_MAX_SAFE_INTEGER`, `SOFTSIGN_LIMIT`,
+  `TAN_OUTPUT_CLAMP`, `SQUARE_OUTPUT_CLAMP`, `CUBE_OUTPUT_CLAMP`.
+- `src/range.rs`: `GELU_MIN`, `SWISH_MIN`, `MISH_MIN`, `SOFTPLUS_MIN`,
+  `SOFTPLUS_MAX`, `F32_LARGE`, and the `apply_limit_range_f64` function.
+
+This is a documentation-only change to the public API surface — no runtime
+behaviour changes. Closes #114.
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verification:
+
+- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"` builds
+  cleanly — the doc comments now render for these items.
+- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets
+  --all-features -- -D warnings` pass.
+- The new behaviour test for the previously-untested public function passes.
+
+```mermaid
+flowchart LR
+    A["// line comment<br/>(invisible to rustdoc)"] --> B["/// doc comment"]
+    B --> C["renders in cargo doc"]
+```
+
+Note: `./quality.sh` halts early on four pre-existing `bats` failures in
+`tests/scripts` (CI `ci.yml`/`bump-deps.sh` workflow assertions, tests 31–33
+and 37). These fail identically on the unmodified base branch and are
+unrelated to this change; the Rust gate (fmt, clippy, check, tests, doc) was
+run directly and passes.
+
+## Test Plan
+
+- Added `neat-core/tests/range.rs::test_limit_range_f64_clamping` — exercises
+  the public `apply_limit_range_f64`: in-range pass-through, out-of-range
+  clamping, `NaN → 0.0`, bounded-range infinity clamping, and
+  unbounded-range infinity clamping to `±F32_LARGE` (stays finite).
+- Existing `tests/range.rs` and `tests/squash.rs` suites continue to pass.

--- a/neat-core/src/range.rs
+++ b/neat-core/src/range.rs
@@ -5,23 +5,24 @@
 
 use crate::squash::{SELU_ALPHA, SELU_LAMBDA, SOFTSIGN_LIMIT, SquashType};
 
-// Special range constants based on TypeScript implementations
-// GELU minimum occurs around x approx -0.509 with value approx -0.17
+// Special range constants based on TypeScript implementations.
+
+/// GELU minimum output (around `x ≈ -0.509`, value `≈ -0.17`).
 pub const GELU_MIN: f32 = -0.17;
 
-// Swish minimum occurs around x approx -1.278 with value approx -0.278
+/// Swish minimum output (around `x ≈ -1.278`, value `≈ -0.278`).
 pub const SWISH_MIN: f32 = -0.278;
 
-// Mish minimum occurs around x approx -1.19 with value approx -0.309
+/// Mish minimum output (around `x ≈ -1.19`, value `≈ -0.309`).
 pub const MISH_MIN: f32 = -0.309;
 
-// Softplus practical lower bound (small positive)
+/// Softplus practical lower bound (small positive).
 pub const SOFTPLUS_MIN: f32 = 1e-15;
 
-// Softplus practical upper bound (prevents overflow)
+/// Softplus practical upper bound (prevents overflow).
 pub const SOFTPLUS_MAX: f32 = 100.0;
 
-// Use f32::MAX as a practical "unbounded" value since we're in WASM/f32 space
+/// Practical "unbounded" magnitude (`f32::MAX`) for WASM/f32 ranges.
 pub const F32_LARGE: f32 = 3.4028235e38;
 
 /// Get the range (low, high) for an activation function
@@ -130,6 +131,11 @@ pub fn apply_limit_range(squash_type: SquashType, value: f32) -> f32 {
     value.max(low).min(high)
 }
 
+/// Clamp an `f64` value to the valid output range of `squash_type`.
+///
+/// `NaN` maps to `0.0`. Infinities are clamped to the activation's finite
+/// bounds, themselves capped at `±F32_LARGE` so the result never overflows
+/// back to infinity. The `f32` counterpart is [`apply_limit_range`].
 #[allow(dead_code)]
 #[inline(always)]
 pub fn apply_limit_range_f64(squash_type: SquashType, value: f64) -> f64 {

--- a/neat-core/src/squash.rs
+++ b/neat-core/src/squash.rs
@@ -3,28 +3,33 @@
 //! This module provides the squash function types and their implementations,
 //! matching the TypeScript activation functions in the NEAT-AI project.
 
-// SELU constants
+/// SELU scale parameter `alpha` (Klambauer et al., 2017).
 pub const SELU_ALPHA: f32 = 1.673_263_2;
+/// SELU scale parameter `lambda` (Klambauer et al., 2017).
 pub const SELU_LAMBDA: f32 = 1.050_701;
 
-// GELU constant
+/// GELU tanh-approximation cubic coefficient.
 pub const GELU_COEFF: f32 = 0.044715;
-pub const SQRT_2_OVER_PI: f32 = 0.797_884_6; // sqrt(2/pi)
+/// GELU tanh-approximation scale factor `sqrt(2/pi)`.
+pub const SQRT_2_OVER_PI: f32 = 0.797_884_6;
 
-// LeakyReLU alpha
+/// LeakyReLU negative-slope coefficient `alpha`.
 pub const LEAKY_RELU_ALPHA: f32 = 0.01;
 
-// Match the JS implementation's practical clamp for very large one-sided outputs.
-// JS uses Number.MAX_SAFE_INTEGER (~9.007e15) as an upper bound for several
-// activations (e.g. Exponential).
+/// Practical upper bound for very large one-sided outputs (e.g. Exponential).
+///
+/// Matches the JS implementation, which uses `Number.MAX_SAFE_INTEGER`
+/// (~9.007e15) as the upper bound for several unbounded activations.
 pub const JS_MAX_SAFE_INTEGER: f32 = 9_007_199_254_740_992.0;
 
-// Softsign approaches but never reaches +/-1
+/// Softsign output limit — the function approaches but never reaches `±1`.
 pub const SOFTSIGN_LIMIT: f32 = 0.99;
 
-// Output clamps for unbounded activations (#2151)
+/// Output clamp for the unbounded Tan activation near its asymptotes (#2151).
 pub const TAN_OUTPUT_CLAMP: f64 = 1000.0;
+/// Output clamp for the unbounded Square activation (#2151).
 pub const SQUARE_OUTPUT_CLAMP: f64 = 1e6;
+/// Output clamp for the unbounded Cube activation (#2151).
 pub const CUBE_OUTPUT_CLAMP: f64 = 1e6;
 
 /// Squash function identifiers - must match TypeScript enum

--- a/neat-core/tests/range.rs
+++ b/neat-core/tests/range.rs
@@ -1,5 +1,6 @@
 //! Range validation tests (moved from `src/range.rs`).
 
+use neat_core::range::apply_limit_range_f64;
 use neat_core::{SquashType, apply_get_range, apply_limit_range, apply_validate_range};
 
 #[test]
@@ -180,6 +181,39 @@ fn test_limit_range_clamping() {
 
     // NaN should return 0
     assert_eq!(apply_limit_range(SquashType::Logistic, f32::NAN), 0.0);
+}
+
+#[test]
+fn test_limit_range_f64_clamping() {
+    // Values within range pass through unchanged.
+    assert_eq!(apply_limit_range_f64(SquashType::Logistic, 0.5), 0.5);
+    assert_eq!(apply_limit_range_f64(SquashType::Tanh, 0.0), 0.0);
+
+    // Out-of-range values are clamped to the activation bounds.
+    assert_eq!(apply_limit_range_f64(SquashType::Logistic, -0.5), 0.0);
+    assert_eq!(apply_limit_range_f64(SquashType::Logistic, 1.5), 1.0);
+    assert_eq!(apply_limit_range_f64(SquashType::Relu6, 10.0), 6.0);
+
+    // NaN maps to 0.
+    assert_eq!(apply_limit_range_f64(SquashType::Logistic, f64::NAN), 0.0);
+
+    // Bounded ranges clamp infinities to the finite bounds.
+    assert_eq!(
+        apply_limit_range_f64(SquashType::Logistic, f64::INFINITY),
+        1.0
+    );
+    assert_eq!(
+        apply_limit_range_f64(SquashType::Logistic, f64::NEG_INFINITY),
+        0.0
+    );
+
+    // Unbounded ranges clamp infinities to ±F32_LARGE (no overflow to inf).
+    let hi = apply_limit_range_f64(SquashType::Identity, f64::INFINITY);
+    assert!(hi.is_finite(), "Identity +inf should be finite");
+    assert!(hi > 1e30, "Identity +inf should clamp to a large positive");
+    let lo = apply_limit_range_f64(SquashType::Identity, f64::NEG_INFINITY);
+    assert!(lo.is_finite(), "Identity -inf should be finite");
+    assert!(lo < -1e30, "Identity -inf should clamp to a large negative");
 }
 
 #[test]


### PR DESCRIPTION
# PR Summary — Issue #114

## Summary

Several `pub const` items in the public `squash` and `range` modules carried
only ordinary `//` line comments, which rustdoc ignores, so they rendered in
`cargo doc` with no explanation. This change promotes those comments to `///`
rustdoc doc comments and adds one-line summaries where none existed. It also
adds a `///` summary to the public `apply_limit_range_f64` function.

Items documented:

- `src/squash.rs`: `SELU_ALPHA`, `SELU_LAMBDA`, `GELU_COEFF`, `SQRT_2_OVER_PI`,
  `LEAKY_RELU_ALPHA`, `JS_MAX_SAFE_INTEGER`, `SOFTSIGN_LIMIT`,
  `TAN_OUTPUT_CLAMP`, `SQUARE_OUTPUT_CLAMP`, `CUBE_OUTPUT_CLAMP`.
- `src/range.rs`: `GELU_MIN`, `SWISH_MIN`, `MISH_MIN`, `SOFTPLUS_MIN`,
  `SOFTPLUS_MAX`, `F32_LARGE`, and the `apply_limit_range_f64` function.

This is a documentation-only change to the public API surface — no runtime
behaviour changes. Closes #114.

## Evidence

Backend/library change with no web interface to screenshot. Verification:

- `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"` builds
  cleanly — the doc comments now render for these items.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets
  --all-features -- -D warnings` pass.
- The new behaviour test for the previously-untested public function passes.

```mermaid
flowchart LR
    A["// line comment<br/>(invisible to rustdoc)"] --> B["/// doc comment"]
    B --> C["renders in cargo doc"]
```

Note: `./quality.sh` halts early on four pre-existing `bats` failures in
`tests/scripts` (CI `ci.yml`/`bump-deps.sh` workflow assertions, tests 31–33
and 37). These fail identically on the unmodified base branch and are
unrelated to this change; the Rust gate (fmt, clippy, check, tests, doc) was
run directly and passes.

## Test Plan

- Added `neat-core/tests/range.rs::test_limit_range_f64_clamping` — exercises
  the public `apply_limit_range_f64`: in-range pass-through, out-of-range
  clamping, `NaN → 0.0`, bounded-range infinity clamping, and
  unbounded-range infinity clamping to `±F32_LARGE` (stays finite).
- Existing `tests/range.rs` and `tests/squash.rs` suites continue to pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpwiccaa-f5679b`<!-- vibe-worker-issue-114 -->