### PR TITLE
perf(bench): add production-scale wide/shallow creature fixtures (Issue #176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,12 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,12 +217,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -262,15 +244,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -282,45 +262,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -350,12 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,12 +301,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
@@ -453,16 +382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -567,12 +486,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,9 +542,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -668,12 +581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,24 +588,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -744,40 +633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -834,100 +689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/docs/archive/pr-summaries/pr-summary-176.md
+++ b/docs/archive/pr-summaries/pr-summary-176.md
@@ -1,0 +1,95 @@
+## Summary
+
+Adds production-scale **wide/shallow** creature fixtures to the `hot_paths`
+Criterion harness so #175's optimisations can be validated against the real
+production topology, not just the dense synthetic nets. Closes #176.
+
+The real production creature has a huge input layer (2461), a modest neuron
+count (1673 non-input) and a sparse ~13 average fan-in (~21677 synapses). That
+shape is **gather-bound** in a way the existing dense feedforward shapes are
+not, so before/after deltas measured only on the synthetic shapes can be
+misleading.
+
+### What changed
+
+- **New shapes** `production` and `production_2x` ("or larger creatures",
+  ~2× neurons/synapses) wired into the `forward_pass`, `batched_scoring` and
+  `backprop` groups. `cargo bench -p neat-core --bench hot_paths -- production`
+  now reports every hot path at production scale.
+- **Varied fan-in**: `build_network`/`build_backprop_data` take a `FanIn`
+  policy. The synthetic shapes keep their exact `Fixed` fan-in (and consume no
+  extra RNG draw, so their existing baselines are unchanged); the production
+  shapes draw fan-in per neuron uniformly around the ~13 average so the gather
+  pattern matches production sparsity.
+- **No committed `network.json`** — the production shape is synthesised from the
+  seeded PRNG to match the real dimensions; the harness stays deterministic.
+- **Single source of truth**: the deterministic builders moved to
+  `neat-core/benches/common/mod.rs`, reused verbatim by the harness *and* by a
+  new integration test (`harness = false` benches can't host runnable tests, so
+  this is how the builders get real `cargo test` coverage).
+- README updated with the shape table and the `-- production` /
+  `--save-baseline before` / `--baseline before` workflow.
+
+```mermaid
+flowchart LR
+    C[benches/common/mod.rs<br/>NetSpec + deterministic builders] --> H[hot_paths.rs<br/>Criterion harness]
+    C --> T[tests/bench_fixtures.rs<br/>cargo test coverage]
+    H --> P["cargo bench -- production<br/>forward_pass / batched_scoring / backprop"]
+```
+
+## Evidence
+
+Backend/bench-only change — no UI to screenshot.
+
+### Acceptance criteria
+
+- ✅ `cargo bench -p neat-core --bench hot_paths -- production` runs and reports
+  `forward_pass`, `batched_scoring` and `backprop` at the `production` and
+  `production_2x` shapes (see baseline below).
+- ✅ README documents the new sizes and the baseline-comparison workflow.
+- ✅ Harness remains deterministic (fixed seed) — asserted by the new tests.
+
+### Initial baseline (indicative)
+
+Captured with a quick sampling profile (`--warm-up-time 0.5 --measurement-time 2
+--sample-size 20`) on the dev machine; absolute numbers are indicative, the
+harness is the deliverable. Re-run with the default profile for committed
+baselines.
+
+| Benchmark | `production` (median) | `production_2x` (median) |
+| --- | --- | --- |
+| `forward_pass` | 23.4 µs | 58.5 µs |
+| `batched_scoring/trace_batch_4way` | 107.0 µs | 209.6 µs |
+| `batched_scoring/mse_sum_8records` | 211.1 µs | 347.1 µs |
+| `backprop` | 76.5 µs | 178.8 µs |
+
+Record a comparable baseline before an optimisation, then compare:
+
+```bash
+cargo bench -p neat-core --bench hot_paths -- production --save-baseline before
+# ...apply optimisation...
+cargo bench -p neat-core --bench hot_paths -- production --baseline before
+```
+
+## Test Plan
+
+New integration test `neat-core/tests/bench_fixtures.rs` (runs under
+`cargo test --workspace --lib --tests`), all "what" tests asserting observable
+outcomes of the shared builders:
+
+- `production_shapes_are_registered_with_expected_dimensions` — the production
+  shapes match the documented dimensions and `production_2x` is ≥2× the neurons.
+- `build_network_matches_production_neuron_and_synapse_counts` — neuron/synapse
+  counts and an average fan-in within `12.0..=14.0`; per-neuron `num_synapses`
+  sums to the flat synapse buffer.
+- `varied_fan_in_actually_varies_unlike_fixed_shapes` — the production shape
+  draws a non-constant fan-in, while a `Fixed` shape stays constant.
+- `build_network_is_deterministic_for_a_fixed_seed` — identical synapses and
+  neurons for the same seed.
+- `production_network_activates_to_finite_outputs` — forward pass yields the
+  right number of finite outputs.
+- `backprop_data_has_consistent_inward_adjacency_at_production_scale` — inward
+  counts sum to the synapse and index-list lengths; reverse topo order length.
+
+Also verified: `cargo clippy --workspace --all-targets --all-features -- -D
+warnings`, `cargo doc`, `codespell`, and `markdownlint-cli2` all clean.

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -11,9 +11,9 @@ gate, so the CI runtime is unaffected.
 
 | Group | Function(s) under test | Sizes |
 | --- | --- | --- |
-| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000 neurons |
-| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same three sizes |
-| `backprop` | one `propagate_topological_loop` step | same three sizes |
+| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
+| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
+| `backprop` | one `propagate_topological_loop` step | same five shapes |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -21,6 +21,32 @@ Networks and inputs are built **once** outside the timed closure from a
 fixed-seed PRNG with fixed topologies, and `criterion::black_box` guards inputs
 and outputs. The harness is therefore deterministic, so before/after
 comparisons across a code change are meaningful.
+
+### Network shapes
+
+The three synthetic shapes are dense feedforward nets with a small input layer
+and a constant fan-in. The two `production` shapes (Issue #176) mirror the real
+production creature — a **wide, shallow** topology with a huge input layer, a
+modest neuron count and a sparse, *varied* fan-in — which is gather-bound in a
+way the dense shapes are not, so deltas measured only on the synthetic shapes
+can be misleading.
+
+| Shape | Inputs | Non-input neurons | Total neurons | Outputs | Avg fan-in | ~Synapses |
+| --- | --- | --- | --- | --- | --- | --- |
+| `small_50` | 8 | 42 | 50 | 4 | 12 (fixed) | ~0.5k |
+| `medium_500` | 16 | 484 | 500 | 8 | 16 (fixed) | ~7.7k |
+| `large_5000` | 32 | 4968 | 5000 | 16 | 24 (fixed) | ~119k |
+| `production` | 2461 | 1673 | 4134 | 1 | ~13 (varied) | ~21.7k |
+| `production_2x` | 4922 | 3346 | 8268 | 2 | ~13 (varied) | ~43.5k |
+
+The `production` shape is synthesised from the seeded PRNG to match the real
+creature's dimensions — the 3 MB `network.json` is **not** committed. Fan-in for
+the production shapes is drawn per neuron (uniform around the ~13 average)
+rather than held constant, so the gather pattern matches production sparsity.
+`production_2x` doubles the neuron and synapse counts to cover #175's "or larger
+creatures" requirement. The deterministic builders live in
+`benches/common/mod.rs` and are exercised by the `bench_fixtures` integration
+test.
 
 ## Running
 
@@ -31,10 +57,17 @@ cargo bench -p neat-core --bench hot_paths
 # Run a single group (regex over benchmark ids).
 cargo bench -p neat-core --bench hot_paths -- forward_pass
 cargo bench -p neat-core --bench hot_paths -- backprop
+
+# Run only the production-scale shapes across every hot path.
+cargo bench -p neat-core --bench hot_paths -- production
 ```
 
 > Use `--bench hot_paths` so Criterion's CLI flags are not handed to the
 > default libtest harness on the library target.
+
+The `production` filter is a regex over benchmark ids, so it matches both the
+`production` and `production_2x` shapes in `forward_pass`, `batched_scoring` and
+`backprop`.
 
 ## Comparing before vs after a change
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -1,0 +1,306 @@
+//! Deterministic fixtures shared by the `hot_paths` Criterion harness
+//! (Issue #152) and the `bench_fixtures` integration test (Issue #176).
+//!
+//! Kept in `benches/common/` (a subdirectory, so Cargo does **not** treat it as
+//! an auto-discovered bench target) and reused verbatim by the test via
+//! `#[path = "../benches/common/mod.rs"]`. That makes the network-building logic
+//! a single source of truth that is exercised by a real `cargo test` run rather
+//! than only compiled inside the `harness = false` bench.
+
+use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::squash::SquashType;
+use neat_core::topological_backprop::{
+    NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, SynapseInput,
+};
+
+/// Tiny deterministic PRNG (SplitMix64-style) so the harness produces fixed
+/// topologies and weights without pulling in an `rand` dependency.
+pub struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform float in `[-1.0, 1.0)`.
+    pub fn next_signed(&mut self) -> f32 {
+        let unit = (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32;
+        unit * 2.0 - 1.0
+    }
+
+    /// Uniform integer in `[0, bound)`.
+    pub fn next_below(&mut self, bound: usize) -> usize {
+        (self.next_u64() % bound as u64) as usize
+    }
+}
+
+/// How a neuron's incoming-connection count is chosen.
+#[derive(Clone, Copy)]
+pub enum FanIn {
+    /// Every neuron draws exactly this many incoming connections (capped by the
+    /// number of strictly earlier neurons). Used by the dense synthetic shapes,
+    /// so their topologies — and therefore existing baselines — are unchanged.
+    Fixed(usize),
+    /// Per-neuron fan-in drawn uniformly in `[1, 2*avg - 1]` so the mean matches
+    /// the production creature's sparse average (~13). Used by the wide/shallow
+    /// `production` shapes, which are gather-bound rather than dense.
+    VariedAround(usize),
+}
+
+impl FanIn {
+    /// Number of incoming connections for a neuron that has `max_fan` strictly
+    /// earlier neurons to draw from. Only [`FanIn::VariedAround`] consumes an
+    /// RNG draw, so [`FanIn::Fixed`] shapes keep their exact prior sequence.
+    pub fn draw(self, rng: &mut Lcg, max_fan: usize) -> usize {
+        let target = match self {
+            FanIn::Fixed(f) => f,
+            FanIn::VariedAround(avg) => {
+                let span = (2 * avg).saturating_sub(1).max(1);
+                1 + rng.next_below(span)
+            }
+        };
+        target.min(max_fan)
+    }
+}
+
+/// A benchmark network shape.
+pub struct NetSpec {
+    pub label: &'static str,
+    /// Total neurons, including the input layer.
+    pub num_neurons: usize,
+    pub num_inputs: usize,
+    pub num_outputs: usize,
+    pub fan_in: FanIn,
+}
+
+impl NetSpec {
+    pub fn num_non_inputs(&self) -> usize {
+        self.num_neurons - self.num_inputs
+    }
+}
+
+/// Representative network shapes wired into every hot-path group.
+///
+/// The three synthetic shapes are dense feedforward nets with a fixed fan-in.
+/// The two `production` shapes (Issue #176) mirror the real production creature:
+/// a huge input layer, a modest neuron count and a sparse ~13 average fan-in,
+/// which is gather-bound in a way the dense shapes are not. `production_2x`
+/// doubles neurons and synapses to cover #175's "or larger creatures" clause.
+pub const NETWORKS: [NetSpec; 5] = [
+    NetSpec {
+        label: "small_50",
+        num_neurons: 50,
+        num_inputs: 8,
+        num_outputs: 4,
+        fan_in: FanIn::Fixed(12),
+    },
+    NetSpec {
+        label: "medium_500",
+        num_neurons: 500,
+        num_inputs: 16,
+        num_outputs: 8,
+        fan_in: FanIn::Fixed(16),
+    },
+    NetSpec {
+        label: "large_5000",
+        num_neurons: 5000,
+        num_inputs: 32,
+        num_outputs: 16,
+        fan_in: FanIn::Fixed(24),
+    },
+    NetSpec {
+        label: "production",
+        // 2461 inputs + 1673 hidden/output neurons; ~13 avg fan-in ⇒ ~21.7k synapses.
+        num_neurons: 4134,
+        num_inputs: 2461,
+        num_outputs: 1,
+        fan_in: FanIn::VariedAround(13),
+    },
+    NetSpec {
+        label: "production_2x",
+        // ~2x the production neuron and synapse counts ("or larger creatures").
+        num_neurons: 8268,
+        num_inputs: 4922,
+        num_outputs: 2,
+        fan_in: FanIn::VariedAround(13),
+    },
+];
+
+/// Build a deterministic feedforward [`CompiledNetwork`] from a [`NetSpec`].
+///
+/// Non-input neurons are emitted in topological order; each draws up to its
+/// fan-in incoming connections from strictly earlier neurons, giving a realistic
+/// synapse density without recurrent edges.
+pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
+    let num_neurons = spec.num_neurons;
+    let num_inputs = spec.num_inputs;
+    let mut rng = Lcg::new(seed);
+    let num_non_inputs = spec.num_non_inputs();
+    let mut neurons = Vec::with_capacity(num_non_inputs);
+    let mut synapses = Vec::new();
+
+    for n in 0..num_non_inputs {
+        let global_idx = num_inputs + n;
+        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        let start_synapse = synapses.len() as u32;
+        for _ in 0..this_fan {
+            let from = rng.next_below(global_idx);
+            synapses.push(SynapseData {
+                weight: rng.next_signed() * 0.5,
+                from_index: from as u32,
+                synapse_type: 0,
+                _padding: [0; 3],
+            });
+        }
+        neurons.push(NeuronData {
+            bias: rng.next_signed() * 0.1,
+            start_synapse,
+            num_synapses: this_fan as u16,
+            squash_type: SquashType::Tanh as u8,
+            is_constant: false,
+        });
+    }
+
+    let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        // Issue #155 - 4-way batch scratch buffers
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+        ],
+    }
+}
+
+/// Deterministic input vector of length `n`.
+pub fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
+    let mut rng = Lcg::new(seed);
+    (0..n).map(|_| rng.next_signed()).collect()
+}
+
+/// Owned backing storage for a `PropagateInput`; built once outside the loop.
+pub struct BackpropData {
+    pub neurons: Vec<NeuronInput>,
+    pub synapses: Vec<SynapseInput>,
+    pub inward_starts: Vec<u32>,
+    pub inward_counts: Vec<u32>,
+    pub inward_indices: Vec<u32>,
+    pub reverse_topo_order: Vec<u32>,
+    pub expected: Vec<f32>,
+    pub input_count: u32,
+    pub output_count: u32,
+}
+
+/// Build a deterministic feedforward backprop input from a [`NetSpec`].
+pub fn build_backprop_data(spec: &NetSpec, seed: u64) -> BackpropData {
+    let num_neurons = spec.num_neurons;
+    let num_inputs = spec.num_inputs;
+    let num_outputs = spec.num_outputs;
+    let mut rng = Lcg::new(seed);
+    let mut neurons = Vec::with_capacity(num_neurons);
+
+    // Input neurons first.
+    for _ in 0..num_inputs {
+        neurons.push(make_neuron(
+            SquashType::Identity,
+            NEURON_TYPE_INPUT,
+            rng.next_signed(),
+        ));
+    }
+
+    // Synapses grouped by target neuron so the inward adjacency is contiguous.
+    let mut synapses: Vec<SynapseInput> = Vec::new();
+    let mut inward_starts = vec![0u32; num_neurons];
+    let mut inward_counts = vec![0u32; num_neurons];
+    let mut inward_indices: Vec<u32> = Vec::new();
+
+    for global_idx in num_inputs..num_neurons {
+        let is_output = global_idx >= num_neurons - num_outputs;
+        let neuron_type = if is_output {
+            NEURON_TYPE_OUTPUT
+        } else {
+            NEURON_TYPE_HIDDEN
+        };
+        neurons.push(make_neuron(
+            SquashType::Tanh,
+            neuron_type,
+            rng.next_signed(),
+        ));
+
+        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        inward_starts[global_idx] = inward_indices.len() as u32;
+        inward_counts[global_idx] = this_fan as u32;
+        for _ in 0..this_fan {
+            let from = rng.next_below(global_idx);
+            let weight = rng.next_signed() * 0.5;
+            inward_indices.push(synapses.len() as u32);
+            synapses.push(SynapseInput {
+                from: from as u32,
+                to: global_idx as u32,
+                original_weight: weight,
+                adjusted_weight: weight,
+                is_self_loop: false,
+            });
+        }
+    }
+
+    // Reverse topological order: non-input neurons from last back to first.
+    let reverse_topo_order: Vec<u32> = (num_inputs..num_neurons).rev().map(|i| i as u32).collect();
+    let expected = (0..num_outputs).map(|_| rng.next_signed()).collect();
+
+    BackpropData {
+        neurons,
+        synapses,
+        inward_starts,
+        inward_counts,
+        inward_indices,
+        reverse_topo_order,
+        expected,
+        input_count: num_inputs as u32,
+        output_count: num_outputs as u32,
+    }
+}
+
+pub fn make_neuron(squash: SquashType, neuron_type: u8, adjusted_activation: f32) -> NeuronInput {
+    NeuronInput {
+        squash_type: squash as u8,
+        neuron_type,
+        propagate_needed: true,
+        update_needed: true,
+        hint_value: 0.0,
+        range_low: -1.0e6,
+        range_high: 1.0e6,
+        adjusted_activation,
+        adjusted_bias: 0.0,
+    }
+}

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -16,144 +16,39 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use std::hint::black_box;
 
 use neat_core::loss::mse_sum_batch_packed;
