### PR TITLE
Use a typed error instead of `Result<_, String>` for public creature/network APIs (Issue #115)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.31"
+version = "0.1.32"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-115.md
+++ b/docs/archive/pr-summaries/pr-summary-115.md
@@ -1,0 +1,84 @@
+# Use typed errors instead of `Result<_, String>` for public creature/network APIs
+
+## Summary
+
+Replaced the stringly-typed `Result<_, String>` returns on the public,
+crate-root re-exported creature/network APIs with custom error types that
+implement `std::error::Error`. This mirrors the existing `TrainingDataError` /
+`DecodeError` idiom already on the same public surface, so callers can match on
+the failure by variant, traverse the `source()` chain, and `?`-propagate into
+their own error type (Rust API Guidelines C-GOOD-ERR). Closes #115.
+
+Three error types were introduced:
+
+| Type | Module | Replaces `String` on |
+| --- | --- | --- |
+| `CreatureError` | `creature.rs` | `parse_squash_name`, `parse_creature_json`, `creature_to_json`, `creature_to_json_pretty`, `compile_creature` |
+| `NetworkError` | `network.rs` | `CompiledNetwork::new` |
+| `PcEngineError` | `pc_inference.rs` | `PredictiveCodingEngine::new` |
+
+`CreatureError::Json` wraps the underlying `serde_json::Error` and exposes it via
+`Error::source()`, so a JSON parse failure stays programmatically distinguishable
+from a structural compile failure (`UnknownSquash`, `UnknownSourceUuid`,
+`OutputCountMismatch`). All three types are re-exported from the crate root.
+
+`CompiledNetwork::new` and `PredictiveCodingEngine::new` are
+`#[wasm_bindgen(constructor)]` on `wasm32`, which requires the error type to
+convert into `JsValue`. Each error type therefore has a `cfg(wasm32)`-gated
+`From<…> for JsValue` impl that preserves the human-readable message. The
+`wasm32-unknown-unknown` build was verified to still compile.
+
+### Error-flow overview
+
+```mermaid
+flowchart LR
+    A[caller] -->|"?"| B[parse_creature_json]
+    B -->|serde_json::Error| C["CreatureError::Json<br/>(source = serde_json::Error)"]
+    A -->|"?"| D[compile_creature]
+    D --> E["CreatureError::UnknownSquash<br/>UnknownSourceUuid<br/>OutputCountMismatch"]
+    C --> F["impl std::error::Error<br/>+ Display + From"]
+    E --> F
+    F -->|wasm32 only| G["From&lt;…&gt; for JsValue"]
+```
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+test suite and toolchain checks:
+
+- `cargo test --workspace` — all suites green (incl. the new `typed_errors`
+  suite and the updated `creature_compile` assertions).
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`,
+  `RUSTDOCFLAGS="-D warnings" cargo doc` — clean.
+- `cargo build -p neat-core --target wasm32-unknown-unknown` — compiles, so the
+  `#[wasm_bindgen(constructor)]` error conversions are intact.
+
+### Deno regression avoided
+
+Not applicable — this is a Rust-only crate with no Deno tooling.
+
+## Test Plan
+
+New `neat-core/tests/typed_errors.rs` (8 tests) exercises the new contract via
+real calls and observable outcomes:
+
+- `parse_creature_json_error_is_std_error_with_serde_source` — error is a
+  `CreatureError::Json` whose `source()` downcasts to `serde_json::Error`.
+- `parse_squash_name_unknown_returns_typed_variant` — `UnknownSquash` variant,
+  no source chain.
+- `compile_creature_output_mismatch_returns_typed_variant` — `OutputCountMismatch
+  { expected, found }` carries the structured counts.
+- `compile_creature_unknown_source_uuid_returns_typed_variant` — `UnknownSourceUuid`
+  carries the offending UUID.
+- `creature_round_trip_helpers_return_ok` — `creature_to_json` /
+  `creature_to_json_pretty` return `Result<String, CreatureError>`.
+- `creature_error_propagates_via_question_mark` — `CreatureError` `?`-propagates
+  into a caller's `Box<dyn Error>`.
+- `compiled_network_new_truncated_returns_typed_error` /
+  `pc_engine_new_truncated_returns_typed_error` — truncated buffers yield
+  `TruncatedData`, which implements `std::error::Error`.
+
+Updated (business-logic change, documented): two assertions in
+`neat-core/tests/creature_compile.rs` that previously called `.contains(...)`
+directly on a `String` error now call `.to_string().contains(...)` on the typed
+error's preserved `Display` message. No existing tests were removed or disabled.

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -81,11 +81,67 @@ pub struct SynapseExport {
     pub synapse_type: Option<String>,
 }
 
+/// Errors that can occur when parsing, serialising, or compiling a creature.
+///
+/// Replaces the previous `Result<_, String>` returns on the public creature
+/// API (Issue #115). Mirrors the existing [`crate::training_data::TrainingDataError`]
+/// idiom: implements [`std::error::Error`], can be matched on by variant, and
+/// preserves the underlying [`serde_json::Error`] as the error `source()` so
+/// callers can `?`-propagate into their own error type and programmatically
+/// distinguish a JSON failure from a structural compile failure.
+#[derive(Debug)]
+pub enum CreatureError {
+    /// JSON (de)serialisation failed. Exposes the underlying
+    /// [`serde_json::Error`] via [`std::error::Error::source`].
+    Json(serde_json::Error),
+    /// An activation/squash function name was not recognised.
+    UnknownSquash(String),
+    /// A synapse referenced a source neuron UUID that does not exist.
+    UnknownSourceUuid(String),
+    /// The declared output count did not match the number of output neurons found.
+    OutputCountMismatch {
+        /// Output count declared by `CreatureExport::output`.
+        expected: usize,
+        /// Number of neurons of type `"output"` actually present.
+        found: usize,
+    },
+}
+
+impl std::fmt::Display for CreatureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreatureError::Json(e) => write!(f, "Creature JSON error: {e}"),
+            CreatureError::UnknownSquash(name) => write!(f, "Unknown squash function: {name}"),
+            CreatureError::UnknownSourceUuid(uuid) => {
+                write!(f, "Unknown source neuron UUID: {uuid}")
+            }
+            CreatureError::OutputCountMismatch { expected, found } => {
+                write!(f, "Expected {expected} output neurons, found {found}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CreatureError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreatureError::Json(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for CreatureError {
+    fn from(e: serde_json::Error) -> Self {
+        CreatureError::Json(e)
+    }
+}
+
 /// Parse a squash function name string into a `SquashType` enum value.
 ///
 /// Handles all activation function names from the TypeScript codebase,
 /// including aliases (CLIPPED, RELU, INVERSE, SINUSOID).
-pub fn parse_squash_name(name: &str) -> Result<SquashType, String> {
+pub fn parse_squash_name(name: &str) -> Result<SquashType, CreatureError> {
     match name {
         "IDENTITY" => Ok(SquashType::Identity),
         "ReLU" | "RELU" => Ok(SquashType::Relu),
@@ -125,7 +181,7 @@ pub fn parse_squash_name(name: &str) -> Result<SquashType, String> {
         "HYPOT" => Ok(SquashType::Hypotenuse),
         "HYPOTv2" => Ok(SquashType::HypotenuseV2),
         "MEAN" => Ok(SquashType::Mean),
-        _ => Err(format!("Unknown squash function: {name}")),
+        _ => Err(CreatureError::UnknownSquash(name.to_string())),
     }
 }
 
@@ -212,8 +268,8 @@ pub fn synapse_type_name_from(ty: SynapseType) -> Option<&'static str> {
 }
 
 /// Parse a creature JSON string into a `CreatureExport` struct.
-pub fn parse_creature_json(json: &str) -> Result<CreatureExport, String> {
-    serde_json::from_str(json).map_err(|e| format!("Failed to parse creature JSON: {e}"))
+pub fn parse_creature_json(json: &str) -> Result<CreatureExport, CreatureError> {
+    Ok(serde_json::from_str(json)?)
 }
 
 /// Serialise a [`CreatureExport`] to canonical JSON text.
@@ -221,14 +277,13 @@ pub fn parse_creature_json(json: &str) -> Result<CreatureExport, String> {
 /// Output is deterministic: fields are emitted in struct declaration order,
 /// so two calls with the same input produce byte-identical output. This is
 /// the symmetric counterpart to [`parse_creature_json`].
-pub fn creature_to_json(creature: &CreatureExport) -> Result<String, String> {
-    serde_json::to_string(creature).map_err(|e| format!("Failed to serialise creature JSON: {e}"))
+pub fn creature_to_json(creature: &CreatureExport) -> Result<String, CreatureError> {
+    Ok(serde_json::to_string(creature)?)
 }
 
 /// Pretty-printed variant of [`creature_to_json`].
-pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, String> {
-    serde_json::to_string_pretty(creature)
-        .map_err(|e| format!("Failed to serialise creature JSON: {e}"))
+pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, CreatureError> {
+    Ok(serde_json::to_string_pretty(creature)?)
 }
 
 /// Convert a `CreatureExport` into a `CompiledNetwork` for activation.
@@ -238,7 +293,7 @@ pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, Stri
 /// 2. Maps neuron UUIDs to their indices
 /// 3. Resolves synapse UUID references to index-based connections
 /// 4. Maps squash function names and synapse type strings to enum values
-pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, String> {
+pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, CreatureError> {
     let num_inputs = creature.input;
     let num_outputs = creature.output;
 
@@ -258,9 +313,10 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, St
         }
     }
     if output_count != num_outputs {
-        return Err(format!(
-            "Expected {num_outputs} output neurons, found {output_count}"
-        ));
+        return Err(CreatureError::OutputCountMismatch {
+            expected: num_outputs,
+            found: output_count,
+        });
     }
 
     // Assign indices to non-input neurons (they follow input neurons)
@@ -297,7 +353,7 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, St
             for syn in neuron_syn {
                 let from_index = *uuid_to_index
                     .get(syn.from_uuid.as_str())
-                    .ok_or_else(|| format!("Unknown source neuron UUID: {}", syn.from_uuid))?;
+                    .ok_or_else(|| CreatureError::UnknownSourceUuid(syn.from_uuid.clone()))?;
                 let synapse_type = parse_synapse_type(syn.synapse_type.as_deref());
 
                 synapses.push(SynapseData {

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -41,12 +41,12 @@ pub mod wasm_exports;
 
 // Re-export key types for convenience
 pub use creature::{
-    CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
+    CreatureError, CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
     creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
     squash_name_from, synapse_type_name_from,
 };
-pub use network::{CompiledNetwork, NeuronData, SynapseData};
-pub use pc_inference::PredictiveCodingEngine;
+pub use network::{CompiledNetwork, NetworkError, NeuronData, SynapseData};
+pub use pc_inference::{PcEngineError, PredictiveCodingEngine};
 pub use squash::SquashType;
 pub use synapse_type::SynapseType;
 pub use training_data::{

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -19,6 +19,41 @@ use crate::synapse_type::SynapseType;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+/// Errors that can occur when constructing a [`CompiledNetwork`] from serialised bytes.
+///
+/// Replaces the previous `Result<_, String>` return on [`CompiledNetwork::new`]
+/// (Issue #115). Implements [`std::error::Error`] so callers can `?`-propagate
+/// and match on the failure by variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkError {
+    /// The serialised buffer was truncated before a required section could be read.
+    TruncatedData {
+        /// The section that could not be read in full ("header", "neuron", or "synapse").
+        section: &'static str,
+    },
+}
+
+impl std::fmt::Display for NetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NetworkError::TruncatedData { section } => {
+                write!(f, "Data too short for {section}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NetworkError {}
+
+// On `wasm32`, `CompiledNetwork::new` is a `#[wasm_bindgen(constructor)]`, which
+// requires the error type to convert into a `JsValue`.
+#[cfg(target_arch = "wasm32")]
+impl From<NetworkError> for wasm_bindgen::JsValue {
+    fn from(err: NetworkError) -> Self {
+        wasm_bindgen::JsValue::from_str(&err.to_string())
+    }
+}
+
 /// Neuron data structure for cache-efficient access
 /// Issue #1175 - Use typed structs instead of tuples for neuron/synapse data
 #[derive(Clone, Copy)]
@@ -128,9 +163,9 @@ impl CompiledNetwork {
     ///     - u8: padding
     ///     - f64: weight
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
-    pub fn new(data: &[u8]) -> Result<CompiledNetwork, String> {
+    pub fn new(data: &[u8]) -> Result<CompiledNetwork, NetworkError> {
         if data.len() < 8 {
-            return Err("Data too short for header".to_string());
+            return Err(NetworkError::TruncatedData { section: "header" });
         }
 
         let num_neurons = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
@@ -144,7 +179,7 @@ impl CompiledNetwork {
         for _ in num_inputs..num_neurons {
             // Neuron header is 12 bytes with f64 bias.
             if offset + 12 > data.len() {
-                return Err("Data too short for neuron".to_string());
+                return Err(NetworkError::TruncatedData { section: "neuron" });
             }
 
             let bias = f64::from_le_bytes([
@@ -167,7 +202,7 @@ impl CompiledNetwork {
             for _ in 0..num_synapse {
                 // Synapse record is 12 bytes with f64 weight.
                 if offset + 12 > data.len() {
-                    return Err("Data too short for synapse".to_string());
+                    return Err(NetworkError::TruncatedData { section: "synapse" });
                 }
 
                 let from_index = u16::from_le_bytes([data[offset], data[offset + 1]]) as u32;

--- a/neat-core/src/pc_inference.rs
+++ b/neat-core/src/pc_inference.rs
@@ -23,6 +23,42 @@ use crate::squash::{SquashType, apply_squash};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+/// Errors that can occur when constructing a [`PredictiveCodingEngine`] from
+/// serialised bytes.
+///
+/// Replaces the previous `Result<_, String>` return on
+/// [`PredictiveCodingEngine::new`] (Issue #115). Implements
+/// [`std::error::Error`] so callers can `?`-propagate and match on the failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PcEngineError {
+    /// The serialised buffer was truncated before a required section could be read.
+    TruncatedData {
+        /// The section that could not be read in full ("header", "neuron", or "connection").
+        section: &'static str,
+    },
+}
+
+impl std::fmt::Display for PcEngineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PcEngineError::TruncatedData { section } => {
+                write!(f, "Data too short for PC {section}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PcEngineError {}
+
+// On `wasm32`, `PredictiveCodingEngine::new` is a `#[wasm_bindgen(constructor)]`,
+// which requires the error type to convert into a `JsValue`.
+#[cfg(target_arch = "wasm32")]
+impl From<PcEngineError> for wasm_bindgen::JsValue {
+    fn from(err: PcEngineError) -> Self {
+        wasm_bindgen::JsValue::from_str(&err.to_string())
+    }
+}
+
 /// Neuron definition for the predictive coding engine.
 /// Represents the topology of a single non-input neuron.
 #[derive(Clone, Debug)]
@@ -370,9 +406,9 @@ impl PredictiveCodingEngine {
     ///     - u16: from_index
     ///     - f32: weight (as 4 bytes, little-endian)
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
-    pub fn new(data: &[u8]) -> Result<PredictiveCodingEngine, String> {
+    pub fn new(data: &[u8]) -> Result<PredictiveCodingEngine, PcEngineError> {
         if data.len() < 24 {
-            return Err("Data too short for PC engine header".to_string());
+            return Err(PcEngineError::TruncatedData { section: "header" });
         }
 
         let num_inputs = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
@@ -389,7 +425,7 @@ impl PredictiveCodingEngine {
 
         for _ in 0..num_non_inputs {
             if offset + 8 > data.len() {
-                return Err("Data too short for PC neuron".to_string());
+                return Err(PcEngineError::TruncatedData { section: "neuron" });
             }
 
             let bias = f32::from_le_bytes([
@@ -407,7 +443,9 @@ impl PredictiveCodingEngine {
 
             for _ in 0..num_conn {
                 if offset + 6 > data.len() {
-                    return Err("Data too short for PC connection".to_string());
+                    return Err(PcEngineError::TruncatedData {
+                        section: "connection",
+                    });
                 }
 
                 let from = u16::from_le_bytes([data[offset], data[offset + 1]]) as usize;

--- a/neat-core/tests/creature_compile.rs
+++ b/neat-core/tests/creature_compile.rs
@@ -405,8 +405,10 @@ fn test_compile_creature_output_count_mismatch() {
         }"#;
 
     let creature = parse_creature_json(json).unwrap();
+    // Issue #115: compile_creature now returns a typed CreatureError; assert on
+    // the Display message (preserved) rather than a bare String.
     let err = compile_creature(&creature).err().expect("should fail");
-    assert!(err.contains("Expected 2 output neurons"));
+    assert!(err.to_string().contains("Expected 2 output neurons"));
 }
 
 #[test]
@@ -423,8 +425,9 @@ fn test_compile_creature_unknown_source_uuid() {
         }"#;
 
     let creature = parse_creature_json(json).unwrap();
+    // Issue #115: typed CreatureError; assert on the preserved Display message.
     let err = compile_creature(&creature).err().expect("should fail");
-    assert!(err.contains("Unknown source neuron UUID"));
+    assert!(err.to_string().contains("Unknown source neuron UUID"));
 }
 
 #[test]

--- a/neat-core/tests/typed_errors.rs
+++ b/neat-core/tests/typed_errors.rs
@@ -1,0 +1,139 @@
+//! Typed-error contract tests for the public creature/network APIs (Issue #115).
+//!
+//! These verify that the crate-root functions which previously returned
+//! `Result<_, String>` now return custom error types implementing
+//! `std::error::Error`, can be matched on by variant, and preserve the
+//! underlying `serde_json::Error` as a `source()` chain.
+
+use std::error::Error;
+
+use neat_core::{
+    CompiledNetwork, CreatureError, NetworkError, PcEngineError, PredictiveCodingEngine,
+    compile_creature, creature_to_json, creature_to_json_pretty, parse_creature_json,
+    parse_squash_name,
+};
+
+/// A valid minimal creature: 1 input, 1 output, single synapse.
+fn minimal_creature_json() -> &'static str {
+    r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+        ]
+    }"#
+}
+
+#[test]
+fn parse_creature_json_error_is_std_error_with_serde_source() {
+    let err = parse_creature_json("{ not valid json").unwrap_err();
+    // Matches on a typed variant rather than inspecting a String.
+    assert!(matches!(err, CreatureError::Json(_)));
+    // The underlying serde_json::Error is preserved as the error source.
+    let source = err.source().expect("Json variant must expose a source");
+    assert!(source.downcast_ref::<serde_json::Error>().is_some());
+}
+
+#[test]
+fn parse_squash_name_unknown_returns_typed_variant() {
+    let err = parse_squash_name("NOT_A_REAL_SQUASH").unwrap_err();
+    match err {
+        CreatureError::UnknownSquash(name) => assert_eq!(name, "NOT_A_REAL_SQUASH"),
+        other => panic!("expected UnknownSquash, got {other:?}"),
+    }
+    // Unknown squash is a structural failure, not a JSON failure: no source chain.
+    assert!(
+        CreatureError::UnknownSquash("x".to_string())
+            .source()
+            .is_none()
+    );
+}
+
+#[test]
+fn compile_creature_output_mismatch_returns_typed_variant() {
+    let json = r#"{
+        "input": 1,
+        "output": 2,
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+        ],
+        "synapses": []
+    }"#;
+    let creature = parse_creature_json(json).unwrap();
+    let err = compile_creature(&creature).err().expect("should fail");
+    match err {
+        CreatureError::OutputCountMismatch { expected, found } => {
+            assert_eq!(expected, 2);
+            assert_eq!(found, 1);
+        }
+        other => panic!("expected OutputCountMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn compile_creature_unknown_source_uuid_returns_typed_variant() {
+    let json = r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY"}
+        ],
+        "synapses": [
+            {"fromUUID": "nonexistent", "toUUID": "output-0", "weight": 1.0}
+        ]
+    }"#;
+    let creature = parse_creature_json(json).unwrap();
+    let err = compile_creature(&creature).err().expect("should fail");
+    match err {
+        CreatureError::UnknownSourceUuid(uuid) => assert_eq!(uuid, "nonexistent"),
+        other => panic!("expected UnknownSourceUuid, got {other:?}"),
+    }
+}
+
+#[test]
+fn creature_round_trip_helpers_return_ok() {
+    let creature = parse_creature_json(minimal_creature_json()).unwrap();
+    // Serialisation helpers return Result<String, CreatureError> and succeed here.
+    let compact: Result<String, CreatureError> = creature_to_json(&creature);
+    let pretty: Result<String, CreatureError> = creature_to_json_pretty(&creature);
+    assert!(compact.unwrap().contains("\"input\":1"));
+    assert!(pretty.unwrap().contains("\"input\""));
+}
+
+#[test]
+fn creature_error_propagates_via_question_mark() {
+    // A caller with its own Box<dyn Error> can `?`-propagate a CreatureError.
+    fn parse(json: &str) -> Result<usize, Box<dyn Error>> {
+        let creature = parse_creature_json(json)?;
+        Ok(creature.input)
+    }
+    assert_eq!(parse(minimal_creature_json()).unwrap(), 1);
+    assert!(parse("{ broken").is_err());
+}
+
+#[test]
+fn compiled_network_new_truncated_returns_typed_error() {
+    // Buffer too short for the 8-byte header. `CompiledNetwork` is not `Debug`,
+    // so extract the error via `.err()` rather than `unwrap_err()`.
+    let err: NetworkError = CompiledNetwork::new(&[0u8; 4]).err().expect("should fail");
+    assert!(matches!(err, NetworkError::TruncatedData { .. }));
+    // Display preserves a human-readable description.
+    assert!(err.to_string().contains("too short"));
+    // Implements std::error::Error.
+    let _as_err: &dyn Error = &err;
+}
+
+#[test]
+fn pc_engine_new_truncated_returns_typed_error() {
+    // Buffer too short for the 24-byte PC header. `PredictiveCodingEngine` is
+    // not `Debug`, so extract the error via `.err()`.
+    let err: PcEngineError = PredictiveCodingEngine::new(&[0u8; 8])
+        .err()
+        .expect("should fail");
+    assert!(matches!(err, PcEngineError::TruncatedData { .. }));
+    assert!(err.to_string().contains("too short"));
+    let _as_err: &dyn Error = &err;
+}


### PR DESCRIPTION
# Use typed errors instead of `Result<_, String>` for public creature/network APIs

## Summary

Replaced the stringly-typed `Result<_, String>` returns on the public,
crate-root re-exported creature/network APIs with custom error types that
implement `std::error::Error`. This mirrors the existing `TrainingDataError` /
`DecodeError` idiom already on the same public surface, so callers can match on
the failure by variant, traverse the `source()` chain, and `?`-propagate into
their own error type (Rust API Guidelines C-GOOD-ERR). Closes #115.

Three error types were introduced:

| Type | Module | Replaces `String` on |
| --- | --- | --- |
| `CreatureError` | `creature.rs` | `parse_squash_name`, `parse_creature_json`, `creature_to_json`, `creature_to_json_pretty`, `compile_creature` |
| `NetworkError` | `network.rs` | `CompiledNetwork::new` |
| `PcEngineError` | `pc_inference.rs` | `PredictiveCodingEngine::new` |

`CreatureError::Json` wraps the underlying `serde_json::Error` and exposes it via
`Error::source()`, so a JSON parse failure stays programmatically distinguishable
from a structural compile failure (`UnknownSquash`, `UnknownSourceUuid`,
`OutputCountMismatch`). All three types are re-exported from the crate root.

`CompiledNetwork::new` and `PredictiveCodingEngine::new` are
`#[wasm_bindgen(constructor)]` on `wasm32`, which requires the error type to
convert into `JsValue`. Each error type therefore has a `cfg(wasm32)`-gated
`From<…> for JsValue` impl that preserves the human-readable message. The
`wasm32-unknown-unknown` build was verified to still compile.

### Error-flow overview

```mermaid
flowchart LR
    A[caller] -->|"?"| B[parse_creature_json]
    B -->|serde_json::Error| C["CreatureError::Json<br/>(source = serde_json::Error)"]
    A -->|"?"| D[compile_creature]
    D --> E["CreatureError::UnknownSquash<br/>UnknownSourceUuid<br/>OutputCountMismatch"]
    C --> F["impl std::error::Error<br/>+ Display + From"]
    E --> F
    F -->|wasm32 only| G["From&lt;…&gt; for JsValue"]
```

## Evidence

Backend/library change only — no web interface to screenshot. Verified via the
test suite and toolchain checks:

- `cargo test --workspace` — all suites green (incl. the new `typed_errors`
  suite and the updated `creature_compile` assertions).
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`,
  `RUSTDOCFLAGS="-D warnings" cargo doc` — clean.
- `cargo build -p neat-core --target wasm32-unknown-unknown` — compiles, so the
  `#[wasm_bindgen(constructor)]` error conversions are intact.

### Deno regression avoided

Not applicable — this is a Rust-only crate with no Deno tooling.

## Test Plan

New `neat-core/tests/typed_errors.rs` (8 tests) exercises the new contract via
real calls and observable outcomes:

- `parse_creature_json_error_is_std_error_with_serde_source` — error is a
  `CreatureError::Json` whose `source()` downcasts to `serde_json::Error`.
- `parse_squash_name_unknown_returns_typed_variant` — `UnknownSquash` variant,
  no source chain.
- `compile_creature_output_mismatch_returns_typed_variant` — `OutputCountMismatch
  { expected, found }` carries the structured counts.
- `compile_creature_unknown_source_uuid_returns_typed_variant` — `UnknownSourceUuid`
  carries the offending UUID.
- `creature_round_trip_helpers_return_ok` — `creature_to_json` /
  `creature_to_json_pretty` return `Result<String, CreatureError>`.
- `creature_error_propagates_via_question_mark` — `CreatureError` `?`-propagates
  into a caller's `Box<dyn Error>`.
- `compiled_network_new_truncated_returns_typed_error` /
  `pc_engine_new_truncated_returns_typed_error` — truncated buffers yield
  `TruncatedData`, which implements `std::error::Error`.

Updated (business-logic change, documented): two assertions in
`neat-core/tests/creature_compile.rs` that previously called `.contains(...)`
directly on a `String` error now call `.to_string().contains(...)` on the typed
error's preserved `Display` message. No existing tests were removed or disabled.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpwks03p-f95c78`<!-- vibe-worker-issue-115 -->