### PR TITLE
🟡 SCR-AUTO-UPDATE: no advisory-triggered security-update channel (only weekly bump) (Issue #121)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Advisory-triggered security-update channel (Issue #121).
+#
+# The weekly `upgrade-dependencies.yml` cron is the routine, general bump path.
+# This file gives Dependabot a *security-update* fast lane: when a RustSec/OSV
+# advisory lands against a crate already in the tree, Dependabot opens a fix PR
+# immediately — independent of the Monday-morning weekly window and the 24h
+# VIBE_BUMP_QUARANTINE_HOURS release-age deferral. Detection still lives in
+# `security.yml` / `ci.yml` (cargo audit); this channel is what *raises* the
+# remediation PR.
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      # Routine version bumps stay weekly to mirror upgrade-dependencies.yml;
+      # security advisories raise PRs immediately, outside this window.
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.34"
+version = "0.1.35"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build (Vibe Coder hook). |
+| `.github/dependabot.yml` | Advisory-triggered security-update fast lane — raises a fix PR the moment a RustSec/OSV advisory lands, independent of the weekly bump. |
 | `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`). |
 | `LICENSE`, `.gitleaks.toml` | Inherited from NEAT-AI `Develop`. |
 
@@ -128,6 +129,36 @@ window may transiently fail the bundle download in `build.sh` because the
 release tag for the latest `Develop` SHA does not yet exist. Re-run the
 PR's checks once the bundle workflow has completed, or wait a minute
 before opening the PR.
+
+## Dependency updates: two channels
+
+Dependency refresh runs on two complementary channels so the urgent
+"patch this advisory now" path is decoupled from the routine weekly bump:
+
+- **Routine bump** — [`.github/workflows/upgrade-dependencies.yml`](.github/workflows/upgrade-dependencies.yml)
+  runs `bump-deps.sh` every Monday (`cron "0 6 * * 1"`), applying the
+  `VIBE_BUMP_QUARANTINE_HOURS` release-age quarantine, `cargo audit`, and
+  dual native/WASM builds before raising a general upgrade PR.
+- **Security fast lane** — [`.github/dependabot.yml`](.github/dependabot.yml)
+  enables Dependabot's Cargo **security-updates** channel. When a
+  RustSec/OSV advisory lands against a crate already in `Cargo.lock`,
+  Dependabot raises a fix PR immediately — independent of the weekly window.
+
+Advisory *detection* still lives in [`security.yml`](.github/workflows/security.yml)
+and the `ci.yml` `security` job (`cargo audit` / `rustsec/audit-check`); the
+new channel is what *raises* the remediation PR rather than waiting for Monday.
+
+```mermaid
+flowchart TD
+    Adv[RustSec/OSV advisory disclosed] --> Detect[cargo audit detects<br/>security.yml / ci.yml]
+    Detect -->|fails PR / scheduled job| Alert[Maintainer alerted]
+    Adv --> Dependabot[dependabot.yml<br/>security-updates channel]
+    Dependabot -->|immediate| FixPR[Advisory fix PR]
+    Cron[Weekly cron Mon 06:00] --> Bump[upgrade-dependencies.yml<br/>bump-deps.sh]
+    Bump -->|general refresh| GenPR[Weekly upgrade PR]
+    FixPR --> Develop[Develop]
+    GenPR --> Develop
+```
 
 ## License
 

