### PR TITLE
perf(squash): vectorise Tanh/Logistic/Gelu/Mish across batch lanes (Issue #180)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-180.md
+++ b/docs/archive/pr-summaries/pr-summary-180.md
@@ -1,0 +1,94 @@
+# [perf] Vectorise the activation (squash) function across batched records
+
+## Summary
+
+The batched activation paths produce one accumulated pre-activation **per
+record** with the SIMD weighted-sum kernels, but then applied the squash **per
+record with the scalar `apply_squash`**. For the hot transcendental squashes
+(`Tanh`, `Logistic`, `Gelu`, `Mish`) that `libm` call dominates the per-neuron
+cost on the wide/shallow production creature (~1673 non-input neurons, ~13
+average fan-in).
+
+This PR adds `neat-core/src/squash_simd.rs`: branchless, fixed-size-array
+approximations of those four squashes that LLVM auto-vectorises (SSE/AVX/FMA on
+`x86_64`, NEON on `aarch64`, `simd128` on `wasm32`) so all 4 (or 8) batch lanes
+are evaluated at once. They are wired into both batched paths:
+
+- `CompiledNetwork::activate_and_trace_batch_4way` (`network.rs`)
+- the 8-record / 4-record loss path (`loss.rs`)
+
+Every vectorised type is bounded within `5e-6` (tighter than the `1e-5` the
+existing batch-parity tests already assert) of the scalar `apply_squash`. Squash
+types **without** a vectorised approximation return `None`, so the caller keeps
+the existing scalar path and their numerics are unchanged. Scalar `apply_squash`
+remains the single source of truth for correctness.
+
+No hand-written platform intrinsics or `unsafe` are introduced — the kernels are
+plain branchless `f32` arithmetic over `[f32; N]` arrays, which the optimiser
+vectorises and which also compiles for `wasm32`.
+
+Closes #180.
+
+```mermaid
+flowchart LR
+    A["SIMD weighted sum<br/>(per record)"] --> B{squash type}
+    B -- "Tanh / Logistic<br/>Gelu / Mish" --> C["squash_x4 / squash_x8<br/>(lane-parallel approx)"]
+    B -- other --> D["scalar apply_squash<br/>(unchanged numerics)"]
+    C --> E["apply_limit_range<br/>per lane"]
+    D --> E
+```
+
+## Evidence (performance)
+
+Backend/CLI change — no UI. Measured with the repo's Criterion harness on
+`aarch64` via `--save-baseline before` / `--baseline`.
+
+### Production fixtures — `batched_scoring`
+
+| Benchmark | Before | After | Change |
+|---|---|---|---|
+| `trace_batch_4way/production` | ~48.7 µs | ~34.0 µs | **−31%** |
+| `trace_batch_4way/production_2x` | ~133 µs | ~79 µs | **−42%** |
+| `mse_sum_8records/production` | ~83.3 µs | ~77.3 µs | −7% to −11% |
+| `mse_sum_8records/production_2x` | ~335 µs | ~330 µs | ~noise |
+
+The 4-way traced activation path (the direct target) improves ~30–42%
+reproducibly. The 8-record MSE loss path is more memory-bound — the squash is a
+smaller fraction there — so its gain is smaller and `production_2x` sits inside
+run-to-run noise (that fixture already reported ~13% high-severe outliers at
+baseline).
+
+### Per-call squash speedup — `squash_x4` (4 lanes)
+
+| Squash | Scalar ×4 | SIMD `squash_x4` | Speedup |
+|---|---|---|---|
+| Tanh | 6.25 ns | 1.98 ns | 3.2× |
+| Logistic | 4.83 ns | 2.39 ns | 2.0× |
+| Gelu | 8.11 ns | 2.56 ns | 3.2× |
+| Mish | 19.07 ns | 3.04 ns | 6.3× |
+
+## Test Plan
+
+New range/property tests in `neat-core/src/squash_simd.rs` (assert the bounded
+error vs scalar `apply_squash`, the acceptance criterion):
+
+- `tanh_within_tolerance_over_range`, `logistic_within_tolerance_over_range`,
+  `gelu_within_tolerance_over_range`, `mish_within_tolerance_over_range` — sweep
+  the finite input range and assert max abs error ≤ `SQUASH_SIMD_MAX_ABS_ERR`.
+- `all_four_lanes_match_scalar`, `x8_matches_x4` — each lane reproduces its own
+  scalar squash for the 4- and 8-lane entry points.
+- `non_vectorised_types_opt_out` — non-transcendental types return `None` (caller
+  falls back to scalar, unchanged numerics).
+- `extreme_inputs_are_finite` — saturating/overflow-prone inputs stay finite (no
+  NaN/Inf from the `exp`/ratio reconstruction).
+
+Existing batch-parity tests continue to pass unchanged, confirming the
+vectorised path stays within the established `1e-5` tolerance of the
+single-record scalar path:
+
+- `network.rs::test_batch_4way_matches_single_tanh_logistic`
+- full `cargo test --workspace --lib --tests` green.
+
+Benchmark additions: a `squash_x4` Criterion group (scalar ×4 vs `simd_x4`) for
+the four vectorised types, alongside the existing `batched_scoring` production
+fixtures used for the before/after comparison above.

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -22,6 +22,7 @@ use neat_core::simd::{
     weighted_sum_simd_4records, weighted_sum_simd_8records,
 };
 use neat_core::squash::{SquashType, apply_squash};
+use neat_core::squash_simd::squash_x4;
 use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
 use neat_core::unsquash::apply_unsquash;
 
@@ -265,6 +266,42 @@ fn bench_activation_primitives(c: &mut Criterion) {
         );
     }
     squash_group.finish();
