### PR TITLE
Document emergency quarantine override for dependency bumps (Issue #124)

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -5,6 +5,14 @@ on:
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
+    inputs:
+      emergency_bypass:
+        description: >-
+          Bypass the release-age quarantine for an actively-exploited advisory
+          whose fix is newer than the window (sets VIBE_BUMP_QUARANTINE_HOURS=0).
+          See SECURITY.md — confirm cargo audit is clean before merge.
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -38,8 +46,10 @@ jobs:
       - name: Refresh dependencies via bump-deps.sh (quarantine-aware)
         env:
           # Crates.io versions younger than this many hours are deferred —
-          # the quarantine window closed in Issue #76.
-          VIBE_BUMP_QUARANTINE_HOURS: ${{ vars.VIBE_BUMP_QUARANTINE_HOURS || '24' }}
+          # the quarantine window closed in Issue #76. The emergency_bypass
+          # workflow_dispatch input collapses the window to 0 for an
+          # actively-exploited advisory (Issue #124 — see SECURITY.md).
+          VIBE_BUMP_QUARANTINE_HOURS: ${{ inputs.emergency_bypass == true && '0' || vars.VIBE_BUMP_QUARANTINE_HOURS || '24' }}
         run: |
           # bump-deps.sh applies the release-age quarantine, then runs
           # cargo audit + dual native/wasm builds. A non-zero exit means the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.36"
+version = "0.1.37"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Advisory *detection* still lives in [`security.yml`](.github/workflows/security.
 and the `ci.yml` `security` job (`cargo audit` / `rustsec/audit-check`); the
 new channel is what *raises* the remediation PR rather than waiting for Monday.
 
+When an actively-exploited advisory's fix is newer than the
+`VIBE_BUMP_QUARANTINE_HOURS` window, an approver can take the documented
+**emergency quarantine override** — dispatch *Upgrade Cargo Dependencies* with
+`emergency_bypass: true` (or run `./bump-deps.sh --quarantine-hours 0`) and
+confirm `cargo audit` is clean before merge. See
+[`SECURITY.md`](SECURITY.md#emergency-quarantine-override).
+
 ```mermaid
 flowchart TD
     Adv[RustSec/OSV advisory disclosed] --> Detect[cargo audit detects<br/>security.yml / ci.yml]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security policy
+
+This document covers operational security procedures for NEAT-AI-core. It
+complements the automated supply-chain defences described in
+[`README.md`](README.md#dependency-updates-two-channels) — the weekly
+quarantine-aware bump, the Dependabot security fast lane, and `cargo audit`
+detection.
+
+## Dependency bump quarantine
+
+Dependency bumps honour a release-age **quarantine window**
+(`VIBE_BUMP_QUARANTINE_HOURS`, default 24h — Issue #76). Crates.io versions
+published less than that many hours ago are deferred, which defends against
+fast-flagged malicious publishes that are later yanked. `bump-deps.sh` applies
+the window, and the *Upgrade Cargo Dependencies* workflow feeds it from the
+`VIBE_BUMP_QUARANTINE_HOURS` repository variable.
+
+## Emergency quarantine override
+
+The quarantine window is a deliberate trade-off: it defers brand-new crate
+versions for 24h. That same delay can *block* the urgent case — when the only
+patched version of a vulnerable crate was published minutes ago and the
+advisory is being actively exploited now.
+
+When an actively-exploited advisory's fix is newer than the quarantine window,
+an approver may run the upgrade with the window disabled:
+
+- **Via the workflow** — dispatch *Upgrade Cargo Dependencies*
+  (`workflow_dispatch`) with the `emergency_bypass` input set to `true`. This
+  collapses the effective window to `VIBE_BUMP_QUARANTINE_HOURS=0` for that run
+  so the freshly-published fix is applied immediately.
+- **Locally** — run `./bump-deps.sh --quarantine-hours 0`.
+
+After bypassing the window you **must** manually confirm `cargo audit` reports
+no advisories against the bumped tree before merge. The bypass disables only
+the release-age deferral; it does not relax the audit or build gates.
+
+```mermaid
+flowchart TD
+    Adv[Actively-exploited advisory<br/>fix published &lt; window] --> Approver{Approver decision}
+    Approver -->|emergency_bypass=true| Zero[Effective window = 0h]
+    Approver -->|--quarantine-hours 0| Zero
+    Zero --> Bump[bump-deps.sh applies fix immediately]
+    Bump --> Audit{cargo audit clean?}
+    Audit -->|yes| Merge[Merge fix]
+    Audit -->|no| Revert[Revert — do not merge]
+```
+
+Use this path only for an actively-exploited advisory whose fix falls inside
+the quarantine window. Routine bumps must continue to honour the default
+window.

--- a/docs/archive/pr-summaries/pr-summary-124.md
+++ b/docs/archive/pr-summaries/pr-summary-124.md
@@ -1,0 +1,78 @@
+# PR Summary — Issue #124 (SCR-QUARANTINE-OVERRIDE)
+
+## Summary
+
+The repo enforces a release-age quarantine on dependency bumps
+(`VIBE_BUMP_QUARANTINE_HOURS`, default 24h — Issue #76) but had **no documented
+emergency-override / fast-lane procedure** for bypassing that window when an
+actively-exploited advisory's fix is a freshly-published crate. The override
+capability already existed (`bump-deps.sh --quarantine-hours 0`) but was
+undocumented and not surfaced in the *Upgrade Cargo Dependencies* workflow.
+
+This PR makes the safe escape hatch explicit and auditable:
+
+- Adds **`SECURITY.md`** with an *Emergency quarantine override* section: when an
+  actively-exploited advisory's fix is newer than the window, an approver runs
+  the upgrade with the window disabled (`VIBE_BUMP_QUARANTINE_HOURS=0` /
+  `./bump-deps.sh --quarantine-hours 0`) and must confirm `cargo audit` is clean
+  before merge.
+- Adds a self-documenting **`emergency_bypass` `workflow_dispatch` input** to
+  `upgrade-dependencies.yml`, wired so that `emergency_bypass: true` collapses the
+  effective window to `0` for that run. The input is cosmetic-proof — the env
+  expression actually feeds `bump-deps.sh`.
+- Cross-links the procedure from `README.md`'s dependency-updates section.
+
+The bypass disables only the release-age deferral — the `cargo audit` and dual
+native/WASM build gates still run.
+
+Closes #124.
+
+## Evidence
+
+Backend/CLI/docs change — no web interface to screenshot. Verified via the bats
+suite and the local quality gates (bash syntax, shellcheck, codespell,
+markdownlint) which all pass.
+
+New TDD test `tests/scripts/security_quarantine_override.bats` — failing before
+the change (no `SECURITY.md`, no `emergency_bypass` input), passing after:
+
+```
+1..7
+ok 1 SECURITY.md exists
+ok 2 SECURITY.md documents the emergency quarantine override section
+ok 3 SECURITY.md spells out the zero-hour bypass mechanism
+ok 4 SECURITY.md requires a clean cargo audit before merge on the fast lane
+ok 5 SECURITY.md scopes the override to approver / actively-exploited cases
+ok 6 upgrade-dependencies.yml exposes an emergency_bypass workflow_dispatch input
+ok 7 upgrade-dependencies.yml wires emergency_bypass to a zero-hour window
+```
+
+Override decision flow documented in `SECURITY.md`:
+
+```mermaid
+flowchart TD
+    Adv[Actively-exploited advisory<br/>fix published inside window] --> Approver{Approver decision}
+    Approver -->|emergency_bypass=true| Zero[Effective window = 0h]
+    Approver -->|--quarantine-hours 0| Zero
+    Zero --> Bump[bump-deps.sh applies fix immediately]
+    Bump --> Audit{cargo audit clean?}
+    Audit -->|yes| Merge[Merge fix]
+    Audit -->|no| Revert[Revert — do not merge]
+```
+
+## Test Plan
+
+- Added `tests/scripts/security_quarantine_override.bats` (7 cases) covering the
+  documented override path and the workflow input wiring.
+- `bats tests/scripts/security_quarantine_override.bats` — 7/7 pass.
+- Pre-existing failures in `ci_workflow_quarantine.bats` (ci.yml not invoking
+  bump-deps.sh) are unrelated to this issue and present on the base branch — left
+  untouched per change-scope.
+- Local gates pass for the changed files: bash syntax, shellcheck, codespell,
+  markdownlint.
+
+## Notes
+
+`actionlint` reports three pre-existing `SC2016` info-level findings on the
+unrelated "Build summary" step (single-quoted literal markdown echoes); these
+predate this PR and are out of scope.

--- a/tests/scripts/security_quarantine_override.bats
+++ b/tests/scripts/security_quarantine_override.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# Regression assertion for Issue #124 (SCR-QUARANTINE-OVERRIDE) — the repo
+# enforces a release-age quarantine on dependency bumps
+# (VIBE_BUMP_QUARANTINE_HOURS, Issue #76) but had no documented emergency
+# fast-lane for bypassing that window when an actively-exploited advisory's
+# fix is newer than the quarantine. These tests pin down that the documented
+# override path (SECURITY.md) and the self-documenting workflow_dispatch input
+# (emergency_bypass) both exist and stay wired.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SECURITY_MD="${REPO_ROOT}/SECURITY.md"
+  UPGRADE_WF="${REPO_ROOT}/.github/workflows/upgrade-dependencies.yml"
+}
+
+@test "SECURITY.md exists" {
+  [ -f "$SECURITY_MD" ]
+}
+
+@test "SECURITY.md documents the emergency quarantine override section" {
+  [ -f "$SECURITY_MD" ]
+  run grep -qi 'Emergency quarantine override' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md spells out the zero-hour bypass mechanism" {
+  [ -f "$SECURITY_MD" ]
+  # Both documented levers must appear: the env var set to 0 and the
+  # equivalent bump-deps.sh flag.
+  run grep -q 'VIBE_BUMP_QUARANTINE_HOURS=0' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+  run grep -q -- '--quarantine-hours 0' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md requires a clean cargo audit before merge on the fast lane" {
+  [ -f "$SECURITY_MD" ]
+  run grep -qi 'cargo audit' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md scopes the override to approver / actively-exploited cases" {
+  [ -f "$SECURITY_MD" ]
+  run grep -qi 'exploited' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "upgrade-dependencies.yml exposes an emergency_bypass workflow_dispatch input" {
+  [ -f "$UPGRADE_WF" ]
+  run grep -q 'emergency_bypass' "$UPGRADE_WF"
+  [ "$status" -eq 0 ]
+}
+
+@test "upgrade-dependencies.yml wires emergency_bypass to a zero-hour window" {
+  [ -f "$UPGRADE_WF" ]
+  # When the bypass input is set, the effective quarantine window must collapse
+  # to 0 hours; otherwise the input would be cosmetic.
+  run grep -Eq "emergency_bypass.*==.*'?true'?" "$UPGRADE_WF"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #124 (SCR-QUARANTINE-OVERRIDE)

## Summary

The repo enforces a release-age quarantine on dependency bumps
(`VIBE_BUMP_QUARANTINE_HOURS`, default 24h — Issue #76) but had **no documented
emergency-override / fast-lane procedure** for bypassing that window when an
actively-exploited advisory's fix is a freshly-published crate. The override
capability already existed (`bump-deps.sh --quarantine-hours 0`) but was
undocumented and not surfaced in the *Upgrade Cargo Dependencies* workflow.

This PR makes the safe escape hatch explicit and auditable:

- Adds **`SECURITY.md`** with an *Emergency quarantine override* section: when an
  actively-exploited advisory's fix is newer than the window, an approver runs
  the upgrade with the window disabled (`VIBE_BUMP_QUARANTINE_HOURS=0` /
  `./bump-deps.sh --quarantine-hours 0`) and must confirm `cargo audit` is clean
  before merge.
- Adds a self-documenting **`emergency_bypass` `workflow_dispatch` input** to
  `upgrade-dependencies.yml`, wired so that `emergency_bypass: true` collapses the
  effective window to `0` for that run. The input is cosmetic-proof — the env
  expression actually feeds `bump-deps.sh`.
- Cross-links the procedure from `README.md`'s dependency-updates section.

The bypass disables only the release-age deferral — the `cargo audit` and dual
native/WASM build gates still run.

Closes #124.

## Evidence

Backend/CLI/docs change — no web interface to screenshot. Verified via the bats
suite and the local quality gates (bash syntax, shellcheck, codespell,
markdownlint) which all pass.

New TDD test `tests/scripts/security_quarantine_override.bats` — failing before
the change (no `SECURITY.md`, no `emergency_bypass` input), passing after:

```
1..7
ok 1 SECURITY.md exists
ok 2 SECURITY.md documents the emergency quarantine override section
ok 3 SECURITY.md spells out the zero-hour bypass mechanism
ok 4 SECURITY.md requires a clean cargo audit before merge on the fast lane
ok 5 SECURITY.md scopes the override to approver / actively-exploited cases
ok 6 upgrade-dependencies.yml exposes an emergency_bypass workflow_dispatch input
ok 7 upgrade-dependencies.yml wires emergency_bypass to a zero-hour window
```

Override decision flow documented in `SECURITY.md`:

```mermaid
flowchart TD
    Adv[Actively-exploited advisory<br/>fix published inside window] --> Approver{Approver decision}
    Approver -->|emergency_bypass=true| Zero[Effective window = 0h]
    Approver -->|--quarantine-hours 0| Zero
    Zero --> Bump[bump-deps.sh applies fix immediately]
    Bump --> Audit{cargo audit clean?}
    Audit -->|yes| Merge[Merge fix]
    Audit -->|no| Revert[Revert — do not merge]
```

## Test Plan

- Added `tests/scripts/security_quarantine_override.bats` (7 cases) covering the
  documented override path and the workflow input wiring.
- `bats tests/scripts/security_quarantine_override.bats` — 7/7 pass.
- Pre-existing failures in `ci_workflow_quarantine.bats` (ci.yml not invoking
  bump-deps.sh) are unrelated to this issue and present on the base branch — left
  untouched per change-scope.
- Local gates pass for the changed files: bash syntax, shellcheck, codespell,
  markdownlint.

## Notes

`actionlint` reports three pre-existing `SC2016` info-level findings on the
unrelated "Build summary" step (single-quoted literal markdown echoes); these
predate this PR and are out of scope.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq2oumo5-cea436`<!-- vibe-worker-issue-124 -->