--- a/docs/archive/pr-summaries/pr-summary-121.md
+++ b/docs/archive/pr-summaries/pr-summary-121.md
@@ -1,0 +1,65 @@
+## Summary
+
+Added an advisory-triggered security-update channel so a freshly-disclosed
+RustSec/OSV advisory no longer waits up to six days for the Monday-morning
+weekly bump. A minimal `.github/dependabot.yml` enables Dependabot's Cargo
+**security-updates** channel, which opens a fix PR the moment an advisory lands
+against a crate already in `Cargo.lock` — independent of the weekly
+`upgrade-dependencies.yml` cron and the 24h `VIBE_BUMP_QUARANTINE_HOURS`
+release-age window. Detection still lives in `security.yml` / `ci.yml`
+(`cargo audit` / `rustsec/audit-check`); this change adds the missing channel
+that *raises* the remediation PR. Closes #121.
+
+## Change detail
+
+- **`.github/dependabot.yml`** (new) — `version: 2`, Cargo ecosystem at root
+  `/`, weekly routine schedule (mirrors `upgrade-dependencies.yml`),
+  `open-pull-requests-limit: 10` so the advisory fast-lane is not throttled to
+  the default of 5. Security-update PRs are raised immediately on advisory
+  disclosure, outside the weekly window.
+- **`tests/scripts/dependabot_config.bats`** (new) — "what" tests that parse
+  the YAML and assert observable configuration: file exists, schema version 2,
+  cargo ecosystem targets `/`, a schedule interval is declared, and a positive
+  `open-pull-requests-limit` is set.
+- **`README.md`** — documented the new config in the repository-layout table
+  and added a "Dependency updates: two channels" section with a Mermaid
+  flowchart of the routine-bump vs security-fast-lane model.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+bats suite (TDD: tests written first, confirmed red, then green):
+
+```
+ok 39 dependabot config file exists
+ok 40 dependabot config is valid YAML using schema version 2
+ok 41 dependabot enables the cargo ecosystem at the workspace root
+ok 42 cargo ecosystem entry declares an update schedule
+ok 43 cargo ecosystem entry sets an open-pull-requests-limit
+```
+
+`markdownlint-cli2` (0 errors) and `codespell` (clean) pass against the changed
+files.
+
+```mermaid
+flowchart TD
+    Adv[RustSec/OSV advisory disclosed] --> Dependabot[dependabot.yml<br/>security-updates channel]
+    Dependabot -->|immediate fix PR| Develop[Develop]
+    Cron[Weekly cron Mon 06:00] --> Bump[upgrade-dependencies.yml]
+    Bump -->|general refresh PR| Develop
+```
+
+## Test Plan
+
+- Added `tests/scripts/dependabot_config.bats` — 5 "what" tests covering the
+  presence, schema, ecosystem, schedule, and PR-limit of the new config.
+- Full `bats tests/scripts` suite: the 5 new tests pass; all other suites
+  unchanged.
+
+## Pre-existing failures (out of scope)
+
+`./quality.sh` reports 4 failures in `tests/scripts/ci_workflow_quarantine.bats`
+(tests 31–33, 37) about `ci.yml` calling `cargo upgrade --incompatible` /
+`cargo update` directly at lines 104–106. These were confirmed present on the
+clean base branch (via `git stash -u`) and concern `ci.yml`, which this PR does
+not touch. They are unrelated to issue #121 and are left for a dedicated fix.

--- a/tests/scripts/dependabot_config.bats
+++ b/tests/scripts/dependabot_config.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# Tests for the advisory-triggered security-update channel (Issue #121).
+#
+# Rationale: the weekly `upgrade-dependencies.yml` cron is the only mechanism
+# that *raises* a dependency-bump PR. An advisory disclosed mid-week therefore
+# sits undefended-by-automation for up to six days. A `.github/dependabot.yml`
+# with the Cargo ecosystem enabled gives Dependabot a security-updates channel
+# that opens a fix PR the moment a RustSec/OSV advisory lands against a crate
+# already in the tree — decoupling the urgent patch path from the routine
+# weekly bump.
+#
+# These are "what" tests: they parse the YAML and assert on observable
+# configuration outcomes (version, ecosystem, directory, schedule), not on
+# source-text heuristics.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  DEPENDABOT_FILE="${REPO_ROOT}/.github/dependabot.yml"
+}
+
+@test "dependabot config file exists" {
+  [ -f "$DEPENDABOT_FILE" ]
+}
+
+@test "dependabot config is valid YAML using schema version 2" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import sys, yaml
+with open("$DEPENDABOT_FILE") as fh:
+    data = yaml.safe_load(fh)
+assert isinstance(data, dict), "top level must be a mapping"
+assert data.get("version") == 2, f"expected version 2, got {data.get('version')!r}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "dependabot enables the cargo ecosystem at the workspace root" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import sys, yaml
+with open("$DEPENDABOT_FILE") as fh:
+    data = yaml.safe_load(fh)
+updates = data.get("updates") or []
+cargo = [u for u in updates if u.get("package-ecosystem") == "cargo"]
+assert cargo, "no cargo package-ecosystem entry found"
+roots = [u for u in cargo if u.get("directory") == "/"]
+assert roots, "cargo ecosystem must target the workspace root '/'"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "cargo ecosystem entry declares an update schedule" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import sys, yaml
+with open("$DEPENDABOT_FILE") as fh:
+    data = yaml.safe_load(fh)
+cargo = [u for u in (data.get("updates") or []) if u.get("package-ecosystem") == "cargo"]
+assert cargo, "no cargo package-ecosystem entry found"
+for u in cargo:
+    schedule = u.get("schedule") or {}
+    assert schedule.get("interval"), "cargo ecosystem entry must declare schedule.interval"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Security-update PRs are raised independently of the version-update schedule,
+# but a bounded open-pull-requests-limit keeps the advisory fast-lane from
+# being throttled to the default of 5. Assert the cargo entry sets one.
+@test "cargo ecosystem entry sets an open-pull-requests-limit" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import sys, yaml
+with open("$DEPENDABOT_FILE") as fh:
+    data = yaml.safe_load(fh)
+cargo = [u for u in (data.get("updates") or []) if u.get("package-ecosystem") == "cargo"]
+assert cargo, "no cargo package-ecosystem entry found"
+for u in cargo:
+    limit = u.get("open-pull-requests-limit")
+    assert isinstance(limit, int) and limit > 0, \
+        f"cargo ecosystem entry must set a positive open-pull-requests-limit, got {limit!r}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Added an advisory-triggered security-update channel so a freshly-disclosed
RustSec/OSV advisory no longer waits up to six days for the Monday-morning
weekly bump. A minimal `.github/dependabot.yml` enables Dependabot's Cargo
**security-updates** channel, which opens a fix PR the moment an advisory lands
against a crate already in `Cargo.lock` — independent of the weekly
`upgrade-dependencies.yml` cron and the 24h `VIBE_BUMP_QUARANTINE_HOURS`
release-age window. Detection still lives in `security.yml` / `ci.yml`
(`cargo audit` / `rustsec/audit-check`); this change adds the missing channel
that *raises* the remediation PR. Closes #121.

