### PR TITLE
Attest build provenance for published wasm_activation bundle (Issue #122)

### DIFF
--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -10,7 +10,9 @@ on:
     branches: [Develop]
 
 permissions:
-  contents: write   # required by `gh release create`
+  contents: write       # required by `gh release create`
+  id-token: write       # Issue #122 — OIDC token for keyless Sigstore signing
+  attestations: write   # Issue #122 — record the build-provenance attestation
 
 jobs:
   publish:
@@ -79,6 +81,25 @@ jobs:
           # cargo-cyclonedx writes <package>.cdx.json into each crate directory;
           # publish it under a deterministic, bundle-matching asset name.
           cp neat-core/neat-core.cdx.json wasm_activation-pkg.cdx.json
+
+      # Issue #122 — attest build provenance for the published artefacts.
+      # Pinning by SHA + post-publish content re-verification proves the
+      # bundle's *shape* but not its *origin*: anyone with contents:write
+      # could swap the Release asset for a malicious tarball of the right
+      # shape and downstream checks would still pass. A Sigstore-backed
+      # keyless provenance attestation lets a consumer assert "this artefact
+      # was built by NEAT-AI-core's wasm-bundle workflow at commit X" before
+      # trusting it, closing the published-artefact-substitution attack class.
+      # Attesting before publish signs the exact bytes we then upload, so the
+      # recorded subject digest matches what consumers download and verify
+      # with `gh attestation verify`. SHA-pinned per Issue #77.
+      - name: Attest wasm_activation bundle provenance
+        # actions/attest-build-provenance@v4.1.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: |
+            wasm_activation-pkg.tar.gz
+            wasm_activation-pkg.cdx.json
 
       - name: Publish per-commit Release
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.35"
+version = "0.1.36"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ Vibe Coder hook (`bump-deps.sh` runs before `quality.sh` on every PR).
   bundle and updates `deno.json`'s `neatCore.rev` field in lock-step.
 - A fresh PR in NEAT-AI is therefore sufficient to pick up the latest
   `Develop` of NEAT-AI-core.
+- The published bundle (and its CycloneDX SBOM) carries a Sigstore-backed
+  build-provenance attestation, so a consumer can cryptographically confirm
+  the tarball was produced by this workflow from the pinned commit before
+  trusting it. Verify in the bump flow with:
+
+  ```bash
+  gh attestation verify wasm_activation-pkg.tar.gz \
+    --repo stSoftwareAU/NEAT-AI-core
+  ```
+
+  Pinning by SHA and the post-publish content re-verification prove the
+  bundle's *shape*; the attestation proves its *origin*, closing the
+  published-artefact-substitution attack class.
 
 ### NEAT-AI-scorer (Rust + path dependency)
 
@@ -104,9 +117,11 @@ sequenceDiagram
 
     Dev->>Core: merge enhancement
     Core->>CI: push to Develop
+    CI->>CI: attest build provenance (Sigstore, keyless)
     CI->>Rel: build & publish wasm_activation-pkg.tar.gz
     Dev->>Main: open PR
     Main->>Rel: bump-deps.sh -> build.sh download
+    Main->>Rel: gh attestation verify (origin proof)
     Note over Main: deno.json neatCore.rev advances
     Dev->>Scorer: open PR
     Scorer->>Core: actions/checkout @Develop

--- a/docs/archive/pr-summaries/pr-summary-122.md
+++ b/docs/archive/pr-summaries/pr-summary-122.md
@@ -1,0 +1,91 @@
+# SCR-PROVENANCE: attest build provenance for the published wasm_activation bundle
+
+## Summary
+
+The per-commit `wasm_activation` bundle published by `wasm-bundle.yml` carried
+**no build-provenance attestation**, so a downstream consumer (NEAT-AI pins
+`neatCore.rev` to a Develop SHA) could not cryptographically verify that the
+tarball it downloaded was produced by this CI pipeline from the pinned source
+commit. Pinning by SHA and the post-publish content re-verification prove the
+bundle's *shape*; nothing proved its *origin*, leaving the
+published-artefact-substitution attack class open (anyone with
+`contents:write` could swap the Release asset for a malicious tarball of the
+right shape and downstream `build.sh` checks would still pass).
+
+This change wires a Sigstore-backed, keyless build-provenance attestation into
+the publish job:
+
+- Grants the token scopes attestation requires — `id-token: write` (OIDC
+  signing identity) and `attestations: write` (record the attestation) —
+  alongside the existing `contents: write`.
+- Adds an `actions/attest-build-provenance` step, SHA-pinned to
+  `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` (v4.1.0) per the repo's
+  SHA-pinning rule (Issue #77), attesting both published assets
+  (`wasm_activation-pkg.tar.gz` and the CycloneDX SBOM
+  `wasm_activation-pkg.cdx.json`). It runs after the bundle is built and
+  before publish, so the signed subject digest matches the bytes consumers
+  download.
+- Documents the downstream verification one-liner
+  (`gh attestation verify wasm_activation-pkg.tar.gz --repo stSoftwareAU/NEAT-AI-core`)
+  in the README propagation section and reflects the attest step in the
+  end-to-end sequence diagram.
+
+Closes #122.
+
+## Evidence
+
+This is a CI/supply-chain change with no web interface to screenshot. Evidence
+is the new behavioural ("what") bats suite that parses `wasm-bundle.yml` and
+asserts the observable outcomes, plus the unchanged-and-still-green
+SHA-pinning, actionlint, and SBOM suites.
+
+Flow added to the publish job:
+
+```mermaid
+flowchart LR
+    A[Build wasm_activation-pkg.tar.gz] --> B[Generate CycloneDX SBOM]
+    B --> C[Attest build provenance<br/>Sigstore keyless]
+    C --> D[gh release create<br/>publish per-commit Release]
+    D --> E[Verify published bundle<br/>shape/size re-check]
+    C -. records subject digest .-> F[(GitHub attestations store)]
+    F -. gh attestation verify .-> G[Downstream NEAT-AI<br/>origin proof before trust]
+```
+
+Selected test run (`bats tests/scripts/wasm_bundle_provenance.bats`):
+
+```
+ok 1 wasm-bundle workflow file exists
+ok 2 wasm-bundle workflow grants the token scopes attestation requires
+ok 3 publish job has a step that attests build provenance
+ok 4 provenance attestation covers the published bundle tarball
+ok 5 attest-build-provenance action is SHA-pinned for supply-chain hygiene
+ok 6 provenance is attested only after the bundle is built
+```
+
+The existing `workflow_sha_pinning.bats`, `actionlint_workflow.bats`, and
+`wasm_bundle_sbom.bats` suites continue to pass against the modified workflow
+(the new action is SHA-pinned with a version comment and actionlint validates
+the YAML).
+
+## Test Plan
+
+- **Added** `tests/scripts/wasm_bundle_provenance.bats` — six "what" tests:
+  - workflow file exists;
+  - token scopes (`id-token: write`, `attestations: write`, retained
+    `contents: write`) are granted;
+  - a step uses `actions/attest-build-provenance`;
+  - the attestation's `subject-path` covers `wasm_activation-pkg.tar.gz`;
+  - the action is SHA-pinned to a 40-char commit SHA;
+  - provenance is attested only after the bundle is built.
+- **Regression coverage**: tests 2–6 fail against the unfixed workflow and
+  pass after the change.
+
+## Quality gate note
+
+`./quality.sh` reports four **pre-existing, unrelated** failures in
+`tests/scripts/ci_workflow_quarantine.bats` (tests about `ci.yml` calling
+`cargo upgrade`/`cargo update` directly — finding-id unrelated to provenance).
+These fail identically on a clean `HEAD` with my changes stashed, concern
+`ci.yml` which this PR does not touch, and are therefore out of scope for
+#122. All shellcheck, actionlint, SHA-pinning, SBOM, verify-bundle, and the
+new provenance suites pass.

--- a/tests/scripts/wasm_bundle_provenance.bats
+++ b/tests/scripts/wasm_bundle_provenance.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Tests for the build-provenance attestation attached to the wasm_activation
+# bundle Release (Issue #122). Downstream consumers pin the bundle by commit
+# SHA and re-verify its *contents/size* post-publish, but neither proves
+# *origin*: anyone with `contents:write` could swap the Release asset for a
+# malicious tarball of the right shape. A Sigstore-backed keyless provenance
+# attestation lets a consumer assert "this artefact was built by this
+# workflow at commit X" before trusting it, closing the published-artefact
+# substitution attack class.
+#
+# These are "what" tests (AGENTS.md): they parse wasm-bundle.yml and assert on
+# observable outcomes — the workflow grants the attestation token scopes, runs
+# the attest action over the published bundle, and pins the action by SHA —
+# not on incidental source text.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/wasm-bundle.yml"
+}
+
+@test "wasm-bundle workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "wasm-bundle workflow grants the token scopes attestation requires" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+# attest-build-provenance needs an OIDC token (id-token: write) to fetch a
+# Sigstore signing identity and attestations: write to record the bundle.
+# Permissions may be set at the top level or on the publish job.
+top = data.get("permissions", {}) or {}
+job = data["jobs"]["publish"].get("permissions", {}) or {}
+perms = {**top, **job}
+assert perms.get("id-token") == "write", perms
+assert perms.get("attestations") == "write", perms
+# The pre-existing contents:write for `gh release create` must be retained.
+assert perms.get("contents") == "write", perms
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "publish job has a step that attests build provenance" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+uses = [s.get("uses", "") for s in steps]
+assert any("actions/attest-build-provenance@" in u for u in uses), uses
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "provenance attestation covers the published bundle tarball" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+attest = next(s for s in steps if "actions/attest-build-provenance@" in s.get("uses", ""))
+subject = attest.get("with", {}).get("subject-path", "")
+assert "wasm_activation-pkg.tar.gz" in subject, subject
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "attest-build-provenance action is SHA-pinned for supply-chain hygiene" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+attest = next(s for s in steps if "actions/attest-build-provenance@" in s.get("uses", ""))
+ref = attest["uses"]
+# Mirrors the SHA-pinning rule (Issue #77): a 40-char hex commit SHA, never
+# a floating tag like @v4.
+assert re.match(r"^actions/attest-build-provenance@[0-9a-f]{40}$", ref), ref
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "provenance is attested only after the bundle is built" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+steps = data["jobs"]["publish"]["steps"]
+build_idx = next(i for i, s in enumerate(steps) if "build-wasm-bundle.sh" in s.get("run", ""))
+attest_idx = next(i for i, s in enumerate(steps) if "actions/attest-build-provenance@" in s.get("uses", ""))
+# Attesting before the artefact exists would sign nothing meaningful.
+assert build_idx < attest_idx, (build_idx, attest_idx)
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# SCR-PROVENANCE: attest build provenance for the published wasm_activation bundle

## Summary

The per-commit `wasm_activation` bundle published by `wasm-bundle.yml` carried
**no build-provenance attestation**, so a downstream consumer (NEAT-AI pins
`neatCore.rev` to a Develop SHA) could not cryptographically verify that the
tarball it downloaded was produced by this CI pipeline from the pinned source
commit. Pinning by SHA and the post-publish content re-verification prove the
bundle's *shape*; nothing proved its *origin*, leaving the
published-artefact-substitution attack class open (anyone with
`contents:write` could swap the Release asset for a malicious tarball of the
right shape and downstream `build.sh` checks would still pass).

This change wires a Sigstore-backed, keyless build-provenance attestation into
the publish job:

- Grants the token scopes attestation requires — `id-token: write` (OIDC
  signing identity) and `attestations: write` (record the attestation) —
  alongside the existing `contents: write`.
- Adds an `actions/attest-build-provenance` step, SHA-pinned to
  `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` (v4.1.0) per the repo's
  SHA-pinning rule (Issue #77), attesting both published assets
  (`wasm_activation-pkg.tar.gz` and the CycloneDX SBOM
  `wasm_activation-pkg.cdx.json`). It runs after the bundle is built and
  before publish, so the signed subject digest matches the bytes consumers
  download.
- Documents the downstream verification one-liner
  (`gh attestation verify wasm_activation-pkg.tar.gz --repo stSoftwareAU/NEAT-AI-core`)
  in the README propagation section and reflects the attest step in the
  end-to-end sequence diagram.

Closes #122.

## Evidence

This is a CI/supply-chain change with no web interface to screenshot. Evidence
is the new behavioural ("what") bats suite that parses `wasm-bundle.yml` and
asserts the observable outcomes, plus the unchanged-and-still-green
SHA-pinning, actionlint, and SBOM suites.

Flow added to the publish job:

```mermaid
flowchart LR
    A[Build wasm_activation-pkg.tar.gz] --> B[Generate CycloneDX SBOM]
    B --> C[Attest build provenance<br/>Sigstore keyless]
    C --> D[gh release create<br/>publish per-commit Release]
    D --> E[Verify published bundle<br/>shape/size re-check]
    C -. records subject digest .-> F[(GitHub attestations store)]
    F -. gh attestation verify .-> G[Downstream NEAT-AI<br/>origin proof before trust]
```

Selected test run (`bats tests/scripts/wasm_bundle_provenance.bats`):

```
ok 1 wasm-bundle workflow file exists
ok 2 wasm-bundle workflow grants the token scopes attestation requires
ok 3 publish job has a step that attests build provenance
ok 4 provenance attestation covers the published bundle tarball
ok 5 attest-build-provenance action is SHA-pinned for supply-chain hygiene
ok 6 provenance is attested only after the bundle is built
```

The existing `workflow_sha_pinning.bats`, `actionlint_workflow.bats`, and
`wasm_bundle_sbom.bats` suites continue to pass against the modified workflow
(the new action is SHA-pinned with a version comment and actionlint validates
the YAML).

## Test Plan

- **Added** `tests/scripts/wasm_bundle_provenance.bats` — six "what" tests:
  - workflow file exists;
  - token scopes (`id-token: write`, `attestations: write`, retained
    `contents: write`) are granted;
  - a step uses `actions/attest-build-provenance`;
  - the attestation's `subject-path` covers `wasm_activation-pkg.tar.gz`;
  - the action is SHA-pinned to a 40-char commit SHA;
  - provenance is attested only after the bundle is built.
- **Regression coverage**: tests 2–6 fail against the unfixed workflow and
  pass after the change.

## Quality gate note

`./quality.sh` reports four **pre-existing, unrelated** failures in
`tests/scripts/ci_workflow_quarantine.bats` (tests about `ci.yml` calling
`cargo upgrade`/`cargo update` directly — finding-id unrelated to provenance).
These fail identically on a clean `HEAD` with my changes stashed, concern
`ci.yml` which this PR does not touch, and are therefore out of scope for
#122. All shellcheck, actionlint, SHA-pinning, SBOM, verify-bundle, and the
new provenance suites pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq2g19fj-800d3a`<!-- vibe-worker-issue-122 -->