### PR TITLE
[perf] Remove redundant intermediate allocation/copy in fused error distribution (#156)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.41"
+version = "0.1.42"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-156.md
+++ b/docs/archive/pr-summaries/pr-summary-156.md
@@ -1,0 +1,78 @@
+# [perf] Remove redundant intermediate allocation/copy in fused error distribution
+
+## Summary
+
+`apply_fused_error_distribution` (called per-neuron during backprop) built a
+`safe_zone_factors: Vec<f32>` in Step 2, then copied it into `result` in a
+**separate second loop** — a redundant allocation (`count` elements) plus a
+full extra pass per neuron.
+
+This change pushes each safe-zone factor **straight into `result`** as it is
+computed, so the factors live at `result[1 .. 1 + count]`. The Step-3 scores
+loop now reads each factor back from `result[1 + i]` instead of the removed
+`safe_zone_factors` vec. This eliminates one `Vec<f32>` allocation and one copy
+loop per call. The arithmetic is unchanged — only the read source moves — so
+results are **numerically identical** (verified bit-for-bit by a new test).
+
+The `scores` vector is kept as-is; it is genuinely needed for the two-pass
+denominator normalisation.
+
+Closes #156.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        A1[Step 2: compute factors] --> A2[push into safe_zone_factors Vec]
+        A2 --> A3[copy loop: Vec -> result]
+        A3 --> A4[Step 3: read safe_zone_factors_i]
+    end
+    subgraph After
+        B1[Step 2: compute factors] --> B2[push factor into result_1+i]
+        B2 --> B3[Step 3: read result_1+i]
+    end
+```
+
+## Evidence
+
+Backend/Rust change — no web interface to screenshot. Verified via the
+Criterion `backprop` benchmark (#152) and the workspace test suite.
+
+### Benchmark (`cargo bench --bench hot_paths -- backprop`)
+
+Before vs after, same machine, Criterion baseline comparison
+(`--save-baseline before` then `--baseline before`):
+
+| Network        | Before (median) | After (median) | Change (time) |
+|----------------|-----------------|----------------|---------------|
+| `small_50`     | 11.568 µs       | 10.647 µs      | **−8.35 %**   |
+| `medium_500`   | 150.25 µs       | 139.92 µs      | **−6.14 %**   |
+| `large_5000`   | 2.1938 ms       | 2.0511 ms      | **−6.50 %**   |
+
+All three sizes improved with `p < 0.05` ("Performance has improved"), matching
+the issue's expectation of a small allocation/throughput win on the per-neuron
+backprop path.
+
+## Test Plan
+
+- **Added** `neat-core/tests/fused_error.rs::test_fused_wide_neuron_layout_bit_for_bit`
+  — a wide-neuron (6 inward synapses, mixed squash types) regression guard. It
+  independently recomputes the entire expected output (error, all safe-zone
+  factors, all proportional shares) using the public `apply_calculate_error` and
+  `apply_safe_zone_adjustment` primitives, and asserts a **bit-for-bit** match
+  against `apply_fused_error_distribution`. This catches any change to the stored
+  or read-back factor values, not just an arithmetic regression.
+- **Existing** fused-error tests (`test_fused_basic_identity`,
+  `test_fused_zero_error`, `test_fused_empty_synapses`,
+  `test_fused_single_synapse`) all still pass unchanged.
+- `cargo test --workspace` — all 145+ tests pass.
+- `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings`
+  pass clean.
+
+### Pre-existing unrelated failures
+
+`./quality.sh` reports 4 failing bats tests in
+`tests/scripts/ci_workflow_quarantine.bats` (#31, #32, #33, #37 — about
+`ci.yml`/`bump-deps.sh` wiring). These fail identically on the base branch
+before this change (confirmed by stashing the change and re-running) and are
+unrelated to the fused-error path. They are left untouched, per change-scope
+guidance.

--- a/neat-core/src/fused_error.rs
+++ b/neat-core/src/fused_error.rs
@@ -64,8 +64,10 @@ pub fn apply_fused_error_distribution(
 
     let provisional_error_per_link = error / (count as f32);
 
-    // Step 2: Safe zone adjustment per synapse
-    let mut safe_zone_factors = Vec::with_capacity(count);
+    // Step 2: Safe zone adjustment per synapse.
+    // Push each factor straight into `result` (no separate `safe_zone_factors`
+    // Vec or copy loop — Issue #156). The factors live at `result[1 .. 1 + count]`
+    // and are read back in Step 3.
     for i in 0..count {
         let squash = SquashType::from(upstream_squash_types[i]);
         let raw_input = upstream_hint_values[i];
@@ -76,11 +78,6 @@ pub fn apply_fused_error_distribution(
         };
         let factor =
             apply_safe_zone_adjustment(squash, raw_input, provisional_error_per_link, weight);
-        safe_zone_factors.push(factor);
-    }
-
-    // Push safe zone factors into result
-    for &factor in &safe_zone_factors {
         result.push(factor);
     }
 
@@ -90,7 +87,8 @@ pub fn apply_fused_error_distribution(
     let mut denom: f32 = 0.0;
     for i in 0..count {
         let activation = upstream_activations[i];
-        let safe = safe_zone_factors[i];
+        // Safe-zone factor written above at result[1 + i].
+        let safe = result[1 + i];
 
         if !activation.is_finite() || !safe.is_finite() {
             scores.push(0.0);

--- a/neat-core/tests/fused_error.rs
+++ b/neat-core/tests/fused_error.rs
@@ -1,6 +1,8 @@
 //! Fused error distribution tests (moved from `src/fused_error.rs`).
 
-use neat_core::{SquashType, apply_fused_error_distribution};
+use neat_core::{
+    SquashType, apply_calculate_error, apply_fused_error_distribution, apply_safe_zone_adjustment,
+};
 
 #[test]
 fn test_fused_basic_identity() {
@@ -102,5 +104,130 @@ fn test_fused_single_synapse() {
         "single synapse should get all error: share={}, error={}",
         share,
         error,
+    );
+}
+
+/// Issue #156 — wide-neuron regression guard.
+///
+/// The Step-2 safe-zone factors are written directly into `result[1 .. 1 + count]`
+/// (no separate `safe_zone_factors` Vec/copy loop) and read back in the Step-3
+/// scores loop. This test independently recomputes the entire expected output
+/// using the public `apply_calculate_error` / `apply_safe_zone_adjustment`
+/// primitives and asserts a **bit-for-bit** match, so any change to the stored
+/// or read-back values (not just an arithmetic regression) is caught.
+#[test]
+fn test_fused_wide_neuron_layout_bit_for_bit() {
+    // A deliberately wide neuron with a spread of upstream squash types,
+    // raw inputs, activations and weights.
+    let upstream_squash = [
+        SquashType::Identity as u8,
+        SquashType::Relu as u8,
+        SquashType::Tanh as u8,
+        SquashType::Logistic as u8,
+        SquashType::LeakyRelu as u8,
+        SquashType::Gelu as u8,
+    ];
+    let hint_values = [0.5_f32, -2.0, 1.5, -0.3, 3.0, 0.1];
+    let activations = [0.2_f32, -1.0, 0.8, 0.4, -0.6, 1.2];
+    let weights = [1.0_f32, -0.5, 2.0, 0.3, -1.5, 0.7];
+
+    let neuron_squash = SquashType::Tanh;
+    let neuron_activation = 0.25_f32;
+    let neuron_target = 0.75_f32;
+    let neuron_hint = 0.25_f32;
+
+    let result = apply_fused_error_distribution(
+        neuron_squash,
+        neuron_activation,
+        neuron_target,
+        neuron_hint,
+        &upstream_squash,
+        &hint_values,
+        &activations,
+        &weights,
+    );
+
+    let count = upstream_squash.len();
+    assert_eq!(result.len(), 1 + 2 * count, "flat layout length");
+
+    // Independently recompute the expected output.
+    let error = apply_calculate_error(neuron_squash, neuron_activation, neuron_target, neuron_hint);
+    assert_eq!(result[0], error, "error slot must match the primitive");
+    assert_ne!(error, 0.0, "test input must exercise the non-zero path");
+
+    let provisional = error / (count as f32);
+
+    // Expected safe-zone factors at result[1 .. 1 + count].
+    let mut expected_safe = Vec::with_capacity(count);
+    for i in 0..count {
+        let squash = SquashType::from(upstream_squash[i]);
+        let weight = if weights[i].is_finite() {
+            weights[i]
+        } else {
+            1.0
+        };
+        let factor = apply_safe_zone_adjustment(squash, hint_values[i], provisional, weight);
+        expected_safe.push(factor);
+        assert_eq!(
+            result[1 + i],
+            factor,
+            "safe-zone factor at result[{}] must match primitive",
+            1 + i
+        );
+    }
+
+    // Expected scores and proportional shares at result[1 + count .. 1 + 2*count].
+    let mut scores = Vec::with_capacity(count);
+    let mut denom = 0.0_f32;
+    for i in 0..count {
+        let a = activations[i];
+        let safe = expected_safe[i];
+        let score = if !a.is_finite() || !safe.is_finite() {
+            0.0
+        } else {
+            a * a * safe.clamp(0.0, 1.0)
+        };
+        scores.push(score);
+        denom += score;
+    }
+    assert!(
+        denom > 1e-12,
+        "test input must exercise the score-based path"
+    );
+
+    let mut sum = 0.0_f32;
+    let mut best_idx = 0usize;
+    let mut best_score = f32::NEG_INFINITY;
+    let mut expected_shares = vec![0.0_f32; count];
+    for i in 0..count {
+        let share = error * (scores[i] / denom);
+        expected_shares[i] = share;
+        sum += share;
+        if scores[i] > best_score {
+            best_score = scores[i];
+            best_idx = i;
+        }
+    }
+    let residue = error - sum;
+    if residue.abs() > 1e-12 {
+        expected_shares[best_idx] += residue;
+    }
+
+    for i in 0..count {
+        assert_eq!(
+            result[1 + count + i],
+            expected_shares[i],
+            "share at result[{}] must match independent recomputation",
+            1 + count + i
+        );
+    }
+
+    // Shares must sum to error (residue cleanup invariant).
+    let share_sum: f32 = result[1 + count..].iter().sum();
+    assert!(
+        (share_sum - error).abs() < 1e-5,
+        "shares must sum to error: {} vs {}",
+        share_sum,
+        error
     );
 }


### PR DESCRIPTION
# [perf] Remove redundant intermediate allocation/copy in fused error distribution

## Summary

`apply_fused_error_distribution` (called per-neuron during backprop) built a
`safe_zone_factors: Vec<f32>` in Step 2, then copied it into `result` in a
**separate second loop** — a redundant allocation (`count` elements) plus a
full extra pass per neuron.

This change pushes each safe-zone factor **straight into `result`** as it is
computed, so the factors live at `result[1 .. 1 + count]`. The Step-3 scores
loop now reads each factor back from `result[1 + i]` instead of the removed
`safe_zone_factors` vec. This eliminates one `Vec<f32>` allocation and one copy
loop per call. The arithmetic is unchanged — only the read source moves — so
results are **numerically identical** (verified bit-for-bit by a new test).

The `scores` vector is kept as-is; it is genuinely needed for the two-pass
denominator normalisation.

Closes #156.

```mermaid
flowchart LR
    subgraph Before
        A1[Step 2: compute factors] --> A2[push into safe_zone_factors Vec]
        A2 --> A3[copy loop: Vec -> result]
        A3 --> A4[Step 3: read safe_zone_factors_i]
    end
    subgraph After
        B1[Step 2: compute factors] --> B2[push factor into result_1+i]
        B2 --> B3[Step 3: read result_1+i]
    end
```

## Evidence

Backend/Rust change — no web interface to screenshot. Verified via the
Criterion `backprop` benchmark (#152) and the workspace test suite.

### Benchmark (`cargo bench --bench hot_paths -- backprop`)

Before vs after, same machine, Criterion baseline comparison
(`--save-baseline before` then `--baseline before`):

| Network        | Before (median) | After (median) | Change (time) |
|----------------|-----------------|----------------|---------------|
| `small_50`     | 11.568 µs       | 10.647 µs      | **−8.35 %**   |
| `medium_500`   | 150.25 µs       | 139.92 µs      | **−6.14 %**   |
| `large_5000`   | 2.1938 ms       | 2.0511 ms      | **−6.50 %**   |

All three sizes improved with `p < 0.05` ("Performance has improved"), matching
the issue's expectation of a small allocation/throughput win on the per-neuron
backprop path.

## Test Plan

- **Added** `neat-core/tests/fused_error.rs::test_fused_wide_neuron_layout_bit_for_bit`
  — a wide-neuron (6 inward synapses, mixed squash types) regression guard. It
  independently recomputes the entire expected output (error, all safe-zone
  factors, all proportional shares) using the public `apply_calculate_error` and
  `apply_safe_zone_adjustment` primitives, and asserts a **bit-for-bit** match
  against `apply_fused_error_distribution`. This catches any change to the stored
  or read-back factor values, not just an arithmetic regression.
- **Existing** fused-error tests (`test_fused_basic_identity`,
  `test_fused_zero_error`, `test_fused_empty_synapses`,
  `test_fused_single_synapse`) all still pass unchanged.
- `cargo test --workspace` — all 145+ tests pass.
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings`
  pass clean.

### Pre-existing unrelated failures

`./quality.sh` reports 4 failing bats tests in
`tests/scripts/ci_workflow_quarantine.bats` (#31, #32, #33, #37 — about
`ci.yml`/`bump-deps.sh` wiring). These fail identically on the base branch
before this change (confirmed by stashing the change and re-running) and are
unrelated to the fused-error path. They are left untouched, per change-scope
guidance.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqc7ed2y-c064d0`<!-- vibe-worker-issue-156 -->