### PR TITLE
Ship CycloneDX SBOM with wasm_activation bundle (Issue #125)

### DIFF
--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -60,15 +60,37 @@ jobs:
             --rev "${GITHUB_SHA}" \
             --out wasm_activation-pkg.tar.gz
 
+      # Issue #125 — emit a CycloneDX SBOM from the locked dependency graph and
+      # publish it next to the bundle. Because downstream consumers pin
+      # wasm_activation by SHA they otherwise receive an opaque blob; an SBOM
+      # on the Release lets responders answer "is the vulnerable crate inside a
+      # bundle we shipped?" in seconds when the next advisory drops. The SBOM is
+      # resolved against the wasm32 target (the artefact's actual triple) so it
+      # captures wasm-bindgen and friends, and is exact rather than approximate
+      # because it derives from Cargo.lock. cargo-cyclonedx is version-pinned
+      # and --locked for supply-chain hygiene (mirrors wasm-pack, Issue #78).
+      - name: Generate CycloneDX SBOM
+        env:
+          CARGO_CYCLONEDX_VERSION: "0.5.7"
+        run: |
+          set -euo pipefail
+          cargo install cargo-cyclonedx --version "${CARGO_CYCLONEDX_VERSION}" --locked
+          cargo cyclonedx --format json --target wasm32-unknown-unknown
+          # cargo-cyclonedx writes <package>.cdx.json into each crate directory;
+          # publish it under a deterministic, bundle-matching asset name.
+          cp neat-core/neat-core.cdx.json wasm_activation-pkg.cdx.json
+
       - name: Publish per-commit Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="wasm-bundle-${GITHUB_SHA}"
-          gh release create "$tag" wasm_activation-pkg.tar.gz \
+          gh release create "$tag" \
+            wasm_activation-pkg.tar.gz \
+            wasm_activation-pkg.cdx.json \
             --target "$GITHUB_SHA" \
             --title "wasm_activation bundle for ${GITHUB_SHA::7}" \
-            --notes "Auto-built wasm_activation/pkg for commit ${GITHUB_SHA}."
+            --notes "Auto-built wasm_activation/pkg for commit ${GITHUB_SHA}. CycloneDX SBOM attached as wasm_activation-pkg.cdx.json."
 
       # Issue #48 — re-download the asset we just published and prove it
       # extracts cleanly with all four files NEAT-AI's build.sh checks for

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 # CI-only artefacts written by upgrade-dependencies.yml / cargo upgrade --dry-run.
 upgrade.log
 upgrade-dry-run.txt
+
+# CycloneDX SBOMs are generated in CI (wasm-bundle.yml, Issue #125) and by the
+# SBOM bats test; they are Release assets, never committed to the tree.
+*.cdx.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
@@ -132,9 +132,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.33"
+version = "0.1.34"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-125.md
+++ b/docs/archive/pr-summaries/pr-summary-125.md
@@ -1,0 +1,78 @@
+# SCR-SBOM: ship a CycloneDX SBOM with the wasm_activation bundle
+
+## Summary
+
+`wasm-bundle.yml` publishes a built `wasm_activation` tarball as a per-commit
+GitHub Release that downstream consumers pin by SHA, but shipped **no SBOM** —
+so a consumer received an opaque binary blob with no machine-readable inventory
+of the crates it was built from. This PR adds a CycloneDX SBOM, generated from
+the locked dependency graph and published as a second asset on the same
+Release. When the next advisory drops, responders can answer "is the vulnerable
+crate inside a bundle we shipped?" by reading the attached SBOM instead of
+rebuilding each pinned commit.
+
+Because the SBOM derives from `Cargo.lock` it is **exact, not approximate**, and
+it is resolved against the `wasm32-unknown-unknown` target (the artefact's
+actual triple) so it captures `wasm-bindgen` and the other wasm-only crates
+that ship in the bundle.
+
+Closes #125.
+
+## Changes
+
+- **`.github/workflows/wasm-bundle.yml`**
+  - New **Generate CycloneDX SBOM** step: installs `cargo-cyclonedx`
+    version-pinned and `--locked` (mirrors the wasm-pack supply-chain hygiene
+    from Issue #78), runs `cargo cyclonedx --format json --target
+    wasm32-unknown-unknown`, and copies the result to a deterministic asset
+    name `wasm_activation-pkg.cdx.json`.
+  - **Publish per-commit Release** step now uploads the `.cdx.json` alongside
+    the tarball in the same `gh release create` call.
+- **`.gitignore`** — ignore `*.cdx.json` (generated in CI and by the SBOM test;
+  it is a Release asset, never committed).
+- **`tests/scripts/wasm_bundle_sbom.bats`** — new "what" tests (see below).
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[Build wasm_activation bundle] --> B[Generate CycloneDX SBOM<br/>cargo cyclonedx --target wasm32]
+    B --> C[gh release create<br/>tarball + .cdx.json]
+    C --> D[Verify published bundle]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by:
+
+- New bats suite passes (7/7), including a **behavioural** test that installs
+  nothing extra but, when `cargo-cyclonedx` is present, generates a real SBOM
+  from this repo's manifest and asserts `bomFormat == "CycloneDX"`, a non-empty
+  `specVersion`, and that `serde` appears in the components.
+- `actionlint .github/workflows/wasm-bundle.yml` passes.
+- Existing workflow guards still pass: SHA-pinning, script-injection,
+  wasm-pack pinning suites all green.
+- Manual confirmation that `cargo cyclonedx --target wasm32-unknown-unknown`
+  produces a SBOM containing `wasm-bindgen` (the wasm-only dep), proving the
+  inventory is exact for the published artefact.
+
+## Test Plan
+
+Added `tests/scripts/wasm_bundle_sbom.bats`:
+
+- `publish job has a step that generates a CycloneDX SBOM`
+- `cargo-cyclonedx install is version-pinned for supply-chain hygiene`
+- `SBOM is published as a Release asset (.cdx.json)`
+- `SBOM is generated before the Release is published`
+- `cargo-cyclonedx produces valid CycloneDX JSON from this repo's manifest`
+  (behavioural; skips cleanly if `cargo-cyclonedx` is not installed)
+- plus workflow-exists / valid-YAML guards.
+
+## Known pre-existing failures (out of scope)
+
+`./quality.sh` reports 4 failures in `tests/scripts/ci_workflow_quarantine.bats`
+(`ci.yml` version-increment / `bump-deps.sh` wiring). These pre-exist on the
+base branch — confirmed by stashing this PR's changes and re-running the suite —
+and concern `ci.yml`, not the wasm-bundle workflow, so they are outside this
+issue's scope. The Rust gate (`cargo build` / `clippy` / `test` / build
+release) is green.

--- a/tests/scripts/wasm_bundle_sbom.bats
+++ b/tests/scripts/wasm_bundle_sbom.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# Tests for the CycloneDX SBOM attached to the wasm_activation bundle Release
+# (Issue #125). The bundle is a *built binary artefact* downstream consumers
+# pin by SHA, so it must ship a machine-readable crate inventory alongside it.
+#
+# These are "what" tests (AGENTS.md): they parse wasm-bundle.yml and assert on
+# observable outcomes — that an SBOM is generated from the locked graph and
+# published as a Release asset — not on incidental source text. The final test
+# is behavioural: if cargo-cyclonedx is installed locally it generates a real
+# SBOM from this repo's manifest and asserts it is valid CycloneDX JSON.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/wasm-bundle.yml"
+}
+
+@test "wasm-bundle workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "wasm-bundle workflow is valid YAML" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "publish job has a step that generates a CycloneDX SBOM" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+runs = [s.get("run", "") for s in steps]
+# A step must actually invoke cargo-cyclonedx to build the SBOM.
+assert any("cargo cyclonedx" in r for r in runs), runs
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "cargo-cyclonedx install is version-pinned for supply-chain hygiene" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+# Locate the step(s) that install cargo-cyclonedx and assert the install is
+# pinned to an explicit --version (mirrors the wasm-pack pinning, Issue #78).
+install_lines = []
+for s in steps:
+    run = s.get("run", "")
+    for line in run.splitlines():
+        if "cargo install cargo-cyclonedx" in line:
+            install_lines.append(line)
+assert install_lines, "no cargo install cargo-cyclonedx step found"
+pin_re = re.compile(r"--version[= ]\\S+")
+for line in install_lines:
+    assert pin_re.search(line), f"install not version-pinned: {line!r}"
+    assert "--locked" in line, f"install not --locked: {line!r}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "SBOM is published as a Release asset (.cdx.json)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+runs = [s.get("run", "") for s in steps]
+# The CycloneDX JSON asset must be handed to `gh release create` or
+# `gh release upload` so it lands on the same per-commit Release.
+attaches = any(
+    ".cdx.json" in r and ("gh release create" in r or "gh release upload" in r)
+    for r in runs
+)
+assert attaches, runs
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "SBOM is generated before the Release is published" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+gen_idx = next(i for i, s in enumerate(steps) if "cargo cyclonedx" in s.get("run", ""))
+pub_idx = next(i for i, s in enumerate(steps) if "gh release create" in s.get("run", ""))
+assert gen_idx < pub_idx, (gen_idx, pub_idx)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "cargo-cyclonedx produces valid CycloneDX JSON from this repo's manifest" {
+  if ! command -v cargo-cyclonedx &>/dev/null; then
+    skip "cargo-cyclonedx not installed — install: cargo install cargo-cyclonedx --locked"
+  fi
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for JSON parsing"
+  fi
+  ( cd "$REPO_ROOT" && cargo cyclonedx --format json --manifest-path Cargo.toml >/dev/null 2>&1 )
+  # cargo-cyclonedx writes <package>.cdx.json into each crate directory.
+  sbom=""
+  for f in "$REPO_ROOT"/neat-core/*.cdx.json; do
+    [ -f "$f" ] && sbom="$f"
+  done
+  [ -n "$sbom" ]
+  run python3 - "$sbom" <<'PY'
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert doc.get("bomFormat") == "CycloneDX", doc.get("bomFormat")
+assert doc.get("specVersion"), doc
+# The locked graph must include our direct dependencies (e.g. serde).
+names = {c.get("name") for c in doc.get("components", [])}
+assert "serde" in names, sorted(names)
+PY
+  # SBOMs are Release assets, never tree artefacts — clean up what we generated.
+  rm -f "$REPO_ROOT"/neat-core/*.cdx.json
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# SCR-SBOM: ship a CycloneDX SBOM with the wasm_activation bundle

## Summary

`wasm-bundle.yml` publishes a built `wasm_activation` tarball as a per-commit
GitHub Release that downstream consumers pin by SHA, but shipped **no SBOM** —
so a consumer received an opaque binary blob with no machine-readable inventory
of the crates it was built from. This PR adds a CycloneDX SBOM, generated from
the locked dependency graph and published as a second asset on the same
Release. When the next advisory drops, responders can answer "is the vulnerable
crate inside a bundle we shipped?" by reading the attached SBOM instead of
rebuilding each pinned commit.

Because the SBOM derives from `Cargo.lock` it is **exact, not approximate**, and
it is resolved against the `wasm32-unknown-unknown` target (the artefact's
actual triple) so it captures `wasm-bindgen` and the other wasm-only crates
that ship in the bundle.

Closes #125.

## Changes

- **`.github/workflows/wasm-bundle.yml`**
  - New **Generate CycloneDX SBOM** step: installs `cargo-cyclonedx`
    version-pinned and `--locked` (mirrors the wasm-pack supply-chain hygiene
    from Issue #78), runs `cargo cyclonedx --format json --target
    wasm32-unknown-unknown`, and copies the result to a deterministic asset
    name `wasm_activation-pkg.cdx.json`.
  - **Publish per-commit Release** step now uploads the `.cdx.json` alongside
    the tarball in the same `gh release create` call.
- **`.gitignore`** — ignore `*.cdx.json` (generated in CI and by the SBOM test;
  it is a Release asset, never committed).
- **`tests/scripts/wasm_bundle_sbom.bats`** — new "what" tests (see below).

## Flow

```mermaid
flowchart LR
    A[Build wasm_activation bundle] --> B[Generate CycloneDX SBOM<br/>cargo cyclonedx --target wasm32]
    B --> C[gh release create<br/>tarball + .cdx.json]
    C --> D[Verify published bundle]
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified by:

- New bats suite passes (7/7), including a **behavioural** test that installs
  nothing extra but, when `cargo-cyclonedx` is present, generates a real SBOM
  from this repo's manifest and asserts `bomFormat == "CycloneDX"`, a non-empty
  `specVersion`, and that `serde` appears in the components.
- `actionlint .github/workflows/wasm-bundle.yml` passes.
- Existing workflow guards still pass: SHA-pinning, script-injection,
  wasm-pack pinning suites all green.
- Manual confirmation that `cargo cyclonedx --target wasm32-unknown-unknown`
  produces a SBOM containing `wasm-bindgen` (the wasm-only dep), proving the
  inventory is exact for the published artefact.

## Test Plan

Added `tests/scripts/wasm_bundle_sbom.bats`:

- `publish job has a step that generates a CycloneDX SBOM`
- `cargo-cyclonedx install is version-pinned for supply-chain hygiene`
- `SBOM is published as a Release asset (.cdx.json)`
- `SBOM is generated before the Release is published`
- `cargo-cyclonedx produces valid CycloneDX JSON from this repo's manifest`
  (behavioural; skips cleanly if `cargo-cyclonedx` is not installed)
- plus workflow-exists / valid-YAML guards.

## Known pre-existing failures (out of scope)

`./quality.sh` reports 4 failures in `tests/scripts/ci_workflow_quarantine.bats`
(`ci.yml` version-increment / `bump-deps.sh` wiring). These pre-exist on the
base branch — confirmed by stashing this PR's changes and re-running the suite —
and concern `ci.yml`, not the wasm-bundle workflow, so they are outside this
issue's scope. The Rust gate (`cargo build` / `clippy` / `test` / build
release) is green.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq28uywd-db15c3`<!-- vibe-worker-issue-125 -->