+
+    // Lane-parallel squash (Issue #180): vectorised 4-lane approximation versus
+    // four scalar `apply_squash` calls, for the hot transcendental squashes.
+    let mut squash4_group = c.benchmark_group("squash_x4");
+    let lanes = [0.42_f32, -1.3, 2.7, -0.05];
+    for squash_type in [
+        SquashType::Tanh,
+        SquashType::Logistic,
+        SquashType::Gelu,
+        SquashType::Mish,
+    ] {
+        let label = format!("{squash_type:?}");
+        squash4_group.bench_with_input(
+            BenchmarkId::new("scalar_x4", label.clone()),
+            &squash_type,
+            |b, &st| {
+                b.iter(|| {
+                    let x = black_box(lanes);
+                    black_box([
+                        apply_squash(st, x[0]),
+                        apply_squash(st, x[1]),
+                        apply_squash(st, x[2]),
+                        apply_squash(st, x[3]),
+                    ])
+                });
+            },
+        );
+        squash4_group.bench_with_input(
+            BenchmarkId::new("simd_x4", label),
+            &squash_type,
+            |b, &st| {
+                b.iter(|| black_box(squash_x4(black_box(st), black_box(lanes))));
+            },
+        );
+    }
+    squash4_group.finish();
 }
 
 criterion_group!(

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod safe_zone;
 pub mod score_scan;
 pub mod simd;
 pub mod squash;
+pub mod squash_simd;
 pub mod synapse_type;
 pub mod topological_backprop;
 pub mod topology_export;

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -10,6 +10,7 @@ use crate::network::CompiledNetwork;
 use crate::range::apply_limit_range;
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
 use crate::squash::{SquashType, apply_squash};
+use crate::squash_simd::{squash_x4, squash_x8};
 use crate::synapse_type::SynapseType;
 
 #[cfg(target_arch = "wasm32")]
@@ -206,24 +207,35 @@ macro_rules! batch_8way_activation {
                                     neuron.bias,
                                 );
 
-                            let apply_squash_inline = |sum: f32| -> f32 {
-                                match neuron.squash_type {
-                                    0 => sum,
-                                    1 => sum.max(0.0),
-                                    6 => 1.0 / (1.0 + (-sum).exp()),
-                                    7 => sum.tanh(),
-                                    _ => apply_squash(squash, sum),
+                            // Hot transcendental squashes evaluate all 8 batch
+                            // lanes at once via the vectorised approximation
+                            // (Issue #180); other types keep the scalar inline
+                            // squash so their numerics are unchanged.
+                            let sums = [sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7];
+                            let squashed = match squash_x8(squash, sums) {
+                                Some(vec) => vec,
+                                None => {
+                                    let apply_squash_inline = |sum: f32| -> f32 {
+                                        match neuron.squash_type {
+                                            0 => sum,
+                                            1 => sum.max(0.0),
+                                            6 => 1.0 / (1.0 + (-sum).exp()),
+                                            7 => sum.tanh(),
+                                            _ => apply_squash(squash, sum),
+                                        }
+                                    };
+                                    sums.map(apply_squash_inline)
                                 }
                             };
 
-                            act0[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum0));
-                            act1[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum1));
-                            act2[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum2));
-                            act3[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum3));
-                            act4[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum4));
-                            act5[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum5));
-                            act6[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum6));
-                            act7[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum7));
+                            act0[actual_idx] = apply_limit_range(squash, squashed[0]);
+                            act1[actual_idx] = apply_limit_range(squash, squashed[1]);
+                            act2[actual_idx] = apply_limit_range(squash, squashed[2]);
+                            act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                            act4[actual_idx] = apply_limit_range(squash, squashed[4]);
+                            act5[actual_idx] = apply_limit_range(squash, squashed[5]);
+                            act6[actual_idx] = apply_limit_range(squash, squashed[6]);
+                            act7[actual_idx] = apply_limit_range(squash, squashed[7]);
                         }
                     }
                 }
