### PR TITLE
Add // SAFETY: comments to SIMD dispatch unsafe blocks (Issue #112)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.32"
+version = "0.1.33"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-112.md
+++ b/docs/archive/pr-summaries/pr-summary-112.md
@@ -1,0 +1,44 @@
+## Summary
+
+Added `// SAFETY:` comments to the four SIMD dispatch `unsafe` blocks in
+`neat-core/src/simd_native.rs`. Each comment names the runtime feature-detection
+guard (`is_x86_feature_detected!` / `is_aarch64_feature_detected!`) that proves
+the corresponding `#[target_feature(...)]` precondition documented on the callee,
+recording the soundness proof next to the code it protects. This is a
+documentation-only change — no behaviour, control flow, or generated code is
+affected. Closes #112.
+
+The four blocks updated:
+
+| Dispatch | Guard | Callee precondition |
+|----------|-------|---------------------|
+| 8-record AVX2 | `is_x86_feature_detected!("avx2")` | `#[target_feature(enable = "avx2")]` |
+| 8-record NEON | `is_aarch64_feature_detected!("neon")` | `#[target_feature(enable = "neon")]` |
+| 4-record FMA  | `is_x86_feature_detected!("fma")` | `#[target_feature(enable = "fma")]` |
+| 4-record NEON | `is_aarch64_feature_detected!("neon")` | `#[target_feature(enable = "neon")]` |
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verified by:
+
+- `cargo fmt --all -- --check` — clean (exit 0).
+- `cargo clippy --workspace --all-targets` — no warnings.
+- `cargo test --package neat-core simd_native` — `native_4_matches_scalar_small`
+  and `native_8_matches_scalar_small` pass, confirming the SIMD dispatch paths
+  still produce results matching the scalar reference.
+
+Each comment's `#[target_feature]` text was cross-checked against the actual
+attributes on the callee functions (lines 81, 124, 163, 212) to ensure accuracy.
+
+Note: `quality.sh` reports four pre-existing failures (tests 31, 32, 33, 37)
+relating to `ci.yml`/`bump-deps.sh`. These were confirmed present on the clean
+tree before this change (via `git stash`) and are unrelated to this issue.
+
+## Test Plan
+
+No new tests — this is a comment-only change with no observable behaviour to
+assert on (per AGENTS.md, "what" tests cover behaviour; comments have none).
+Existing coverage exercising the touched dispatch paths:
+
+- `simd::simd_native::tests::native_8_matches_scalar_small`
+- `simd::simd_native::tests::native_4_matches_scalar_small`

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -266,6 +266,9 @@ pub fn weighted_sum_simd_8records(
     #[cfg(target_arch = "x86_64")]
     {
         if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: the `is_x86_feature_detected!("avx2")` guard above proves
+            // AVX2 is available, satisfying the `#[target_feature(enable = "avx2")]`
+            // precondition documented on `weighted_sum_simd_8records_avx2`.
             return unsafe {
                 x86::weighted_sum_simd_8records_avx2(
                     synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
@@ -277,6 +280,9 @@ pub fn weighted_sum_simd_8records(
     #[cfg(target_arch = "aarch64")]
     {
         if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: the `is_aarch64_feature_detected!("neon")` guard above proves
+            // NEON is available, satisfying the `#[target_feature(enable = "neon")]`
+            // precondition documented on `weighted_sum_simd_8records_neon`.
             return unsafe {
                 aarch64::weighted_sum_simd_8records_neon(
                     synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
@@ -311,6 +317,9 @@ pub fn weighted_sum_simd_4records(
     #[cfg(target_arch = "x86_64")]
     {
         if std::arch::is_x86_feature_detected!("fma") {
+            // SAFETY: the `is_x86_feature_detected!("fma")` guard above proves
+            // FMA is available, satisfying the `#[target_feature(enable = "fma")]`
+            // precondition documented on `weighted_sum_simd_4records_fma`.
             return unsafe {
                 x86::weighted_sum_simd_4records_fma(
                     synapses, act0, act1, act2, act3, start, end, bias,
@@ -322,6 +331,9 @@ pub fn weighted_sum_simd_4records(
     #[cfg(target_arch = "aarch64")]
     {
         if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: the `is_aarch64_feature_detected!("neon")` guard above proves
+            // NEON is available, satisfying the `#[target_feature(enable = "neon")]`
+            // precondition documented on `weighted_sum_simd_4records_neon`.
             return unsafe {
                 aarch64::weighted_sum_simd_4records_neon(
                     synapses, act0, act1, act2, act3, start, end, bias,


### PR DESCRIPTION
## Summary

Added `// SAFETY:` comments to the four SIMD dispatch `unsafe` blocks in
`neat-core/src/simd_native.rs`. Each comment names the runtime feature-detection
guard (`is_x86_feature_detected!` / `is_aarch64_feature_detected!`) that proves
the corresponding `#[target_feature(...)]` precondition documented on the callee,
recording the soundness proof next to the code it protects. This is a
documentation-only change — no behaviour, control flow, or generated code is
affected. Closes #112.

The four blocks updated:

| Dispatch | Guard | Callee precondition |
|----------|-------|---------------------|
| 8-record AVX2 | `is_x86_feature_detected!("avx2")` | `#[target_feature(enable = "avx2")]` |
| 8-record NEON | `is_aarch64_feature_detected!("neon")` | `#[target_feature(enable = "neon")]` |
| 4-record FMA  | `is_x86_feature_detected!("fma")` | `#[target_feature(enable = "fma")]` |
| 4-record NEON | `is_aarch64_feature_detected!("neon")` | `#[target_feature(enable = "neon")]` |

## Evidence

Backend/library change with no web interface to screenshot. Verified by:

- `cargo fmt --all -- --check` — clean (exit 0).
- `cargo clippy --workspace --all-targets` — no warnings.
- `cargo test --package neat-core simd_native` — `native_4_matches_scalar_small`
  and `native_8_matches_scalar_small` pass, confirming the SIMD dispatch paths
  still produce results matching the scalar reference.

Each comment's `#[target_feature]` text was cross-checked against the actual
attributes on the callee functions (lines 81, 124, 163, 212) to ensure accuracy.

Note: `quality.sh` reports four pre-existing failures (tests 31, 32, 33, 37)
relating to `ci.yml`/`bump-deps.sh`. These were confirmed present on the clean
tree before this change (via `git stash`) and are unrelated to this issue.

## Test Plan

No new tests — this is a comment-only change with no observable behaviour to
assert on (per AGENTS.md, "what" tests cover behaviour; comments have none).
Existing coverage exercising the touched dispatch paths:

- `simd::simd_native::tests::native_8_matches_scalar_small`
- `simd::simd_native::tests::native_4_matches_scalar_small`



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpxh7qtz-e48213`<!-- vibe-worker-issue-112 -->