### PR TITLE
[perf] Add a Criterion benchmark harness for core hot paths (#152)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,37 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -21,10 +48,141 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -55,6 +213,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +247,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -89,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,10 +306,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -146,6 +376,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 name = "neat-core"
 version = "0.1.40"
 dependencies = [
+ "criterion",
  "serde",
  "serde_json",
  "tempfile",
@@ -153,10 +384,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "prettyplease"
@@ -193,6 +473,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +539,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -261,6 +599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +629,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +649,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasip2"
@@ -391,6 +755,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -500,6 +883,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -113,25 +132,24 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -139,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -205,6 +223,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -282,12 +306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,21 +324,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -374,7 +381,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "criterion",
  "serde",
@@ -403,6 +410,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -599,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +791,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +814,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.40"
+version = "0.1.41"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 | `neat-core/` | Shared computation library; **140+** unit tests in `src/**/*.rs` plus integration tests in `neat-core/tests/` (>350 total). |
 | `Cargo.toml` | Virtual workspace root; `[workspace.package]` holds semver for release automation. |
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
+| `neat-core/benches/` | Opt-in Criterion harness for core hot paths (`cargo bench -p neat-core --bench hot_paths`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
 | `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build (Vibe Coder hook). |
@@ -31,6 +32,8 @@ export RUSTFLAGS="-D warnings"
 cargo test --workspace
 # or full gate:
 ./quality.sh
+# opt-in performance benchmarks (not part of the test gate):
+cargo bench -p neat-core --bench hot_paths
 ```
 
 ## Related Repositories

--- a/docs/archive/pr-summaries/pr-summary-152.md
+++ b/docs/archive/pr-summaries/pr-summary-152.md
@@ -1,0 +1,101 @@
+# Add a Criterion benchmark harness for core hot paths
+
+## Summary
+
+Adds an **opt-in** [Criterion](https://github.com/bheisler/criterion.rs)
+benchmark harness for `neat-core`'s hottest paths so future performance work
+(the #151 sub-issues) can be validated against reproducible numbers instead of
+reasoning alone. This is additive tooling only — no library behaviour changes.
+Closes #152.
+
+Changes:
+
+- `neat-core/Cargo.toml` — add `criterion` (with `html_reports`) as a
+  dev-dependency and register a `harness = false` `[[bench]]` target named
+  `hot_paths`.
+- `neat-core/benches/hot_paths.rs` — deterministic benchmark groups for the
+  forward pass, batched scoring, backprop, and activation primitives.
+- `neat-core/benches/README.md` — how to run the benches and compare
+  before/after with Criterion baselines.
+- `README.md` — layout/build pointers to the opt-in harness.
+- `Cargo.lock` — criterion + transitive dev-dependencies (licences/advisories
+  pass `cargo deny check`).
+
+### Coverage
+
+| Group | Functions under test | Sizes |
+| --- | --- | --- |
+| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000 |
+| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same three |
+| `backprop` | one `propagate_topological_loop` step | same three |
+| `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- & 8-record) | 64-synapse block |
+| `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
+
+Networks and inputs are built **once** outside the timed closure from a
+fixed-seed PRNG with fixed topologies; `criterion::black_box` guards inputs and
+outputs. The harness is deterministic so before/after comparisons are
+meaningful.
+
+```mermaid
+flowchart LR
+    subgraph "cargo test / quality.sh"
+        T[lib + integration tests]
+    end
+    subgraph "cargo bench -p neat-core --bench hot_paths (opt-in)"
+        F[forward_pass] --> R[(target/criterion)]
+        B[batched_scoring] --> R
+        P[backprop] --> R
+        S[primitives: weighted_sum_simd + squash] --> R
+    end
+    T -. harness=false keeps benches out of the gate .-> F
+```
+
+## Evidence
+
+Backend/CLI tooling — no web interface to screenshot. Evidence is the harness
+running and producing stable numbers.
+
+`cargo bench -p neat-core --bench hot_paths` (abbreviated, short measurement
+window — representative magnitudes, not a tuned baseline):
+
+```text
+forward_pass/small_50      time:   [409.60 ns 412.41 ns 417.45 ns]
+forward_pass/medium_500    time:   [5.3811 µs 5.4147 µs 5.4434 µs]
+forward_pass/large_5000    time:   [81.874 µs 82.240 µs 82.676 µs]
+batched_scoring/trace_batch_4way/medium_500  time: [10.776 µs 10.857 µs 10.951 µs]
+batched_scoring/mse_sum_8records/medium_500  time: [19.161 µs 19.380 µs 19.599 µs]
+backprop/medium_500        time:   [151.56 µs 152.61 µs 154.26 µs]
+weighted_sum_simd/single   time:   [16.958 ns 17.042 ns 17.111 ns]
+weighted_sum_simd/batch_8records  time: [70.350 ns 70.726 ns 70.986 ns]
+squash/apply_squash/Tanh   time:   [1.7994 ns 1.8199 ns 1.8430 ns]
+```
+
+This issue is the foundation for #151 — it establishes the baseline so later
+perf changes can be measured. It introduces no perf change of its own, so there
+is no before/after delta to report here.
+
+## Test Plan
+
+- `cargo bench -p neat-core --bench hot_paths` runs all four groups and reports
+  stable numbers (acceptance criterion 1).
+- Benches stay out of the test gate: `cargo test --workspace --lib --tests`
+  does not run them (`harness = false` + opt-in `[[bench]]`), so `quality.sh`
+  runtime is unaffected (acceptance criterion 2).
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
+  (the bench compiles under the lint gate).
+- `cargo check --all-targets`, `cargo test --workspace --lib --tests`,
+  `cargo doc`, and `cargo build --release` all pass.
+- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` with
+  the new criterion dependency tree.
+
+### Note on the local gate
+
+`./quality.sh` reports 4 **pre-existing** `bats` failures in
+`tests/scripts/ci_workflow_quarantine.bats` (about `ci.yml` calling
+`cargo upgrade`/`cargo update` directly). These are present on the clean base
+branch, are unrelated to this change, and were left untouched per change-scope
+rules. All Rust gates that follow were run individually and pass.
+
+This is additive tooling (a benchmark target), so there is no library behaviour
+to add unit tests for; the harness compiling under the clippy `--all-targets`
+gate and running cleanly is the verification.

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -24,3 +24,11 @@ wasm-bindgen = "0.2.125"
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+# Issue #152 - opt-in Criterion harness for core hot paths. `harness = false`
+# keeps these out of `cargo test`/CI so `quality.sh` runtime is unaffected;
+# run explicitly with `cargo bench -p neat-core`.
+[[bench]]
+name = "hot_paths"
+harness = false

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -24,7 +24,7 @@ wasm-bindgen = "0.2.125"
 
 [dev-dependencies]
 tempfile = "3"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 # Issue #152 - opt-in Criterion harness for core hot paths. `harness = false`
 # keeps these out of `cargo test`/CI so `quality.sh` runtime is unaffected;

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -1,0 +1,54 @@
+# neat-core benchmarks
+
+Criterion harness for the core hot paths (Issue #152). These benchmarks are
+**opt-in only** — `harness = false` plus the `[[bench]]` target in
+`neat-core/Cargo.toml` keeps them out of `cargo test` and the `quality.sh`
+gate, so the CI runtime is unaffected.
+
+## What is measured
+
+`hot_paths.rs` covers the four hottest paths in the crate:
+
+| Group | Function(s) under test | Sizes |
+| --- | --- | --- |
+| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000 neurons |
+| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same three sizes |
+| `backprop` | one `propagate_topological_loop` step | same three sizes |
+| `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
+| `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
+
+Networks and inputs are built **once** outside the timed closure from a
+fixed-seed PRNG with fixed topologies, and `criterion::black_box` guards inputs
+and outputs. The harness is therefore deterministic, so before/after
+comparisons across a code change are meaningful.
+
+## Running
+
+```bash
+# Run every group.
+cargo bench -p neat-core --bench hot_paths
+
+# Run a single group (regex over benchmark ids).
+cargo bench -p neat-core --bench hot_paths -- forward_pass
+cargo bench -p neat-core --bench hot_paths -- backprop
+```
+
+> Use `--bench hot_paths` so Criterion's CLI flags are not handed to the
+> default libtest harness on the library target.
+
+## Comparing before vs after a change
+
+Criterion stores a baseline under `target/criterion/` and reports the delta on
+the next run automatically:
+
+```bash
+# 1. On the unchanged code, record a named baseline.
+cargo bench -p neat-core --bench hot_paths -- --save-baseline before
+
+# 2. Apply your change, then compare against it.
+cargo bench -p neat-core --bench hot_paths -- --baseline before
+```
+
+Criterion prints the percentage change and whether it is statistically
+significant. HTML reports (enabled via the `html_reports` feature) are written
+to `target/criterion/report/index.html`.

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -1,0 +1,453 @@
+//! Criterion benchmark harness for neat-core hot paths (Issue #152).
+//!
+//! Opt-in only: `harness = false` plus the `[[bench]]` target in
+//! `neat-core/Cargo.toml` keeps these out of `cargo test` / the `quality.sh`
+//! gate. Run them explicitly with:
+//!
+//! ```text
+//! cargo bench -p neat-core
+//! ```
+//!
+//! The harness is deterministic — networks are built from a fixed-seed LCG and
+//! fixed topologies — so before/after comparisons across a code change are
+//! meaningful. See `neat-core/benches/README.md` for the comparison workflow.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_simd,
+    weighted_sum_simd_4records, weighted_sum_simd_8records,
+};
+use neat_core::squash::{SquashType, apply_squash};
+use neat_core::topological_backprop::{
+    NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, PropagateInput,
+    SynapseInput, propagate_topological_loop,
+};
+use neat_core::loss::mse_sum_batch_packed;
+use neat_core::unsquash::apply_unsquash;
+
+/// Tiny deterministic PRNG (SplitMix64-style) so the harness produces fixed
+/// topologies and weights without pulling in an `rand` dependency.
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform float in `[-1.0, 1.0)`.
+    fn next_signed(&mut self) -> f32 {
+        let unit = (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32;
+        unit * 2.0 - 1.0
+    }
+
+    /// Uniform integer in `[0, bound)`.
+    fn next_below(&mut self, bound: usize) -> usize {
+        (self.next_u64() % bound as u64) as usize
+    }
+}
+
+/// Build a deterministic feedforward [`CompiledNetwork`].
+///
+/// Non-input neurons are emitted in topological order; each draws up to
+/// `fan_in` incoming connections from strictly earlier neurons, giving a
+/// realistic synapse density without recurrent edges.
+fn build_network(
+    num_neurons: usize,
+    num_inputs: usize,
+    fan_in: usize,
+    seed: u64,
+) -> CompiledNetwork {
+    let mut rng = Lcg::new(seed);
+    let num_non_inputs = num_neurons - num_inputs;
+    let mut neurons = Vec::with_capacity(num_non_inputs);
+    let mut synapses = Vec::new();
+
+    for n in 0..num_non_inputs {
+        let global_idx = num_inputs + n;
+        let this_fan = fan_in.min(global_idx);
+        let start_synapse = synapses.len() as u32;
+        for _ in 0..this_fan {
+            let from = rng.next_below(global_idx);
+            synapses.push(SynapseData {
+                weight: rng.next_signed() * 0.5,
+                from_index: from as u32,
+                synapse_type: 0,
+                _padding: [0; 3],
+            });
+        }
+        neurons.push(NeuronData {
+            bias: rng.next_signed() * 0.1,
+            start_synapse,
+            num_synapses: this_fan as u16,
+            squash_type: SquashType::Tanh as u8,
+            is_constant: false,
+        });
+    }
+
+    let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+    }
+}
+
+/// Deterministic input vector of length `n`.
+fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
+    let mut rng = Lcg::new(seed);
+    (0..n).map(|_| rng.next_signed()).collect()
+}
+
+/// Representative network sizes: (label, total neurons, inputs, outputs, fan-in).
+const NETWORKS: [(&str, usize, usize, usize, usize); 3] = [
+    ("small_50", 50, 8, 4, 12),
+    ("medium_500", 500, 16, 8, 16),
+    ("large_5000", 5000, 32, 16, 24),
+];
+
+/// Forward pass — `CompiledNetwork::activate` across representative sizes.
+fn bench_forward_pass(c: &mut Criterion) {
+    let mut group = c.benchmark_group("forward_pass");
+    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
+        let mut net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
+        let inputs = build_inputs(num_inputs, 0xA1B2_C3D4);
+        group.throughput(Throughput::Elements(num_neurons as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(label), &inputs, |b, inputs| {
+            b.iter(|| {
+                let out = net.activate(black_box(inputs), black_box(num_outputs));
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Batched scoring — 4-way traced activation and the 8-record loss path.
+fn bench_batched_scoring(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batched_scoring");
+
+    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
+        let net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
+
+        // 4 records packed back-to-back for the traced batch path.
+        let batch4 = build_inputs(num_inputs * 4, 0x0BAD_F00D);
+        group.bench_with_input(
+            BenchmarkId::new("trace_batch_4way", label),
+            &batch4,
+            |b, batch| {
+                b.iter(|| {
+                    let out = net.activate_and_trace_batch_4way(
+                        black_box(batch),
+                        black_box(num_inputs),
+                        black_box(num_outputs),
+                    );
+                    black_box(out);
+                });
+            },
+        );
+
+        // 8 records of [inputs..., targets...] for the fused MSE loss path.
+        let mut loss_net = net.clone();
+        let records = build_inputs((num_inputs + num_outputs) * 8, 0xFEED_BEEF);
+        group.bench_with_input(
+            BenchmarkId::new("mse_sum_8records", label),
+            &records,
+            |b, records| {
+                b.iter(|| {
+                    let sum = mse_sum_batch_packed(
+                        &mut loss_net,
+                        black_box(records),
+                        black_box(num_inputs),
+                        black_box(num_outputs),
+                        black_box(true),
+                    );
+                    black_box(sum);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Owned backing storage for a [`PropagateInput`]; built once outside the loop.
+struct BackpropData {
+    neurons: Vec<NeuronInput>,
+    synapses: Vec<SynapseInput>,
+    inward_starts: Vec<u32>,
+    inward_counts: Vec<u32>,
+    inward_indices: Vec<u32>,
+    reverse_topo_order: Vec<u32>,
+    expected: Vec<f32>,
+    input_count: u32,
+    output_count: u32,
+}
+
+/// Build a deterministic feedforward backprop input of `num_neurons` neurons.
+fn build_backprop_data(
+    num_neurons: usize,
+    num_inputs: usize,
+    num_outputs: usize,
+    fan_in: usize,
+    seed: u64,
+) -> BackpropData {
+    let mut rng = Lcg::new(seed);
+    let mut neurons = Vec::with_capacity(num_neurons);
+
+    // Input neurons first.
+    for _ in 0..num_inputs {
+        neurons.push(make_neuron(
+            SquashType::Identity,
+            NEURON_TYPE_INPUT,
+            rng.next_signed(),
+        ));
+    }
+
+    // Synapses grouped by target neuron so the inward adjacency is contiguous.
+    let mut synapses: Vec<SynapseInput> = Vec::new();
+    let mut inward_starts = vec![0u32; num_neurons];
+    let mut inward_counts = vec![0u32; num_neurons];
+    let mut inward_indices: Vec<u32> = Vec::new();
+
+    for global_idx in num_inputs..num_neurons {
+        let is_output = global_idx >= num_neurons - num_outputs;
+        let neuron_type = if is_output {
+            NEURON_TYPE_OUTPUT
+        } else {
+            NEURON_TYPE_HIDDEN
+        };
+        neurons.push(make_neuron(SquashType::Tanh, neuron_type, rng.next_signed()));
+
+        let this_fan = fan_in.min(global_idx);
+        inward_starts[global_idx] = inward_indices.len() as u32;
+        inward_counts[global_idx] = this_fan as u32;
+        for _ in 0..this_fan {
+            let from = rng.next_below(global_idx);
+            let weight = rng.next_signed() * 0.5;
+            inward_indices.push(synapses.len() as u32);
+            synapses.push(SynapseInput {
+                from: from as u32,
+                to: global_idx as u32,
+                original_weight: weight,
+                adjusted_weight: weight,
+                is_self_loop: false,
+            });
+        }
+    }
+
+    // Reverse topological order: non-input neurons from last back to first.
+    let reverse_topo_order: Vec<u32> = (num_inputs..num_neurons).rev().map(|i| i as u32).collect();
+    let expected = (0..num_outputs).map(|_| rng.next_signed()).collect();
+
+    BackpropData {
+        neurons,
+        synapses,
+        inward_starts,
+        inward_counts,
+        inward_indices,
+        reverse_topo_order,
+        expected,
+        input_count: num_inputs as u32,
+        output_count: num_outputs as u32,
+    }
+}
+
+fn make_neuron(squash: SquashType, neuron_type: u8, adjusted_activation: f32) -> NeuronInput {
+    NeuronInput {
+        squash_type: squash as u8,
+        neuron_type,
+        propagate_needed: true,
+        update_needed: true,
+        hint_value: 0.0,
+        range_low: -1.0e6,
+        range_high: 1.0e6,
+        adjusted_activation,
+        adjusted_bias: 0.0,
+    }
+}
+
+/// Backprop — one `propagate_topological_loop` step on representative sizes.
+fn bench_backprop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("backprop");
+    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
+        let data =
+            build_backprop_data(num_neurons, num_inputs, num_outputs, fan_in, 0x1357_9BDF);
+        group.throughput(Throughput::Elements(num_neurons as u64));
+        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+            b.iter(|| {
+                let input = PropagateInput {
+                    neurons: &data.neurons,
+                    synapses: &data.synapses,
+                    inward_starts: &data.inward_starts,
+                    inward_counts: &data.inward_counts,
+                    inward_synapse_indices: &data.inward_indices,
+                    reverse_topo_order: &data.reverse_topo_order,
+                    expected: &data.expected,
+                    input_count: data.input_count,
+                    output_count: data.output_count,
+                    plank_constant: 1e-7,
+                    normalise_gradients: false,
+                };
+                let out = propagate_topological_loop(black_box(&input));
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Representative spread of activation functions for the squash primitives.
+const SQUASH_SPREAD: [SquashType; 10] = [
+    SquashType::Identity,
+    SquashType::Relu,
+    SquashType::LeakyRelu,
+    SquashType::Logistic,
+    SquashType::Tanh,
+    SquashType::Gelu,
+    SquashType::Swish,
+    SquashType::Mish,
+    SquashType::Sine,
+    SquashType::Gaussian,
+];
+
+/// Activation primitives — `weighted_sum_simd` family plus squash/unsquash.
+fn bench_activation_primitives(c: &mut Criterion) {
+    // weighted_sum_simd family over a representative synapse block.
+    let mut sum_group = c.benchmark_group("weighted_sum_simd");
+    let synapse_count = 64usize;
+    let mut rng = Lcg::new(0x2468_ACE0);
+    let synapses: Vec<SynapseData> = (0..synapse_count)
+        .map(|i| SynapseData {
+            weight: rng.next_signed(),
+            from_index: i as u32,
+            synapse_type: 0,
+            _padding: [0; 3],
+        })
+        .collect();
+    let activations: Vec<f32> = (0..synapse_count).map(|_| rng.next_signed()).collect();
+    let (a0, a1, a2, a3) = (
+        activations.clone(),
+        activations.clone(),
+        activations.clone(),
+        activations.clone(),
+    );
+    let (a4, a5, a6, a7) = (
+        activations.clone(),
+        activations.clone(),
+        activations.clone(),
+        activations.clone(),
+    );
+    let end = synapse_count;
+
+    sum_group.bench_function("single", |b| {
+        b.iter(|| {
+            black_box(weighted_sum_simd(
+                black_box(&synapses),
+                black_box(&activations),
+                0,
+                end,
+                0.25,
+            ))
+        });
+    });
+    sum_group.bench_function("no_bias", |b| {
+        b.iter(|| {
+            black_box(weighted_sum_no_bias_simd(
+                black_box(&synapses),
+                black_box(&activations),
+                0,
+                end,
+            ))
+        });
+    });
+    sum_group.bench_function("of_squares", |b| {
+        b.iter(|| {
+            black_box(weighted_sum_of_squares_simd(
+                black_box(&synapses),
+                black_box(&activations),
+                0,
+                end,
+            ))
+        });
+    });
+    sum_group.bench_function("batch_4records", |b| {
+        b.iter(|| {
+            black_box(weighted_sum_simd_4records(
+                black_box(&synapses),
+                &a0,
+                &a1,
+                &a2,
+                &a3,
+                0,
+                end,
+                0.25,
+            ))
+        });
+    });
+    sum_group.bench_function("batch_8records", |b| {
+        b.iter(|| {
+            black_box(weighted_sum_simd_8records(
+                black_box(&synapses),
+                &a0,
+                &a1,
+                &a2,
+                &a3,
+                &a4,
+                &a5,
+                &a6,
+                &a7,
+                0,
+                end,
+                0.25,
+            ))
+        });
+    });
+    sum_group.finish();
+
+    // apply_squash / apply_unsquash across a spread of SquashTypes.
+    let mut squash_group = c.benchmark_group("squash");
+    for squash_type in SQUASH_SPREAD {
+        let label = format!("{squash_type:?}");
+        squash_group.bench_with_input(
+            BenchmarkId::new("apply_squash", label.clone()),
+            &squash_type,
+            |b, &st| {
+                b.iter(|| black_box(apply_squash(black_box(st), black_box(0.42))));
+            },
+        );
+        squash_group.bench_with_input(
+            BenchmarkId::new("apply_unsquash", label),
+            &squash_type,
+            |b, &st| {
+                b.iter(|| {
+                    black_box(apply_unsquash(black_box(st), black_box(0.42), black_box(0.0)))
+                });
+            },
+        );
+    }
+    squash_group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_forward_pass,
+    bench_batched_scoring,
+    bench_backprop,
+    bench_activation_primitives,
+);
+criterion_main!(benches);

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -14,6 +14,7 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 
+use neat_core::loss::mse_sum_batch_packed;
 use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
 use neat_core::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_simd,
@@ -24,7 +25,6 @@ use neat_core::topological_backprop::{
     NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, PropagateInput,
     SynapseInput, propagate_topological_loop,
 };
-use neat_core::loss::mse_sum_batch_packed;
 use neat_core::unsquash::apply_unsquash;
 
 /// Tiny deterministic PRNG (SplitMix64-style) so the harness produces fixed
@@ -231,7 +231,11 @@ fn build_backprop_data(
         } else {
             NEURON_TYPE_HIDDEN
         };
-        neurons.push(make_neuron(SquashType::Tanh, neuron_type, rng.next_signed()));
+        neurons.push(make_neuron(
+            SquashType::Tanh,
+            neuron_type,
+            rng.next_signed(),
+        ));
 
         let this_fan = fan_in.min(global_idx);
         inward_starts[global_idx] = inward_indices.len() as u32;
@@ -285,8 +289,7 @@ fn make_neuron(squash: SquashType, neuron_type: u8, adjusted_activation: f32) ->
 fn bench_backprop(c: &mut Criterion) {
     let mut group = c.benchmark_group("backprop");
     for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
-        let data =
-            build_backprop_data(num_neurons, num_inputs, num_outputs, fan_in, 0x1357_9BDF);
+        let data = build_backprop_data(num_neurons, num_inputs, num_outputs, fan_in, 0x1357_9BDF);
         group.throughput(Throughput::Elements(num_neurons as u64));
         group.bench_function(BenchmarkId::from_parameter(label), |b| {
             b.iter(|| {
@@ -435,7 +438,11 @@ fn bench_activation_primitives(c: &mut Criterion) {
             &squash_type,
             |b, &st| {
                 b.iter(|| {
-                    black_box(apply_unsquash(black_box(st), black_box(0.42), black_box(0.0)))
+                    black_box(apply_unsquash(
+                        black_box(st),
+                        black_box(0.42),
+                        black_box(0.0),
+                    ))
                 });
             },
         );

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -12,7 +12,8 @@
 //! fixed topologies — so before/after comparisons across a code change are
 //! meaningful. See `neat-core/benches/README.md` for the comparison workflow.
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use neat_core::loss::mse_sum_batch_packed;
 use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};


### PR DESCRIPTION
# Add a Criterion benchmark harness for core hot paths

## Summary

Adds an **opt-in** [Criterion](https://github.com/bheisler/criterion.rs)
benchmark harness for `neat-core`'s hottest paths so future performance work
(the #151 sub-issues) can be validated against reproducible numbers instead of
reasoning alone. This is additive tooling only — no library behaviour changes.
Closes #152.

Changes:

- `neat-core/Cargo.toml` — add `criterion` (with `html_reports`) as a
  dev-dependency and register a `harness = false` `[[bench]]` target named
  `hot_paths`.
- `neat-core/benches/hot_paths.rs` — deterministic benchmark groups for the
  forward pass, batched scoring, backprop, and activation primitives.
- `neat-core/benches/README.md` — how to run the benches and compare
  before/after with Criterion baselines.
- `README.md` — layout/build pointers to the opt-in harness.
- `Cargo.lock` — criterion + transitive dev-dependencies (licences/advisories
  pass `cargo deny check`).

### Coverage

| Group | Functions under test | Sizes |
| --- | --- | --- |
| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000 |
| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same three |
| `backprop` | one `propagate_topological_loop` step | same three |
| `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- & 8-record) | 64-synapse block |
| `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |

Networks and inputs are built **once** outside the timed closure from a
fixed-seed PRNG with fixed topologies; `criterion::black_box` guards inputs and
outputs. The harness is deterministic so before/after comparisons are
meaningful.

```mermaid
flowchart LR
    subgraph "cargo test / quality.sh"
        T[lib + integration tests]
    end
    subgraph "cargo bench -p neat-core --bench hot_paths (opt-in)"
        F[forward_pass] --> R[(target/criterion)]
        B[batched_scoring] --> R
        P[backprop] --> R
        S[primitives: weighted_sum_simd + squash] --> R
    end
    T -. harness=false keeps benches out of the gate .-> F
```

## Evidence

Backend/CLI tooling — no web interface to screenshot. Evidence is the harness
running and producing stable numbers.

`cargo bench -p neat-core --bench hot_paths` (abbreviated, short measurement
window — representative magnitudes, not a tuned baseline):

```text
forward_pass/small_50      time:   [409.60 ns 412.41 ns 417.45 ns]
forward_pass/medium_500    time:   [5.3811 µs 5.4147 µs 5.4434 µs]
forward_pass/large_5000    time:   [81.874 µs 82.240 µs 82.676 µs]
batched_scoring/trace_batch_4way/medium_500  time: [10.776 µs 10.857 µs 10.951 µs]
batched_scoring/mse_sum_8records/medium_500  time: [19.161 µs 19.380 µs 19.599 µs]
backprop/medium_500        time:   [151.56 µs 152.61 µs 154.26 µs]
weighted_sum_simd/single   time:   [16.958 ns 17.042 ns 17.111 ns]
weighted_sum_simd/batch_8records  time: [70.350 ns 70.726 ns 70.986 ns]
squash/apply_squash/Tanh   time:   [1.7994 ns 1.8199 ns 1.8430 ns]
```

This issue is the foundation for #151 — it establishes the baseline so later
perf changes can be measured. It introduces no perf change of its own, so there
is no before/after delta to report here.

## Test Plan

- `cargo bench -p neat-core --bench hot_paths` runs all four groups and reports
  stable numbers (acceptance criterion 1).
- Benches stay out of the test gate: `cargo test --workspace --lib --tests`
  does not run them (`harness = false` + opt-in `[[bench]]`), so `quality.sh`
  runtime is unaffected (acceptance criterion 2).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
  (the bench compiles under the lint gate).
- `cargo check --all-targets`, `cargo test --workspace --lib --tests`,
  `cargo doc`, and `cargo build --release` all pass.
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` with
  the new criterion dependency tree.

### Note on the local gate

`./quality.sh` reports 4 **pre-existing** `bats` failures in
`tests/scripts/ci_workflow_quarantine.bats` (about `ci.yml` calling
`cargo upgrade`/`cargo update` directly). These are present on the clean base
branch, are unrelated to this change, and were left untouched per change-scope
rules. All Rust gates that follow were run individually and pass.

This is additive tooling (a benchmark target), so there is no library behaviour
to add unit tests for; the harness compiling under the clippy `--all-targets`
gate and running cleanly is the verification.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqc4cawc-d69411`<!-- vibe-worker-issue-152 -->