@@ -403,24 +415,29 @@ macro_rules! batch_8way_activation {
                                     neuron.bias,
                                 );
 
-                                let apply_squash_inline = |sum: f32| -> f32 {
-                                    match neuron.squash_type {
-                                        0 => sum,
-                                        1 => sum.max(0.0),
-                                        6 => 1.0 / (1.0 + (-sum).exp()),
-                                        7 => sum.tanh(),
-                                        _ => apply_squash(squash, sum),
+                                // Vectorised squash for the hot transcendental
+                                // types (Issue #180); scalar fallback otherwise.
+                                let sums = [sum0, sum1, sum2, sum3];
+                                let squashed = match squash_x4(squash, sums) {
+                                    Some(vec) => vec,
+                                    None => {
+                                        let apply_squash_inline = |sum: f32| -> f32 {
+                                            match neuron.squash_type {
+                                                0 => sum,
+                                                1 => sum.max(0.0),
+                                                6 => 1.0 / (1.0 + (-sum).exp()),
+                                                7 => sum.tanh(),
+                                                _ => apply_squash(squash, sum),
+                                            }
+                                        };
+                                        sums.map(apply_squash_inline)
                                     }
                                 };
 
-                                act0[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum0));
-                                act1[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum1));
-                                act2[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum2));
-                                act3[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum3));
+                                act0[actual_idx] = apply_limit_range(squash, squashed[0]);
+                                act1[actual_idx] = apply_limit_range(squash, squashed[1]);
+                                act2[actual_idx] = apply_limit_range(squash, squashed[2]);
+                                act3[actual_idx] = apply_limit_range(squash, squashed[3]);
                             }
                         }
                     }

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -14,6 +14,7 @@ use crate::simd::{
     weighted_sum_simd, weighted_sum_simd_4records,
 };
 use crate::squash::{SquashType, apply_squash};
+use crate::squash_simd::squash_x4;
 use crate::synapse_type::SynapseType;
 
 #[cfg(target_arch = "wasm32")]
@@ -1133,11 +1134,20 @@ impl CompiledNetwork {
                             neuron.bias,
                         );
 
-                        // Apply squash to all 4 records
-                        let sq0 = Self::apply_inline_squash(neuron.squash_type, squash, s0);
-                        let sq1 = Self::apply_inline_squash(neuron.squash_type, squash, s1);
-                        let sq2 = Self::apply_inline_squash(neuron.squash_type, squash, s2);
-                        let sq3 = Self::apply_inline_squash(neuron.squash_type, squash, s3);
+                        // Apply squash to all 4 records. The hot transcendental
+                        // squashes (Tanh/Logistic/Gelu/Mish) evaluate every batch
+                        // lane at once via the vectorised approximation (Issue
+                        // #180); all other types keep the scalar inline squash so
+                        // their numerics are unchanged.
+                        let [sq0, sq1, sq2, sq3] = match squash_x4(squash, [s0, s1, s2, s3]) {
+                            Some(vec) => vec,
+                            None => [
+                                Self::apply_inline_squash(neuron.squash_type, squash, s0),
+                                Self::apply_inline_squash(neuron.squash_type, squash, s1),
+                                Self::apply_inline_squash(neuron.squash_type, squash, s2),
+                                Self::apply_inline_squash(neuron.squash_type, squash, s3),
+                            ],
+                        };
 
                         let a0 = apply_limit_range(squash, sq0);
                         let a1 = apply_limit_range(squash, sq1);