## Change detail

- **`.github/dependabot.yml`** (new) — `version: 2`, Cargo ecosystem at root
  `/`, weekly routine schedule (mirrors `upgrade-dependencies.yml`),
  `open-pull-requests-limit: 10` so the advisory fast-lane is not throttled to
  the default of 5. Security-update PRs are raised immediately on advisory
  disclosure, outside the weekly window.
- **`tests/scripts/dependabot_config.bats`** (new) — "what" tests that parse
  the YAML and assert observable configuration: file exists, schema version 2,
  cargo ecosystem targets `/`, a schedule interval is declared, and a positive
  `open-pull-requests-limit` is set.
- **`README.md`** — documented the new config in the repository-layout table
  and added a "Dependency updates: two channels" section with a Mermaid
  flowchart of the routine-bump vs security-fast-lane model.

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
bats suite (TDD: tests written first, confirmed red, then green):

```
ok 39 dependabot config file exists
ok 40 dependabot config is valid YAML using schema version 2
ok 41 dependabot enables the cargo ecosystem at the workspace root
ok 42 cargo ecosystem entry declares an update schedule
ok 43 cargo ecosystem entry sets an open-pull-requests-limit
```

`markdownlint-cli2` (0 errors) and `codespell` (clean) pass against the changed
files.

```mermaid
flowchart TD
    Adv[RustSec/OSV advisory disclosed] --> Dependabot[dependabot.yml<br/>security-updates channel]
    Dependabot -->|immediate fix PR| Develop[Develop]
    Cron[Weekly cron Mon 06:00] --> Bump[upgrade-dependencies.yml]
    Bump -->|general refresh PR| Develop
```

## Test Plan

- Added `tests/scripts/dependabot_config.bats` — 5 "what" tests covering the
  presence, schema, ecosystem, schedule, and PR-limit of the new config.
- Full `bats tests/scripts` suite: the 5 new tests pass; all other suites
  unchanged.

## Pre-existing failures (out of scope)

`./quality.sh` reports 4 failures in `tests/scripts/ci_workflow_quarantine.bats`
(tests 31–33, 37) about `ci.yml` calling `cargo upgrade --incompatible` /
`cargo update` directly at lines 104–106. These were confirmed present on the
clean base branch (via `git stash -u`) and concern `ci.yml`, which this PR does
not touch. They are unrelated to issue #121 and are left for a dedicated fix.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq2c6bw7-53a3f2`<!-- vibe-worker-issue-121 -->