-use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::network::SynapseData;
 use neat_core::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_simd,
     weighted_sum_simd_4records, weighted_sum_simd_8records,
 };
 use neat_core::squash::{SquashType, apply_squash};
-use neat_core::topological_backprop::{
-    NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, PropagateInput,
-    SynapseInput, propagate_topological_loop,
-};
+use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
 use neat_core::unsquash::apply_unsquash;
 
-/// Tiny deterministic PRNG (SplitMix64-style) so the harness produces fixed
-/// topologies and weights without pulling in an `rand` dependency.
-struct Lcg {
-    state: u64,
-}
-
-impl Lcg {
-    fn new(seed: u64) -> Self {
-        Self { state: seed }
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
-        let mut z = self.state;
-        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-        z ^ (z >> 31)
-    }
-
-    /// Uniform float in `[-1.0, 1.0)`.
-    fn next_signed(&mut self) -> f32 {
-        let unit = (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32;
-        unit * 2.0 - 1.0
-    }
-
-    /// Uniform integer in `[0, bound)`.
-    fn next_below(&mut self, bound: usize) -> usize {
-        (self.next_u64() % bound as u64) as usize
-    }
-}
-
-/// Build a deterministic feedforward [`CompiledNetwork`].
-///
-/// Non-input neurons are emitted in topological order; each draws up to
-/// `fan_in` incoming connections from strictly earlier neurons, giving a
-/// realistic synapse density without recurrent edges.
-fn build_network(
-    num_neurons: usize,
-    num_inputs: usize,
-    fan_in: usize,
-    seed: u64,
-) -> CompiledNetwork {
-    let mut rng = Lcg::new(seed);
-    let num_non_inputs = num_neurons - num_inputs;
-    let mut neurons = Vec::with_capacity(num_non_inputs);
-    let mut synapses = Vec::new();
-
-    for n in 0..num_non_inputs {
-        let global_idx = num_inputs + n;
-        let this_fan = fan_in.min(global_idx);
-        let start_synapse = synapses.len() as u32;
-        for _ in 0..this_fan {
-            let from = rng.next_below(global_idx);
-            synapses.push(SynapseData {
-                weight: rng.next_signed() * 0.5,
-                from_index: from as u32,
-                synapse_type: 0,
-                _padding: [0; 3],
-            });
-        }
-        neurons.push(NeuronData {
-            bias: rng.next_signed() * 0.1,
-            start_synapse,
-            num_synapses: this_fan as u16,
-            squash_type: SquashType::Tanh as u8,
-            is_constant: false,
-        });
-    }
-
-    let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
-    CompiledNetwork {
-        num_neurons,
-        num_inputs,
-        neurons,
-        synapses,
-        activations: vec![0.0; num_neurons],
-        hint_values_buffer: vec![0.0; num_non_inputs],
-        trace_data_buffer: Vec::with_capacity(estimated_trace_size),
-        // Issue #155 - 4-way batch scratch buffers
-        batch_activations: [
-            vec![0.0; num_neurons],
-            vec![0.0; num_neurons],
-            vec![0.0; num_neurons],
-            vec![0.0; num_neurons],
-        ],
-        batch_hints: [
-            vec![0.0; num_non_inputs],
-            vec![0.0; num_non_inputs],
-            vec![0.0; num_non_inputs],
-            vec![0.0; num_non_inputs],
-        ],
-        batch_traces: [
-            Vec::with_capacity(estimated_trace_size),
-            Vec::with_capacity(estimated_trace_size),
-            Vec::with_capacity(estimated_trace_size),
-            Vec::with_capacity(estimated_trace_size),
-        ],
-    }
-}
-
-/// Deterministic input vector of length `n`.
-fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
-    let mut rng = Lcg::new(seed);
-    (0..n).map(|_| rng.next_signed()).collect()
-}
-
-/// Representative network sizes: (label, total neurons, inputs, outputs, fan-in).
-const NETWORKS: [(&str, usize, usize, usize, usize); 3] = [
-    ("small_50", 50, 8, 4, 12),
-    ("medium_500", 500, 16, 8, 16),
-    ("large_5000", 5000, 32, 16, 24),
-];
+/// Deterministic network/backprop fixtures, shared with the `bench_fixtures`
+/// integration test (Issue #176) so the production-scale builders are exercised
+/// by a real `cargo test` run as well as the harness.
+mod common;
+use common::{Lcg, NETWORKS, build_backprop_data, build_inputs, build_network};
 
 /// Forward pass — `CompiledNetwork::activate` across representative sizes.
 fn bench_forward_pass(c: &mut Criterion) {
     let mut group = c.benchmark_group("forward_pass");
-    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
-        let mut net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
-        let inputs = build_inputs(num_inputs, 0xA1B2_C3D4);
-        group.throughput(Throughput::Elements(num_neurons as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(label), &inputs, |b, inputs| {
-            b.iter(|| {
-                let out = net.activate(black_box(inputs), black_box(num_outputs));
-                black_box(out);
-            });
-        });
+    for spec in &NETWORKS {
+        let mut net = build_network(spec, 0x5152_5354);
+        let inputs = build_inputs(spec.num_inputs, 0xA1B2_C3D4);
+        let num_outputs = spec.num_outputs;
+        group.throughput(Throughput::Elements(spec.num_neurons as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(spec.label),
+            &inputs,
+            |b, inputs| {
+                b.iter(|| {
+                    let out = net.activate(black_box(inputs), black_box(num_outputs));
+                    black_box(out);
+                });
+            },
+        );
     }
     group.finish();
 }
@@ -162,14 +57,16 @@ fn bench_forward_pass(c: &mut Criterion) {
 fn bench_batched_scoring(c: &mut Criterion) {
     let mut group = c.benchmark_group("batched_scoring");
 
-    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
+    for spec in &NETWORKS {
+        let num_inputs = spec.num_inputs;
+        let num_outputs = spec.num_outputs;
         // `mut` so the 4-way traced batch path can reuse its scratch buffers (Issue #155).
-        let mut net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
+        let mut net = build_network(spec, 0x5152_5354);
 
         // 4 records packed back-to-back for the traced batch path.
         let batch4 = build_inputs(num_inputs * 4, 0x0BAD_F00D);
         group.bench_with_input(
-            BenchmarkId::new("trace_batch_4way", label),
+            BenchmarkId::new("trace_batch_4way", spec.label),
             &batch4,
             |b, batch| {
                 b.iter(|| {
@@ -187,7 +84,7 @@ fn bench_batched_scoring(c: &mut Criterion) {
         let mut loss_net = net.clone();
         let records = build_inputs((num_inputs + num_outputs) * 8, 0xFEED_BEEF);
         group.bench_with_input(
-            BenchmarkId::new("mse_sum_8records", label),
+            BenchmarkId::new("mse_sum_8records", spec.label),
             &records,
             |b, records| {
                 b.iter(|| {
@@ -206,113 +103,13 @@ fn bench_batched_scoring(c: &mut Criterion) {
     group.finish();
 }
 
-/// Owned backing storage for a [`PropagateInput`]; built once outside the loop.
-struct BackpropData {
-    neurons: Vec<NeuronInput>,
-    synapses: Vec<SynapseInput>,
-    inward_starts: Vec<u32>,
-    inward_counts: Vec<u32>,
-    inward_indices: Vec<u32>,
-    reverse_topo_order: Vec<u32>,
-    expected: Vec<f32>,
-    input_count: u32,
-    output_count: u32,
-}
-
-/// Build a deterministic feedforward backprop input of `num_neurons` neurons.
-fn build_backprop_data(
-    num_neurons: usize,
-    num_inputs: usize,
-    num_outputs: usize,
-    fan_in: usize,
-    seed: u64,
-) -> BackpropData {
-    let mut rng = Lcg::new(seed);
-    let mut neurons = Vec::with_capacity(num_neurons);
-
-    // Input neurons first.
-    for _ in 0..num_inputs {
-        neurons.push(make_neuron(
-            SquashType::Identity,
-            NEURON_TYPE_INPUT,
-            rng.next_signed(),
-        ));
-    }
-
-    // Synapses grouped by target neuron so the inward adjacency is contiguous.
-    let mut synapses: Vec<SynapseInput> = Vec::new();
-    let mut inward_starts = vec![0u32; num_neurons];
-    let mut inward_counts = vec![0u32; num_neurons];
-    let mut inward_indices: Vec<u32> = Vec::new();
-
-    for global_idx in num_inputs..num_neurons {
-        let is_output = global_idx >= num_neurons - num_outputs;
-        let neuron_type = if is_output {
-            NEURON_TYPE_OUTPUT
-        } else {
-            NEURON_TYPE_HIDDEN
-        };
-        neurons.push(make_neuron(
-            SquashType::Tanh,
-            neuron_type,
-            rng.next_signed(),
-        ));
-
-        let this_fan = fan_in.min(global_idx);
-        inward_starts[global_idx] = inward_indices.len() as u32;
-        inward_counts[global_idx] = this_fan as u32;
-        for _ in 0..this_fan {
-            let from = rng.next_below(global_idx);
-            let weight = rng.next_signed() * 0.5;
-            inward_indices.push(synapses.len() as u32);
-            synapses.push(SynapseInput {
-                from: from as u32,
-                to: global_idx as u32,
-                original_weight: weight,
-                adjusted_weight: weight,
-                is_self_loop: false,
-            });
-        }
-    }
-
-    // Reverse topological order: non-input neurons from last back to first.
-    let reverse_topo_order: Vec<u32> = (num_inputs..num_neurons).rev().map(|i| i as u32).collect();
-    let expected = (0..num_outputs).map(|_| rng.next_signed()).collect();
-
-    BackpropData {
-        neurons,
-        synapses,
-        inward_starts,
-        inward_counts,
-        inward_indices,
-        reverse_topo_order,
-        expected,
-        input_count: num_inputs as u32,
-        output_count: num_outputs as u32,
-    }
-}
-
-fn make_neuron(squash: SquashType, neuron_type: u8, adjusted_activation: f32) -> NeuronInput {
-    NeuronInput {
-        squash_type: squash as u8,
-        neuron_type,
-        propagate_needed: true,
-        update_needed: true,
-        hint_value: 0.0,
-        range_low: -1.0e6,
-        range_high: 1.0e6,
-        adjusted_activation,
-        adjusted_bias: 0.0,
-    }
-}
-
 /// Backprop — one `propagate_topological_loop` step on representative sizes.
 fn bench_backprop(c: &mut Criterion) {
     let mut group = c.benchmark_group("backprop");
-    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
-        let data = build_backprop_data(num_neurons, num_inputs, num_outputs, fan_in, 0x1357_9BDF);
-        group.throughput(Throughput::Elements(num_neurons as u64));
-        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+    for spec in &NETWORKS {
+        let data = build_backprop_data(spec, 0x1357_9BDF);
+        group.throughput(Throughput::Elements(spec.num_neurons as u64));
+        group.bench_function(BenchmarkId::from_parameter(spec.label), |b| {
             b.iter(|| {
                 let input = PropagateInput {
                     neurons: &data.neurons,

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -1,0 +1,134 @@
+//! Behavioural tests for the deterministic fixtures behind the `hot_paths`
+//! Criterion harness (Issue #176). The builders live in `benches/common/mod.rs`
+//! and are reused here verbatim via `#[path]`, so the production-scale shape is
+//! validated by a real `cargo test` run rather than only compiled in the bench.
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{FanIn, NETWORKS, NetSpec, build_backprop_data, build_inputs, build_network};
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+#[test]
+fn production_shapes_are_registered_with_expected_dimensions() {
+    let prod = spec("production");
+    assert_eq!(prod.num_inputs, 2461);
+    assert_eq!(prod.num_outputs, 1);
+    assert_eq!(prod.num_non_inputs(), 1673);
+    assert_eq!(prod.num_neurons, 4134);
+
+    let prod2x = spec("production_2x");
+    // "or larger creatures": ~2x neurons.
+    assert!(
+        prod2x.num_non_inputs() >= 2 * prod.num_non_inputs(),
+        "production_2x should have at least double the non-input neurons"
+    );
+    assert!(prod2x.num_inputs >= prod.num_inputs);
+}
+
+#[test]
+fn build_network_matches_production_neuron_and_synapse_counts() {
+    let prod = spec("production");
+    let net = build_network(prod, 0x5152_5354);
+
+    // One NeuronData per non-input neuron; total count includes the input layer.
+    assert_eq!(net.neurons.len(), prod.num_non_inputs());
+    assert_eq!(net.num_neurons, prod.num_neurons);
+    assert_eq!(net.num_inputs, prod.num_inputs);
+
+    // Sparse ~13 average fan-in ⇒ roughly 21.7k synapses for the real creature.
+    let total_synapses = net.synapses.len();
+    let avg_fan_in = total_synapses as f64 / prod.num_non_inputs() as f64;
+    assert!(
+        (12.0..=14.0).contains(&avg_fan_in),
+        "average fan-in {avg_fan_in} should sit near the production ~13"
+    );
+
+    // num_synapses on each neuron must sum to the flat synapse buffer length.
+    let summed: usize = net.neurons.iter().map(|n| n.num_synapses as usize).sum();
+    assert_eq!(summed, total_synapses);
+}
+
+#[test]
+fn varied_fan_in_actually_varies_unlike_fixed_shapes() {
+    // The wide/shallow production shape must draw a non-constant fan-in.
+    let prod = spec("production");
+    let net = build_network(prod, 0x5152_5354);
+    let distinct: std::collections::BTreeSet<u16> =
+        net.neurons.iter().map(|n| n.num_synapses).collect();
+    assert!(
+        distinct.len() > 1,
+        "production fan-in should vary, saw only {distinct:?}"
+    );
+
+    // A fixed-shape network keeps a single fan-in (away from the early cap).
+    let small = spec("small_50");
+    if let FanIn::Fixed(f) = small.fan_in {
+        let net = build_network(small, 0x5152_5354);
+        let tail = &net.neurons[small.num_inputs..];
+        assert!(
+            tail.iter().all(|n| n.num_synapses as usize == f),
+            "fixed shapes should keep a constant fan-in past the early ramp"
+        );
+    }
+}
+
+#[test]
+fn build_network_is_deterministic_for_a_fixed_seed() {
+    let prod = spec("production");
+    let a = build_network(prod, 0x5152_5354);
+    let b = build_network(prod, 0x5152_5354);
+
+    assert_eq!(a.synapses.len(), b.synapses.len());
+    assert!(
+        a.synapses
+            .iter()
+            .zip(&b.synapses)
+            .all(|(x, y)| x.weight == y.weight && x.from_index == y.from_index),
+        "same seed must reproduce identical synapses"
+    );
+    assert!(
+        a.neurons
+            .iter()
+            .zip(&b.neurons)
+            .all(|(x, y)| x.bias == y.bias && x.num_synapses == y.num_synapses),
+        "same seed must reproduce identical neurons"
+    );
+}
+
+#[test]
+fn production_network_activates_to_finite_outputs() {
+    let prod = spec("production");
+    let mut net = build_network(prod, 0x5152_5354);
+    let inputs = build_inputs(prod.num_inputs, 0xA1B2_C3D4);
+
+    let out = net.activate(&inputs, prod.num_outputs);
+    assert_eq!(out.len(), prod.num_outputs);
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "production forward pass must produce finite outputs"
+    );
+}
+
+#[test]
+fn backprop_data_has_consistent_inward_adjacency_at_production_scale() {
+    let prod = spec("production");
+    let data = build_backprop_data(prod, 0x1357_9BDF);
+
+    assert_eq!(data.neurons.len(), prod.num_neurons);
+    assert_eq!(data.input_count as usize, prod.num_inputs);
+    assert_eq!(data.output_count as usize, prod.num_outputs);
+    assert_eq!(data.reverse_topo_order.len(), prod.num_non_inputs());
+
+    // Inward counts must sum to the flat synapse buffer and index list length.
+    let summed: usize = data.inward_counts.iter().map(|&c| c as usize).sum();
+    assert_eq!(summed, data.synapses.len());
+    assert_eq!(summed, data.inward_indices.len());
+}


### PR DESCRIPTION
## Summary

Adds production-scale **wide/shallow** creature fixtures to the `hot_paths`
Criterion harness so #175's optimisations can be validated against the real
production topology, not just the dense synthetic nets. Closes #176.

The real production creature has a huge input layer (2461), a modest neuron
count (1673 non-input) and a sparse ~13 average fan-in (~21677 synapses). That
shape is **gather-bound** in a way the existing dense feedforward shapes are
not, so before/after deltas measured only on the synthetic shapes can be
misleading.

### What changed

- **New shapes** `production` and `production_2x` ("or larger creatures",
  ~2× neurons/synapses) wired into the `forward_pass`, `batched_scoring` and
  `backprop` groups. `cargo bench -p neat-core --bench hot_paths -- production`
  now reports every hot path at production scale.
- **Varied fan-in**: `build_network`/`build_backprop_data` take a `FanIn`
  policy. The synthetic shapes keep their exact `Fixed` fan-in (and consume no
  extra RNG draw, so their existing baselines are unchanged); the production
  shapes draw fan-in per neuron uniformly around the ~13 average so the gather
  pattern matches production sparsity.
- **No committed `network.json`** — the production shape is synthesised from the
  seeded PRNG to match the real dimensions; the harness stays deterministic.
- **Single source of truth**: the deterministic builders moved to
  `neat-core/benches/common/mod.rs`, reused verbatim by the harness *and* by a
  new integration test (`harness = false` benches can't host runnable tests, so
  this is how the builders get real `cargo test` coverage).
- README updated with the shape table and the `-- production` /
  `--save-baseline before` / `--baseline before` workflow.

```mermaid
flowchart LR
    C[benches/common/mod.rs<br/>NetSpec + deterministic builders] --> H[hot_paths.rs<br/>Criterion harness]
    C --> T[tests/bench_fixtures.rs<br/>cargo test coverage]
    H --> P["cargo bench -- production<br/>forward_pass / batched_scoring / backprop"]
```

## Evidence

Backend/bench-only change — no UI to screenshot.

### Acceptance criteria

- ✅ `cargo bench -p neat-core --bench hot_paths -- production` runs and reports
  `forward_pass`, `batched_scoring` and `backprop` at the `production` and
  `production_2x` shapes (see baseline below).
- ✅ README documents the new sizes and the baseline-comparison workflow.
- ✅ Harness remains deterministic (fixed seed) — asserted by the new tests.

### Initial baseline (indicative)

Captured with a quick sampling profile (`--warm-up-time 0.5 --measurement-time 2
--sample-size 20`) on the dev machine; absolute numbers are indicative, the
harness is the deliverable. Re-run with the default profile for committed
baselines.

| Benchmark | `production` (median) | `production_2x` (median) |
| --- | --- | --- |
| `forward_pass` | 23.4 µs | 58.5 µs |
| `batched_scoring/trace_batch_4way` | 107.0 µs | 209.6 µs |
| `batched_scoring/mse_sum_8records` | 211.1 µs | 347.1 µs |
| `backprop` | 76.5 µs | 178.8 µs |

Record a comparable baseline before an optimisation, then compare:

```bash
cargo bench -p neat-core --bench hot_paths -- production --save-baseline before
# ...apply optimisation...
cargo bench -p neat-core --bench hot_paths -- production --baseline before
```

## Test Plan

New integration test `neat-core/tests/bench_fixtures.rs` (runs under
`cargo test --workspace --lib --tests`), all "what" tests asserting observable
outcomes of the shared builders:

- `production_shapes_are_registered_with_expected_dimensions` — the production
  shapes match the documented dimensions and `production_2x` is ≥2× the neurons.
- `build_network_matches_production_neuron_and_synapse_counts` — neuron/synapse
  counts and an average fan-in within `12.0..=14.0`; per-neuron `num_synapses`
  sums to the flat synapse buffer.
- `varied_fan_in_actually_varies_unlike_fixed_shapes` — the production shape
  draws a non-constant fan-in, while a `Fixed` shape stays constant.
- `build_network_is_deterministic_for_a_fixed_seed` — identical synapses and
  neurons for the same seed.
- `production_network_activates_to_finite_outputs` — forward pass yields the
  right number of finite outputs.
- `backprop_data_has_consistent_inward_adjacency_at_production_scale` — inward
  counts sum to the synapse and index-list lengths; reverse topo order length.

Also verified: `cargo clippy --workspace --all-targets --all-features -- -D
warnings`, `cargo doc`, `codespell`, and `markdownlint-cli2` all clean.



## Milestone
This PR is part of the **#175 Please suggest performance improvements for production size creatures/data** milestone and targets the `milestone/175-please-suggest-performance-improvements-for-pr` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqlzd3gh-a204b8`<!-- vibe-worker-issue-176 -->