### PR TITLE
perf: add opt-in data-parallel record scoring via rayon (Issue #179)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ name = "neat-core"
 version = "0.1.45"
 dependencies = [
  "criterion",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 | `neat-core/` | Shared computation library; **140+** unit tests in `src/**/*.rs` plus integration tests in `neat-core/tests/` (>350 total). |
 | `Cargo.toml` | Virtual workspace root; `[workspace.package]` holds semver for release automation. |
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
-| `neat-core/benches/` | Opt-in Criterion harness for core hot paths (`cargo bench -p neat-core --bench hot_paths`); see `neat-core/benches/README.md`. |
+| `neat-core/benches/` | Opt-in Criterion harnesses: `hot_paths` (core hot paths) and `parallel_scoring` (data-parallel scoring, needs `--features parallel`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
 | `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build (Vibe Coder hook). |
@@ -34,6 +34,46 @@ cargo test --workspace
 ./quality.sh
 # opt-in performance benchmarks (not part of the test gate):
 cargo bench -p neat-core --bench hot_paths
+```
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
+
+Scoring a production-size dataset pushes many records through one creature — an
+embarrassingly parallel workload *across records*. With the `parallel` feature
+the throughput scales with core count, while results stay **identical** to the
+sequential path (each record is scored by the same `activate`, with no
+cross-record state — each rayon worker owns a cloned scratch context):
+
+```rust
+// Off-feature / wasm: transparently runs sequentially.
+let outputs = net.score_records(&records, num_outputs);
+
+// With `--features parallel` on native: scored across the rayon pool,
+// same results, in input order.
+let outputs = net.score_records_parallel(&records, num_outputs);
+```
+
+```mermaid
+flowchart LR
+    R[records] --> S{parallel feature?}
+    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
+    S -- on, native --> P[score_records_parallel]
+    P --> W1[worker 1<br/>cloned scratch]
+    P --> W2[worker 2<br/>cloned scratch]
+    P --> Wn[worker N<br/>cloned scratch]
+    W1 --> O[outputs in input order]
+    W2 --> O
+    Wn --> O
+    Q --> O
+```
+
+```bash
+# Run the data-parallel scoring throughput bench (1 vs all cores).
+cargo bench -p neat-core --features parallel --bench parallel_scoring
 ```
 
 ## Related Repositories

--- a/docs/archive/pr-summaries/pr-summary-179.md
+++ b/docs/archive/pr-summaries/pr-summary-179.md
@@ -1,0 +1,105 @@
+# Native, feature-gated data-parallel record scoring (rayon)
+
+## Summary
+
+Adds an **opt-in, native-only** data-parallel scoring path so a production-size
+dataset can be pushed through one creature across all cores — the embarrassingly
+parallel "data" half of #175. Scoring N records is independent per record, so it
+scales near-linearly with core count and composes with the per-record
+micro-optimisations from the sibling sub-issues. Closes #179.
+
+What changed:
+
+- **New `parallel` Cargo feature** (off by default) pulling in `rayon`. `rayon`
+  is declared under a `cfg(not(target_arch = "wasm32"))` target table, and the
+  parallel code is gated `#[cfg(all(feature = "parallel", not(target_arch =
+  "wasm32")))]`, so the **default build and the `wasm32` build pull in no rayon
+  symbols** and keep their single-thread path.
+- **`CompiledNetwork::score_records_parallel(&self, records, num_outputs)`** —
+  chunks records across the rayon pool via `par_iter().map_init(...)`. Each
+  worker initialises **its own cloned scratch context** (the `Clone` carries
+  `activations` / `hint_values_buffer` / the 4-way batch buffers), so no
+  `&mut self` is shared across threads: immutable weights are read through
+  `&self` while every worker owns its buffers. When the feature is off or on
+  wasm, the method is a thin fallback to the sequential path.
+- **`CompiledNetwork::score_records(&self, records, num_outputs)`** — the
+  sequential reference (one scratch clone), used as the fallback and the parity
+  baseline.
+- **`parallel_scoring` Criterion bench** reporting records/sec at 1 vs all
+  cores on the `production` / `production_2x` fixtures (#175/#176). No-op shim
+  without the feature so the target builds on every configuration.
+
+Determinism: every record is scored by the same `activate` used sequentially,
+with no cross-record state, and `collect()` preserves input order — so results
+are **identical** to the sequential path regardless of thread count (verified by
+tests).
+
+### Drive-by fix (required for a green build)
+
+The milestone branch's bench fixtures (`benches/common/mod.rs` and
+`benches/hot_paths.rs`) still constructed `SynapseData` with the pre-#177 layout
+(`from_index: u32` + `_padding`), so `cargo check --tests` / `--all-targets`
+failed to compile on the milestone branch before this PR. Updated both to the
+current `from_index: u16` layout. This was necessary to build the
+acceptance-criteria benchmark and to keep `quality.sh` green.
+
+```mermaid
+flowchart LR
+    R[records] --> S{parallel feature?}
+    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
+    S -- on, native --> P[score_records_parallel]
+    P --> W1[worker 1<br/>cloned scratch]
+    P --> W2[worker 2<br/>cloned scratch]
+    P --> Wn[worker N<br/>cloned scratch]
+    W1 --> O[outputs in input order]
+    W2 --> O
+    Wn --> O
+    Q --> O
+```
+
+## Evidence (performance)
+
+`cargo bench -p neat-core --features parallel --bench parallel_scoring`, scoring
+2048 records, on a 12-core host (`nproc` = 12). Throughput is records/sec
+(Criterion `thrpt`, median):
+
+| Fixture | 1 core | 12 cores | Speed-up |
+|---------|--------|----------|----------|
+| `production` (4134 neurons, ~21.7k synapses) | 52.4 ms → **39.06 Kelem/s** | 7.18 ms → **285.4 Kelem/s** | **~7.3×** |
+| `production_2x` (8268 neurons, ~43.5k synapses) | 111.3 ms → **18.40 Kelem/s** | 20.78 ms → **98.56 Kelem/s** | **~5.4×** |
+
+Throughput scales with core count, satisfying the acceptance criterion. (Per
+the Performance Task Workflow, the "before" is the 1-core measurement, which is
+the existing single-threaded behaviour; the parallel path is the gain.)
+
+Default + wasm builds unchanged:
+
+- `cargo check -p neat-core --target wasm32-unknown-unknown` — clean.
+- `cargo check -p neat-core --target wasm32-unknown-unknown --features parallel`
+  — clean and **does not compile rayon** for wasm (target-gated dependency).
+- `cargo deny check` — advisories / bans / licenses / sources all OK with rayon
+  added.
+
+## Test Plan
+
+New `neat-core/tests/parallel_scoring.rs` (passes both default and
+`--features parallel`, which `quality.sh` exercises via `--all-features`):
+
+- `parallel_scoring_matches_sequential_on_production_fixture` — 257 records (not
+  a multiple of any core count) on the production fixture, equal to an
+  independent sequential reference.
+- `parallel_scoring_matches_sequential_across_shapes` — parity across
+  `small_50`, `medium_500`, `production`, `production_2x`.
+- `output_order_is_preserved` — index-aligned against the reference with 200
+  distinct records.
+- `each_output_has_num_outputs_elements`, `single_record_matches_direct_activate`,
+  `empty_records_yields_empty_output`, `score_records_matches_reference`.
+
+Gates run green locally: `cargo clippy --workspace --all-targets --all-features
+-- -D warnings`, `cargo test --workspace --lib --tests --all-features`,
+`cargo doc`, release build, `cargo deny check`.
+
+> Note: `quality.sh`'s `bats` suite has 4 **pre-existing** failures
+> (`ci.yml ...bump-deps.sh`, tests 31/32/33/37) that exist on the clean
+> milestone branch independent of this change and are unrelated to #179
+> (they assert `ci.yml` wiring, untouched here).

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -19,6 +19,16 @@ crate-type = ["cdylib", "rlib"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# Issue #179 - opt-in data-parallel record scoring. `rayon` is native-only
+# (it is not wasm-friendly), so it is declared under a `cfg(not(wasm32))`
+# target table. The `parallel` feature is off by default, so default and
+# `wasm32` builds pull in no rayon symbols and keep their single-thread path.
+[features]
+parallel = ["dep:rayon"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rayon = { version = "1.10", optional = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.125"
 
@@ -31,4 +41,10 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # run explicitly with `cargo bench -p neat-core`.
 [[bench]]
 name = "hot_paths"
+harness = false
+
+# Issue #179 - data-parallel scoring throughput (records/sec at 1 vs all cores).
+# Requires `--features parallel`; without it the bench's `main` is a no-op shim.
+[[bench]]
+name = "parallel_scoring"
 harness = false

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -5,6 +5,13 @@ Criterion harness for the core hot paths (Issue #152). These benchmarks are
 `neat-core/Cargo.toml` keeps them out of `cargo test` and the `quality.sh`
 gate, so the CI runtime is unaffected.
 
+There are two bench targets:
+
+- `hot_paths` — the per-record hot paths (always available).
+- `parallel_scoring` — data-parallel record scoring throughput (Issue #179),
+  **requires `--features parallel`**. Without the feature its `main` is a no-op
+  shim, so the target still builds on every configuration.
+
 ## What is measured
 
 `hot_paths.rs` covers the four hottest paths in the crate:
@@ -64,6 +71,19 @@ cargo bench -p neat-core --bench hot_paths -- production
 
 > Use `--bench hot_paths` so Criterion's CLI flags are not handed to the
 > default libtest harness on the library target.
+
+### Data-parallel scoring (Issue #179)
+
+`parallel_scoring.rs` reports records/sec for scoring a batch through one
+creature on **a single core versus all available cores**, using the
+`production`/`production_2x` shapes. It scores inside a rayon pool of a fixed
+size, so the 1-core and all-core measurements share one code path and differ
+only in pool size.
+
+```bash
+# Requires the `parallel` feature (rayon, native targets only).
+cargo bench -p neat-core --features parallel --bench parallel_scoring
+```
 
 The `production` filter is a regex over benchmark ids, so it matches both the
 `production` and `production_2x` shapes in `forward_pass`, `batched_scoring` and

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -157,9 +157,8 @@ pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
             let from = rng.next_below(global_idx);
             synapses.push(SynapseData {
                 weight: rng.next_signed() * 0.5,
-                from_index: from as u32,
+                from_index: from as u16,
                 synapse_type: 0,
-                _padding: [0; 3],
             });
         }
         neurons.push(NeuronData {

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -155,9 +155,8 @@ fn bench_activation_primitives(c: &mut Criterion) {
     let synapses: Vec<SynapseData> = (0..synapse_count)
         .map(|i| SynapseData {
             weight: rng.next_signed(),
-            from_index: i as u32,
+            from_index: i as u16,
             synapse_type: 0,
-            _padding: [0; 3],
         })
         .collect();
     let activations: Vec<f32> = (0..synapse_count).map(|_| rng.next_signed()).collect();

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -1,0 +1,104 @@
+//! Criterion harness for data-parallel record scoring (Issue #179).
+//!
+//! Reports throughput (records/sec) for scoring a batch of records through one
+//! creature on a single core versus all available cores, demonstrating the
+//! per-core scaling that is the throughput lever for the "data" half of #175.
+//!
+//! Opt-in only — requires the `parallel` feature (rayon, native targets):
+//!
+//! ```text
+//! cargo bench -p neat-core --features parallel --bench parallel_scoring
+//! ```
+//!
+//! Without the feature the bench's `main` is a no-op shim so the target still
+//! builds under `cargo build --all-targets` on every configuration. The
+//! deterministic fixtures are shared with the `hot_paths` harness and the
+//! `bench_fixtures` test via `benches/common/mod.rs`.
+
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+#[path = "common/mod.rs"]
+#[allow(dead_code)] // shared fixture module; this bench uses only a subset
+mod common;
+
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+mod bench {
+    use super::common::{NETWORKS, NetSpec, build_inputs, build_network};
+    use criterion::{Criterion, Throughput, criterion_group};
+    use neat_core::network::CompiledNetwork;
+    use rayon::ThreadPoolBuilder;
+    use std::hint::black_box;
+
+    fn spec(label: &str) -> &'static NetSpec {
+        NETWORKS
+            .iter()
+            .find(|s| s.label == label)
+            .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+    }
+
+    fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+        (0..count)
+            .map(|i| build_inputs(net.num_inputs(), 0x5C0E_0000 + i as u64))
+            .collect()
+    }
+
+    /// Score `records` inside a rayon pool of exactly `threads` workers, so the
+    /// 1-core and all-core measurements share one code path and differ only in
+    /// pool size.
+    fn score_in_pool(
+        net: &CompiledNetwork,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        threads: usize,
+    ) -> Vec<Vec<f32>> {
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .expect("failed to build rayon pool");
+        pool.install(|| net.score_records_parallel(records, num_outputs))
+    }
+
+    pub fn bench_parallel_scoring(c: &mut Criterion) {
+        let all_cores = std::thread::available_parallelism().map_or(1, |n| n.get());
+        const NUM_RECORDS: usize = 2048;
+
+        for label in ["production", "production_2x"] {
+            let s = spec(label);
+            let net = build_network(s, 0x5EED);
+            let records = build_records(&net, NUM_RECORDS);
+            let num_outputs = s.num_outputs;
+
+            let mut group = c.benchmark_group(format!("score_records/{label}"));
+            group.throughput(Throughput::Elements(NUM_RECORDS as u64));
+
+            group.bench_function("1_core", |b| {
+                b.iter(|| black_box(score_in_pool(&net, black_box(&records), num_outputs, 1)))
+            });
+
+            group.bench_function(format!("{all_cores}_cores"), |b| {
+                b.iter(|| {
+                    black_box(score_in_pool(
+                        &net,
+                        black_box(&records),
+                        num_outputs,
+                        all_cores,
+                    ))
+                })
+            });
+
+            group.finish();
+        }
+    }
+
+    criterion_group!(benches, bench_parallel_scoring);
+}
+
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+criterion::criterion_main!(bench::benches);
+
+#[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+fn main() {
+    eprintln!(
+        "parallel_scoring bench is a no-op without `--features parallel` (native only); \
+         run: cargo bench -p neat-core --features parallel --bench parallel_scoring"
+    );
+}

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod error;
 pub mod fused_error;
 pub mod loss;
 pub mod network;
+pub mod parallel_scoring;
 pub mod pc_inference;
 pub mod pc_learning;
 pub mod propagate_codec;

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -1,0 +1,97 @@
+//! Data-parallel record scoring (Issue #179).
+//!
+//! Scoring a production-size dataset pushes many records through one large
+//! creature — an embarrassingly parallel workload *across records*. The
+//! per-record forward path ([`CompiledNetwork::activate`]) is single-threaded,
+//! so on a multi-core host most of the machine sits idle. This module adds an
+//! opt-in, native-only parallel scoring path that chunks records across the
+//! `rayon` thread pool.
+//!
+//! # Feature gating
+//!
+//! The parallel path is gated `#[cfg(all(feature = "parallel", not(target_arch
+//! = "wasm32")))]`. `rayon` is declared as a `cfg(not(wasm32))` optional
+//! dependency, so:
+//!
+//! - the **default** build pulls in no `rayon` symbols (feature off), and
+//! - the **`wasm32`** build is completely unaffected — it keeps the existing
+//!   single-thread behaviour even if the feature is requested.
+//!
+//! When the feature is off (or on wasm), [`CompiledNetwork::score_records_parallel`]
+//! transparently falls back to the sequential [`CompiledNetwork::score_records`].
+//!
+//! # Determinism
+//!
+//! Results are **identical** to the sequential path regardless of thread count:
+//!
+//! - Every record is scored by the same [`CompiledNetwork::activate`] call used
+//!   sequentially. `activate` overwrites every non-input activation each call,
+//!   so there is no cross-record state.
+//! - No `&mut self` is shared across threads. `CompiledNetwork` is `Clone`, and
+//!   the clone carries the per-call scratch buffers (`activations`,
+//!   `hint_values_buffer`, the 4-way batch buffers). The immutable weights are
+//!   read through `&self`; each rayon worker initialises **its own** cloned
+//!   scratch context via `map_init` and owns its buffers for the duration.
+//! - Output order matches input order — `par_iter().map(...).collect()`
+//!   preserves indexed order.
+
+use crate::network::CompiledNetwork;
+
+impl CompiledNetwork {
+    /// Score every record sequentially, returning one output vector per record.
+    ///
+    /// Shared read-only weights (`&self`) plus a single owned scratch context
+    /// (one clone of the network). This is the fallback used when the `parallel`
+    /// feature is off or when building for `wasm32`, and the reference path the
+    /// parallel results must match exactly.
+    ///
+    /// Each record is scored with [`CompiledNetwork::activate`]; the first
+    /// `num_outputs` … (`num_neurons - num_outputs ..`) activations are returned.
+    pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+        let mut scratch = self.clone();
+        records
+            .iter()
+            .map(|record| scratch.activate(record, num_outputs))
+            .collect()
+    }
+
+    /// Score every record across the `rayon` thread pool, returning one output
+    /// vector per record in input order.
+    ///
+    /// Each rayon worker initialises its own cloned scratch context via
+    /// `map_init`, so no `&mut self` is shared across threads: immutable weights
+    /// are read through `&self` while every worker owns its activation buffers.
+    /// Because each record is scored by the same [`CompiledNetwork::activate`]
+    /// used by [`CompiledNetwork::score_records`] and there is no cross-record
+    /// state, the results are identical to the sequential path.
+    ///
+    /// Available with the `parallel` feature on native targets.
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    pub fn score_records_parallel(
+        &self,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+    ) -> Vec<Vec<f32>> {
+        use rayon::prelude::*;
+        records
+            .par_iter()
+            .map_init(
+                || self.clone(),
+                |scratch, record| scratch.activate(record, num_outputs),
+            )
+            .collect()
+    }
+
+    /// Sequential fallback for [`CompiledNetwork::score_records_parallel`] when
+    /// the `parallel` feature is disabled or building for `wasm32` (where
+    /// `rayon` is unavailable). Same signature and identical results to the
+    /// feature-on path — just single-threaded.
+    #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+    pub fn score_records_parallel(
+        &self,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+    ) -> Vec<Vec<f32>> {
+        self.score_records(records, num_outputs)
+    }
+}

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -1,0 +1,128 @@
+//! Behavioural tests for data-parallel record scoring (Issue #179).
+//!
+//! These assert on observable outcomes — the returned output vectors — rather
+//! than on threading mechanics. They run in both feature modes: with the
+//! `parallel` feature off, `score_records_parallel` is the sequential fallback;
+//! with `--features parallel` (as `quality.sh` runs via `--all-features`), the
+//! same assertions exercise the rayon path. Either way the contract is the same:
+//! results identical to the sequential reference, in input order.
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{NETWORKS, NetSpec, build_inputs, build_network};
+use neat_core::network::CompiledNetwork;
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+/// Build `count` distinct input records sized to the network's input layer.
+fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| build_inputs(net.num_inputs(), 0x51A7_0000 + i as u64))
+        .collect()
+}
+
+/// Independent sequential reference: a fresh scratch clone scored one record at
+/// a time. Deliberately does not call `score_records`, so the parity assertion
+/// does not assume the two share an implementation.
+fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+    let mut scratch = net.clone();
+    records
+        .iter()
+        .map(|r| scratch.activate(r, num_outputs))
+        .collect()
+}
+
+#[test]
+fn parallel_scoring_matches_sequential_on_production_fixture() {
+    let s = spec("production");
+    let net = build_network(s, 0xC0FFEE);
+    let records = build_records(&net, 257); // not a multiple of any core count
+
+    let expected = reference(&net, &records, s.num_outputs);
+    let actual = net.score_records_parallel(&records, s.num_outputs);
+
+    assert_eq!(actual.len(), records.len());
+    assert_eq!(actual, expected, "parallel results must equal sequential");
+}
+
+#[test]
+fn parallel_scoring_matches_sequential_across_shapes() {
+    for label in ["small_50", "medium_500", "production", "production_2x"] {
+        let s = spec(label);
+        let net = build_network(s, 0xABCD_1234);
+        let records = build_records(&net, 128);
+
+        let expected = reference(&net, &records, s.num_outputs);
+        let actual = net.score_records_parallel(&records, s.num_outputs);
+
+        assert_eq!(actual, expected, "mismatch for shape {label}");
+    }
+}
+
+#[test]
+fn score_records_matches_reference() {
+    let s = spec("medium_500");
+    let net = build_network(s, 0x1357);
+    let records = build_records(&net, 64);
+
+    let expected = reference(&net, &records, s.num_outputs);
+    assert_eq!(net.score_records(&records, s.num_outputs), expected);
+}
+
+#[test]
+fn output_order_is_preserved() {
+    let s = spec("small_50");
+    let net = build_network(s, 0x2468);
+    let records = build_records(&net, 200);
+
+    // Each record is distinct, so a re-ordered result would not match the
+    // index-aligned reference.
+    let expected = reference(&net, &records, s.num_outputs);
+    let actual = net.score_records_parallel(&records, s.num_outputs);
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(a, e, "record {i} out of order or incorrect");
+    }
+}
+
+#[test]
+fn each_output_has_num_outputs_elements() {
+    let s = spec("medium_500");
+    let net = build_network(s, 0x99);
+    let records = build_records(&net, 16);
+
+    let out = net.score_records_parallel(&records, s.num_outputs);
+    assert_eq!(out.len(), 16);
+    for row in &out {
+        assert_eq!(row.len(), s.num_outputs);
+    }
+}
+
+#[test]
+fn empty_records_yields_empty_output() {
+    let s = spec("small_50");
+    let net = build_network(s, 0x7);
+    let empty: Vec<Vec<f32>> = Vec::new();
+
+    assert!(net.score_records_parallel(&empty, s.num_outputs).is_empty());
+    assert!(net.score_records(&empty, s.num_outputs).is_empty());
+}
+
+#[test]
+fn single_record_matches_direct_activate() {
+    let s = spec("production");
+    let net = build_network(s, 0x42);
+    let record = build_inputs(net.num_inputs(), 0xDEAD);
+
+    let mut scratch = net.clone();
+    let direct = scratch.activate(&record, s.num_outputs);
+    let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
+
+    assert_eq!(via_parallel, vec![direct]);
+}


### PR DESCRIPTION
# Native, feature-gated data-parallel record scoring (rayon)

## Summary

Adds an **opt-in, native-only** data-parallel scoring path so a production-size
dataset can be pushed through one creature across all cores — the embarrassingly
parallel "data" half of #175. Scoring N records is independent per record, so it
scales near-linearly with core count and composes with the per-record
micro-optimisations from the sibling sub-issues. Closes #179.

What changed:

- **New `parallel` Cargo feature** (off by default) pulling in `rayon`. `rayon`
  is declared under a `cfg(not(target_arch = "wasm32"))` target table, and the
  parallel code is gated `#[cfg(all(feature = "parallel", not(target_arch =
  "wasm32")))]`, so the **default build and the `wasm32` build pull in no rayon
  symbols** and keep their single-thread path.
- **`CompiledNetwork::score_records_parallel(&self, records, num_outputs)`** —
  chunks records across the rayon pool via `par_iter().map_init(...)`. Each
  worker initialises **its own cloned scratch context** (the `Clone` carries
  `activations` / `hint_values_buffer` / the 4-way batch buffers), so no
  `&mut self` is shared across threads: immutable weights are read through
  `&self` while every worker owns its buffers. When the feature is off or on
  wasm, the method is a thin fallback to the sequential path.
- **`CompiledNetwork::score_records(&self, records, num_outputs)`** — the
  sequential reference (one scratch clone), used as the fallback and the parity
  baseline.
- **`parallel_scoring` Criterion bench** reporting records/sec at 1 vs all
  cores on the `production` / `production_2x` fixtures (#175/#176). No-op shim
  without the feature so the target builds on every configuration.

Determinism: every record is scored by the same `activate` used sequentially,
with no cross-record state, and `collect()` preserves input order — so results
are **identical** to the sequential path regardless of thread count (verified by
tests).

### Drive-by fix (required for a green build)

The milestone branch's bench fixtures (`benches/common/mod.rs` and
`benches/hot_paths.rs`) still constructed `SynapseData` with the pre-#177 layout
(`from_index: u32` + `_padding`), so `cargo check --tests` / `--all-targets`
failed to compile on the milestone branch before this PR. Updated both to the
current `from_index: u16` layout. This was necessary to build the
acceptance-criteria benchmark and to keep `quality.sh` green.

```mermaid
flowchart LR
    R[records] --> S{parallel feature?}
    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
    S -- on, native --> P[score_records_parallel]
    P --> W1[worker 1<br/>cloned scratch]
    P --> W2[worker 2<br/>cloned scratch]
    P --> Wn[worker N<br/>cloned scratch]
    W1 --> O[outputs in input order]
    W2 --> O
    Wn --> O
    Q --> O
```

## Evidence (performance)

`cargo bench -p neat-core --features parallel --bench parallel_scoring`, scoring
2048 records, on a 12-core host (`nproc` = 12). Throughput is records/sec
(Criterion `thrpt`, median):

| Fixture | 1 core | 12 cores | Speed-up |
|---------|--------|----------|----------|
| `production` (4134 neurons, ~21.7k synapses) | 52.4 ms → **39.06 Kelem/s** | 7.18 ms → **285.4 Kelem/s** | **~7.3×** |
| `production_2x` (8268 neurons, ~43.5k synapses) | 111.3 ms → **18.40 Kelem/s** | 20.78 ms → **98.56 Kelem/s** | **~5.4×** |

Throughput scales with core count, satisfying the acceptance criterion. (Per
the Performance Task Workflow, the "before" is the 1-core measurement, which is
the existing single-threaded behaviour; the parallel path is the gain.)

Default + wasm builds unchanged:

- `cargo check -p neat-core --target wasm32-unknown-unknown` — clean.
- `cargo check -p neat-core --target wasm32-unknown-unknown --features parallel`
  — clean and **does not compile rayon** for wasm (target-gated dependency).
- `cargo deny check` — advisories / bans / licenses / sources all OK with rayon
  added.

## Test Plan

New `neat-core/tests/parallel_scoring.rs` (passes both default and
`--features parallel`, which `quality.sh` exercises via `--all-features`):

- `parallel_scoring_matches_sequential_on_production_fixture` — 257 records (not
  a multiple of any core count) on the production fixture, equal to an
  independent sequential reference.
- `parallel_scoring_matches_sequential_across_shapes` — parity across
  `small_50`, `medium_500`, `production`, `production_2x`.
- `output_order_is_preserved` — index-aligned against the reference with 200
  distinct records.
- `each_output_has_num_outputs_elements`, `single_record_matches_direct_activate`,
  `empty_records_yields_empty_output`, `score_records_matches_reference`.

Gates run green locally: `cargo clippy --workspace --all-targets --all-features
-- -D warnings`, `cargo test --workspace --lib --tests --all-features`,
`cargo doc`, release build, `cargo deny check`.

> Note: `quality.sh`'s `bats` suite has 4 **pre-existing** failures
> (`ci.yml ...bump-deps.sh`, tests 31/32/33/37) that exist on the clean
> milestone branch independent of this change and are unrelated to #179
> (they assert `ci.yml` wiring, untouched here).



## Milestone
This PR is part of the **#175 Please suggest performance improvements for production size creatures/data** milestone and targets the `milestone/175-please-suggest-performance-improvements-for-pr` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqlzu07f-6aa347`<!-- vibe-worker-issue-179 -->