--- a/neat-core/src/squash_simd.rs
+++ b/neat-core/src/squash_simd.rs
@@ -1,0 +1,316 @@
+//! Lane-parallel (SIMD-friendly) approximations of the transcendental-heavy
+//! squash functions used by the batched activation paths (Issue #180).
+//!
+//! ## Why
+//!
+//! The batched activation paths (`activate_and_trace_batch_4way` in
+//! [`crate::network`] and the 8-record loss path in [`crate::loss`]) compute one
+//! pre-activation **per record** with the SIMD weighted-sum kernels, but then
+//! apply the squash **per record with the scalar `apply_squash`**. For the hot
+//! transcendental squashes (`Tanh`, `Logistic`, `Gelu`, `Mish`) that scalar
+//! `libm` call dominates the per-neuron cost on the wide/shallow production
+//! creature (~1673 non-input neurons, ~13 average fan-in).
+//!
+//! Because a batch already holds 4 (or 8) records' pre-activations contiguously,
+//! the squash is a natural fit for a lane-parallel evaluation. The functions here
+//! are written **branchlessly over fixed-size arrays** so LLVM auto-vectorises
+//! the per-lane loop (SSE/AVX/FMA on `x86_64`, NEON on `aarch64`, `simd128` on
+//! `wasm32`) without hand-written platform intrinsics.
+//!
+//! ## Accuracy
+//!
+//! Every vectorised type is bounded within [`SQUASH_SIMD_MAX_ABS_ERR`] of the
+//! scalar [`apply_squash`](crate::squash::apply_squash) across the finite input range (asserted by the range
+//! tests below). Squash types **without** a vectorised implementation return
+//! `None` from [`squash_x4`] / [`squash_x8`] so the caller falls back to the
+//! scalar path, leaving their numerics unchanged. The scalar `apply_squash`
+//! remains the single source of truth for correctness.
+
+use crate::squash::{GELU_COEFF, SQRT_2_OVER_PI, SquashType};
+
+/// Documented maximum absolute error of the vectorised squashes versus the
+/// scalar [`apply_squash`](crate::squash::apply_squash) over the finite input range. Chosen tighter than the
+/// `1e-5` tolerance the batch parity tests already assert, so the vectorised
+/// path is a safe drop-in for the hot transcendental squashes.
+pub const SQUASH_SIMD_MAX_ABS_ERR: f32 = 5.0e-6;
+
+/// Branchless single-lane `tanh` approximation (rational minimax, valid after
+/// clamping to `±C`). Accurate to a few `1e-7` over the whole finite range; the
+/// odd symmetry and saturation to `±1` are preserved exactly. Kept `#[inline]`
+/// and branchless so the array wrappers auto-vectorise.
+#[inline(always)]
+fn tanh_approx(x: f32) -> f32 {
+    // Beyond ±C, tanh is ±1 to well within f32 precision; clamping keeps the
+    // rational polynomial in its valid range.
+    const C: f32 = 7.999_882;
+    let x = x.clamp(-C, C);
+    let x2 = x * x;
+
+    // Numerator: odd polynomial p(x) = x * (a1 + x2*(a3 + ... + x2*a13)).
+    let mut p = -2.760_768_5e-16;
+    p = p * x2 + 2.000_188e-13;
+    p = p * x2 + -8.604_672e-11;
+    p = p * x2 + 5.122_297e-8;
+    p = p * x2 + 1.485_722_4e-5;
+    p = p * x2 + 6.372_619_4e-4;
+    p = p * x2 + 4.893_524_6e-3;
+    p *= x;
+
+    // Denominator: even polynomial q(x) = b0 + x2*(b2 + x2*(b4 + x2*b6)).
+    let mut q = 1.198_258_4e-6;
+    q = q * x2 + 1.185_347e-4;
+    q = q * x2 + 2.268_434_6e-3;
+    q = q * x2 + 4.893_525e-3;
+
+    p / q
+}
+
+/// Branchless single-lane `exp` approximation (Cephes `expf` reduction). Used to
+/// build `Logistic` and `Mish`. Accurate to ~1 ULP; the argument is clamped to a
+/// finite window so `2^n` reconstruction never overflows to a NaN.
+#[inline(always)]
+fn exp_approx(x: f32) -> f32 {
+    // Clamp to the representable exp window (exp(88.7) ≈ f32::MAX).
+    const HI: f32 = 88.722_84;
+    const LO: f32 = -87.336_55;
+    let x = x.clamp(LO, HI);
+
+    const C1: f32 = 0.693_359_4; // ln2 high
+    const C2: f32 = -2.121_944_4e-4; // ln2 low
+
+    // n = round(x / ln2); reduce x into [-ln2/2, ln2/2].
+    let fx = (x * core::f32::consts::LOG2_E + 0.5).floor();
+    let xr = x - fx * C1 - fx * C2;
+    let z = xr * xr;
+
+    // Degree-5 minimax polynomial for exp on the reduced range.
+    let mut y = 1.987_569_1e-4;
+    y = y * xr + 1.398_199_9e-3;
+    y = y * xr + 8.333_452e-3;
+    y = y * xr + 4.166_579_6e-2;
+    y = y * xr + 1.666_666_5e-1;
+    y = y * xr + 5e-1;
+    y = y * z + xr + 1.0;
+
+    // Reconstruct 2^n by direct exponent-bits assembly (branchless ldexp).
+    let n = fx as i32;
+    let pow2n = f32::from_bits(((n + 127) as u32) << 23);
+    y * pow2n
+}
+
+/// `tanh` over a lane array.
+#[inline]
+fn tanh_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = tanh_approx(x[i]);
+    }
+    out
+}
+
+/// `Logistic` (sigmoid) over a lane array: `1 / (1 + exp(-x))`.
+#[inline]
+fn logistic_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = 1.0 / (1.0 + exp_approx(-x[i]));
+    }
+    out
+}
+
+/// `Gelu` (tanh approximation) over a lane array, matching the scalar formula
+/// `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 x^3)))`.
+#[inline]
+fn gelu_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        let inner = SQRT_2_OVER_PI * (v + GELU_COEFF * v * v * v);
+        out[i] = 0.5 * v * (1.0 + tanh_approx(inner));
+    }
+    out
+}
+
+/// `Mish` over a lane array.
+///
+/// Uses the closed-form identity `mish(x) = x * tanh(softplus(x))` rewritten
+/// purely in terms of `w = exp(x)`:
+///
+/// ```text
+/// tanh(softplus(x)) = w(w + 2) / (w(w + 2) + 2)
+/// ```
+///
+/// so only a single `exp` per lane is needed (no separate `ln`/`tanh`). The exp
+/// argument is clamped at `20` for the ratio only — beyond that the ratio is
+/// `1.0` to f32 precision and `mish(x) → x` — which keeps `w^2` finite and avoids
+/// an `inf/inf` NaN while leaving the outer `x` factor exact.
+#[inline]
+fn mish_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        let w = exp_approx(v.min(20.0));
+        let t = w * (w + 2.0);
+        out[i] = v * (t / (t + 2.0));
+    }
+    out
+}
+
+/// Vectorised squash dispatch over `N` lanes.
+///
+/// Returns `Some([..])` for the hot transcendental squashes that have a
+/// lane-parallel approximation within [`SQUASH_SIMD_MAX_ABS_ERR`] of scalar
+/// [`apply_squash`](crate::squash::apply_squash); returns `None` for every other type so the caller keeps the
+/// existing scalar path (unchanged numerics).
+#[inline]
+fn squash_lanes<const N: usize>(squash: SquashType, x: [f32; N]) -> Option<[f32; N]> {
+    match squash {
+        SquashType::Tanh => Some(tanh_lanes(x)),
+        SquashType::Logistic => Some(logistic_lanes(x)),
+        SquashType::Gelu => Some(gelu_lanes(x)),
+        SquashType::Mish => Some(mish_lanes(x)),
+        _ => None,
+    }
+}
+
+/// Vectorised squash for a 4-record batch lane. See `squash_lanes`.
+#[inline]
+pub fn squash_x4(squash: SquashType, x: [f32; 4]) -> Option<[f32; 4]> {
+    squash_lanes(squash, x)
+}
+
+/// Vectorised squash for an 8-record batch lane. See `squash_lanes`.
+#[inline]
+pub fn squash_x8(squash: SquashType, x: [f32; 8]) -> Option<[f32; 8]> {
+    squash_lanes(squash, x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::squash::apply_squash;
+
+    /// Squash types with a vectorised implementation, and the others which must
+    /// opt out (so the caller falls back to scalar with unchanged numerics).
+    const VECTORISED: [SquashType; 4] = [
+        SquashType::Tanh,
+        SquashType::Logistic,
+        SquashType::Gelu,
+        SquashType::Mish,
+    ];
+
+    /// Max absolute error of a vectorised squash versus scalar `apply_squash`
+    /// across a fine sweep of the finite input range.
+    fn max_abs_err(squash: SquashType, lo: f32, hi: f32, steps: usize) -> f32 {
+        let mut worst = 0.0_f32;
+        for k in 0..=steps {
+            let x = lo + (hi - lo) * (k as f32) / (steps as f32);
+            let want = apply_squash(squash, x);
+            let got = squash_x4(squash, [x, x, x, x]).unwrap()[0];
+            worst = worst.max((want - got).abs());
+        }
+        worst
+    }
+
+    #[test]
+    fn tanh_within_tolerance_over_range() {
+        let err = max_abs_err(SquashType::Tanh, -20.0, 20.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "tanh max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn logistic_within_tolerance_over_range() {
+        let err = max_abs_err(SquashType::Logistic, -40.0, 40.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "logistic max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn gelu_within_tolerance_over_range() {
+        // Gelu grows like x, so compare on a bounded window where the activation
+        // is used in practice; the relative shape is captured by abs error here.
+        let err = max_abs_err(SquashType::Gelu, -10.0, 10.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "gelu max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn mish_within_tolerance_over_range() {
+        let err = max_abs_err(SquashType::Mish, -20.0, 20.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "mish max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn all_four_lanes_match_scalar() {
+        // The same value in every lane must reproduce the scalar result; distinct
+        // values per lane must each match their own scalar squash.
+        let xs = [-1.3_f32, 0.0, 0.42, 2.7];
+        for squash in VECTORISED {
+            let got = squash_x4(squash, xs).unwrap();
+            for (lane, &x) in xs.iter().enumerate() {
+                let want = apply_squash(squash, x);
+                assert!(
+                    (want - got[lane]).abs() <= SQUASH_SIMD_MAX_ABS_ERR,
+                    "{squash:?} lane {lane}: want {want}, got {}",
+                    got[lane]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn x8_matches_x4() {
+        let xs = [-3.0_f32, -0.5, 0.0, 0.25, 0.9, 1.5, 4.0, -2.2];
+        for squash in VECTORISED {
+            let got = squash_x8(squash, xs).unwrap();
+            for (lane, &x) in xs.iter().enumerate() {
+                let want = apply_squash(squash, x);
+                assert!(
+                    (want - got[lane]).abs() <= SQUASH_SIMD_MAX_ABS_ERR,
+                    "{squash:?} lane {lane}: want {want}, got {}",
+                    got[lane]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn non_vectorised_types_opt_out() {
+        // A representative spread of non-transcendental / specially-handled types
+        // must return None so the caller keeps the scalar numerics.
+        for squash in [
+            SquashType::Identity,
+            SquashType::Relu,
+            SquashType::Sine,
+            SquashType::Gaussian,
+            SquashType::Softplus,
+            SquashType::Minimum,
+        ] {
+            assert!(
+                squash_x4(squash, [0.1, 0.2, 0.3, 0.4]).is_none(),
+                "{squash:?} must fall back to scalar"
+            );
+        }
+    }
+
+    #[test]
+    fn extreme_inputs_are_finite() {
+        // Saturating / overflow-prone inputs must not produce NaN/Inf.
+        for squash in VECTORISED {
+            for &x in &[-1e6_f32, -100.0, 100.0, 1e6, 0.0] {
+                let got = squash_x4(squash, [x, x, x, x]).unwrap()[0];
+                assert!(got.is_finite(), "{squash:?}({x}) = {got} not finite");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# [perf] Vectorise the activation (squash) function across batched records

## Summary

The batched activation paths produce one accumulated pre-activation **per
record** with the SIMD weighted-sum kernels, but then applied the squash **per
record with the scalar `apply_squash`**. For the hot transcendental squashes
(`Tanh`, `Logistic`, `Gelu`, `Mish`) that `libm` call dominates the per-neuron
cost on the wide/shallow production creature (~1673 non-input neurons, ~13
average fan-in).

This PR adds `neat-core/src/squash_simd.rs`: branchless, fixed-size-array
approximations of those four squashes that LLVM auto-vectorises (SSE/AVX/FMA on
`x86_64`, NEON on `aarch64`, `simd128` on `wasm32`) so all 4 (or 8) batch lanes
are evaluated at once. They are wired into both batched paths:

- `CompiledNetwork::activate_and_trace_batch_4way` (`network.rs`)
- the 8-record / 4-record loss path (`loss.rs`)

Every vectorised type is bounded within `5e-6` (tighter than the `1e-5` the
existing batch-parity tests already assert) of the scalar `apply_squash`. Squash
types **without** a vectorised approximation return `None`, so the caller keeps
the existing scalar path and their numerics are unchanged. Scalar `apply_squash`
remains the single source of truth for correctness.

No hand-written platform intrinsics or `unsafe` are introduced — the kernels are
plain branchless `f32` arithmetic over `[f32; N]` arrays, which the optimiser
vectorises and which also compiles for `wasm32`.

Closes #180.

```mermaid
flowchart LR
    A["SIMD weighted sum<br/>(per record)"] --> B{squash type}
    B -- "Tanh / Logistic<br/>Gelu / Mish" --> C["squash_x4 / squash_x8<br/>(lane-parallel approx)"]
    B -- other --> D["scalar apply_squash<br/>(unchanged numerics)"]
    C --> E["apply_limit_range<br/>per lane"]
    D --> E
```

## Evidence (performance)

Backend/CLI change — no UI. Measured with the repo's Criterion harness on
`aarch64` via `--save-baseline before` / `--baseline`.

### Production fixtures — `batched_scoring`

| Benchmark | Before | After | Change |
|---|---|---|---|
| `trace_batch_4way/production` | ~48.7 µs | ~34.0 µs | **−31%** |
| `trace_batch_4way/production_2x` | ~133 µs | ~79 µs | **−42%** |
| `mse_sum_8records/production` | ~83.3 µs | ~77.3 µs | −7% to −11% |
| `mse_sum_8records/production_2x` | ~335 µs | ~330 µs | ~noise |

The 4-way traced activation path (the direct target) improves ~30–42%
reproducibly. The 8-record MSE loss path is more memory-bound — the squash is a
smaller fraction there — so its gain is smaller and `production_2x` sits inside
run-to-run noise (that fixture already reported ~13% high-severe outliers at
baseline).

### Per-call squash speedup — `squash_x4` (4 lanes)

| Squash | Scalar ×4 | SIMD `squash_x4` | Speedup |
|---|---|---|---|
| Tanh | 6.25 ns | 1.98 ns | 3.2× |
| Logistic | 4.83 ns | 2.39 ns | 2.0× |
| Gelu | 8.11 ns | 2.56 ns | 3.2× |
| Mish | 19.07 ns | 3.04 ns | 6.3× |

## Test Plan

New range/property tests in `neat-core/src/squash_simd.rs` (assert the bounded
error vs scalar `apply_squash`, the acceptance criterion):

- `tanh_within_tolerance_over_range`, `logistic_within_tolerance_over_range`,
  `gelu_within_tolerance_over_range`, `mish_within_tolerance_over_range` — sweep
  the finite input range and assert max abs error ≤ `SQUASH_SIMD_MAX_ABS_ERR`.
- `all_four_lanes_match_scalar`, `x8_matches_x4` — each lane reproduces its own
  scalar squash for the 4- and 8-lane entry points.
- `non_vectorised_types_opt_out` — non-transcendental types return `None` (caller
  falls back to scalar, unchanged numerics).
- `extreme_inputs_are_finite` — saturating/overflow-prone inputs stay finite (no
  NaN/Inf from the `exp`/ratio reconstruction).

Existing batch-parity tests continue to pass unchanged, confirming the
vectorised path stays within the established `1e-5` tolerance of the
single-record scalar path:

- `network.rs::test_batch_4way_matches_single_tanh_logistic`
- full `cargo test --workspace --lib --tests` green.

Benchmark additions: a `squash_x4` Criterion group (scalar ×4 vs `simd_x4`) for
the four vectorised types, alongside the existing `batched_scoring` production
fixtures used for the before/after comparison above.



## Milestone
This PR is part of the **#175 Please suggest performance improvements for production size creatures/data** milestone and targets the `milestone/175-please-suggest-performance-improvements-for-pr` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqm2lrus-da6c55`<!-- vibe-worker-issue-180 -->