### PR TITLE
[perf] Reuse scratch buffers in activate_and_trace_batch_4way (#155)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.1.42"
+version = "0.1.43"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.42"
+version = "0.1.43"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-155.md
+++ b/docs/archive/pr-summaries/pr-summary-155.md
@@ -1,0 +1,85 @@
+# [perf] Reuse buffers in `activate_and_trace_batch_4way`
+
+## Summary
+
+`activate_and_trace_batch_4way` previously allocated **12 fresh vectors on every
+call** — 4 activation buffers, 4 hint buffers and 4 trace buffers. This extends
+the buffer-reuse precedent established for the single-record path (#1173, which
+added `hint_values_buffer` / `trace_data_buffer`) to the 4-way batch path.
+
+The 12 scratch buffers are now stored on `CompiledNetwork` as `[Vec<f32>; 4]`
+fields (`batch_activations`, `batch_hints`, `batch_traces`), pre-allocated in the
+constructor and **reused** across calls. Each invocation resets the buffers to
+the exact initial state a fresh allocation would have had — activations zeroed
+then inputs re-copied, hints zeroed, traces cleared — so output is byte-identical
+to the previous behaviour.
+
+The method now takes `&mut self`, consistent with the other buffered methods
+(`activate`, `activate_and_trace`). Per the `CompiledNetwork` struct doc, batch
+scoring runs with each thread owning its own `CompiledNetwork`, so `&mut self` is
+compatible with the threading model. The only non-test caller (the Criterion
+bench) was updated to a `mut` binding; `pc_inference.rs` merely references the
+method by name in a doc comment.
+
+Closes #155.
+
+## Allocation change
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — per call"]
+        A["12 × vec! / Vec::new()"] --> B[process] --> C[build result]
+    end
+    subgraph After["After — per call"]
+        D["fill(0.0) / clear()<br/>reuse preallocated buffers"] --> E[process] --> F[build result]
+    end
+```
+
+| Buffer set        | Before (per call)        | After (per call)              |
+|-------------------|--------------------------|-------------------------------|
+| activations (×4)  | `vec![0.0; num_neurons]` | `fill(0.0)` + re-copy inputs  |
+| hints (×4)        | `vec![0.0; num_non_inputs]` | `fill(0.0)`                |
+| traces (×4)       | `Vec::new()`             | `clear()`                     |
+
+## Evidence — benchmark (Issue #152 harness)
+
+Backend / CLI change — no UI to screenshot. Measured with the existing Criterion
+harness: `cargo bench --bench hot_paths -- batched_scoring/trace_batch_4way`
+(`--warm-up-time 1 --measurement-time 3`), same machine, before vs after.
+
+| Network      | Before (median) | After (median) | Change        |
+|--------------|-----------------|----------------|---------------|
+| small_50     | 982.31 ns       | 846.45 ns      | **~13.8% faster** |
+| medium_500   | 11.196 µs       | 10.985 µs      | ~1.9% faster  |
+| large_5000   | 262.23 µs       | 262.41 µs      | unchanged (compute-bound) |
+
+The win is largest on small networks, where the 12 eliminated allocations
+dominate runtime. On large networks per-call compute dwarfs allocation, so the
+result is unchanged (within noise) — i.e. no regression. The acceptance
+criterion of reduced per-call allocation is met: 12 heap allocations are removed
+from every invocation.
+
+## Test Plan
+
+- **New regression test** `neat-core/tests/network_activate_trace_batch.rs::test_batch_4way_buffer_reuse_no_state_leak`
+  — calls the method twice (then a third time) on the **same** `&mut` network with
+  different interleaved inputs, and asserts each output equals that of a fresh
+  network for the same input. This fails if the reused buffers are not correctly
+  reset between calls (state leak), and passes with the implementation.
+- All existing batch parity tests (`test_batch_4way_matches_single_*`,
+  `*_aggregate`, `*_constant_neuron`, `*_multi_layer`) continue to pass,
+  confirming identical output (8/8 in the batch suite).
+- `cargo test --workspace` — all green.
+- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
+
+> Note: `./quality.sh` reports 4 pre-existing `bats` failures (tests 31, 32, 33,
+> 37) about `.github/workflows/ci.yml` / `bump-deps.sh`, which are unrelated to
+> this change and also fail on the base branch (verified via `git stash`). No
+> files under `.github/` or `bump-deps.sh` were touched. The Rust gates
+> (fmt/clippy/check/test) all pass.
+
+## Pre-PR Security Self-Check
+
+- Input handling unchanged; the method reads the same `inputs` slice ranges as
+  before. No new external input, SQL, shell, filesystem, or HTTP surface.
+- No secrets or hidden files staged.

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -106,6 +106,25 @@ fn build_network(
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        // Issue #155 - 4-way batch scratch buffers
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+        ],
     }
 }
 
@@ -144,7 +163,8 @@ fn bench_batched_scoring(c: &mut Criterion) {
     let mut group = c.benchmark_group("batched_scoring");
 
     for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
-        let net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
+        // `mut` so the 4-way traced batch path can reuse its scratch buffers (Issue #155).
+        let mut net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
 
         // 4 records packed back-to-back for the traced batch path.
         let batch4 = build_inputs(num_inputs * 4, 0x0BAD_F00D);

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -388,5 +388,24 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, Cr
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        // Issue #155 - 4-way batch scratch buffers
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+        ],
     })
 }

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -131,6 +131,22 @@ pub struct CompiledNetwork {
     /// Issue #1173 - Eliminates heap allocation per call
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub trace_data_buffer: Vec<f32>,
+    /// Pre-allocated per-record activation buffers for the 4-way batch path.
+    /// Issue #155 - Extends the #1173 buffer-reuse precedent to
+    /// `activate_and_trace_batch_4way` so the 4 activation buffers are reused
+    /// across calls instead of re-allocated each invocation.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub batch_activations: [Vec<f32>; 4],
+    /// Pre-allocated per-record hint-value buffers for the 4-way batch path.
+    /// Issue #155 - Reused across calls (zeroed per call), mirroring
+    /// `hint_values_buffer`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub batch_hints: [Vec<f32>; 4],
+    /// Pre-allocated per-record trace-data buffers for the 4-way batch path.
+    /// Issue #155 - Reused across calls (cleared per call), mirroring
+    /// `trace_data_buffer`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub batch_traces: [Vec<f32>; 4],
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
@@ -252,6 +268,25 @@ impl CompiledNetwork {
             hint_values_buffer: vec![0.0; num_non_inputs],
             // Issue #1173 - Pre-allocate trace data buffer
             trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+            // Issue #155 - Pre-allocate the 4-way batch scratch buffers
+            batch_activations: [
+                vec![0.0; num_neurons],
+                vec![0.0; num_neurons],
+                vec![0.0; num_neurons],
+                vec![0.0; num_neurons],
+            ],
+            batch_hints: [
+                vec![0.0; num_non_inputs],
+                vec![0.0; num_non_inputs],
+                vec![0.0; num_non_inputs],
+                vec![0.0; num_non_inputs],
+            ],
+            batch_traces: [
+                Vec::with_capacity(estimated_trace_size),
+                Vec::with_capacity(estimated_trace_size),
+                Vec::with_capacity(estimated_trace_size),
+                Vec::with_capacity(estimated_trace_size),
+            ],
         })
     }
 
@@ -863,39 +898,33 @@ impl CompiledNetwork {
     /// Four `Vec<f32>` values, one per record. Each has the same format as `activate_and_trace`:
     /// [outputs..., activations..., hints..., trace_data...]
     pub fn activate_and_trace_batch_4way(
-        &self,
+        &mut self,
         inputs: &[f32],
         input_size: usize,
         num_outputs: usize,
     ) -> Vec<f32> {
-        let num_non_inputs = self.num_neurons - self.num_inputs;
-        let effective_input_len = input_size.min(self.num_inputs);
+        let num_neurons = self.num_neurons;
+        let num_inputs = self.num_inputs;
+        let num_non_inputs = num_neurons - num_inputs;
+        let effective_input_len = input_size.min(num_inputs);
 
-        // Allocate 4 separate activation buffers
-        let mut act0 = vec![0.0f32; self.num_neurons];
-        let mut act1 = vec![0.0f32; self.num_neurons];
-        let mut act2 = vec![0.0f32; self.num_neurons];
-        let mut act3 = vec![0.0f32; self.num_neurons];
+        // Issue #155 - Reuse the preallocated 4-way scratch buffers instead of
+        // allocating 12 fresh vectors per call. Reset each buffer to the same
+        // initial state a fresh allocation would have: activations zeroed then
+        // inputs re-copied, hints zeroed, traces cleared.
+        for r in 0..4 {
+            self.batch_activations[r].fill(0.0);
+            self.batch_hints[r].fill(0.0);
+            self.batch_traces[r].clear();
+            let src = &inputs[r * input_size..r * input_size + effective_input_len];
+            self.batch_activations[r][..effective_input_len].copy_from_slice(src);
+        }
 
-        // Copy inputs for each record
-        act0[..effective_input_len].copy_from_slice(&inputs[..effective_input_len]);
-        act1[..effective_input_len]
-            .copy_from_slice(&inputs[input_size..input_size + effective_input_len]);
-        act2[..effective_input_len]
-            .copy_from_slice(&inputs[2 * input_size..2 * input_size + effective_input_len]);
-        act3[..effective_input_len]
-            .copy_from_slice(&inputs[3 * input_size..3 * input_size + effective_input_len]);
-
-        // Allocate 4 sets of hint values and trace data buffers
-        let mut hints0 = vec![0.0f32; num_non_inputs];
-        let mut hints1 = vec![0.0f32; num_non_inputs];
-        let mut hints2 = vec![0.0f32; num_non_inputs];
-        let mut hints3 = vec![0.0f32; num_non_inputs];
-
-        let mut trace0: Vec<f32> = Vec::new();
-        let mut trace1: Vec<f32> = Vec::new();
-        let mut trace2: Vec<f32> = Vec::new();
-        let mut trace3: Vec<f32> = Vec::new();
+        // Destructure into per-record references for disjoint mutable access
+        // within the processing loop (each field is a distinct borrow of self).
+        let [act0, act1, act2, act3] = &mut self.batch_activations;
+        let [hints0, hints1, hints2, hints3] = &mut self.batch_hints;
+        let [trace0, trace1, trace2, trace3] = &mut self.batch_traces;
 
         // Process each neuron for all 4 records
         for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
@@ -922,147 +951,147 @@ impl CompiledNetwork {
                         // Process each record independently for MINIMUM aggregate
                         Self::process_minimum_4way(
                             &self.synapses,
-                            &mut act0,
-                            &mut act1,
-                            &mut act2,
-                            &mut act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             actual_idx,
                             neuron_idx,
                             neuron.bias,
                             start_synapse,
                             num_synapse,
-                            &mut hints0,
-                            &mut hints1,
-                            &mut hints2,
-                            &mut hints3,
-                            &mut trace0,
-                            &mut trace1,
-                            &mut trace2,
-                            &mut trace3,
+                            hints0,
+                            hints1,
+                            hints2,
+                            hints3,
+                            trace0,
+                            trace1,
+                            trace2,
+                            trace3,
                         );
                     }
                     SquashType::Maximum => {
                         // Process each record independently for MAXIMUM aggregate
                         Self::process_maximum_4way(
                             &self.synapses,
-                            &mut act0,
-                            &mut act1,
-                            &mut act2,
-                            &mut act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             actual_idx,
                             neuron_idx,
                             neuron.bias,
                             start_synapse,
                             num_synapse,
-                            &mut hints0,
-                            &mut hints1,
-                            &mut hints2,
-                            &mut hints3,
-                            &mut trace0,
-                            &mut trace1,
-                            &mut trace2,
-                            &mut trace3,
+                            hints0,
+                            hints1,
+                            hints2,
+                            hints3,
+                            trace0,
+                            trace1,
+                            trace2,
+                            trace3,
                         );
                     }
                     SquashType::If => {
                         // Process each record independently for IF aggregate
                         Self::process_if_4way(
                             &self.synapses,
-                            &mut act0,
-                            &mut act1,
-                            &mut act2,
-                            &mut act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             actual_idx,
                             neuron_idx,
                             neuron.bias,
                             start_synapse,
                             end_synapse,
-                            &mut hints0,
-                            &mut hints1,
-                            &mut hints2,
-                            &mut hints3,
-                            &mut trace0,
-                            &mut trace1,
-                            &mut trace2,
-                            &mut trace3,
+                            hints0,
+                            hints1,
+                            hints2,
+                            hints3,
+                            trace0,
+                            trace1,
+                            trace2,
+                            trace3,
                         );
                     }
                     SquashType::Hypotenuse => {
                         // Hypotenuse needs per-record processing (sum of squares)
                         Self::process_hypotenuse_4way(
                             &self.synapses,
-                            &mut act0,
-                            &mut act1,
-                            &mut act2,
-                            &mut act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             actual_idx,
                             neuron_idx,
                             neuron.bias,
                             start_synapse,
                             end_synapse,
-                            &mut hints0,
-                            &mut hints1,
-                            &mut hints2,
-                            &mut hints3,
-                            &mut trace0,
-                            &mut trace1,
-                            &mut trace2,
-                            &mut trace3,
+                            hints0,
+                            hints1,
+                            hints2,
+                            hints3,
+                            trace0,
+                            trace1,
+                            trace2,
+                            trace3,
                         );
                     }
                     SquashType::HypotenuseV2 => {
                         Self::process_hypotenuse_v2_4way(
                             &self.synapses,
-                            &mut act0,
-                            &mut act1,
-                            &mut act2,
-                            &mut act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             actual_idx,
                             neuron_idx,
                             neuron.bias,
                             start_synapse,
                             end_synapse,
-                            &mut hints0,
-                            &mut hints1,
-                            &mut hints2,
-                            &mut hints3,
-                            &mut trace0,
-                            &mut trace1,
-                            &mut trace2,
-                            &mut trace3,
+                            hints0,
+                            hints1,
+                            hints2,
+                            hints3,
+                            trace0,
+                            trace1,
+                            trace2,
+                            trace3,
                         );
                     }
                     SquashType::Mean => {
                         Self::process_mean_4way(
                             &self.synapses,
-                            &mut act0,
-                            &mut act1,
-                            &mut act2,
-                            &mut act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             actual_idx,
                             neuron_idx,
                             neuron.bias,
                             start_synapse,
                             end_synapse,
                             num_synapse,
-                            &mut hints0,
-                            &mut hints1,
-                            &mut hints2,
-                            &mut hints3,
-                            &mut trace0,
-                            &mut trace1,
-                            &mut trace2,
-                            &mut trace3,
+                            hints0,
+                            hints1,
+                            hints2,
+                            hints3,
+                            trace0,
+                            trace1,
+                            trace2,
+                            trace3,
                         );
                     }
                     _ => {
                         // Standard squash: use SIMD 4-record weighted sum
                         let (s0, s1, s2, s3) = weighted_sum_simd_4records(
                             &self.synapses,
-                            &act0,
-                            &act1,
-                            &act2,
-                            &act3,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
                             start_synapse,
                             end_synapse,
                             neuron.bias,
@@ -1122,25 +1151,25 @@ impl CompiledNetwork {
         result.extend_from_slice(&act0[output_start..output_start + num_outputs]);
         result.extend_from_slice(&act0[self.num_inputs..]);
         result.extend_from_slice(&hints0[..num_non_inputs]);
-        result.extend_from_slice(&trace0);
+        result.extend_from_slice(trace0);
 
         // Record 1
         result.extend_from_slice(&act1[output_start..output_start + num_outputs]);
         result.extend_from_slice(&act1[self.num_inputs..]);
         result.extend_from_slice(&hints1[..num_non_inputs]);
-        result.extend_from_slice(&trace1);
+        result.extend_from_slice(trace1);
 
         // Record 2
         result.extend_from_slice(&act2[output_start..output_start + num_outputs]);
         result.extend_from_slice(&act2[self.num_inputs..]);
         result.extend_from_slice(&hints2[..num_non_inputs]);
-        result.extend_from_slice(&trace2);
+        result.extend_from_slice(trace2);
 
         // Record 3
         result.extend_from_slice(&act3[output_start..output_start + num_outputs]);
         result.extend_from_slice(&act3[self.num_inputs..]);
         result.extend_from_slice(&hints3[..num_non_inputs]);
-        result.extend_from_slice(&trace3);
+        result.extend_from_slice(trace3);
 
         result
     }
@@ -1672,6 +1701,24 @@ mod tests {
             activations: vec![0.0; num_neurons],
             hint_values_buffer: vec![0.0; num_non_inputs],
             trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+            batch_activations: [
+                vec![0.0; num_neurons],
+                vec![0.0; num_neurons],
+                vec![0.0; num_neurons],
+                vec![0.0; num_neurons],
+            ],
+            batch_hints: [
+                vec![0.0; num_non_inputs],
+                vec![0.0; num_non_inputs],
+                vec![0.0; num_non_inputs],
+                vec![0.0; num_non_inputs],
+            ],
+            batch_traces: [
+                Vec::with_capacity(estimated_trace_size),
+                Vec::with_capacity(estimated_trace_size),
+                Vec::with_capacity(estimated_trace_size),
+                Vec::with_capacity(estimated_trace_size),
+            ],
         }
     }
 
@@ -1766,7 +1813,7 @@ mod tests {
         }
 
         // Run batch 4-way
-        let net = make_network(2, neurons.clone(), synapses.clone());
+        let mut net = make_network(2, neurons.clone(), synapses.clone());
         let packed_input: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed_input, 2, 1);
 
@@ -1808,7 +1855,7 @@ mod tests {
             single_results.push(result);
         }
 
-        let net = make_network(2, neurons.clone(), synapses.clone());
+        let mut net = make_network(2, neurons.clone(), synapses.clone());
         let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -1843,7 +1890,7 @@ mod tests {
             single_results.push(result);
         }
 
-        let net = make_network(2, neurons.clone(), synapses.clone());
+        let mut net = make_network(2, neurons.clone(), synapses.clone());
         let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -1872,7 +1919,7 @@ mod tests {
             single_results.push(result);
         }
 
-        let net = make_network(2, neurons.clone(), synapses.clone());
+        let mut net = make_network(2, neurons.clone(), synapses.clone());
         let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -1912,7 +1959,7 @@ mod tests {
             single_results.push(result);
         }
 
-        let net = make_network(3, neurons.clone(), synapses.clone());
+        let mut net = make_network(3, neurons.clone(), synapses.clone());
         let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed, 3, 1);
 
@@ -1952,7 +1999,7 @@ mod tests {
             single_results.push(result);
         }
 
-        let net = make_network(2, neurons.clone(), synapses.clone());
+        let mut net = make_network(2, neurons.clone(), synapses.clone());
         let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -2008,7 +2055,7 @@ mod tests {
             single_results.push(result);
         }
 
-        let net = make_network(2, neurons.clone(), synapses.clone());
+        let mut net = make_network(2, neurons.clone(), synapses.clone());
         let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
         let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 

--- a/neat-core/tests/network_activate_trace_batch.rs
+++ b/neat-core/tests/network_activate_trace_batch.rs
@@ -19,6 +19,25 @@ fn make_network(
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        // Issue #155 - 4-way batch scratch buffers
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+        ],
     }
 }
 
@@ -77,7 +96,7 @@ fn test_batch_4way_matches_single_relu() {
     }
 
     // Run batch 4-way
-    let net = make_network(2, neurons.clone(), synapses.clone());
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
     let packed_input: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed_input, 2, 1);
 
@@ -151,7 +170,7 @@ fn test_batch_4way_matches_single_tanh_logistic() {
         single_results.push(result);
     }
 
-    let net = make_network(2, neurons.clone(), synapses.clone());
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
     let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -209,7 +228,7 @@ fn test_batch_4way_minimum_aggregate() {
         single_results.push(result);
     }
 
-    let net = make_network(2, neurons.clone(), synapses.clone());
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
     let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -261,7 +280,7 @@ fn test_batch_4way_maximum_aggregate() {
         single_results.push(result);
     }
 
-    let net = make_network(2, neurons.clone(), synapses.clone());
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
     let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -324,7 +343,7 @@ fn test_batch_4way_if_aggregate() {
         single_results.push(result);
     }
 
-    let net = make_network(3, neurons.clone(), synapses.clone());
+    let mut net = make_network(3, neurons.clone(), synapses.clone());
     let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed, 3, 1);
 
@@ -387,7 +406,7 @@ fn test_batch_4way_constant_neuron() {
         single_results.push(result);
     }
 
-    let net = make_network(2, neurons.clone(), synapses.clone());
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
     let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -460,7 +479,7 @@ fn test_batch_4way_multi_layer() {
         single_results.push(result);
     }
 
-    let net = make_network(2, neurons.clone(), synapses.clone());
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
     let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
     let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
 
@@ -482,4 +501,71 @@ fn test_batch_4way_multi_layer() {
             );
         }
     }
+}
+
+/// Issue #155 - Regression test for buffer reuse in `activate_and_trace_batch_4way`.
+///
+/// The method now reuses preallocated scratch buffers across calls instead of
+/// allocating 12 fresh vectors each time. This verifies the reused buffers are
+/// correctly reset between calls: invoking the method twice on the same network
+/// (with different inputs interleaved) must produce byte-identical output to a
+/// fresh network for each call, proving no state leaks between invocations.
+#[test]
+fn test_batch_4way_buffer_reuse_no_state_leak() {
+    // Network exercising standard, aggregate and trace-producing squashes so the
+    // hint and trace buffers are non-trivially populated each call.
+    let synapses = vec![
+        make_synapse(0, 0.7),          // hidden(MAX) <- input0
+        make_synapse(1, -0.4),         // hidden(MAX) <- input1
+        make_synapse_typed(2, 1.0, 0), // output(TANH) <- hidden
+    ];
+    let neurons = vec![
+        NeuronData {
+            bias: 0.05,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: 33, // MAXIMUM (aggregate -> writes trace data)
+            is_constant: false,
+        },
+        NeuronData {
+            bias: -0.1,
+            start_synapse: 2,
+            num_synapses: 1,
+            squash_type: 7, // TANH
+            is_constant: false,
+        },
+    ];
+
+    let batch_a: [&[f32]; 4] = [&[1.0, 2.0], &[0.5, -1.0], &[-2.0, 3.0], &[0.4, 0.1]];
+    let batch_b: [&[f32]; 4] = [&[-1.5, 0.2], &[3.0, 1.0], &[0.0, -0.5], &[2.0, -2.0]];
+
+    let packed_a: Vec<f32> = batch_a.iter().flat_map(|i| i.iter().copied()).collect();
+    let packed_b: Vec<f32> = batch_b.iter().flat_map(|i| i.iter().copied()).collect();
+
+    // Reference outputs from fresh networks (no buffer reuse possible).
+    let mut ref_net_a = make_network(2, neurons.clone(), synapses.clone());
+    let expected_a = ref_net_a.activate_and_trace_batch_4way(&packed_a, 2, 1);
+    let mut ref_net_b = make_network(2, neurons.clone(), synapses.clone());
+    let expected_b = ref_net_b.activate_and_trace_batch_4way(&packed_b, 2, 1);
+
+    // Reused network: two consecutive calls on the SAME instance.
+    let mut net = make_network(2, neurons.clone(), synapses.clone());
+    let got_a = net.activate_and_trace_batch_4way(&packed_a, 2, 1);
+    let got_b = net.activate_and_trace_batch_4way(&packed_b, 2, 1);
+
+    assert_eq!(
+        got_a, expected_a,
+        "First reused call must match fresh-network output"
+    );
+    assert_eq!(
+        got_b, expected_b,
+        "Second reused call must match fresh-network output (no state leak)"
+    );
+
+    // A third call repeating the first inputs must again equal the first output.
+    let got_a_again = net.activate_and_trace_batch_4way(&packed_a, 2, 1);
+    assert_eq!(
+        got_a_again, expected_a,
+        "Repeating inputs after other calls must reproduce output"
+    );
 }


### PR DESCRIPTION
# [perf] Reuse buffers in `activate_and_trace_batch_4way`

## Summary

`activate_and_trace_batch_4way` previously allocated **12 fresh vectors on every
call** — 4 activation buffers, 4 hint buffers and 4 trace buffers. This extends
the buffer-reuse precedent established for the single-record path (#1173, which
added `hint_values_buffer` / `trace_data_buffer`) to the 4-way batch path.

The 12 scratch buffers are now stored on `CompiledNetwork` as `[Vec<f32>; 4]`
fields (`batch_activations`, `batch_hints`, `batch_traces`), pre-allocated in the
constructor and **reused** across calls. Each invocation resets the buffers to
the exact initial state a fresh allocation would have had — activations zeroed
then inputs re-copied, hints zeroed, traces cleared — so output is byte-identical
to the previous behaviour.

The method now takes `&mut self`, consistent with the other buffered methods
(`activate`, `activate_and_trace`). Per the `CompiledNetwork` struct doc, batch
scoring runs with each thread owning its own `CompiledNetwork`, so `&mut self` is
compatible with the threading model. The only non-test caller (the Criterion
bench) was updated to a `mut` binding; `pc_inference.rs` merely references the
method by name in a doc comment.

Closes #155.

## Allocation change

```mermaid
flowchart LR
    subgraph Before["Before — per call"]
        A["12 × vec! / Vec::new()"] --> B[process] --> C[build result]
    end
    subgraph After["After — per call"]
        D["fill(0.0) / clear()<br/>reuse preallocated buffers"] --> E[process] --> F[build result]
    end
```

| Buffer set        | Before (per call)        | After (per call)              |
|-------------------|--------------------------|-------------------------------|
| activations (×4)  | `vec![0.0; num_neurons]` | `fill(0.0)` + re-copy inputs  |
| hints (×4)        | `vec![0.0; num_non_inputs]` | `fill(0.0)`                |
| traces (×4)       | `Vec::new()`             | `clear()`                     |

## Evidence — benchmark (Issue #152 harness)

Backend / CLI change — no UI to screenshot. Measured with the existing Criterion
harness: `cargo bench --bench hot_paths -- batched_scoring/trace_batch_4way`
(`--warm-up-time 1 --measurement-time 3`), same machine, before vs after.

| Network      | Before (median) | After (median) | Change        |
|--------------|-----------------|----------------|---------------|
| small_50     | 982.31 ns       | 846.45 ns      | **~13.8% faster** |
| medium_500   | 11.196 µs       | 10.985 µs      | ~1.9% faster  |
| large_5000   | 262.23 µs       | 262.41 µs      | unchanged (compute-bound) |

The win is largest on small networks, where the 12 eliminated allocations
dominate runtime. On large networks per-call compute dwarfs allocation, so the
result is unchanged (within noise) — i.e. no regression. The acceptance
criterion of reduced per-call allocation is met: 12 heap allocations are removed
from every invocation.

## Test Plan

- **New regression test** `neat-core/tests/network_activate_trace_batch.rs::test_batch_4way_buffer_reuse_no_state_leak`
  — calls the method twice (then a third time) on the **same** `&mut` network with
  different interleaved inputs, and asserts each output equals that of a fresh
  network for the same input. This fails if the reused buffers are not correctly
  reset between calls (state leak), and passes with the implementation.
- All existing batch parity tests (`test_batch_4way_matches_single_*`,
  `*_aggregate`, `*_constant_neuron`, `*_multi_layer`) continue to pass,
  confirming identical output (8/8 in the batch suite).
- `cargo test --workspace` — all green.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

> Note: `./quality.sh` reports 4 pre-existing `bats` failures (tests 31, 32, 33,
> 37) about `.github/workflows/ci.yml` / `bump-deps.sh`, which are unrelated to
> this change and also fail on the base branch (verified via `git stash`). No
> files under `.github/` or `bump-deps.sh` were touched. The Rust gates
> (fmt/clippy/check/test) all pass.

## Pre-PR Security Self-Check

- Input handling unchanged; the method reads the same `inputs` slice ranges as
  before. No new external input, SQL, shell, filesystem, or HTTP surface.
- No secrets or hidden files staged.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqcbyn4z-6f1f0c`<!-- vibe-worker-issue-155 -->