### PR TITLE
Milestone: #175 Please suggest performance improvements for production size creatures/data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,12 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,12 +217,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -262,15 +244,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -282,45 +262,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -350,12 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,12 +301,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
@@ -453,16 +382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -567,12 +486,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,9 +542,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -668,12 +581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,24 +588,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -744,40 +633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -834,100 +689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -310,7 +310,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.1.45"
+version = "0.1.46"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ name = "neat-core"
 version = "0.1.45"
 dependencies = [
  "criterion",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.45"
+version = "0.1.46"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 | `neat-core/` | Shared computation library; **140+** unit tests in `src/**/*.rs` plus integration tests in `neat-core/tests/` (>350 total). |
 | `Cargo.toml` | Virtual workspace root; `[workspace.package]` holds semver for release automation. |
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
-| `neat-core/benches/` | Opt-in Criterion harness for core hot paths (`cargo bench -p neat-core --bench hot_paths`); see `neat-core/benches/README.md`. |
+| `neat-core/benches/` | Opt-in Criterion harnesses: `hot_paths` (core hot paths) and `parallel_scoring` (data-parallel scoring, needs `--features parallel`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
 | `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build (Vibe Coder hook). |
@@ -34,6 +34,46 @@ cargo test --workspace
 ./quality.sh
 # opt-in performance benchmarks (not part of the test gate):
 cargo bench -p neat-core --bench hot_paths
+```
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
+
+Scoring a production-size dataset pushes many records through one creature — an
+embarrassingly parallel workload *across records*. With the `parallel` feature
+the throughput scales with core count, while results stay **identical** to the
+sequential path (each record is scored by the same `activate`, with no
+cross-record state — each rayon worker owns a cloned scratch context):
+
+```rust
+// Off-feature / wasm: transparently runs sequentially.
+let outputs = net.score_records(&records, num_outputs);
+
+// With `--features parallel` on native: scored across the rayon pool,
+// same results, in input order.
+let outputs = net.score_records_parallel(&records, num_outputs);
+```
+
+```mermaid
+flowchart LR
+    R[records] --> S{parallel feature?}
+    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
+    S -- on, native --> P[score_records_parallel]
+    P --> W1[worker 1<br/>cloned scratch]
+    P --> W2[worker 2<br/>cloned scratch]
+    P --> Wn[worker N<br/>cloned scratch]
+    W1 --> O[outputs in input order]
+    W2 --> O
+    Wn --> O
+    Q --> O
+```
+
+```bash
+# Run the data-parallel scoring throughput bench (1 vs all cores).
+cargo bench -p neat-core --features parallel --bench parallel_scoring
 ```
 
 ## Related Repositories

--- a/docs/archive/pr-summaries/pr-summary-176.md
+++ b/docs/archive/pr-summaries/pr-summary-176.md
@@ -1,0 +1,95 @@
+## Summary
+
+Adds production-scale **wide/shallow** creature fixtures to the `hot_paths`
+Criterion harness so #175's optimisations can be validated against the real
+production topology, not just the dense synthetic nets. Closes #176.
+
+The real production creature has a huge input layer (2461), a modest neuron
+count (1673 non-input) and a sparse ~13 average fan-in (~21677 synapses). That
+shape is **gather-bound** in a way the existing dense feedforward shapes are
+not, so before/after deltas measured only on the synthetic shapes can be
+misleading.
+
+### What changed
+
+- **New shapes** `production` and `production_2x` ("or larger creatures",
+  ~2× neurons/synapses) wired into the `forward_pass`, `batched_scoring` and
+  `backprop` groups. `cargo bench -p neat-core --bench hot_paths -- production`
+  now reports every hot path at production scale.
+- **Varied fan-in**: `build_network`/`build_backprop_data` take a `FanIn`
+  policy. The synthetic shapes keep their exact `Fixed` fan-in (and consume no
+  extra RNG draw, so their existing baselines are unchanged); the production
+  shapes draw fan-in per neuron uniformly around the ~13 average so the gather
+  pattern matches production sparsity.
+- **No committed `network.json`** — the production shape is synthesised from the
+  seeded PRNG to match the real dimensions; the harness stays deterministic.
+- **Single source of truth**: the deterministic builders moved to
+  `neat-core/benches/common/mod.rs`, reused verbatim by the harness *and* by a
+  new integration test (`harness = false` benches can't host runnable tests, so
+  this is how the builders get real `cargo test` coverage).
+- README updated with the shape table and the `-- production` /
+  `--save-baseline before` / `--baseline before` workflow.
+
+```mermaid
+flowchart LR
+    C[benches/common/mod.rs<br/>NetSpec + deterministic builders] --> H[hot_paths.rs<br/>Criterion harness]
+    C --> T[tests/bench_fixtures.rs<br/>cargo test coverage]
+    H --> P["cargo bench -- production<br/>forward_pass / batched_scoring / backprop"]
+```
+
+## Evidence
+
+Backend/bench-only change — no UI to screenshot.
+
+### Acceptance criteria
+
+- ✅ `cargo bench -p neat-core --bench hot_paths -- production` runs and reports
+  `forward_pass`, `batched_scoring` and `backprop` at the `production` and
+  `production_2x` shapes (see baseline below).
+- ✅ README documents the new sizes and the baseline-comparison workflow.
+- ✅ Harness remains deterministic (fixed seed) — asserted by the new tests.
+
+### Initial baseline (indicative)
+
+Captured with a quick sampling profile (`--warm-up-time 0.5 --measurement-time 2
+--sample-size 20`) on the dev machine; absolute numbers are indicative, the
+harness is the deliverable. Re-run with the default profile for committed
+baselines.
+
+| Benchmark | `production` (median) | `production_2x` (median) |
+| --- | --- | --- |
+| `forward_pass` | 23.4 µs | 58.5 µs |
+| `batched_scoring/trace_batch_4way` | 107.0 µs | 209.6 µs |
+| `batched_scoring/mse_sum_8records` | 211.1 µs | 347.1 µs |
+| `backprop` | 76.5 µs | 178.8 µs |
+
+Record a comparable baseline before an optimisation, then compare:
+
+```bash
+cargo bench -p neat-core --bench hot_paths -- production --save-baseline before
+# ...apply optimisation...
+cargo bench -p neat-core --bench hot_paths -- production --baseline before
+```
+
+## Test Plan
+
+New integration test `neat-core/tests/bench_fixtures.rs` (runs under
+`cargo test --workspace --lib --tests`), all "what" tests asserting observable
+outcomes of the shared builders:
+
+- `production_shapes_are_registered_with_expected_dimensions` — the production
+  shapes match the documented dimensions and `production_2x` is ≥2× the neurons.
+- `build_network_matches_production_neuron_and_synapse_counts` — neuron/synapse
+  counts and an average fan-in within `12.0..=14.0`; per-neuron `num_synapses`
+  sums to the flat synapse buffer.
+- `varied_fan_in_actually_varies_unlike_fixed_shapes` — the production shape
+  draws a non-constant fan-in, while a `Fixed` shape stays constant.
+- `build_network_is_deterministic_for_a_fixed_seed` — identical synapses and
+  neurons for the same seed.
+- `production_network_activates_to_finite_outputs` — forward pass yields the
+  right number of finite outputs.
+- `backprop_data_has_consistent_inward_adjacency_at_production_scale` — inward
+  counts sum to the synapse and index-list lengths; reverse topo order length.
+
+Also verified: `cargo clippy --workspace --all-targets --all-features -- -D
+warnings`, `cargo doc`, `codespell`, and `markdownlint-cli2` all clean.

--- a/docs/archive/pr-summaries/pr-summary-177.md
+++ b/docs/archive/pr-summaries/pr-summary-177.md
@@ -1,0 +1,116 @@
+## Summary
+
+Shrink `SynapseData` from **12 bytes to 8 bytes** to cut forward-pass memory
+bandwidth. The forward pass is gather-bound — the whole synapse array is streamed
+once per activation — so a smaller per-synapse record means less memory traffic
+and better cache-line utilisation.
+
+The change narrows `from_index` from `u32` to `u16` and drops the explicit
+3-byte padding field. The on-wire format already stores `from_index` as a `u16`
+(`u16::from_le_bytes(...)` in the decoder), so **no precision is lost** and
+numeric outputs are unchanged. Every gather site (`synapse.from_index as usize`)
+works unchanged because `u16 as usize` is identical at the call sites.
+
+Because `from_index` is now a `u16`, a network may address at most
+`u16::MAX + 1` (65536) nodes. This is captured as a documented `MAX_NODE_COUNT`
+constant and enforced at load time:
+
+- `CompiledNetwork::new` returns `NetworkError::TooManyNodes` for oversized
+  serialised networks.
+- `compile_creature` returns `CreatureError::TooManyNodes` for oversized
+  creatures.
+
+Closes #177.
+
+### Layout: before vs after
+
+```rust
+// Before — 12 bytes (4 weight + 4 from_index + 1 type + 3 padding)
+#[repr(C)]
+pub struct SynapseData {
+    pub weight: f32,
+    pub from_index: u32,
+    pub synapse_type: u8,
+    pub _padding: [u8; 3],
+}
+
+// After — 8 bytes (4 weight + 2 from_index + 1 type + 1 trailing pad)
+#[repr(C)]
+pub struct SynapseData {
+    pub weight: f32,
+    pub from_index: u16,
+    pub synapse_type: u8,
+}
+```
+
+`repr(C)` keeps 4-byte alignment, so the SIMD weight loads stay aligned
+(asserted by a test).
+
+### Load-time invariant
+
+```mermaid
+flowchart TD
+    A[Serialised bytes / CreatureExport] --> B[read num_neurons]
+    B --> C{num_neurons > MAX_NODE_COUNT?}
+    C -- yes --> D[Err TooManyNodes]
+    C -- no --> E[decode synapses: from_index as u16]
+    E --> F[CompiledNetwork]
+```
+
+## Evidence
+
+Backend/library change — no web UI to screenshot. Evidence is the Criterion
+benchmark delta plus the test suite.
+
+### Benchmark results (`cargo bench -p neat-core --bench hot_paths`)
+
+Measured with `--warm-up-time 1 --measurement-time 3 --sample-size 30`,
+`--save-baseline before` (12-byte struct) then `--baseline before` (8-byte
+struct). A new wide/shallow `production_4134` fixture (4134 nodes, mean fan-in
+≈ 5 → ~20.6k synapses) mirrors the #175 production creature shape; no `.bin`
+production fixture exists on this branch yet, so the shape is reproduced
+deterministically in the harness.
+
+| Benchmark | Change | Significant (p<0.05) |
+|---|---|---|
+| `forward_pass/production_4134` | **−2.05%** | ✅ |
+| `forward_pass/large_5000` | **−3.44%** | ✅ |
+| `forward_pass/medium_500` | **−3.42%** | ✅ |
+| `forward_pass/small_50` | −0.14% | no (noise) |
+| `batched_scoring/trace_batch_4way/large_5000` | **−6.92%** | ✅ |
+| `batched_scoring/mse_sum_8records/medium_500` | **−5.60%** | ✅ |
+| `batched_scoring/trace_batch_4way/small_50` | −1.25% | ✅ |
+
+The gather-bound `forward_pass` path improves measurably and significantly
+across the medium/large/production fixtures — the primary target of the issue.
+The `batched_scoring` paths do more per-synapse work (squash, trace recording),
+so memory bandwidth is a smaller fraction; their larger fixtures still show
+significant wins (trace_batch_4way/large_5000 −6.9%) while a few small/noisy
+cases land within measurement noise.
+
+## Test Plan
+
+New tests:
+
+- `neat-core/src/network.rs`
+  - `synapse_data_is_eight_bytes` — asserts `size_of::<SynapseData>() == 8` and
+    `align_of == 4` (the observable footprint invariant this issue delivers).
+  - `new_rejects_networks_exceeding_max_node_count` — header over `MAX_NODE_COUNT`
+    yields `NetworkError::TooManyNodes`.
+  - `new_accepts_max_node_count_boundary` — exactly `MAX_NODE_COUNT` nodes loads.
+  - `new_preserves_high_source_index` — a `from_index` of 64000 round-trips
+    through the loader without truncation.
+- `neat-core/tests/creature_compile.rs`
+  - `compile_creature_rejects_too_many_nodes` — oversized creature yields
+    `CreatureError::TooManyNodes`.
+
+Updated construction/helper sites to the 8-byte struct (no `_padding`, `u16`
+`from_index`): `creature.rs`, `topology_export.rs`, `simd_native.rs` test
+helper, the `hot_paths` bench, the `bench_single_record_weighted_sums` example,
+and the `simd_weighted_sums` / `network_activate_trace_batch` integration tests.
+
+Gate: `cargo test --workspace` (153 lib + integration tests pass), `cargo clippy
+-D warnings`, `cargo fmt`, `cargo check`, `RUSTDOCFLAGS=-D warnings cargo doc`,
+and `cargo build --release` all pass. Pre-existing, unrelated `tests/scripts`
+bats failures about `ci.yml` invoking `cargo upgrade`/`bump-deps.sh` are not
+touched by this change.

--- a/docs/archive/pr-summaries/pr-summary-179.md
+++ b/docs/archive/pr-summaries/pr-summary-179.md
@@ -1,0 +1,105 @@
+# Native, feature-gated data-parallel record scoring (rayon)
+
+## Summary
+
+Adds an **opt-in, native-only** data-parallel scoring path so a production-size
+dataset can be pushed through one creature across all cores — the embarrassingly
+parallel "data" half of #175. Scoring N records is independent per record, so it
+scales near-linearly with core count and composes with the per-record
+micro-optimisations from the sibling sub-issues. Closes #179.
+
+What changed:
+
+- **New `parallel` Cargo feature** (off by default) pulling in `rayon`. `rayon`
+  is declared under a `cfg(not(target_arch = "wasm32"))` target table, and the
+  parallel code is gated `#[cfg(all(feature = "parallel", not(target_arch =
+  "wasm32")))]`, so the **default build and the `wasm32` build pull in no rayon
+  symbols** and keep their single-thread path.
+- **`CompiledNetwork::score_records_parallel(&self, records, num_outputs)`** —
+  chunks records across the rayon pool via `par_iter().map_init(...)`. Each
+  worker initialises **its own cloned scratch context** (the `Clone` carries
+  `activations` / `hint_values_buffer` / the 4-way batch buffers), so no
+  `&mut self` is shared across threads: immutable weights are read through
+  `&self` while every worker owns its buffers. When the feature is off or on
+  wasm, the method is a thin fallback to the sequential path.
+- **`CompiledNetwork::score_records(&self, records, num_outputs)`** — the
+  sequential reference (one scratch clone), used as the fallback and the parity
+  baseline.
+- **`parallel_scoring` Criterion bench** reporting records/sec at 1 vs all
+  cores on the `production` / `production_2x` fixtures (#175/#176). No-op shim
+  without the feature so the target builds on every configuration.
+
+Determinism: every record is scored by the same `activate` used sequentially,
+with no cross-record state, and `collect()` preserves input order — so results
+are **identical** to the sequential path regardless of thread count (verified by
+tests).
+
+### Drive-by fix (required for a green build)
+
+The milestone branch's bench fixtures (`benches/common/mod.rs` and
+`benches/hot_paths.rs`) still constructed `SynapseData` with the pre-#177 layout
+(`from_index: u32` + `_padding`), so `cargo check --tests` / `--all-targets`
+failed to compile on the milestone branch before this PR. Updated both to the
+current `from_index: u16` layout. This was necessary to build the
+acceptance-criteria benchmark and to keep `quality.sh` green.
+
+```mermaid
+flowchart LR
+    R[records] --> S{parallel feature?}
+    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
+    S -- on, native --> P[score_records_parallel]
+    P --> W1[worker 1<br/>cloned scratch]
+    P --> W2[worker 2<br/>cloned scratch]
+    P --> Wn[worker N<br/>cloned scratch]
+    W1 --> O[outputs in input order]
+    W2 --> O
+    Wn --> O
+    Q --> O
+```
+
+## Evidence (performance)
+
+`cargo bench -p neat-core --features parallel --bench parallel_scoring`, scoring
+2048 records, on a 12-core host (`nproc` = 12). Throughput is records/sec
+(Criterion `thrpt`, median):
+
+| Fixture | 1 core | 12 cores | Speed-up |
+|---------|--------|----------|----------|
+| `production` (4134 neurons, ~21.7k synapses) | 52.4 ms → **39.06 Kelem/s** | 7.18 ms → **285.4 Kelem/s** | **~7.3×** |
+| `production_2x` (8268 neurons, ~43.5k synapses) | 111.3 ms → **18.40 Kelem/s** | 20.78 ms → **98.56 Kelem/s** | **~5.4×** |
+
+Throughput scales with core count, satisfying the acceptance criterion. (Per
+the Performance Task Workflow, the "before" is the 1-core measurement, which is
+the existing single-threaded behaviour; the parallel path is the gain.)
+
+Default + wasm builds unchanged:
+
+- `cargo check -p neat-core --target wasm32-unknown-unknown` — clean.
+- `cargo check -p neat-core --target wasm32-unknown-unknown --features parallel`
+  — clean and **does not compile rayon** for wasm (target-gated dependency).
+- `cargo deny check` — advisories / bans / licenses / sources all OK with rayon
+  added.
+
+## Test Plan
+
+New `neat-core/tests/parallel_scoring.rs` (passes both default and
+`--features parallel`, which `quality.sh` exercises via `--all-features`):
+
+- `parallel_scoring_matches_sequential_on_production_fixture` — 257 records (not
+  a multiple of any core count) on the production fixture, equal to an
+  independent sequential reference.
+- `parallel_scoring_matches_sequential_across_shapes` — parity across
+  `small_50`, `medium_500`, `production`, `production_2x`.
+- `output_order_is_preserved` — index-aligned against the reference with 200
+  distinct records.
+- `each_output_has_num_outputs_elements`, `single_record_matches_direct_activate`,
+  `empty_records_yields_empty_output`, `score_records_matches_reference`.
+
+Gates run green locally: `cargo clippy --workspace --all-targets --all-features
+-- -D warnings`, `cargo test --workspace --lib --tests --all-features`,
+`cargo doc`, release build, `cargo deny check`.
+
+> Note: `quality.sh`'s `bats` suite has 4 **pre-existing** failures
+> (`ci.yml ...bump-deps.sh`, tests 31/32/33/37) that exist on the clean
+> milestone branch independent of this change and are unrelated to #179
+> (they assert `ci.yml` wiring, untouched here).

--- a/docs/archive/pr-summaries/pr-summary-180.md
+++ b/docs/archive/pr-summaries/pr-summary-180.md
@@ -1,0 +1,94 @@
+# [perf] Vectorise the activation (squash) function across batched records
+
+## Summary
+
+The batched activation paths produce one accumulated pre-activation **per
+record** with the SIMD weighted-sum kernels, but then applied the squash **per
+record with the scalar `apply_squash`**. For the hot transcendental squashes
+(`Tanh`, `Logistic`, `Gelu`, `Mish`) that `libm` call dominates the per-neuron
+cost on the wide/shallow production creature (~1673 non-input neurons, ~13
+average fan-in).
+
+This PR adds `neat-core/src/squash_simd.rs`: branchless, fixed-size-array
+approximations of those four squashes that LLVM auto-vectorises (SSE/AVX/FMA on
+`x86_64`, NEON on `aarch64`, `simd128` on `wasm32`) so all 4 (or 8) batch lanes
+are evaluated at once. They are wired into both batched paths:
+
+- `CompiledNetwork::activate_and_trace_batch_4way` (`network.rs`)
+- the 8-record / 4-record loss path (`loss.rs`)
+
+Every vectorised type is bounded within `5e-6` (tighter than the `1e-5` the
+existing batch-parity tests already assert) of the scalar `apply_squash`. Squash
+types **without** a vectorised approximation return `None`, so the caller keeps
+the existing scalar path and their numerics are unchanged. Scalar `apply_squash`
+remains the single source of truth for correctness.
+
+No hand-written platform intrinsics or `unsafe` are introduced — the kernels are
+plain branchless `f32` arithmetic over `[f32; N]` arrays, which the optimiser
+vectorises and which also compiles for `wasm32`.
+
+Closes #180.
+
+```mermaid
+flowchart LR
+    A["SIMD weighted sum<br/>(per record)"] --> B{squash type}
+    B -- "Tanh / Logistic<br/>Gelu / Mish" --> C["squash_x4 / squash_x8<br/>(lane-parallel approx)"]
+    B -- other --> D["scalar apply_squash<br/>(unchanged numerics)"]
+    C --> E["apply_limit_range<br/>per lane"]
+    D --> E
+```
+
+## Evidence (performance)
+
+Backend/CLI change — no UI. Measured with the repo's Criterion harness on
+`aarch64` via `--save-baseline before` / `--baseline`.
+
+### Production fixtures — `batched_scoring`
+
+| Benchmark | Before | After | Change |
+|---|---|---|---|
+| `trace_batch_4way/production` | ~48.7 µs | ~34.0 µs | **−31%** |
+| `trace_batch_4way/production_2x` | ~133 µs | ~79 µs | **−42%** |
+| `mse_sum_8records/production` | ~83.3 µs | ~77.3 µs | −7% to −11% |
+| `mse_sum_8records/production_2x` | ~335 µs | ~330 µs | ~noise |
+
+The 4-way traced activation path (the direct target) improves ~30–42%
+reproducibly. The 8-record MSE loss path is more memory-bound — the squash is a
+smaller fraction there — so its gain is smaller and `production_2x` sits inside
+run-to-run noise (that fixture already reported ~13% high-severe outliers at
+baseline).
+
+### Per-call squash speedup — `squash_x4` (4 lanes)
+
+| Squash | Scalar ×4 | SIMD `squash_x4` | Speedup |
+|---|---|---|---|
+| Tanh | 6.25 ns | 1.98 ns | 3.2× |
+| Logistic | 4.83 ns | 2.39 ns | 2.0× |
+| Gelu | 8.11 ns | 2.56 ns | 3.2× |
+| Mish | 19.07 ns | 3.04 ns | 6.3× |
+
+## Test Plan
+
+New range/property tests in `neat-core/src/squash_simd.rs` (assert the bounded
+error vs scalar `apply_squash`, the acceptance criterion):
+
+- `tanh_within_tolerance_over_range`, `logistic_within_tolerance_over_range`,
+  `gelu_within_tolerance_over_range`, `mish_within_tolerance_over_range` — sweep
+  the finite input range and assert max abs error ≤ `SQUASH_SIMD_MAX_ABS_ERR`.
+- `all_four_lanes_match_scalar`, `x8_matches_x4` — each lane reproduces its own
+  scalar squash for the 4- and 8-lane entry points.
+- `non_vectorised_types_opt_out` — non-transcendental types return `None` (caller
+  falls back to scalar, unchanged numerics).
+- `extreme_inputs_are_finite` — saturating/overflow-prone inputs stay finite (no
+  NaN/Inf from the `exp`/ratio reconstruction).
+
+Existing batch-parity tests continue to pass unchanged, confirming the
+vectorised path stays within the established `1e-5` tolerance of the
+single-record scalar path:
+
+- `network.rs::test_batch_4way_matches_single_tanh_logistic`
+- full `cargo test --workspace --lib --tests` green.
+
+Benchmark additions: a `squash_x4` Criterion group (scalar ×4 vs `simd_x4`) for
+the four vectorised types, alongside the existing `batched_scoring` production
+fixtures used for the before/after comparison above.

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1"
 parallel = ["dep:rayon"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rayon = { version = "1.10", optional = true }
+rayon = { version = "1.12", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.125"

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -19,6 +19,16 @@ crate-type = ["cdylib", "rlib"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# Issue #179 - opt-in data-parallel record scoring. `rayon` is native-only
+# (it is not wasm-friendly), so it is declared under a `cfg(not(wasm32))`
+# target table. The `parallel` feature is off by default, so default and
+# `wasm32` builds pull in no rayon symbols and keep their single-thread path.
+[features]
+parallel = ["dep:rayon"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rayon = { version = "1.10", optional = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.125"
 
@@ -31,4 +41,10 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # run explicitly with `cargo bench -p neat-core`.
 [[bench]]
 name = "hot_paths"
+harness = false
+
+# Issue #179 - data-parallel scoring throughput (records/sec at 1 vs all cores).
+# Requires `--features parallel`; without it the bench's `main` is a no-op shim.
+[[bench]]
+name = "parallel_scoring"
 harness = false

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -5,6 +5,13 @@ Criterion harness for the core hot paths (Issue #152). These benchmarks are
 `neat-core/Cargo.toml` keeps them out of `cargo test` and the `quality.sh`
 gate, so the CI runtime is unaffected.
 
+There are two bench targets:
+
+- `hot_paths` — the per-record hot paths (always available).
+- `parallel_scoring` — data-parallel record scoring throughput (Issue #179),
+  **requires `--features parallel`**. Without the feature its `main` is a no-op
+  shim, so the target still builds on every configuration.
+
 ## What is measured
 
 `hot_paths.rs` covers the four hottest paths in the crate:
@@ -64,6 +71,19 @@ cargo bench -p neat-core --bench hot_paths -- production
 
 > Use `--bench hot_paths` so Criterion's CLI flags are not handed to the
 > default libtest harness on the library target.
+
+### Data-parallel scoring (Issue #179)
+
+`parallel_scoring.rs` reports records/sec for scoring a batch through one
+creature on **a single core versus all available cores**, using the
+`production`/`production_2x` shapes. It scores inside a rayon pool of a fixed
+size, so the 1-core and all-core measurements share one code path and differ
+only in pool size.
+
+```bash
+# Requires the `parallel` feature (rayon, native targets only).
+cargo bench -p neat-core --features parallel --bench parallel_scoring
+```
 
 The `production` filter is a regex over benchmark ids, so it matches both the
 `production` and `production_2x` shapes in `forward_pass`, `batched_scoring` and

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -11,9 +11,9 @@ gate, so the CI runtime is unaffected.
 
 | Group | Function(s) under test | Sizes |
 | --- | --- | --- |
-| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000 neurons |
-| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same three sizes |
-| `backprop` | one `propagate_topological_loop` step | same three sizes |
+| `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
+| `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
+| `backprop` | one `propagate_topological_loop` step | same five shapes |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -21,6 +21,32 @@ Networks and inputs are built **once** outside the timed closure from a
 fixed-seed PRNG with fixed topologies, and `criterion::black_box` guards inputs
 and outputs. The harness is therefore deterministic, so before/after
 comparisons across a code change are meaningful.
+
+### Network shapes
+
+The three synthetic shapes are dense feedforward nets with a small input layer
+and a constant fan-in. The two `production` shapes (Issue #176) mirror the real
+production creature — a **wide, shallow** topology with a huge input layer, a
+modest neuron count and a sparse, *varied* fan-in — which is gather-bound in a
+way the dense shapes are not, so deltas measured only on the synthetic shapes
+can be misleading.
+
+| Shape | Inputs | Non-input neurons | Total neurons | Outputs | Avg fan-in | ~Synapses |
+| --- | --- | --- | --- | --- | --- | --- |
+| `small_50` | 8 | 42 | 50 | 4 | 12 (fixed) | ~0.5k |
+| `medium_500` | 16 | 484 | 500 | 8 | 16 (fixed) | ~7.7k |
+| `large_5000` | 32 | 4968 | 5000 | 16 | 24 (fixed) | ~119k |
+| `production` | 2461 | 1673 | 4134 | 1 | ~13 (varied) | ~21.7k |
+| `production_2x` | 4922 | 3346 | 8268 | 2 | ~13 (varied) | ~43.5k |
+
+The `production` shape is synthesised from the seeded PRNG to match the real
+creature's dimensions — the 3 MB `network.json` is **not** committed. Fan-in for
+the production shapes is drawn per neuron (uniform around the ~13 average)
+rather than held constant, so the gather pattern matches production sparsity.
+`production_2x` doubles the neuron and synapse counts to cover #175's "or larger
+creatures" requirement. The deterministic builders live in
+`benches/common/mod.rs` and are exercised by the `bench_fixtures` integration
+test.
 
 ## Running
 
@@ -31,10 +57,17 @@ cargo bench -p neat-core --bench hot_paths
 # Run a single group (regex over benchmark ids).
 cargo bench -p neat-core --bench hot_paths -- forward_pass
 cargo bench -p neat-core --bench hot_paths -- backprop
+
+# Run only the production-scale shapes across every hot path.
+cargo bench -p neat-core --bench hot_paths -- production
 ```
 
 > Use `--bench hot_paths` so Criterion's CLI flags are not handed to the
 > default libtest harness on the library target.
+
+The `production` filter is a regex over benchmark ids, so it matches both the
+`production` and `production_2x` shapes in `forward_pass`, `batched_scoring` and
+`backprop`.
 
 ## Comparing before vs after a change
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -157,9 +157,8 @@ pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
             let from = rng.next_below(global_idx);
             synapses.push(SynapseData {
                 weight: rng.next_signed() * 0.5,
-                from_index: from as u32,
+                from_index: from as u16,
                 synapse_type: 0,
-                _padding: [0; 3],
             });
         }
         neurons.push(NeuronData {

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -1,0 +1,306 @@
+//! Deterministic fixtures shared by the `hot_paths` Criterion harness
+//! (Issue #152) and the `bench_fixtures` integration test (Issue #176).
+//!
+//! Kept in `benches/common/` (a subdirectory, so Cargo does **not** treat it as
+//! an auto-discovered bench target) and reused verbatim by the test via
+//! `#[path = "../benches/common/mod.rs"]`. That makes the network-building logic
+//! a single source of truth that is exercised by a real `cargo test` run rather
+//! than only compiled inside the `harness = false` bench.
+
+use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::squash::SquashType;
+use neat_core::topological_backprop::{
+    NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, SynapseInput,
+};
+
+/// Tiny deterministic PRNG (SplitMix64-style) so the harness produces fixed
+/// topologies and weights without pulling in an `rand` dependency.
+pub struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform float in `[-1.0, 1.0)`.
+    pub fn next_signed(&mut self) -> f32 {
+        let unit = (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32;
+        unit * 2.0 - 1.0
+    }
+
+    /// Uniform integer in `[0, bound)`.
+    pub fn next_below(&mut self, bound: usize) -> usize {
+        (self.next_u64() % bound as u64) as usize
+    }
+}
+
+/// How a neuron's incoming-connection count is chosen.
+#[derive(Clone, Copy)]
+pub enum FanIn {
+    /// Every neuron draws exactly this many incoming connections (capped by the
+    /// number of strictly earlier neurons). Used by the dense synthetic shapes,
+    /// so their topologies — and therefore existing baselines — are unchanged.
+    Fixed(usize),
+    /// Per-neuron fan-in drawn uniformly in `[1, 2*avg - 1]` so the mean matches
+    /// the production creature's sparse average (~13). Used by the wide/shallow
+    /// `production` shapes, which are gather-bound rather than dense.
+    VariedAround(usize),
+}
+
+impl FanIn {
+    /// Number of incoming connections for a neuron that has `max_fan` strictly
+    /// earlier neurons to draw from. Only [`FanIn::VariedAround`] consumes an
+    /// RNG draw, so [`FanIn::Fixed`] shapes keep their exact prior sequence.
+    pub fn draw(self, rng: &mut Lcg, max_fan: usize) -> usize {
+        let target = match self {
+            FanIn::Fixed(f) => f,
+            FanIn::VariedAround(avg) => {
+                let span = (2 * avg).saturating_sub(1).max(1);
+                1 + rng.next_below(span)
+            }
+        };
+        target.min(max_fan)
+    }
+}
+
+/// A benchmark network shape.
+pub struct NetSpec {
+    pub label: &'static str,
+    /// Total neurons, including the input layer.
+    pub num_neurons: usize,
+    pub num_inputs: usize,
+    pub num_outputs: usize,
+    pub fan_in: FanIn,
+}
+
+impl NetSpec {
+    pub fn num_non_inputs(&self) -> usize {
+        self.num_neurons - self.num_inputs
+    }
+}
+
+/// Representative network shapes wired into every hot-path group.
+///
+/// The three synthetic shapes are dense feedforward nets with a fixed fan-in.
+/// The two `production` shapes (Issue #176) mirror the real production creature:
+/// a huge input layer, a modest neuron count and a sparse ~13 average fan-in,
+/// which is gather-bound in a way the dense shapes are not. `production_2x`
+/// doubles neurons and synapses to cover #175's "or larger creatures" clause.
+pub const NETWORKS: [NetSpec; 5] = [
+    NetSpec {
+        label: "small_50",
+        num_neurons: 50,
+        num_inputs: 8,
+        num_outputs: 4,
+        fan_in: FanIn::Fixed(12),
+    },
+    NetSpec {
+        label: "medium_500",
+        num_neurons: 500,
+        num_inputs: 16,
+        num_outputs: 8,
+        fan_in: FanIn::Fixed(16),
+    },
+    NetSpec {
+        label: "large_5000",
+        num_neurons: 5000,
+        num_inputs: 32,
+        num_outputs: 16,
+        fan_in: FanIn::Fixed(24),
+    },
+    NetSpec {
+        label: "production",
+        // 2461 inputs + 1673 hidden/output neurons; ~13 avg fan-in ⇒ ~21.7k synapses.
+        num_neurons: 4134,
+        num_inputs: 2461,
+        num_outputs: 1,
+        fan_in: FanIn::VariedAround(13),
+    },
+    NetSpec {
+        label: "production_2x",
+        // ~2x the production neuron and synapse counts ("or larger creatures").
+        num_neurons: 8268,
+        num_inputs: 4922,
+        num_outputs: 2,
+        fan_in: FanIn::VariedAround(13),
+    },
+];
+
+/// Build a deterministic feedforward [`CompiledNetwork`] from a [`NetSpec`].
+///
+/// Non-input neurons are emitted in topological order; each draws up to its
+/// fan-in incoming connections from strictly earlier neurons, giving a realistic
+/// synapse density without recurrent edges.
+pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
+    let num_neurons = spec.num_neurons;
+    let num_inputs = spec.num_inputs;
+    let mut rng = Lcg::new(seed);
+    let num_non_inputs = spec.num_non_inputs();
+    let mut neurons = Vec::with_capacity(num_non_inputs);
+    let mut synapses = Vec::new();
+
+    for n in 0..num_non_inputs {
+        let global_idx = num_inputs + n;
+        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        let start_synapse = synapses.len() as u32;
+        for _ in 0..this_fan {
+            let from = rng.next_below(global_idx);
+            synapses.push(SynapseData {
+                weight: rng.next_signed() * 0.5,
+                from_index: from as u32,
+                synapse_type: 0,
+                _padding: [0; 3],
+            });
+        }
+        neurons.push(NeuronData {
+            bias: rng.next_signed() * 0.1,
+            start_synapse,
+            num_synapses: this_fan as u16,
+            squash_type: SquashType::Tanh as u8,
+            is_constant: false,
+        });
+    }
+
+    let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::with_capacity(estimated_trace_size),
+        // Issue #155 - 4-way batch scratch buffers
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+            Vec::with_capacity(estimated_trace_size),
+        ],
+    }
+}
+
+/// Deterministic input vector of length `n`.
+pub fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
+    let mut rng = Lcg::new(seed);
+    (0..n).map(|_| rng.next_signed()).collect()
+}
+
+/// Owned backing storage for a `PropagateInput`; built once outside the loop.
+pub struct BackpropData {
+    pub neurons: Vec<NeuronInput>,
+    pub synapses: Vec<SynapseInput>,
+    pub inward_starts: Vec<u32>,
+    pub inward_counts: Vec<u32>,
+    pub inward_indices: Vec<u32>,
+    pub reverse_topo_order: Vec<u32>,
+    pub expected: Vec<f32>,
+    pub input_count: u32,
+    pub output_count: u32,
+}
+
+/// Build a deterministic feedforward backprop input from a [`NetSpec`].
+pub fn build_backprop_data(spec: &NetSpec, seed: u64) -> BackpropData {
+    let num_neurons = spec.num_neurons;
+    let num_inputs = spec.num_inputs;
+    let num_outputs = spec.num_outputs;
+    let mut rng = Lcg::new(seed);
+    let mut neurons = Vec::with_capacity(num_neurons);
+
+    // Input neurons first.
+    for _ in 0..num_inputs {
+        neurons.push(make_neuron(
+            SquashType::Identity,
+            NEURON_TYPE_INPUT,
+            rng.next_signed(),
+        ));
+    }
+
+    // Synapses grouped by target neuron so the inward adjacency is contiguous.
+    let mut synapses: Vec<SynapseInput> = Vec::new();
+    let mut inward_starts = vec![0u32; num_neurons];
+    let mut inward_counts = vec![0u32; num_neurons];
+    let mut inward_indices: Vec<u32> = Vec::new();
+
+    for global_idx in num_inputs..num_neurons {
+        let is_output = global_idx >= num_neurons - num_outputs;
+        let neuron_type = if is_output {
+            NEURON_TYPE_OUTPUT
+        } else {
+            NEURON_TYPE_HIDDEN
+        };
+        neurons.push(make_neuron(
+            SquashType::Tanh,
+            neuron_type,
+            rng.next_signed(),
+        ));
+
+        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        inward_starts[global_idx] = inward_indices.len() as u32;
+        inward_counts[global_idx] = this_fan as u32;
+        for _ in 0..this_fan {
+            let from = rng.next_below(global_idx);
+            let weight = rng.next_signed() * 0.5;
+            inward_indices.push(synapses.len() as u32);
+            synapses.push(SynapseInput {
+                from: from as u32,
+                to: global_idx as u32,
+                original_weight: weight,
+                adjusted_weight: weight,
+                is_self_loop: false,
+            });
+        }
+    }
+
+    // Reverse topological order: non-input neurons from last back to first.
+    let reverse_topo_order: Vec<u32> = (num_inputs..num_neurons).rev().map(|i| i as u32).collect();
+    let expected = (0..num_outputs).map(|_| rng.next_signed()).collect();
+
+    BackpropData {
+        neurons,
+        synapses,
+        inward_starts,
+        inward_counts,
+        inward_indices,
+        reverse_topo_order,
+        expected,
+        input_count: num_inputs as u32,
+        output_count: num_outputs as u32,
+    }
+}
+
+pub fn make_neuron(squash: SquashType, neuron_type: u8, adjusted_activation: f32) -> NeuronInput {
+    NeuronInput {
+        squash_type: squash as u8,
+        neuron_type,
+        propagate_needed: true,
+        update_needed: true,
+        hint_value: 0.0,
+        range_low: -1.0e6,
+        range_high: 1.0e6,
+        adjusted_activation,
+        adjusted_bias: 0.0,
+    }
+}

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -16,144 +16,39 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use std::hint::black_box;
 
 use neat_core::loss::mse_sum_batch_packed;
-use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::network::SynapseData;
 use neat_core::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_simd,
     weighted_sum_simd_4records, weighted_sum_simd_8records,
 };
 use neat_core::squash::{SquashType, apply_squash};
-use neat_core::topological_backprop::{
-    NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, PropagateInput,
-    SynapseInput, propagate_topological_loop,
-};
+use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
 use neat_core::unsquash::apply_unsquash;
 
-/// Tiny deterministic PRNG (SplitMix64-style) so the harness produces fixed
-/// topologies and weights without pulling in an `rand` dependency.
-struct Lcg {
-    state: u64,
-}
-
-impl Lcg {
-    fn new(seed: u64) -> Self {
-        Self { state: seed }
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
-        let mut z = self.state;
-        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
-        z ^ (z >> 31)
-    }
-
-    /// Uniform float in `[-1.0, 1.0)`.
-    fn next_signed(&mut self) -> f32 {
-        let unit = (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32;
-        unit * 2.0 - 1.0
-    }
-
-    /// Uniform integer in `[0, bound)`.
-    fn next_below(&mut self, bound: usize) -> usize {
-        (self.next_u64() % bound as u64) as usize
-    }
-}
-
-/// Build a deterministic feedforward [`CompiledNetwork`].
-///
-/// Non-input neurons are emitted in topological order; each draws up to
-/// `fan_in` incoming connections from strictly earlier neurons, giving a
-/// realistic synapse density without recurrent edges.
-fn build_network(
-    num_neurons: usize,
-    num_inputs: usize,
-    fan_in: usize,
-    seed: u64,
-) -> CompiledNetwork {
-    let mut rng = Lcg::new(seed);
-    let num_non_inputs = num_neurons - num_inputs;
-    let mut neurons = Vec::with_capacity(num_non_inputs);
-    let mut synapses = Vec::new();
-
-    for n in 0..num_non_inputs {
-        let global_idx = num_inputs + n;
-        let this_fan = fan_in.min(global_idx);
-        let start_synapse = synapses.len() as u32;
-        for _ in 0..this_fan {
-            let from = rng.next_below(global_idx);
-            synapses.push(SynapseData {
-                weight: rng.next_signed() * 0.5,
-                from_index: from as u32,
-                synapse_type: 0,
-                _padding: [0; 3],
-            });
-        }
-        neurons.push(NeuronData {
-            bias: rng.next_signed() * 0.1,
-            start_synapse,
-            num_synapses: this_fan as u16,
-            squash_type: SquashType::Tanh as u8,
-            is_constant: false,
-        });
-    }
-
-    let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
-    CompiledNetwork {
-        num_neurons,
-        num_inputs,
-        neurons,
-        synapses,
-        activations: vec![0.0; num_neurons],
-        hint_values_buffer: vec![0.0; num_non_inputs],
-        trace_data_buffer: Vec::with_capacity(estimated_trace_size),
-        // Issue #155 - 4-way batch scratch buffers
-        batch_activations: [
-            vec![0.0; num_neurons],
-            vec![0.0; num_neurons],
-            vec![0.0; num_neurons],
-            vec![0.0; num_neurons],
-        ],
-        batch_hints: [
-            vec![0.0; num_non_inputs],
-            vec![0.0; num_non_inputs],
-            vec![0.0; num_non_inputs],
-            vec![0.0; num_non_inputs],
-        ],
-        batch_traces: [
-            Vec::with_capacity(estimated_trace_size),
-            Vec::with_capacity(estimated_trace_size),
-            Vec::with_capacity(estimated_trace_size),
-            Vec::with_capacity(estimated_trace_size),
-        ],
-    }
-}
-
-/// Deterministic input vector of length `n`.
-fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
-    let mut rng = Lcg::new(seed);
-    (0..n).map(|_| rng.next_signed()).collect()
-}
-
-/// Representative network sizes: (label, total neurons, inputs, outputs, fan-in).
-const NETWORKS: [(&str, usize, usize, usize, usize); 3] = [
-    ("small_50", 50, 8, 4, 12),
-    ("medium_500", 500, 16, 8, 16),
-    ("large_5000", 5000, 32, 16, 24),
-];
+/// Deterministic network/backprop fixtures, shared with the `bench_fixtures`
+/// integration test (Issue #176) so the production-scale builders are exercised
+/// by a real `cargo test` run as well as the harness.
+mod common;
+use common::{Lcg, NETWORKS, build_backprop_data, build_inputs, build_network};
 
 /// Forward pass — `CompiledNetwork::activate` across representative sizes.
 fn bench_forward_pass(c: &mut Criterion) {
     let mut group = c.benchmark_group("forward_pass");
-    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
-        let mut net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
-        let inputs = build_inputs(num_inputs, 0xA1B2_C3D4);
-        group.throughput(Throughput::Elements(num_neurons as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(label), &inputs, |b, inputs| {
-            b.iter(|| {
-                let out = net.activate(black_box(inputs), black_box(num_outputs));
-                black_box(out);
-            });
-        });
+    for spec in &NETWORKS {
+        let mut net = build_network(spec, 0x5152_5354);
+        let inputs = build_inputs(spec.num_inputs, 0xA1B2_C3D4);
+        let num_outputs = spec.num_outputs;
+        group.throughput(Throughput::Elements(spec.num_neurons as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(spec.label),
+            &inputs,
+            |b, inputs| {
+                b.iter(|| {
+                    let out = net.activate(black_box(inputs), black_box(num_outputs));
+                    black_box(out);
+                });
+            },
+        );
     }
     group.finish();
 }
@@ -162,14 +57,16 @@ fn bench_forward_pass(c: &mut Criterion) {
 fn bench_batched_scoring(c: &mut Criterion) {
     let mut group = c.benchmark_group("batched_scoring");
 
-    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
+    for spec in &NETWORKS {
+        let num_inputs = spec.num_inputs;
+        let num_outputs = spec.num_outputs;
         // `mut` so the 4-way traced batch path can reuse its scratch buffers (Issue #155).
-        let mut net = build_network(num_neurons, num_inputs, fan_in, 0x5152_5354);
+        let mut net = build_network(spec, 0x5152_5354);
 
         // 4 records packed back-to-back for the traced batch path.
         let batch4 = build_inputs(num_inputs * 4, 0x0BAD_F00D);
         group.bench_with_input(
-            BenchmarkId::new("trace_batch_4way", label),
+            BenchmarkId::new("trace_batch_4way", spec.label),
             &batch4,
             |b, batch| {
                 b.iter(|| {
@@ -187,7 +84,7 @@ fn bench_batched_scoring(c: &mut Criterion) {
         let mut loss_net = net.clone();
         let records = build_inputs((num_inputs + num_outputs) * 8, 0xFEED_BEEF);
         group.bench_with_input(
-            BenchmarkId::new("mse_sum_8records", label),
+            BenchmarkId::new("mse_sum_8records", spec.label),
             &records,
             |b, records| {
                 b.iter(|| {
@@ -206,113 +103,13 @@ fn bench_batched_scoring(c: &mut Criterion) {
     group.finish();
 }
 
-/// Owned backing storage for a [`PropagateInput`]; built once outside the loop.
-struct BackpropData {
-    neurons: Vec<NeuronInput>,
-    synapses: Vec<SynapseInput>,
-    inward_starts: Vec<u32>,
-    inward_counts: Vec<u32>,
-    inward_indices: Vec<u32>,
-    reverse_topo_order: Vec<u32>,
-    expected: Vec<f32>,
-    input_count: u32,
-    output_count: u32,
-}
-
-/// Build a deterministic feedforward backprop input of `num_neurons` neurons.
-fn build_backprop_data(
-    num_neurons: usize,
-    num_inputs: usize,
-    num_outputs: usize,
-    fan_in: usize,
-    seed: u64,
-) -> BackpropData {
-    let mut rng = Lcg::new(seed);
-    let mut neurons = Vec::with_capacity(num_neurons);
-
-    // Input neurons first.
-    for _ in 0..num_inputs {
-        neurons.push(make_neuron(
-            SquashType::Identity,
-            NEURON_TYPE_INPUT,
-            rng.next_signed(),
-        ));
-    }
-
-    // Synapses grouped by target neuron so the inward adjacency is contiguous.
-    let mut synapses: Vec<SynapseInput> = Vec::new();
-    let mut inward_starts = vec![0u32; num_neurons];
-    let mut inward_counts = vec![0u32; num_neurons];
-    let mut inward_indices: Vec<u32> = Vec::new();
-
-    for global_idx in num_inputs..num_neurons {
-        let is_output = global_idx >= num_neurons - num_outputs;
-        let neuron_type = if is_output {
-            NEURON_TYPE_OUTPUT
-        } else {
-            NEURON_TYPE_HIDDEN
-        };
-        neurons.push(make_neuron(
-            SquashType::Tanh,
-            neuron_type,
-            rng.next_signed(),
-        ));
-
-        let this_fan = fan_in.min(global_idx);
-        inward_starts[global_idx] = inward_indices.len() as u32;
-        inward_counts[global_idx] = this_fan as u32;
-        for _ in 0..this_fan {
-            let from = rng.next_below(global_idx);
-            let weight = rng.next_signed() * 0.5;
-            inward_indices.push(synapses.len() as u32);
-            synapses.push(SynapseInput {
-                from: from as u32,
-                to: global_idx as u32,
-                original_weight: weight,
-                adjusted_weight: weight,
-                is_self_loop: false,
-            });
-        }
-    }
-
-    // Reverse topological order: non-input neurons from last back to first.
-    let reverse_topo_order: Vec<u32> = (num_inputs..num_neurons).rev().map(|i| i as u32).collect();
-    let expected = (0..num_outputs).map(|_| rng.next_signed()).collect();
-
-    BackpropData {
-        neurons,
-        synapses,
-        inward_starts,
-        inward_counts,
-        inward_indices,
-        reverse_topo_order,
-        expected,
-        input_count: num_inputs as u32,
-        output_count: num_outputs as u32,
-    }
-}
-
-fn make_neuron(squash: SquashType, neuron_type: u8, adjusted_activation: f32) -> NeuronInput {
-    NeuronInput {
-        squash_type: squash as u8,
-        neuron_type,
-        propagate_needed: true,
-        update_needed: true,
-        hint_value: 0.0,
-        range_low: -1.0e6,
-        range_high: 1.0e6,
-        adjusted_activation,
-        adjusted_bias: 0.0,
-    }
-}
-
 /// Backprop — one `propagate_topological_loop` step on representative sizes.
 fn bench_backprop(c: &mut Criterion) {
     let mut group = c.benchmark_group("backprop");
-    for (label, num_neurons, num_inputs, num_outputs, fan_in) in NETWORKS {
-        let data = build_backprop_data(num_neurons, num_inputs, num_outputs, fan_in, 0x1357_9BDF);
-        group.throughput(Throughput::Elements(num_neurons as u64));
-        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+    for spec in &NETWORKS {
+        let data = build_backprop_data(spec, 0x1357_9BDF);
+        group.throughput(Throughput::Elements(spec.num_neurons as u64));
+        group.bench_function(BenchmarkId::from_parameter(spec.label), |b| {
             b.iter(|| {
                 let input = PropagateInput {
                     neurons: &data.neurons,

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -22,6 +22,7 @@ use neat_core::simd::{
     weighted_sum_simd_4records, weighted_sum_simd_8records,
 };
 use neat_core::squash::{SquashType, apply_squash};
+use neat_core::squash_simd::squash_x4;
 use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
 use neat_core::unsquash::apply_unsquash;
 
@@ -265,6 +266,42 @@ fn bench_activation_primitives(c: &mut Criterion) {
         );
     }
     squash_group.finish();
+
+    // Lane-parallel squash (Issue #180): vectorised 4-lane approximation versus
+    // four scalar `apply_squash` calls, for the hot transcendental squashes.
+    let mut squash4_group = c.benchmark_group("squash_x4");
+    let lanes = [0.42_f32, -1.3, 2.7, -0.05];
+    for squash_type in [
+        SquashType::Tanh,
+        SquashType::Logistic,
+        SquashType::Gelu,
+        SquashType::Mish,
+    ] {
+        let label = format!("{squash_type:?}");
+        squash4_group.bench_with_input(
+            BenchmarkId::new("scalar_x4", label.clone()),
+            &squash_type,
+            |b, &st| {
+                b.iter(|| {
+                    let x = black_box(lanes);
+                    black_box([
+                        apply_squash(st, x[0]),
+                        apply_squash(st, x[1]),
+                        apply_squash(st, x[2]),
+                        apply_squash(st, x[3]),
+                    ])
+                });
+            },
+        );
+        squash4_group.bench_with_input(
+            BenchmarkId::new("simd_x4", label),
+            &squash_type,
+            |b, &st| {
+                b.iter(|| black_box(squash_x4(black_box(st), black_box(lanes))));
+            },
+        );
+    }
+    squash4_group.finish();
 }
 
 criterion_group!(

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -155,9 +155,8 @@ fn bench_activation_primitives(c: &mut Criterion) {
     let synapses: Vec<SynapseData> = (0..synapse_count)
         .map(|i| SynapseData {
             weight: rng.next_signed(),
-            from_index: i as u32,
+            from_index: i as u16,
             synapse_type: 0,
-            _padding: [0; 3],
         })
         .collect();
     let activations: Vec<f32> = (0..synapse_count).map(|_| rng.next_signed()).collect();

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -1,0 +1,104 @@
+//! Criterion harness for data-parallel record scoring (Issue #179).
+//!
+//! Reports throughput (records/sec) for scoring a batch of records through one
+//! creature on a single core versus all available cores, demonstrating the
+//! per-core scaling that is the throughput lever for the "data" half of #175.
+//!
+//! Opt-in only — requires the `parallel` feature (rayon, native targets):
+//!
+//! ```text
+//! cargo bench -p neat-core --features parallel --bench parallel_scoring
+//! ```
+//!
+//! Without the feature the bench's `main` is a no-op shim so the target still
+//! builds under `cargo build --all-targets` on every configuration. The
+//! deterministic fixtures are shared with the `hot_paths` harness and the
+//! `bench_fixtures` test via `benches/common/mod.rs`.
+
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+#[path = "common/mod.rs"]
+#[allow(dead_code)] // shared fixture module; this bench uses only a subset
+mod common;
+
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+mod bench {
+    use super::common::{NETWORKS, NetSpec, build_inputs, build_network};
+    use criterion::{Criterion, Throughput, criterion_group};
+    use neat_core::network::CompiledNetwork;
+    use rayon::ThreadPoolBuilder;
+    use std::hint::black_box;
+
+    fn spec(label: &str) -> &'static NetSpec {
+        NETWORKS
+            .iter()
+            .find(|s| s.label == label)
+            .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+    }
+
+    fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+        (0..count)
+            .map(|i| build_inputs(net.num_inputs(), 0x5C0E_0000 + i as u64))
+            .collect()
+    }
+
+    /// Score `records` inside a rayon pool of exactly `threads` workers, so the
+    /// 1-core and all-core measurements share one code path and differ only in
+    /// pool size.
+    fn score_in_pool(
+        net: &CompiledNetwork,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        threads: usize,
+    ) -> Vec<Vec<f32>> {
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .expect("failed to build rayon pool");
+        pool.install(|| net.score_records_parallel(records, num_outputs))
+    }
+
+    pub fn bench_parallel_scoring(c: &mut Criterion) {
+        let all_cores = std::thread::available_parallelism().map_or(1, |n| n.get());
+        const NUM_RECORDS: usize = 2048;
+
+        for label in ["production", "production_2x"] {
+            let s = spec(label);
+            let net = build_network(s, 0x5EED);
+            let records = build_records(&net, NUM_RECORDS);
+            let num_outputs = s.num_outputs;
+
+            let mut group = c.benchmark_group(format!("score_records/{label}"));
+            group.throughput(Throughput::Elements(NUM_RECORDS as u64));
+
+            group.bench_function("1_core", |b| {
+                b.iter(|| black_box(score_in_pool(&net, black_box(&records), num_outputs, 1)))
+            });
+
+            group.bench_function(format!("{all_cores}_cores"), |b| {
+                b.iter(|| {
+                    black_box(score_in_pool(
+                        &net,
+                        black_box(&records),
+                        num_outputs,
+                        all_cores,
+                    ))
+                })
+            });
+
+            group.finish();
+        }
+    }
+
+    criterion_group!(benches, bench_parallel_scoring);
+}
+
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+criterion::criterion_main!(bench::benches);
+
+#[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+fn main() {
+    eprintln!(
+        "parallel_scoring bench is a no-op without `--features parallel` (native only); \
+         run: cargo bench -p neat-core --features parallel --bench parallel_scoring"
+    );
+}

--- a/neat-core/examples/bench_single_record_weighted_sums.rs
+++ b/neat-core/examples/bench_single_record_weighted_sums.rs
@@ -19,12 +19,11 @@ use neat_core::simd::{
 };
 use std::time::Instant;
 
-fn make_synapse(from_index: u32, weight: f32) -> SynapseData {
+fn make_synapse(from_index: u16, weight: f32) -> SynapseData {
     SynapseData {
         weight,
         from_index,
         synapse_type: 0,
-        _padding: [0; 3],
     }
 }
 
@@ -40,7 +39,7 @@ fn main() {
         .map(|i| ((i as f32) * 0.137).sin())
         .collect();
     let synapses: Vec<SynapseData> = (0..num_synapses)
-        .map(|i| make_synapse((i % num_inputs) as u32, ((i as f32) * 0.0731).cos()))
+        .map(|i| make_synapse((i % num_inputs) as u16, ((i as f32) * 0.0731).cos()))
         .collect();
 
     // `black_box` the slices and bias on every call so the optimiser cannot hoist

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -27,7 +27,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::network::{CompiledNetwork, NeuronData, SynapseData};
+use crate::network::{CompiledNetwork, MAX_NODE_COUNT, NeuronData, SynapseData};
 use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
 
@@ -105,6 +105,14 @@ pub enum CreatureError {
         /// Number of neurons of type `"output"` actually present.
         found: usize,
     },
+    /// The creature declares more nodes than the `u16` source-index field can address.
+    ///
+    /// Issue #177 - mirrors [`crate::network::NetworkError::TooManyNodes`]; a creature
+    /// may contain at most [`crate::network::MAX_NODE_COUNT`] nodes.
+    TooManyNodes {
+        /// The node count that exceeded [`crate::network::MAX_NODE_COUNT`].
+        count: usize,
+    },
 }
 
 impl std::fmt::Display for CreatureError {
@@ -117,6 +125,14 @@ impl std::fmt::Display for CreatureError {
             }
             CreatureError::OutputCountMismatch { expected, found } => {
                 write!(f, "Expected {expected} output neurons, found {found}")
+            }
+            CreatureError::TooManyNodes { count } => {
+                write!(
+                    f,
+                    "Creature has {count} nodes, exceeding the maximum of {} \
+                     addressable by a u16 source index",
+                    crate::network::MAX_NODE_COUNT
+                )
             }
         }
     }
@@ -327,6 +343,13 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, Cr
 
     let num_neurons = num_inputs + creature.neurons.len();
 
+    // Issue #177 - source indices are stored as u16 in SynapseData, so reject
+    // creatures whose node count would overflow the index space rather than
+    // silently truncating `from_index` during compilation.
+    if num_neurons > MAX_NODE_COUNT {
+        return Err(CreatureError::TooManyNodes { count: num_neurons });
+    }
+
     // Group synapses by destination neuron UUID for ordered construction
     let mut synapses_by_target: HashMap<&str, Vec<&SynapseExport>> = HashMap::new();
     for synapse in &creature.synapses {
@@ -358,9 +381,10 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, Cr
 
                 synapses.push(SynapseData {
                     weight: syn.weight as f32,
-                    from_index: from_index as u32,
+                    // Issue #177 - source indices are u16; the node-count guard above
+                    // guarantees every index fits, so this cast cannot truncate.
+                    from_index: from_index as u16,
                     synapse_type: synapse_type as u8,
-                    _padding: [0; 3],
                 });
                 num_synapses += 1;
             }

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod error;
 pub mod fused_error;
 pub mod loss;
 pub mod network;
+pub mod parallel_scoring;
 pub mod pc_inference;
 pub mod pc_learning;
 pub mod propagate_codec;

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod safe_zone;
 pub mod score_scan;
 pub mod simd;
 pub mod squash;
+pub mod squash_simd;
 pub mod synapse_type;
 pub mod topological_backprop;
 pub mod topology_export;

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -10,6 +10,7 @@ use crate::network::CompiledNetwork;
 use crate::range::apply_limit_range;
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
 use crate::squash::{SquashType, apply_squash};
+use crate::squash_simd::{squash_x4, squash_x8};
 use crate::synapse_type::SynapseType;
 
 #[cfg(target_arch = "wasm32")]
@@ -206,24 +207,35 @@ macro_rules! batch_8way_activation {
                                     neuron.bias,
                                 );
 
-                            let apply_squash_inline = |sum: f32| -> f32 {
-                                match neuron.squash_type {
-                                    0 => sum,
-                                    1 => sum.max(0.0),
-                                    6 => 1.0 / (1.0 + (-sum).exp()),
-                                    7 => sum.tanh(),
-                                    _ => apply_squash(squash, sum),
+                            // Hot transcendental squashes evaluate all 8 batch
+                            // lanes at once via the vectorised approximation
+                            // (Issue #180); other types keep the scalar inline
+                            // squash so their numerics are unchanged.
+                            let sums = [sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7];
+                            let squashed = match squash_x8(squash, sums) {
+                                Some(vec) => vec,
+                                None => {
+                                    let apply_squash_inline = |sum: f32| -> f32 {
+                                        match neuron.squash_type {
+                                            0 => sum,
+                                            1 => sum.max(0.0),
+                                            6 => 1.0 / (1.0 + (-sum).exp()),
+                                            7 => sum.tanh(),
+                                            _ => apply_squash(squash, sum),
+                                        }
+                                    };
+                                    sums.map(apply_squash_inline)
                                 }
                             };
 
-                            act0[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum0));
-                            act1[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum1));
-                            act2[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum2));
-                            act3[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum3));
-                            act4[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum4));
-                            act5[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum5));
-                            act6[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum6));
-                            act7[actual_idx] = apply_limit_range(squash, apply_squash_inline(sum7));
+                            act0[actual_idx] = apply_limit_range(squash, squashed[0]);
+                            act1[actual_idx] = apply_limit_range(squash, squashed[1]);
+                            act2[actual_idx] = apply_limit_range(squash, squashed[2]);
+                            act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                            act4[actual_idx] = apply_limit_range(squash, squashed[4]);
+                            act5[actual_idx] = apply_limit_range(squash, squashed[5]);
+                            act6[actual_idx] = apply_limit_range(squash, squashed[6]);
+                            act7[actual_idx] = apply_limit_range(squash, squashed[7]);
                         }
                     }
                 }
@@ -403,24 +415,29 @@ macro_rules! batch_8way_activation {
                                     neuron.bias,
                                 );
 
-                                let apply_squash_inline = |sum: f32| -> f32 {
-                                    match neuron.squash_type {
-                                        0 => sum,
-                                        1 => sum.max(0.0),
-                                        6 => 1.0 / (1.0 + (-sum).exp()),
-                                        7 => sum.tanh(),
-                                        _ => apply_squash(squash, sum),
+                                // Vectorised squash for the hot transcendental
+                                // types (Issue #180); scalar fallback otherwise.
+                                let sums = [sum0, sum1, sum2, sum3];
+                                let squashed = match squash_x4(squash, sums) {
+                                    Some(vec) => vec,
+                                    None => {
+                                        let apply_squash_inline = |sum: f32| -> f32 {
+                                            match neuron.squash_type {
+                                                0 => sum,
+                                                1 => sum.max(0.0),
+                                                6 => 1.0 / (1.0 + (-sum).exp()),
+                                                7 => sum.tanh(),
+                                                _ => apply_squash(squash, sum),
+                                            }
+                                        };
+                                        sums.map(apply_squash_inline)
                                     }
                                 };
 
-                                act0[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum0));
-                                act1[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum1));
-                                act2[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum2));
-                                act3[actual_idx] =
-                                    apply_limit_range(squash, apply_squash_inline(sum3));
+                                act0[actual_idx] = apply_limit_range(squash, squashed[0]);
+                                act1[actual_idx] = apply_limit_range(squash, squashed[1]);
+                                act2[actual_idx] = apply_limit_range(squash, squashed[2]);
+                                act3[actual_idx] = apply_limit_range(squash, squashed[3]);
                             }
                         }
                     }

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -31,6 +31,16 @@ pub enum NetworkError {
         /// The section that could not be read in full ("header", "neuron", or "synapse").
         section: &'static str,
     },
+    /// The network declares more nodes than the `u16` source-index field can address.
+    ///
+    /// Issue #177 - `SynapseData::from_index` is a `u16`, so every node index must
+    /// fit in `0..=u16::MAX`. A network may therefore contain at most
+    /// [`MAX_NODE_COUNT`] nodes; loading a larger one is rejected here rather than
+    /// silently truncating source indices.
+    TooManyNodes {
+        /// The declared node count that exceeded [`MAX_NODE_COUNT`].
+        count: usize,
+    },
 }
 
 impl std::fmt::Display for NetworkError {
@@ -38,6 +48,13 @@ impl std::fmt::Display for NetworkError {
         match self {
             NetworkError::TruncatedData { section } => {
                 write!(f, "Data too short for {section}")
+            }
+            NetworkError::TooManyNodes { count } => {
+                write!(
+                    f,
+                    "Network has {count} nodes, exceeding the maximum of {MAX_NODE_COUNT} \
+                     addressable by a u16 source index"
+                )
             }
         }
     }
@@ -71,19 +88,32 @@ pub struct NeuronData {
     pub is_constant: bool,
 }
 
+/// Maximum number of nodes a [`CompiledNetwork`] may contain.
+///
+/// Issue #177 - [`SynapseData::from_index`] is a `u16`, so the largest source-node
+/// index is `u16::MAX` (65535) and a network may hold at most `u16::MAX + 1`
+/// (65536) nodes. Networks exceeding this are rejected at load time with
+/// [`NetworkError::TooManyNodes`] rather than silently truncating indices.
+pub const MAX_NODE_COUNT: usize = u16::MAX as usize + 1;
+
 /// Synapse data structure for cache-efficient access
 /// Issue #1175 - Use typed structs instead of tuples for neuron/synapse data
+///
+/// Issue #177 - Narrowed `from_index` from `u32` to `u16` and dropped the explicit
+/// padding so the struct is **8 bytes** instead of 12 (33% less memory streamed
+/// per forward pass). `repr(C)` lays this out as `weight` (4) + `from_index` (2) +
+/// `synapse_type` (1) + 1 trailing pad byte = 8, keeping 4-byte alignment for the
+/// SIMD weight loads. The on-wire format already stores `from_index` as a `u16`,
+/// so no precision is lost; see [`MAX_NODE_COUNT`] for the enforced node ceiling.
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SynapseData {
     /// Weight of the synapse
     pub weight: f32,
-    /// Index of the source neuron
-    pub from_index: u32,
+    /// Index of the source neuron (≤ `u16::MAX`; see [`MAX_NODE_COUNT`])
+    pub from_index: u16,
     /// Synapse type (for IF activation)
     pub synapse_type: u8,
-    /// Padding for alignment
-    pub _padding: [u8; 3],
 }
 
 /// Compiled network data structure
@@ -186,6 +216,13 @@ impl CompiledNetwork {
 
         let num_neurons = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
         let num_inputs = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
+
+        // Issue #177 - source indices are u16, so reject networks whose node count
+        // would overflow the index space before reading any synapses.
+        if num_neurons > MAX_NODE_COUNT {
+            return Err(NetworkError::TooManyNodes { count: num_neurons });
+        }
+
         let num_non_inputs = num_neurons - num_inputs;
 
         let mut neurons = Vec::with_capacity(num_non_inputs);
@@ -221,7 +258,7 @@ impl CompiledNetwork {
                     return Err(NetworkError::TruncatedData { section: "synapse" });
                 }
 
-                let from_index = u16::from_le_bytes([data[offset], data[offset + 1]]) as u32;
+                let from_index = u16::from_le_bytes([data[offset], data[offset + 1]]);
                 let synapse_type = data[offset + 2];
                 // offset + 3 is padding
                 let weight = f64::from_le_bytes([
@@ -240,7 +277,6 @@ impl CompiledNetwork {
                     weight: weight as f32,
                     from_index,
                     synapse_type,
-                    _padding: [0; 3],
                 });
             }
 
@@ -1722,21 +1758,19 @@ mod tests {
         }
     }
 
-    fn make_synapse(from_index: u32, weight: f32) -> SynapseData {
+    fn make_synapse(from_index: u16, weight: f32) -> SynapseData {
         SynapseData {
             weight,
             from_index,
             synapse_type: 0,
-            _padding: [0; 3],
         }
     }
 
-    fn make_synapse_typed(from_index: u32, weight: f32, synapse_type: u8) -> SynapseData {
+    fn make_synapse_typed(from_index: u16, weight: f32, synapse_type: u8) -> SynapseData {
         SynapseData {
             weight,
             from_index,
             synapse_type,
-            _padding: [0; 3],
         }
     }
 
@@ -2061,5 +2095,77 @@ mod tests {
 
         let batch_records = split_batch_records(&batch_result);
         assert_records_match(&single_results, &batch_records);
+    }
+
+    // ---- Issue #177: SynapseData footprint + node-count invariant ----
+
+    /// Serialise a minimal one-non-input-neuron, one-synapse network into the
+    /// on-wire format understood by [`CompiledNetwork::new`]. `from_index` is
+    /// written as the `u16` the format already uses, so the round-trip exercises
+    /// the loader directly.
+    fn serialise_single_synapse_network(
+        num_neurons: u32,
+        num_inputs: u32,
+        from_index: u16,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&num_neurons.to_le_bytes());
+        bytes.extend_from_slice(&num_inputs.to_le_bytes());
+        // Exactly one non-input neuron (callers pass num_neurons - num_inputs == 1).
+        bytes.extend_from_slice(&0.0f64.to_le_bytes()); // bias
+        bytes.push(SquashType::Identity as u8); // squash_type
+        bytes.push(0); // is_constant
+        bytes.extend_from_slice(&1u16.to_le_bytes()); // num_synapses
+        // One synapse referencing `from_index`.
+        bytes.extend_from_slice(&from_index.to_le_bytes()); // from_index (u16)
+        bytes.push(0); // synapse_type
+        bytes.push(0); // padding byte
+        bytes.extend_from_slice(&1.0f64.to_le_bytes()); // weight
+        bytes
+    }
+
+    #[test]
+    fn synapse_data_is_eight_bytes() {
+        // Issue #177 - narrowing from_index to u16 + dropping padding must land the
+        // struct at 8 bytes so the forward pass streams 33% less per synapse.
+        assert_eq!(std::mem::size_of::<SynapseData>(), 8);
+        // Alignment stays 4 so SIMD weight loads remain aligned.
+        assert_eq!(std::mem::align_of::<SynapseData>(), 4);
+    }
+
+    #[test]
+    fn new_rejects_networks_exceeding_max_node_count() {
+        // A header declaring more than MAX_NODE_COUNT nodes must fail fast with a
+        // clear TooManyNodes error rather than silently truncating source indices.
+        let too_many = (MAX_NODE_COUNT + 1) as u32;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&too_many.to_le_bytes()); // num_neurons
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // num_inputs
+
+        match CompiledNetwork::new(&bytes) {
+            Err(NetworkError::TooManyNodes { count }) => assert_eq!(count, MAX_NODE_COUNT + 1),
+            Err(other) => panic!("expected TooManyNodes, got {other:?}"),
+            Ok(_) => panic!("expected TooManyNodes error, network loaded"),
+        }
+    }
+
+    #[test]
+    fn new_accepts_max_node_count_boundary() {
+        // Exactly MAX_NODE_COUNT nodes is the largest network the u16 index allows.
+        let bytes =
+            serialise_single_synapse_network(MAX_NODE_COUNT as u32, (MAX_NODE_COUNT - 1) as u32, 0);
+        let net = CompiledNetwork::new(&bytes).expect("boundary node count must load");
+        assert_eq!(net.num_neurons, MAX_NODE_COUNT);
+    }
+
+    #[test]
+    fn new_preserves_high_source_index() {
+        // A high source index (close to u16::MAX) must round-trip without truncation,
+        // proving the narrowed u16 field still addresses the full node range.
+        let high = 64_000u16;
+        let bytes = serialise_single_synapse_network(65_000, 64_999, high);
+        let net = CompiledNetwork::new(&bytes).expect("network must load");
+        assert_eq!(net.synapses.len(), 1);
+        assert_eq!(net.synapses[0].from_index, high);
     }
 }

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -14,6 +14,7 @@ use crate::simd::{
     weighted_sum_simd, weighted_sum_simd_4records,
 };
 use crate::squash::{SquashType, apply_squash};
+use crate::squash_simd::squash_x4;
 use crate::synapse_type::SynapseType;
 
 #[cfg(target_arch = "wasm32")]
@@ -1133,11 +1134,20 @@ impl CompiledNetwork {
                             neuron.bias,
                         );
 
-                        // Apply squash to all 4 records
-                        let sq0 = Self::apply_inline_squash(neuron.squash_type, squash, s0);
-                        let sq1 = Self::apply_inline_squash(neuron.squash_type, squash, s1);
-                        let sq2 = Self::apply_inline_squash(neuron.squash_type, squash, s2);
-                        let sq3 = Self::apply_inline_squash(neuron.squash_type, squash, s3);
+                        // Apply squash to all 4 records. The hot transcendental
+                        // squashes (Tanh/Logistic/Gelu/Mish) evaluate every batch
+                        // lane at once via the vectorised approximation (Issue
+                        // #180); all other types keep the scalar inline squash so
+                        // their numerics are unchanged.
+                        let [sq0, sq1, sq2, sq3] = match squash_x4(squash, [s0, s1, s2, s3]) {
+                            Some(vec) => vec,
+                            None => [
+                                Self::apply_inline_squash(neuron.squash_type, squash, s0),
+                                Self::apply_inline_squash(neuron.squash_type, squash, s1),
+                                Self::apply_inline_squash(neuron.squash_type, squash, s2),
+                                Self::apply_inline_squash(neuron.squash_type, squash, s3),
+                            ],
+                        };
 
                         let a0 = apply_limit_range(squash, sq0);
                         let a1 = apply_limit_range(squash, sq1);

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -1,0 +1,97 @@
+//! Data-parallel record scoring (Issue #179).
+//!
+//! Scoring a production-size dataset pushes many records through one large
+//! creature — an embarrassingly parallel workload *across records*. The
+//! per-record forward path ([`CompiledNetwork::activate`]) is single-threaded,
+//! so on a multi-core host most of the machine sits idle. This module adds an
+//! opt-in, native-only parallel scoring path that chunks records across the
+//! `rayon` thread pool.
+//!
+//! # Feature gating
+//!
+//! The parallel path is gated `#[cfg(all(feature = "parallel", not(target_arch
+//! = "wasm32")))]`. `rayon` is declared as a `cfg(not(wasm32))` optional
+//! dependency, so:
+//!
+//! - the **default** build pulls in no `rayon` symbols (feature off), and
+//! - the **`wasm32`** build is completely unaffected — it keeps the existing
+//!   single-thread behaviour even if the feature is requested.
+//!
+//! When the feature is off (or on wasm), [`CompiledNetwork::score_records_parallel`]
+//! transparently falls back to the sequential [`CompiledNetwork::score_records`].
+//!
+//! # Determinism
+//!
+//! Results are **identical** to the sequential path regardless of thread count:
+//!
+//! - Every record is scored by the same [`CompiledNetwork::activate`] call used
+//!   sequentially. `activate` overwrites every non-input activation each call,
+//!   so there is no cross-record state.
+//! - No `&mut self` is shared across threads. `CompiledNetwork` is `Clone`, and
+//!   the clone carries the per-call scratch buffers (`activations`,
+//!   `hint_values_buffer`, the 4-way batch buffers). The immutable weights are
+//!   read through `&self`; each rayon worker initialises **its own** cloned
+//!   scratch context via `map_init` and owns its buffers for the duration.
+//! - Output order matches input order — `par_iter().map(...).collect()`
+//!   preserves indexed order.
+
+use crate::network::CompiledNetwork;
+
+impl CompiledNetwork {
+    /// Score every record sequentially, returning one output vector per record.
+    ///
+    /// Shared read-only weights (`&self`) plus a single owned scratch context
+    /// (one clone of the network). This is the fallback used when the `parallel`
+    /// feature is off or when building for `wasm32`, and the reference path the
+    /// parallel results must match exactly.
+    ///
+    /// Each record is scored with [`CompiledNetwork::activate`]; the first
+    /// `num_outputs` … (`num_neurons - num_outputs ..`) activations are returned.
+    pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+        let mut scratch = self.clone();
+        records
+            .iter()
+            .map(|record| scratch.activate(record, num_outputs))
+            .collect()
+    }
+
+    /// Score every record across the `rayon` thread pool, returning one output
+    /// vector per record in input order.
+    ///
+    /// Each rayon worker initialises its own cloned scratch context via
+    /// `map_init`, so no `&mut self` is shared across threads: immutable weights
+    /// are read through `&self` while every worker owns its activation buffers.
+    /// Because each record is scored by the same [`CompiledNetwork::activate`]
+    /// used by [`CompiledNetwork::score_records`] and there is no cross-record
+    /// state, the results are identical to the sequential path.
+    ///
+    /// Available with the `parallel` feature on native targets.
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    pub fn score_records_parallel(
+        &self,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+    ) -> Vec<Vec<f32>> {
+        use rayon::prelude::*;
+        records
+            .par_iter()
+            .map_init(
+                || self.clone(),
+                |scratch, record| scratch.activate(record, num_outputs),
+            )
+            .collect()
+    }
+
+    /// Sequential fallback for [`CompiledNetwork::score_records_parallel`] when
+    /// the `parallel` feature is disabled or building for `wasm32` (where
+    /// `rayon` is unavailable). Same signature and identical results to the
+    /// feature-on path — just single-threaded.
+    #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+    pub fn score_records_parallel(
+        &self,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+    ) -> Vec<Vec<f32>> {
+        self.score_records(records, num_outputs)
+    }
+}

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -875,12 +875,11 @@ mod tests {
     use super::*;
     use crate::network::SynapseData;
 
-    fn synapse(from: u32, weight: f32) -> SynapseData {
+    fn synapse(from: u16, weight: f32) -> SynapseData {
         SynapseData {
             weight,
             from_index: from,
             synapse_type: 0,
-            _padding: [0; 3],
         }
     }
 

--- a/neat-core/src/squash_simd.rs
+++ b/neat-core/src/squash_simd.rs
@@ -1,0 +1,316 @@
+//! Lane-parallel (SIMD-friendly) approximations of the transcendental-heavy
+//! squash functions used by the batched activation paths (Issue #180).
+//!
+//! ## Why
+//!
+//! The batched activation paths (`activate_and_trace_batch_4way` in
+//! [`crate::network`] and the 8-record loss path in [`crate::loss`]) compute one
+//! pre-activation **per record** with the SIMD weighted-sum kernels, but then
+//! apply the squash **per record with the scalar `apply_squash`**. For the hot
+//! transcendental squashes (`Tanh`, `Logistic`, `Gelu`, `Mish`) that scalar
+//! `libm` call dominates the per-neuron cost on the wide/shallow production
+//! creature (~1673 non-input neurons, ~13 average fan-in).
+//!
+//! Because a batch already holds 4 (or 8) records' pre-activations contiguously,
+//! the squash is a natural fit for a lane-parallel evaluation. The functions here
+//! are written **branchlessly over fixed-size arrays** so LLVM auto-vectorises
+//! the per-lane loop (SSE/AVX/FMA on `x86_64`, NEON on `aarch64`, `simd128` on
+//! `wasm32`) without hand-written platform intrinsics.
+//!
+//! ## Accuracy
+//!
+//! Every vectorised type is bounded within [`SQUASH_SIMD_MAX_ABS_ERR`] of the
+//! scalar [`apply_squash`](crate::squash::apply_squash) across the finite input range (asserted by the range
+//! tests below). Squash types **without** a vectorised implementation return
+//! `None` from [`squash_x4`] / [`squash_x8`] so the caller falls back to the
+//! scalar path, leaving their numerics unchanged. The scalar `apply_squash`
+//! remains the single source of truth for correctness.
+
+use crate::squash::{GELU_COEFF, SQRT_2_OVER_PI, SquashType};
+
+/// Documented maximum absolute error of the vectorised squashes versus the
+/// scalar [`apply_squash`](crate::squash::apply_squash) over the finite input range. Chosen tighter than the
+/// `1e-5` tolerance the batch parity tests already assert, so the vectorised
+/// path is a safe drop-in for the hot transcendental squashes.
+pub const SQUASH_SIMD_MAX_ABS_ERR: f32 = 5.0e-6;
+
+/// Branchless single-lane `tanh` approximation (rational minimax, valid after
+/// clamping to `±C`). Accurate to a few `1e-7` over the whole finite range; the
+/// odd symmetry and saturation to `±1` are preserved exactly. Kept `#[inline]`
+/// and branchless so the array wrappers auto-vectorise.
+#[inline(always)]
+fn tanh_approx(x: f32) -> f32 {
+    // Beyond ±C, tanh is ±1 to well within f32 precision; clamping keeps the
+    // rational polynomial in its valid range.
+    const C: f32 = 7.999_882;
+    let x = x.clamp(-C, C);
+    let x2 = x * x;
+
+    // Numerator: odd polynomial p(x) = x * (a1 + x2*(a3 + ... + x2*a13)).
+    let mut p = -2.760_768_5e-16;
+    p = p * x2 + 2.000_188e-13;
+    p = p * x2 + -8.604_672e-11;
+    p = p * x2 + 5.122_297e-8;
+    p = p * x2 + 1.485_722_4e-5;
+    p = p * x2 + 6.372_619_4e-4;
+    p = p * x2 + 4.893_524_6e-3;
+    p *= x;
+
+    // Denominator: even polynomial q(x) = b0 + x2*(b2 + x2*(b4 + x2*b6)).
+    let mut q = 1.198_258_4e-6;
+    q = q * x2 + 1.185_347e-4;
+    q = q * x2 + 2.268_434_6e-3;
+    q = q * x2 + 4.893_525e-3;
+
+    p / q
+}
+
+/// Branchless single-lane `exp` approximation (Cephes `expf` reduction). Used to
+/// build `Logistic` and `Mish`. Accurate to ~1 ULP; the argument is clamped to a
+/// finite window so `2^n` reconstruction never overflows to a NaN.
+#[inline(always)]
+fn exp_approx(x: f32) -> f32 {
+    // Clamp to the representable exp window (exp(88.7) ≈ f32::MAX).
+    const HI: f32 = 88.722_84;
+    const LO: f32 = -87.336_55;
+    let x = x.clamp(LO, HI);
+
+    const C1: f32 = 0.693_359_4; // ln2 high
+    const C2: f32 = -2.121_944_4e-4; // ln2 low
+
+    // n = round(x / ln2); reduce x into [-ln2/2, ln2/2].
+    let fx = (x * core::f32::consts::LOG2_E + 0.5).floor();
+    let xr = x - fx * C1 - fx * C2;
+    let z = xr * xr;
+
+    // Degree-5 minimax polynomial for exp on the reduced range.
+    let mut y = 1.987_569_1e-4;
+    y = y * xr + 1.398_199_9e-3;
+    y = y * xr + 8.333_452e-3;
+    y = y * xr + 4.166_579_6e-2;
+    y = y * xr + 1.666_666_5e-1;
+    y = y * xr + 5e-1;
+    y = y * z + xr + 1.0;
+
+    // Reconstruct 2^n by direct exponent-bits assembly (branchless ldexp).
+    let n = fx as i32;
+    let pow2n = f32::from_bits(((n + 127) as u32) << 23);
+    y * pow2n
+}
+
+/// `tanh` over a lane array.
+#[inline]
+fn tanh_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = tanh_approx(x[i]);
+    }
+    out
+}
+
+/// `Logistic` (sigmoid) over a lane array: `1 / (1 + exp(-x))`.
+#[inline]
+fn logistic_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = 1.0 / (1.0 + exp_approx(-x[i]));
+    }
+    out
+}
+
+/// `Gelu` (tanh approximation) over a lane array, matching the scalar formula
+/// `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 x^3)))`.
+#[inline]
+fn gelu_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        let inner = SQRT_2_OVER_PI * (v + GELU_COEFF * v * v * v);
+        out[i] = 0.5 * v * (1.0 + tanh_approx(inner));
+    }
+    out
+}
+
+/// `Mish` over a lane array.
+///
+/// Uses the closed-form identity `mish(x) = x * tanh(softplus(x))` rewritten
+/// purely in terms of `w = exp(x)`:
+///
+/// ```text
+/// tanh(softplus(x)) = w(w + 2) / (w(w + 2) + 2)
+/// ```
+///
+/// so only a single `exp` per lane is needed (no separate `ln`/`tanh`). The exp
+/// argument is clamped at `20` for the ratio only — beyond that the ratio is
+/// `1.0` to f32 precision and `mish(x) → x` — which keeps `w^2` finite and avoids
+/// an `inf/inf` NaN while leaving the outer `x` factor exact.
+#[inline]
+fn mish_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        let w = exp_approx(v.min(20.0));
+        let t = w * (w + 2.0);
+        out[i] = v * (t / (t + 2.0));
+    }
+    out
+}
+
+/// Vectorised squash dispatch over `N` lanes.
+///
+/// Returns `Some([..])` for the hot transcendental squashes that have a
+/// lane-parallel approximation within [`SQUASH_SIMD_MAX_ABS_ERR`] of scalar
+/// [`apply_squash`](crate::squash::apply_squash); returns `None` for every other type so the caller keeps the
+/// existing scalar path (unchanged numerics).
+#[inline]
+fn squash_lanes<const N: usize>(squash: SquashType, x: [f32; N]) -> Option<[f32; N]> {
+    match squash {
+        SquashType::Tanh => Some(tanh_lanes(x)),
+        SquashType::Logistic => Some(logistic_lanes(x)),
+        SquashType::Gelu => Some(gelu_lanes(x)),
+        SquashType::Mish => Some(mish_lanes(x)),
+        _ => None,
+    }
+}
+
+/// Vectorised squash for a 4-record batch lane. See `squash_lanes`.
+#[inline]
+pub fn squash_x4(squash: SquashType, x: [f32; 4]) -> Option<[f32; 4]> {
+    squash_lanes(squash, x)
+}
+
+/// Vectorised squash for an 8-record batch lane. See `squash_lanes`.
+#[inline]
+pub fn squash_x8(squash: SquashType, x: [f32; 8]) -> Option<[f32; 8]> {
+    squash_lanes(squash, x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::squash::apply_squash;
+
+    /// Squash types with a vectorised implementation, and the others which must
+    /// opt out (so the caller falls back to scalar with unchanged numerics).
+    const VECTORISED: [SquashType; 4] = [
+        SquashType::Tanh,
+        SquashType::Logistic,
+        SquashType::Gelu,
+        SquashType::Mish,
+    ];
+
+    /// Max absolute error of a vectorised squash versus scalar `apply_squash`
+    /// across a fine sweep of the finite input range.
+    fn max_abs_err(squash: SquashType, lo: f32, hi: f32, steps: usize) -> f32 {
+        let mut worst = 0.0_f32;
+        for k in 0..=steps {
+            let x = lo + (hi - lo) * (k as f32) / (steps as f32);
+            let want = apply_squash(squash, x);
+            let got = squash_x4(squash, [x, x, x, x]).unwrap()[0];
+            worst = worst.max((want - got).abs());
+        }
+        worst
+    }
+
+    #[test]
+    fn tanh_within_tolerance_over_range() {
+        let err = max_abs_err(SquashType::Tanh, -20.0, 20.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "tanh max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn logistic_within_tolerance_over_range() {
+        let err = max_abs_err(SquashType::Logistic, -40.0, 40.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "logistic max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn gelu_within_tolerance_over_range() {
+        // Gelu grows like x, so compare on a bounded window where the activation
+        // is used in practice; the relative shape is captured by abs error here.
+        let err = max_abs_err(SquashType::Gelu, -10.0, 10.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "gelu max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn mish_within_tolerance_over_range() {
+        let err = max_abs_err(SquashType::Mish, -20.0, 20.0, 40_000);
+        assert!(
+            err <= SQUASH_SIMD_MAX_ABS_ERR,
+            "mish max abs err {err} exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+        );
+    }
+
+    #[test]
+    fn all_four_lanes_match_scalar() {
+        // The same value in every lane must reproduce the scalar result; distinct
+        // values per lane must each match their own scalar squash.
+        let xs = [-1.3_f32, 0.0, 0.42, 2.7];
+        for squash in VECTORISED {
+            let got = squash_x4(squash, xs).unwrap();
+            for (lane, &x) in xs.iter().enumerate() {
+                let want = apply_squash(squash, x);
+                assert!(
+                    (want - got[lane]).abs() <= SQUASH_SIMD_MAX_ABS_ERR,
+                    "{squash:?} lane {lane}: want {want}, got {}",
+                    got[lane]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn x8_matches_x4() {
+        let xs = [-3.0_f32, -0.5, 0.0, 0.25, 0.9, 1.5, 4.0, -2.2];
+        for squash in VECTORISED {
+            let got = squash_x8(squash, xs).unwrap();
+            for (lane, &x) in xs.iter().enumerate() {
+                let want = apply_squash(squash, x);
+                assert!(
+                    (want - got[lane]).abs() <= SQUASH_SIMD_MAX_ABS_ERR,
+                    "{squash:?} lane {lane}: want {want}, got {}",
+                    got[lane]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn non_vectorised_types_opt_out() {
+        // A representative spread of non-transcendental / specially-handled types
+        // must return None so the caller keeps the scalar numerics.
+        for squash in [
+            SquashType::Identity,
+            SquashType::Relu,
+            SquashType::Sine,
+            SquashType::Gaussian,
+            SquashType::Softplus,
+            SquashType::Minimum,
+        ] {
+            assert!(
+                squash_x4(squash, [0.1, 0.2, 0.3, 0.4]).is_none(),
+                "{squash:?} must fall back to scalar"
+            );
+        }
+    }
+
+    #[test]
+    fn extreme_inputs_are_finite() {
+        // Saturating / overflow-prone inputs must not produce NaN/Inf.
+        for squash in VECTORISED {
+            for &x in &[-1e6_f32, -100.0, 100.0, 1e6, 0.0] {
+                let got = squash_x4(squash, [x, x, x, x]).unwrap()[0];
+                assert!(got.is_finite(), "{squash:?}({x}) = {got} not finite");
+            }
+        }
+    }
+}

--- a/neat-core/src/topology_export.rs
+++ b/neat-core/src/topology_export.rs
@@ -216,7 +216,8 @@ pub fn to_topology_json(network: &CompiledNetwork, num_outputs: usize) -> String
         for synapse in &network.synapses[start..end] {
             let synapse_type = SynapseType::from(synapse.synapse_type);
             synapses.push(SynapseRecord {
-                from: synapse.from_index,
+                // Issue #177 - from_index narrowed to u16; widen for the export record.
+                from: synapse.from_index as u32,
                 to: to_index,
                 weight: synapse.weight,
                 synapse_type: synapse_type_name(synapse_type),

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -1,0 +1,134 @@
+//! Behavioural tests for the deterministic fixtures behind the `hot_paths`
+//! Criterion harness (Issue #176). The builders live in `benches/common/mod.rs`
+//! and are reused here verbatim via `#[path]`, so the production-scale shape is
+//! validated by a real `cargo test` run rather than only compiled in the bench.
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{FanIn, NETWORKS, NetSpec, build_backprop_data, build_inputs, build_network};
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+#[test]
+fn production_shapes_are_registered_with_expected_dimensions() {
+    let prod = spec("production");
+    assert_eq!(prod.num_inputs, 2461);
+    assert_eq!(prod.num_outputs, 1);
+    assert_eq!(prod.num_non_inputs(), 1673);
+    assert_eq!(prod.num_neurons, 4134);
+
+    let prod2x = spec("production_2x");
+    // "or larger creatures": ~2x neurons.
+    assert!(
+        prod2x.num_non_inputs() >= 2 * prod.num_non_inputs(),
+        "production_2x should have at least double the non-input neurons"
+    );
+    assert!(prod2x.num_inputs >= prod.num_inputs);
+}
+
+#[test]
+fn build_network_matches_production_neuron_and_synapse_counts() {
+    let prod = spec("production");
+    let net = build_network(prod, 0x5152_5354);
+
+    // One NeuronData per non-input neuron; total count includes the input layer.
+    assert_eq!(net.neurons.len(), prod.num_non_inputs());
+    assert_eq!(net.num_neurons, prod.num_neurons);
+    assert_eq!(net.num_inputs, prod.num_inputs);
+
+    // Sparse ~13 average fan-in ⇒ roughly 21.7k synapses for the real creature.
+    let total_synapses = net.synapses.len();
+    let avg_fan_in = total_synapses as f64 / prod.num_non_inputs() as f64;
+    assert!(
+        (12.0..=14.0).contains(&avg_fan_in),
+        "average fan-in {avg_fan_in} should sit near the production ~13"
+    );
+
+    // num_synapses on each neuron must sum to the flat synapse buffer length.
+    let summed: usize = net.neurons.iter().map(|n| n.num_synapses as usize).sum();
+    assert_eq!(summed, total_synapses);
+}
+
+#[test]
+fn varied_fan_in_actually_varies_unlike_fixed_shapes() {
+    // The wide/shallow production shape must draw a non-constant fan-in.
+    let prod = spec("production");
+    let net = build_network(prod, 0x5152_5354);
+    let distinct: std::collections::BTreeSet<u16> =
+        net.neurons.iter().map(|n| n.num_synapses).collect();
+    assert!(
+        distinct.len() > 1,
+        "production fan-in should vary, saw only {distinct:?}"
+    );
+
+    // A fixed-shape network keeps a single fan-in (away from the early cap).
+    let small = spec("small_50");
+    if let FanIn::Fixed(f) = small.fan_in {
+        let net = build_network(small, 0x5152_5354);
+        let tail = &net.neurons[small.num_inputs..];
+        assert!(
+            tail.iter().all(|n| n.num_synapses as usize == f),
+            "fixed shapes should keep a constant fan-in past the early ramp"
+        );
+    }
+}
+
+#[test]
+fn build_network_is_deterministic_for_a_fixed_seed() {
+    let prod = spec("production");
+    let a = build_network(prod, 0x5152_5354);
+    let b = build_network(prod, 0x5152_5354);
+
+    assert_eq!(a.synapses.len(), b.synapses.len());
+    assert!(
+        a.synapses
+            .iter()
+            .zip(&b.synapses)
+            .all(|(x, y)| x.weight == y.weight && x.from_index == y.from_index),
+        "same seed must reproduce identical synapses"
+    );
+    assert!(
+        a.neurons
+            .iter()
+            .zip(&b.neurons)
+            .all(|(x, y)| x.bias == y.bias && x.num_synapses == y.num_synapses),
+        "same seed must reproduce identical neurons"
+    );
+}
+
+#[test]
+fn production_network_activates_to_finite_outputs() {
+    let prod = spec("production");
+    let mut net = build_network(prod, 0x5152_5354);
+    let inputs = build_inputs(prod.num_inputs, 0xA1B2_C3D4);
+
+    let out = net.activate(&inputs, prod.num_outputs);
+    assert_eq!(out.len(), prod.num_outputs);
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "production forward pass must produce finite outputs"
+    );
+}
+
+#[test]
+fn backprop_data_has_consistent_inward_adjacency_at_production_scale() {
+    let prod = spec("production");
+    let data = build_backprop_data(prod, 0x1357_9BDF);
+
+    assert_eq!(data.neurons.len(), prod.num_neurons);
+    assert_eq!(data.input_count as usize, prod.num_inputs);
+    assert_eq!(data.output_count as usize, prod.num_outputs);
+    assert_eq!(data.reverse_topo_order.len(), prod.num_non_inputs());
+
+    // Inward counts must sum to the flat synapse buffer and index list length.
+    let summed: usize = data.inward_counts.iter().map(|&c| c as usize).sum();
+    assert_eq!(summed, data.synapses.len());
+    assert_eq!(summed, data.inward_indices.len());
+}

--- a/neat-core/tests/creature_compile.rs
+++ b/neat-core/tests/creature_compile.rs
@@ -676,3 +676,37 @@ fn test_compile_creature_deprecated_squash() {
         );
     }
 }
+
+/// Issue #177 - `SynapseData::from_index` is a u16, so a creature whose node count
+/// exceeds `MAX_NODE_COUNT` must be rejected at compile time rather than silently
+/// truncating source indices.
+#[test]
+fn compile_creature_rejects_too_many_nodes() {
+    use neat_core::network::MAX_NODE_COUNT;
+    use neat_core::{CreatureError, CreatureExport, NeuronExport};
+
+    // One node over the limit, all hidden so the output count stays 0.
+    let neurons = (0..=MAX_NODE_COUNT)
+        .map(|i| NeuronExport {
+            neuron_type: "hidden".to_string(),
+            uuid: format!("n{i}"),
+            bias: 0.0,
+            squash: None,
+        })
+        .collect();
+
+    let creature = CreatureExport {
+        input: 0,
+        output: 0,
+        neurons,
+        synapses: Vec::new(),
+        semantic_version: None,
+        forward_only: false,
+    };
+
+    match compile_creature(&creature) {
+        Err(CreatureError::TooManyNodes { count }) => assert_eq!(count, MAX_NODE_COUNT + 1),
+        Err(other) => panic!("expected TooManyNodes, got {other:?}"),
+        Ok(_) => panic!("expected TooManyNodes error, creature compiled"),
+    }
+}

--- a/neat-core/tests/network_activate_trace_batch.rs
+++ b/neat-core/tests/network_activate_trace_batch.rs
@@ -41,21 +41,19 @@ fn make_network(
     }
 }
 
-fn make_synapse(from_index: u32, weight: f32) -> SynapseData {
+fn make_synapse(from_index: u16, weight: f32) -> SynapseData {
     SynapseData {
         weight,
         from_index,
         synapse_type: 0,
-        _padding: [0; 3],
     }
 }
 
-fn make_synapse_typed(from_index: u32, weight: f32, synapse_type: u8) -> SynapseData {
+fn make_synapse_typed(from_index: u16, weight: f32, synapse_type: u8) -> SynapseData {
     SynapseData {
         weight,
         from_index,
         synapse_type,
-        _padding: [0; 3],
     }
 }
 

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -1,0 +1,128 @@
+//! Behavioural tests for data-parallel record scoring (Issue #179).
+//!
+//! These assert on observable outcomes — the returned output vectors — rather
+//! than on threading mechanics. They run in both feature modes: with the
+//! `parallel` feature off, `score_records_parallel` is the sequential fallback;
+//! with `--features parallel` (as `quality.sh` runs via `--all-features`), the
+//! same assertions exercise the rayon path. Either way the contract is the same:
+//! results identical to the sequential reference, in input order.
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{NETWORKS, NetSpec, build_inputs, build_network};
+use neat_core::network::CompiledNetwork;
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+/// Build `count` distinct input records sized to the network's input layer.
+fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| build_inputs(net.num_inputs(), 0x51A7_0000 + i as u64))
+        .collect()
+}
+
+/// Independent sequential reference: a fresh scratch clone scored one record at
+/// a time. Deliberately does not call `score_records`, so the parity assertion
+/// does not assume the two share an implementation.
+fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+    let mut scratch = net.clone();
+    records
+        .iter()
+        .map(|r| scratch.activate(r, num_outputs))
+        .collect()
+}
+
+#[test]
+fn parallel_scoring_matches_sequential_on_production_fixture() {
+    let s = spec("production");
+    let net = build_network(s, 0xC0FFEE);
+    let records = build_records(&net, 257); // not a multiple of any core count
+
+    let expected = reference(&net, &records, s.num_outputs);
+    let actual = net.score_records_parallel(&records, s.num_outputs);
+
+    assert_eq!(actual.len(), records.len());
+    assert_eq!(actual, expected, "parallel results must equal sequential");
+}
+
+#[test]
+fn parallel_scoring_matches_sequential_across_shapes() {
+    for label in ["small_50", "medium_500", "production", "production_2x"] {
+        let s = spec(label);
+        let net = build_network(s, 0xABCD_1234);
+        let records = build_records(&net, 128);
+
+        let expected = reference(&net, &records, s.num_outputs);
+        let actual = net.score_records_parallel(&records, s.num_outputs);
+
+        assert_eq!(actual, expected, "mismatch for shape {label}");
+    }
+}
+
+#[test]
+fn score_records_matches_reference() {
+    let s = spec("medium_500");
+    let net = build_network(s, 0x1357);
+    let records = build_records(&net, 64);
+
+    let expected = reference(&net, &records, s.num_outputs);
+    assert_eq!(net.score_records(&records, s.num_outputs), expected);
+}
+
+#[test]
+fn output_order_is_preserved() {
+    let s = spec("small_50");
+    let net = build_network(s, 0x2468);
+    let records = build_records(&net, 200);
+
+    // Each record is distinct, so a re-ordered result would not match the
+    // index-aligned reference.
+    let expected = reference(&net, &records, s.num_outputs);
+    let actual = net.score_records_parallel(&records, s.num_outputs);
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(a, e, "record {i} out of order or incorrect");
+    }
+}
+
+#[test]
+fn each_output_has_num_outputs_elements() {
+    let s = spec("medium_500");
+    let net = build_network(s, 0x99);
+    let records = build_records(&net, 16);
+
+    let out = net.score_records_parallel(&records, s.num_outputs);
+    assert_eq!(out.len(), 16);
+    for row in &out {
+        assert_eq!(row.len(), s.num_outputs);
+    }
+}
+
+#[test]
+fn empty_records_yields_empty_output() {
+    let s = spec("small_50");
+    let net = build_network(s, 0x7);
+    let empty: Vec<Vec<f32>> = Vec::new();
+
+    assert!(net.score_records_parallel(&empty, s.num_outputs).is_empty());
+    assert!(net.score_records(&empty, s.num_outputs).is_empty());
+}
+
+#[test]
+fn single_record_matches_direct_activate() {
+    let s = spec("production");
+    let net = build_network(s, 0x42);
+    let record = build_inputs(net.num_inputs(), 0xDEAD);
+
+    let mut scratch = net.clone();
+    let direct = scratch.activate(&record, s.num_outputs);
+    let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
+
+    assert_eq!(via_parallel, vec![direct]);
+}

--- a/neat-core/tests/simd_weighted_sums.rs
+++ b/neat-core/tests/simd_weighted_sums.rs
@@ -7,12 +7,11 @@ use neat_core::simd::{
 };
 
 /// Helper to create test synapse data
-fn make_synapse(from_index: u32, weight: f32) -> SynapseData {
+fn make_synapse(from_index: u16, weight: f32) -> SynapseData {
     SynapseData {
         weight,
         from_index,
         synapse_type: 0,
-        _padding: [0; 3],
     }
 }
 
@@ -319,7 +318,7 @@ fn simd_and_scalar_agree_across_counts() {
 
     for count in 0..=40usize {
         let synapses: Vec<SynapseData> = (0..count)
-            .map(|i| make_synapse((i % num_inputs) as u32, ((i as f32) * 0.13).cos()))
+            .map(|i| make_synapse((i % num_inputs) as u16, ((i as f32) * 0.13).cos()))
             .collect();
         let end = synapses.len();
 
@@ -363,7 +362,7 @@ fn simd_and_scalar_agree_with_offset() {
     // and a tail remains at the end.
     let activations: Vec<f32> = (0..7).map(|i| (i as f32) * 0.5 - 1.0).collect();
     let synapses: Vec<SynapseData> = (0..30)
-        .map(|i| make_synapse((i % 7) as u32, ((i as f32) * 0.21).sin()))
+        .map(|i| make_synapse((i % 7) as u16, ((i as f32) * 0.21).sin()))
         .collect();
     let bias = -0.7f32;
 


### PR DESCRIPTION
## Milestone: #175 Please suggest performance improvements for production size creatures/data

This PR merges the completed milestone branch into Develop.
Closes #185

### Issues addressed
- #180: [perf] Vectorize the activation (squash) function across batched records
- #179: [perf] Add native, feature-gated data-parallel record scoring (rayon) for production datasets
- #178: [perf] Widen weight-stationary batching from 4-way to 8-way in activate_and_trace_batch
- #177: [perf] Shrink SynapseData (12->8 bytes): narrow from_index to u16 / split to SoA to cut forward-pass memory bandwidth
- #176: [perf] Add a production-scale (wide/shallow) creature fixture to the hot_paths benchmark harness

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.