### PR TITLE
[perf] Share f(x)/f'(x) subexpressions in Mish/Gelu unsquash (#157)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.1.42"
+version = "0.1.43"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.42"
+version = "0.1.43"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-157.md
+++ b/docs/archive/pr-summaries/pr-summary-157.md
@@ -1,0 +1,79 @@
+# [perf] Share f(x)/f'(x) subexpressions in Mish/Gelu Newton-Raphson unsquash
+
+## Summary
+
+`apply_unsquash` inverts the non-invertible Mish and Gelu activations with
+Newton-Raphson iteration (up to 100 iterations). Previously each iteration
+called `apply_squash` **and** `apply_derivative` as two independent full
+evaluations, recomputing the same `exp`/`softplus`/`tanh` transcendentals
+twice per step. The Swish branch already avoided this by deriving both `f(x)`
+and `f'(x)` from shared intermediates computed once per iteration.
+
+This change rewrites the Mish and Gelu loops to the same pattern — the shared
+transcendentals are computed once and both `f` and `f'` are assembled from them,
+removing the redundant second evaluation. Swish is left untouched as the
+reference implementation.
+
+- **Mish**: compute `exp_x = e^x`, `softplus = ln(1+e^x)`, `t = tanh(softplus)`
+  once. Then `f(x) = x·t` and `f'(x) = t + x·(1−t²)·sigmoid(x)` where
+  `sigmoid(x) = e^x/(1+e^x)` reuses `exp_x`. This is the analytically exact
+  Mish derivative (`tanh(softplus) + x·sech²(softplus)·sigmoid`), and it
+  collapses the previous two `exp` calls plus a separate `e^{2x}` in the old
+  derivative path down to a single `exp` per iteration.
+- **Gelu**: compute `inner = √(2/π)·(x + c·x³)` and `tanh(inner)` once, then
+  assemble `f(x) = 0.5·x·(1+tanh(inner))` and `f'(x) = cdf + pdf` from the
+  shared `inner`/`tanh(inner)` — matching the existing `apply_derivative`
+  formula exactly but without recomputing the tanh.
+
+Round-trip accuracy is preserved: the iteration's convergence test still keys
+off the exact `f(x) − activation` error, so the recovered root is unchanged
+within tolerance.
+
+Closes #157.
+
+## Evidence
+
+Backend/CLI change — no UI to screenshot. Verified by the activation-primitive
+benchmark (#152) and round-trip unit tests.
+
+### Benchmark (`cargo bench -p neat-core --bench hot_paths`)
+
+`squash/apply_unsquash`, criterion median of 100 samples, same machine,
+`--save-baseline before` then `--baseline before`:
+
+| Activation | Before  | After   | Change          |
+|------------|---------|---------|-----------------|
+| Mish       | ~353 ns | ~125 ns | **−67%**        |
+| Gelu       | ~85 ns  | ~63 ns  | **−30%**        |
+| Swish      | ~394 ns | ~404 ns | no change (control, untouched) |
+
+Both targeted activations show a clear, statistically significant improvement
+(`p < 0.05`); the untouched Swish control is within noise.
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — per iteration"]
+        S1["apply_squash(x)<br/>exp · softplus · tanh"]
+        D1["apply_derivative(x)<br/>exp · e^2x · tanh (recomputed)"]
+    end
+    subgraph After["After — per iteration"]
+        I["compute exp/softplus/tanh ONCE"]
+        I --> FX["f(x)"]
+        I --> DFX["f'(x)"]
+    end
+    Before -.->|"share subexpressions"| After
+```
+
+## Test Plan
+
+- Added `neat-core/tests/unsquash.rs::test_unsquash_mish_roundtrip` — asserts
+  `squash(unsquash(y)) ≈ y` (tolerance `1e-3`) across a spread of inputs,
+  using the raw `x` as the Newton-Raphson hint to steer onto the correct branch.
+- Added `neat-core/tests/unsquash.rs::test_unsquash_gelu_roundtrip` — same
+  round-trip invariant for Gelu.
+- Both tests pass against the original implementation (behaviour baseline) and
+  the refactored implementation, guarding accuracy across the change.
+- `cargo test --workspace` green; `cargo clippy -p neat-core --all-targets`
+  clean; `./quality.sh` shows no new failures (the 4 pre-existing
+  `ci_workflow_quarantine.bats` failures are unrelated to this change and also
+  fail on the base commit).

--- a/neat-core/src/unsquash.rs
+++ b/neat-core/src/unsquash.rs
@@ -4,8 +4,9 @@
 //! converting activation-space values back to value-space.
 //! Issue #1139 - WASM Migration Phase 7.
 
-use crate::derivative::apply_derivative;
-use crate::squash::{LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SquashType, apply_squash};
+use crate::squash::{
+    GELU_COEFF, LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SQRT_2_OVER_PI, SquashType, apply_squash,
+};
 
 /// Apply an inverse squash (unsquash) function to a value
 /// Issue #1139 - WASM Migration Phase 7: Implement unSquash() in Rust/WASM
@@ -222,14 +223,22 @@ pub fn apply_unsquash(squash_type: SquashType, activation: f32, hint: f32) -> f3
             guess = guess.clamp(-SAFE_LIMIT, SAFE_LIMIT);
 
             for _ in 0..MAX_ITERATIONS {
-                let fx = apply_squash(SquashType::Mish, guess);
+                // Share transcendentals between f(x) and f'(x): one exp, one
+                // softplus, one tanh per iteration (Issue #157, mirroring Swish).
+                // f(x)  = x * tanh(softplus(x)),  softplus(x) = ln(1 + e^x)
+                // f'(x) = t + x * (1 - t^2) * sigmoid(x),  t = tanh(softplus(x))
+                let exp_x = guess.exp();
+                let softplus = (1.0 + exp_x).ln();
+                let t = softplus.tanh();
+                let fx = guess * t;
                 let error = fx - activation;
 
                 if error.abs() < TOLERANCE {
                     break;
                 }
 
-                let derivative = apply_derivative(SquashType::Mish, guess);
+                let sigmoid = exp_x / (1.0 + exp_x);
+                let derivative = t + guess * (1.0 - t * t) * sigmoid;
                 let safe_derivative = if derivative.abs() > 1e-6 {
                     derivative
                 } else {
@@ -266,13 +275,29 @@ pub fn apply_unsquash(squash_type: SquashType, activation: f32, hint: f32) -> f3
             };
 
             for _ in 0..MAX_ITERATIONS {
-                let fx = apply_squash(SquashType::Gelu, x) - activation;
+                // Share `inner`/`tanh(inner)` between f(x) and f'(x) instead of
+                // evaluating apply_squash + apply_derivative separately, each of
+                // which recomputes the same tanh (Issue #157).
+                // f(x)  = 0.5 * x * (1 + tanh(inner))
+                // f'(x) = cdf + pdf
+                //   inner = sqrt(2/pi) * (x + GELU_COEFF * x^3)
+                //   cdf   = 0.5 * (1 + tanh(inner))
+                //   pdf   = 0.5 * x * (1 - tanh^2(inner)) * sqrt(2/pi)
+                //           * (1 + 3 * GELU_COEFF * x^2)
+                let x2 = x * x;
+                let inner = SQRT_2_OVER_PI * (x + GELU_COEFF * x2 * x);
+                let tanh_inner = inner.tanh();
+                let cdf = 0.5 * (1.0 + tanh_inner);
+                let fx = x * cdf - activation;
 
                 if fx.abs() < TOLERANCE {
                     break;
                 }
 
-                let derivative = apply_derivative(SquashType::Gelu, x);
+                let pdf = (0.5 * x * (1.0 - tanh_inner * tanh_inner))
+                    * SQRT_2_OVER_PI
+                    * (1.0 + 3.0 * GELU_COEFF * x2);
+                let derivative = cdf + pdf;
                 if derivative.abs() < 1e-10 {
                     if fx.abs() < 0.1 {
                         return x;

--- a/neat-core/tests/unsquash.rs
+++ b/neat-core/tests/unsquash.rs
@@ -115,6 +115,39 @@ fn test_unsquash_roundtrip() {
 }
 
 #[test]
+fn test_unsquash_mish_roundtrip() {
+    // Mish is non-invertible (it dips below zero around x = -1.19), so we assert
+    // the achievable invariant: squash(unsquash(y)) approx y, with the raw x as
+    // the hint to steer Newton-Raphson onto the correct branch. Issue #157.
+    let xs = [-3.0_f32, -1.5, -0.5, 0.0, 0.25, 0.42, 1.0, 2.5, 5.0, 8.0];
+    for &x in &xs {
+        let activation = apply_squash(SquashType::Mish, x);
+        let recovered = apply_unsquash(SquashType::Mish, activation, x);
+        let reactivation = apply_squash(SquashType::Mish, recovered);
+        assert!(
+            (reactivation - activation).abs() < 1e-3,
+            "Mish roundtrip failed for x={x}: activation={activation}, recovered={recovered}, reactivation={reactivation}"
+        );
+    }
+}
+
+#[test]
+fn test_unsquash_gelu_roundtrip() {
+    // Gelu is non-invertible near its negative dip, so assert squash(unsquash(y))
+    // approx y using the raw x as the Newton-Raphson hint. Issue #157.
+    let xs = [-3.0_f32, -1.0, -0.5, 0.25, 0.42, 1.0, 2.5, 5.0];
+    for &x in &xs {
+        let activation = apply_squash(SquashType::Gelu, x);
+        let recovered = apply_unsquash(SquashType::Gelu, activation, x);
+        let reactivation = apply_squash(SquashType::Gelu, recovered);
+        assert!(
+            (reactivation - activation).abs() < 1e-3,
+            "Gelu roundtrip failed for x={x}: activation={activation}, recovered={recovered}, reactivation={reactivation}"
+        );
+    }
+}
+
+#[test]
 fn test_unsquash_aggregate_functions() {
     // Aggregate functions return hint if provided
     assert_eq!(apply_unsquash(SquashType::Minimum, 1.0, 42.0), 42.0);


### PR DESCRIPTION
# [perf] Share f(x)/f'(x) subexpressions in Mish/Gelu Newton-Raphson unsquash

## Summary

`apply_unsquash` inverts the non-invertible Mish and Gelu activations with
Newton-Raphson iteration (up to 100 iterations). Previously each iteration
called `apply_squash` **and** `apply_derivative` as two independent full
evaluations, recomputing the same `exp`/`softplus`/`tanh` transcendentals
twice per step. The Swish branch already avoided this by deriving both `f(x)`
and `f'(x)` from shared intermediates computed once per iteration.

This change rewrites the Mish and Gelu loops to the same pattern — the shared
transcendentals are computed once and both `f` and `f'` are assembled from them,
removing the redundant second evaluation. Swish is left untouched as the
reference implementation.

- **Mish**: compute `exp_x = e^x`, `softplus = ln(1+e^x)`, `t = tanh(softplus)`
  once. Then `f(x) = x·t` and `f'(x) = t + x·(1−t²)·sigmoid(x)` where
  `sigmoid(x) = e^x/(1+e^x)` reuses `exp_x`. This is the analytically exact
  Mish derivative (`tanh(softplus) + x·sech²(softplus)·sigmoid`), and it
  collapses the previous two `exp` calls plus a separate `e^{2x}` in the old
  derivative path down to a single `exp` per iteration.
- **Gelu**: compute `inner = √(2/π)·(x + c·x³)` and `tanh(inner)` once, then
  assemble `f(x) = 0.5·x·(1+tanh(inner))` and `f'(x) = cdf + pdf` from the
  shared `inner`/`tanh(inner)` — matching the existing `apply_derivative`
  formula exactly but without recomputing the tanh.

Round-trip accuracy is preserved: the iteration's convergence test still keys
off the exact `f(x) − activation` error, so the recovered root is unchanged
within tolerance.

Closes #157.

## Evidence

Backend/CLI change — no UI to screenshot. Verified by the activation-primitive
benchmark (#152) and round-trip unit tests.

### Benchmark (`cargo bench -p neat-core --bench hot_paths`)

`squash/apply_unsquash`, criterion median of 100 samples, same machine,
`--save-baseline before` then `--baseline before`:

| Activation | Before  | After   | Change          |
|------------|---------|---------|-----------------|
| Mish       | ~353 ns | ~125 ns | **−67%**        |
| Gelu       | ~85 ns  | ~63 ns  | **−30%**        |
| Swish      | ~394 ns | ~404 ns | no change (control, untouched) |

Both targeted activations show a clear, statistically significant improvement
(`p < 0.05`); the untouched Swish control is within noise.

```mermaid
flowchart LR
    subgraph Before["Before — per iteration"]
        S1["apply_squash(x)<br/>exp · softplus · tanh"]
        D1["apply_derivative(x)<br/>exp · e^2x · tanh (recomputed)"]
    end
    subgraph After["After — per iteration"]
        I["compute exp/softplus/tanh ONCE"]
        I --> FX["f(x)"]
        I --> DFX["f'(x)"]
    end
    Before -.->|"share subexpressions"| After
```

## Test Plan

- Added `neat-core/tests/unsquash.rs::test_unsquash_mish_roundtrip` — asserts
  `squash(unsquash(y)) ≈ y` (tolerance `1e-3`) across a spread of inputs,
  using the raw `x` as the Newton-Raphson hint to steer onto the correct branch.
- Added `neat-core/tests/unsquash.rs::test_unsquash_gelu_roundtrip` — same
  round-trip invariant for Gelu.
- Both tests pass against the original implementation (behaviour baseline) and
  the refactored implementation, guarding accuracy across the change.
- `cargo test --workspace` green; `cargo clippy -p neat-core --all-targets`
  clean; `./quality.sh` shows no new failures (the 4 pre-existing
  `ci_workflow_quarantine.bats` failures are unrelated to this change and also
  fail on the base commit).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqcbuqiq-d67912`<!-- vibe-worker-issue-157 -->