### PR TITLE
Add disclosure contact and emergency-bump runbook to SECURITY.md (Issue #123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.37"
+version = "0.1.38"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,24 @@ complements the automated supply-chain defences described in
 quarantine-aware bump, the Dependabot security fast lane, and `cargo audit`
 detection.
 
+## Reporting a vulnerability
+
+If you discover a vulnerability — in this code or in one of its dependencies —
+report it privately so a fix can be prepared before any public disclosure:
+
+- **Email** [security@stsoftware.com.au](mailto:security@stsoftware.com.au)
+  with the affected version, a description, and reproduction steps where
+  practical.
+- **Or** open a private advisory via **GitHub Security Advisories**
+  (*Security → Advisories → Report a vulnerability* on this repository).
+
+Please **do not file a public issue** for an embargoed or unpatched
+vulnerability — a public issue leaks the advisory before a fix is available.
+Public issues are fine once an advisory is published and remediated.
+
+We aim to acknowledge a report within two working days and to agree a
+disclosure timeline with the reporter.
+
 ## Dependency bump quarantine
 
 Dependency bumps honour a release-age **quarantine window**
@@ -49,3 +67,28 @@ flowchart TD
 Use this path only for an actively-exploited advisory whose fix falls inside
 the quarantine window. Routine bumps must continue to honour the default
 window.
+
+## Emergency dependency bump
+
+When an advisory needs an out-of-cycle fix, follow this runbook rather than
+waiting for the weekly bump:
+
+1. **Triage.** Confirm the advisory affects a crate in `Cargo.lock` and that a
+   patched version exists. `cargo audit` (run locally or via the `security`
+   job) names the advisory and the fixed version.
+2. **Dispatch the bump.** Trigger the *Upgrade Cargo Dependencies* workflow
+   ([`upgrade-dependencies.yml`](.github/workflows/upgrade-dependencies.yml))
+   via `workflow_dispatch`. If the patched version is newer than the
+   `VIBE_BUMP_QUARANTINE_HOURS` window, set `emergency_bypass: true` to collapse
+   the window to 0h (see *Emergency quarantine override* above). Locally, the
+   equivalent is `./bump-deps.sh --quarantine-hours 0`.
+3. **Verify.** Confirm `cargo audit` reports no advisories against the bumped
+   tree and that the native and WASM builds pass. The bypass relaxes only the
+   release-age deferral — never the audit or build gates.
+4. **Fast-track the PR.** Mark the upgrade PR as security-driven, get an
+   approver review, and merge to `Develop` ahead of the routine queue.
+5. **Close the loop.** Once merged and released, the advisory may be discussed
+   publicly; update or publish the GitHub Security Advisory accordingly.
+
+For the routine (non-urgent) refresh channels, see
+[`README.md`](README.md#dependency-updates-two-channels).

--- a/docs/archive/pr-summaries/pr-summary-123.md
+++ b/docs/archive/pr-summaries/pr-summary-123.md
@@ -1,0 +1,72 @@
+# SCR-RUNBOOK: add disclosure contact and emergency-bump runbook to SECURITY.md
+
+## Summary
+
+`SECURITY.md` existed but only documented the dependency-bump quarantine and
+its emergency override (SCR-QUARANTINE-OVERRIDE). It had **no named disclosure
+contact** and **no written emergency-bump response procedure**, so vulnerability
+reports defaulted to public issues and the response steps lived only in
+maintainers' heads.
+
+This PR closes the SCR-RUNBOOK posture gap by adding two sections to
+`SECURITY.md`:
+
+- **Reporting a vulnerability** — names a disclosure contact
+  (`security@stsoftware.com.au`), offers the private GitHub Security Advisories
+  channel, and warns reporters not to file public issues for embargoed
+  advisories.
+- **Emergency dependency bump** — a 5-step runbook a responder can follow to
+  triage, dispatch the *Upgrade Cargo Dependencies* workflow (or run
+  `./bump-deps.sh`), verify `cargo audit`/builds, fast-track the PR, and close
+  the loop on the advisory. It cross-links the existing *Emergency quarantine
+  override* section and the README's routine refresh channels.
+
+No code paths changed — this is a documentation/posture fix.
+
+Closes #123.
+
+```mermaid
+flowchart TD
+    Reporter[Reporter spots vulnerability] -->|email security@stsoftware.com.au| Triage
+    Reporter -->|private GitHub Security Advisory| Triage
+    Triage{Advisory affects<br/>Cargo.lock crate?} -->|yes| Dispatch[Dispatch Upgrade Cargo Dependencies<br/>or ./bump-deps.sh]
+    Dispatch --> Verify{cargo audit clean<br/>+ builds pass?}
+    Verify -->|yes| FastTrack[Fast-track PR to Develop]
+    Verify -->|no| Revert[Revert — do not merge]
+    FastTrack --> Close[Publish advisory once released]
+```
+
+## Evidence
+
+Backend/docs change — no web interface to screenshot. Verified via bats tests
+mirroring the repo's existing `security_quarantine_override.bats` pattern:
+
+```
+$ bats tests/scripts/security_runbook.bats
+1..7
+ok 1 SECURITY.md exists
+ok 2 SECURITY.md has a vulnerability-reporting section
+ok 3 SECURITY.md names a disclosure contact address
+ok 4 SECURITY.md offers a private GitHub Security Advisory channel
+ok 5 SECURITY.md warns against public issues for embargoed advisories
+ok 6 SECURITY.md documents an emergency dependency-bump procedure
+ok 7 the emergency-bump runbook names the workflow and the bump-deps.sh fallback
+```
+
+`markdownlint-cli2 SECURITY.md` and `codespell` both pass clean.
+
+> Note: `./quality.sh` reports four pre-existing, unrelated failures in
+> `tests/scripts/ci_workflow_quarantine.bats` (ci.yml invoking `cargo upgrade`/
+> `cargo update` directly). These fail on the branch with this PR's changes
+> stashed and are a separate finding — out of scope for #123.
+
+## Test Plan
+
+- Added `tests/scripts/security_runbook.bats` — 7 "what" assertions on the
+  observable content of `SECURITY.md` (disclosure section, contact address,
+  private advisory channel, public-issue warning, emergency-bump runbook, and
+  the workflow + `bump-deps.sh` fallback being named).
+- Confirmed the new tests fail against the pre-change `SECURITY.md` (TDD) and
+  pass after the edit.
+- Re-ran `tests/scripts/security_quarantine_override.bats` to confirm the
+  existing override assertions still hold.

--- a/tests/scripts/security_runbook.bats
+++ b/tests/scripts/security_runbook.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# Regression assertion for Issue #123 (SCR-RUNBOOK) — the repo had a SECURITY.md
+# covering the dependency-bump quarantine override, but no named disclosure
+# contact and no written emergency-bump *response* procedure a responder could
+# follow. These tests pin down that SECURITY.md now carries both the
+# vulnerability-reporting channel and the emergency dependency-bump runbook,
+# so disclosure no longer defaults to a public issue and the response steps no
+# longer live only in maintainers' heads.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SECURITY_MD="${REPO_ROOT}/SECURITY.md"
+}
+
+@test "SECURITY.md exists" {
+  [ -f "$SECURITY_MD" ]
+}
+
+@test "SECURITY.md has a vulnerability-reporting section" {
+  [ -f "$SECURITY_MD" ]
+  run grep -qi 'Reporting a vulnerability' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md names a disclosure contact address" {
+  [ -f "$SECURITY_MD" ]
+  run grep -q 'security@stsoftware.com.au' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md offers a private GitHub Security Advisory channel" {
+  [ -f "$SECURITY_MD" ]
+  run grep -qi 'Security Advisor' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md warns against public issues for embargoed advisories" {
+  [ -f "$SECURITY_MD" ]
+  # The disclosure guidance must explicitly steer reporters away from public
+  # issues so embargoed advisories are not leaked.
+  run grep -qi 'public issue' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "SECURITY.md documents an emergency dependency-bump procedure" {
+  [ -f "$SECURITY_MD" ]
+  run grep -qi 'Emergency dependency bump' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}
+
+@test "the emergency-bump runbook names the workflow and the bump-deps.sh fallback" {
+  [ -f "$SECURITY_MD" ]
+  # A responder must be able to find both levers: the dispatchable workflow and
+  # the local script fallback.
+  run grep -qi 'Upgrade Cargo Dependencies' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+  run grep -q 'bump-deps.sh' "$SECURITY_MD"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# SCR-RUNBOOK: add disclosure contact and emergency-bump runbook to SECURITY.md

## Summary

`SECURITY.md` existed but only documented the dependency-bump quarantine and
its emergency override (SCR-QUARANTINE-OVERRIDE). It had **no named disclosure
contact** and **no written emergency-bump response procedure**, so vulnerability
reports defaulted to public issues and the response steps lived only in
maintainers' heads.

This PR closes the SCR-RUNBOOK posture gap by adding two sections to
`SECURITY.md`:

- **Reporting a vulnerability** — names a disclosure contact
  (`security@stsoftware.com.au`), offers the private GitHub Security Advisories
  channel, and warns reporters not to file public issues for embargoed
  advisories.
- **Emergency dependency bump** — a 5-step runbook a responder can follow to
  triage, dispatch the *Upgrade Cargo Dependencies* workflow (or run
  `./bump-deps.sh`), verify `cargo audit`/builds, fast-track the PR, and close
  the loop on the advisory. It cross-links the existing *Emergency quarantine
  override* section and the README's routine refresh channels.

No code paths changed — this is a documentation/posture fix.

Closes #123.

```mermaid
flowchart TD
    Reporter[Reporter spots vulnerability] -->|email security@stsoftware.com.au| Triage
    Reporter -->|private GitHub Security Advisory| Triage
    Triage{Advisory affects<br/>Cargo.lock crate?} -->|yes| Dispatch[Dispatch Upgrade Cargo Dependencies<br/>or ./bump-deps.sh]
    Dispatch --> Verify{cargo audit clean<br/>+ builds pass?}
    Verify -->|yes| FastTrack[Fast-track PR to Develop]
    Verify -->|no| Revert[Revert — do not merge]
    FastTrack --> Close[Publish advisory once released]
```

## Evidence

Backend/docs change — no web interface to screenshot. Verified via bats tests
mirroring the repo's existing `security_quarantine_override.bats` pattern:

```
$ bats tests/scripts/security_runbook.bats
1..7
ok 1 SECURITY.md exists
ok 2 SECURITY.md has a vulnerability-reporting section
ok 3 SECURITY.md names a disclosure contact address
ok 4 SECURITY.md offers a private GitHub Security Advisory channel
ok 5 SECURITY.md warns against public issues for embargoed advisories
ok 6 SECURITY.md documents an emergency dependency-bump procedure
ok 7 the emergency-bump runbook names the workflow and the bump-deps.sh fallback
```

`markdownlint-cli2 SECURITY.md` and `codespell` both pass clean.

> Note: `./quality.sh` reports four pre-existing, unrelated failures in
> `tests/scripts/ci_workflow_quarantine.bats` (ci.yml invoking `cargo upgrade`/
> `cargo update` directly). These fail on the branch with this PR's changes
> stashed and are a separate finding — out of scope for #123.

## Test Plan

- Added `tests/scripts/security_runbook.bats` — 7 "what" assertions on the
  observable content of `SECURITY.md` (disclosure section, contact address,
  private advisory channel, public-issue warning, emergency-bump runbook, and
  the workflow + `bump-deps.sh` fallback being named).
- Confirmed the new tests fail against the pre-change `SECURITY.md` (TDD) and
  pass after the edit.
- Re-ran `tests/scripts/security_quarantine_override.bats` to confirm the
  existing override assertions still hold.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq2vpqtx-07aca6`<!-- vibe-worker-issue-123 -->