### PR TITLE
Add CI lint + compile gates for Rust (Issue #143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,45 @@ jobs:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --no-deps
 
+  rust-gates:
+    name: Lint & Compile Gates
+    runs-on: ubuntu-latest
+    # Issue #143 — explicit Rust lint + compile/syntax gates that run on every
+    # push to Develop AND every pull request. Deliberately independent of the
+    # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
+    # (which skip those jobs) are still gated against lint regressions and
+    # syntax errors. The full `quality` job remains the comprehensive PR gate.
+    env:
+      RUSTFLAGS: "-D warnings"
+
+    steps:
+      - name: Checkout code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          components: clippy
+
+      - name: Rust cache
+        # Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          workspaces: ". -> target"
+
+      # Compile/syntax gate — fail the build on syntax or type errors across
+      # every target before the slower lint pass runs.
+      - name: Compile gate (cargo check)
+        run: cargo check --workspace --all-targets --all-features
+
+      # Lint gate — clippy with -D warnings so lint regressions fail the build.
+      - name: Lint gate (cargo clippy)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
   scripts-and-spelling:
     name: Scripts & spelling
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "neat-core"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.38"
+version = "0.1.39"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 | `Cargo.toml` | Virtual workspace root; `[workspace.package]` holds semver for release automation. |
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
+| `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build (Vibe Coder hook). |
 | `.github/dependabot.yml` | Advisory-triggered security-update fast lane — raises a fix PR the moment a RustSec/OSV advisory lands, independent of the weekly bump. |
 | `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`). |

--- a/docs/archive/pr-summaries/pr-summary-143.md
+++ b/docs/archive/pr-summaries/pr-summary-143.md
@@ -1,0 +1,72 @@
+# Add CI lint + compile gates for Rust (Issue #143)
+
+## Summary
+
+Added explicit Rust **lint** and **compile/syntax** gates to CI that run on
+**every push to `Develop` and every pull request**, so lint regressions and
+syntax errors fail the build regardless of how a change reaches `Develop`.
+Closes #143.
+
+A `ci.yml` workflow already existed (the finding's "no workflows found" note
+was stale), and it ran `cargo clippy -D warnings` — but **only** inside the
+`quality` job, which is gated `if: github.event_name == 'pull_request'` and
+depends on the PR-only auto-bump / auto-format jobs. Two real gaps remained:
+
+1. **No CI ran on `push` to `Develop`** — every job was restricted to
+   `pull_request`, so a direct push to `Develop` got zero lint/compile
+   coverage.
+2. **No explicit compile/syntax gate** — only a comment
+   ("skip redundant cargo check / cargo build").
+
+### Change
+
+Added a self-contained `rust-gates` job to `.github/workflows/ci.yml`:
+
+- **Compile gate** — `cargo check --workspace --all-targets --all-features`.
+- **Lint gate** — `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
+- Runs on both push (to `Develop`) and pull request, with `RUSTFLAGS=-D warnings`.
+- Deliberately **independent** of the PR-only auto-bump / auto-format jobs, so
+  direct pushes to `Develop` are gated too. The existing `quality` job remains
+  the comprehensive PR pipeline and is left untouched.
+
+```mermaid
+flowchart LR
+    Push[push to Develop] --> Gates
+    PR[pull request] --> Gates
+    PR --> Quality[quality job<br/>full PR pipeline]
+    subgraph Gates[rust-gates job]
+        C[cargo check<br/>--all-targets] --> L[cargo clippy<br/>-D warnings]
+    end
+    L -->|regression| Fail[(build fails)]
+    C -->|syntax error| Fail
+```
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified locally with the
+same commands the new job runs, plus the workflow tooling CI uses:
+
+- `cargo fmt --all -- --check` → clean.
+- `cargo check --workspace --all-targets --all-features` → compiles (`neat-core v0.1.38`).
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean.
+- `cargo test --workspace --lib --tests --all-features` → 9 passed, 0 failed.
+- `actionlint -no-color -ignore 'SC2016' .github/workflows/ci.yml` → passes.
+- `bats tests/scripts` → 120 tests pass (includes the new suite and the
+  repo-wide SHA-pin / tainted-context security scans, which now also cover the
+  new job's actions).
+
+## Test Plan
+
+Added `tests/scripts/rust_gates_workflow.bats` — a contract test for the CI
+wiring (the issue's requirement *is* the wiring). It asserts on observable
+outcomes by parsing `ci.yml`:
+
+- the workflow triggers on PRs and on pushes to `Develop`;
+- a job runs the clippy lint gate with `-D warnings`;
+- a job runs an explicit compile/syntax gate (`cargo check`/`cargo build` with `--all-targets`);
+- a single job carries **both** gates and is **not** restricted to
+  `pull_request` only (so pushes to `Develop` are gated) — this assertion
+  failed before the change and passes after;
+- third-party actions in the workflow are SHA-pinned.
+
+All existing tests remain unmodified.

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.122"
+wasm-bindgen = "0.2.123"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tests/scripts/rust_gates_workflow.bats
+++ b/tests/scripts/rust_gates_workflow.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# Tests for the Rust CI lint + compile gates (Issue #143).
+#
+# The contract under test IS the CI wiring: the issue requires that every push
+# and every pull request run a Rust lint gate (cargo clippy) and a
+# compile/syntax gate (cargo check / cargo build) so lint regressions and
+# syntax errors fail the build. These are "what" tests in the sense allowed by
+# AGENTS.md — they assert on the observable CI contract, not on private
+# implementation detail.
+#
+# Asserts on observable outcomes:
+#   - ci.yml parses as YAML,
+#   - the workflow triggers on pushes to Develop AND on pull requests,
+#   - a job invokes the clippy lint gate with `-D warnings`,
+#   - a job invokes an explicit compile/syntax gate (cargo check / cargo build),
+#   - the gate job runs on push (not restricted to pull_request only), so direct
+#     pushes to Develop are gated too,
+#   - third-party actions in the gate job are SHA-pinned (Issue #77).
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "ci workflow is valid YAML" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "ci workflow triggers on PRs and on pushes to Develop" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+# YAML parses bare 'on:' as boolean True in some loaders; tolerate both.
+triggers = data.get("on") or data.get(True)
+assert triggers is not None, data
+assert "pull_request" in triggers, triggers
+push = triggers.get("push") or {}
+branches = push.get("branches") or []
+assert "Develop" in branches, branches
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci workflow runs a clippy lint gate with -D warnings" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+runs = [
+    s.get("run", "")
+    for job in data["jobs"].values()
+    for s in job.get("steps", [])
+]
+assert any("cargo clippy" in r and "-D warnings" in r for r in runs), runs
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci workflow runs an explicit compile/syntax gate (cargo check or build)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+runs = [
+    s.get("run", "")
+    for job in data["jobs"].values()
+    for s in job.get("steps", [])
+]
+def is_gate(r):
+    return ("cargo check" in r or "cargo build" in r) and "--all-targets" in r
+assert any(is_gate(r) for r in runs), runs
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci workflow gates lint + compile on push (not pull_request only)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+
+def has_lint(job):
+    return any(
+        "cargo clippy" in s.get("run", "") and "-D warnings" in s.get("run", "")
+        for s in job.get("steps", [])
+    )
+
+def has_compile(job):
+    return any(
+        ("cargo check" in s.get("run", "") or "cargo build" in s.get("run", ""))
+        and "--all-targets" in s.get("run", "")
+        for s in job.get("steps", [])
+    )
+
+# At least one job must carry BOTH gates and must not be restricted to
+# pull_request only, so direct pushes to Develop are gated too.
+gate_jobs = [
+    job for job in data["jobs"].values()
+    if has_lint(job) and has_compile(job)
+]
+assert gate_jobs, "no single job carries both the lint and compile gates"
+runs_on_push = [
+    job for job in gate_jobs
+    if "pull_request" not in str(job.get("if", ""))
+]
+assert runs_on_push, "lint+compile gate job is restricted to pull_request only"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci workflow pins third-party actions to commit SHAs" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+sha_re = re.compile(r"^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$")
+for job in data["jobs"].values():
+    for step in job.get("steps", []):
+        uses = step.get("uses")
+        if uses is None:
+            continue
+        assert sha_re.match(uses), f"action not SHA-pinned: {uses}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Add CI lint + compile gates for Rust (Issue #143)

## Summary

Added explicit Rust **lint** and **compile/syntax** gates to CI that run on
**every push to `Develop` and every pull request**, so lint regressions and
syntax errors fail the build regardless of how a change reaches `Develop`.
Closes #143.

A `ci.yml` workflow already existed (the finding's "no workflows found" note
was stale), and it ran `cargo clippy -D warnings` — but **only** inside the
`quality` job, which is gated `if: github.event_name == 'pull_request'` and
depends on the PR-only auto-bump / auto-format jobs. Two real gaps remained:

1. **No CI ran on `push` to `Develop`** — every job was restricted to
   `pull_request`, so a direct push to `Develop` got zero lint/compile
   coverage.
2. **No explicit compile/syntax gate** — only a comment
   ("skip redundant cargo check / cargo build").

### Change

Added a self-contained `rust-gates` job to `.github/workflows/ci.yml`:

- **Compile gate** — `cargo check --workspace --all-targets --all-features`.
- **Lint gate** — `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
- Runs on both push (to `Develop`) and pull request, with `RUSTFLAGS=-D warnings`.
- Deliberately **independent** of the PR-only auto-bump / auto-format jobs, so
  direct pushes to `Develop` are gated too. The existing `quality` job remains
  the comprehensive PR pipeline and is left untouched.

```mermaid
flowchart LR
    Push[push to Develop] --> Gates
    PR[pull request] --> Gates
    PR --> Quality[quality job<br/>full PR pipeline]
    subgraph Gates[rust-gates job]
        C[cargo check<br/>--all-targets] --> L[cargo clippy<br/>-D warnings]
    end
    L -->|regression| Fail[(build fails)]
    C -->|syntax error| Fail
```

## Evidence

Backend/CI change — no web interface to screenshot. Verified locally with the
same commands the new job runs, plus the workflow tooling CI uses:

- `cargo fmt --all -- --check` → clean.
- `cargo check --workspace --all-targets --all-features` → compiles (`neat-core v0.1.38`).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean.
- `cargo test --workspace --lib --tests --all-features` → 9 passed, 0 failed.
- `actionlint -no-color -ignore 'SC2016' .github/workflows/ci.yml` → passes.
- `bats tests/scripts` → 120 tests pass (includes the new suite and the
  repo-wide SHA-pin / tainted-context security scans, which now also cover the
  new job's actions).

## Test Plan

Added `tests/scripts/rust_gates_workflow.bats` — a contract test for the CI
wiring (the issue's requirement *is* the wiring). It asserts on observable
outcomes by parsing `ci.yml`:

- the workflow triggers on PRs and on pushes to `Develop`;
- a job runs the clippy lint gate with `-D warnings`;
- a job runs an explicit compile/syntax gate (`cargo check`/`cargo build` with `--all-targets`);
- a single job carries **both** gates and is **not** restricted to
  `pull_request` only (so pushes to `Develop` are gated) — this assertion
  failed before the change and passes after;
- third-party actions in the workflow are SHA-pinned.

All existing tests remain unmodified.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq7m1x1y-fff629`<!-- vibe-worker-issue-143 -->