### PR TITLE
feat(release): signal breaking changes via semver bump + git tags/releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
           tool: cargo-edit,cargo-outdated
 
       - name: Bump crate version (if needed) and upgrade dependencies
+        # PR_BREAKING_LABEL is the boolean result of a controlled GitHub
+        # expression (not user text), so it is safe to read from the env.
+        env:
+          PR_BREAKING_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: |
           set -euo pipefail
           BASE_BRANCH="Develop"
@@ -90,11 +94,27 @@ jobs:
           if [ "$SKIP_VERSION_BUMP" = false ]; then
             CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
             echo "Current crate version: $CURRENT_VERSION"
-            IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-            major=${major:-0}
-            minor=${minor:-0}
-            patch=${patch:-0}
-            NEW_VERSION="$major.$minor.$((patch + 1))"
+
+            # Issue #251: a breaking change is a major-equivalent bump (pre-1.0:
+            # minor), a non-breaking change a patch bump. Detect the breaking
+            # signal from the `breaking-change` PR label or Conventional Commit
+            # markers (`type!:` subject, or a `BREAKING CHANGE:` footer).
+            BREAKING=false
+            if [ "${PR_BREAKING_LABEL:-false}" = "true" ]; then
+              BREAKING=true
+            fi
+            if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
+              RANGE="origin/$BASE_BRANCH..HEAD"
+            else
+              RANGE="HEAD"
+            fi
+            chmod +x scripts/detect-breaking.sh scripts/next-version.sh
+            if [ "$(scripts/detect-breaking.sh "$RANGE")" = "true" ]; then
+              BREAKING=true
+            fi
+            echo "Breaking change signalled: $BREAKING"
+
+            NEW_VERSION=$(scripts/next-version.sh "$CURRENT_VERSION" "$BREAKING")
             echo "Bumping crate version to: $NEW_VERSION"
             ESCAPED_CURRENT=$(printf '%s' "$CURRENT_VERSION" | sed 's/[\/.^$*+?()[\]{}|]/\\&/g')
             sed -i.bak "s/^version = \"$ESCAPED_CURRENT\"/version = \"$NEW_VERSION\"/" Cargo.toml
@@ -117,6 +137,55 @@ jobs:
             git commit -m "chore: auto-increment versions for changed projects"
             git push origin "$HEAD_REF"
           fi
+
+  # Issue #251 — fail a PR whose breaking change ships on a patch-only bump.
+  # Runs after version-increment so it validates the final (post auto-bump)
+  # version. Keys off the same breaking signal: the `breaking-change` label or
+  # a Conventional Commit marker in the PR's commits.
+  version-gate:
+    name: Breaking-change version gate
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: [version-increment]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Enforce breaking ⇒ major-equivalent bump
+        env:
+          PR_BREAKING_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: |
+          set -euo pipefail
+          BASE_BRANCH="Develop"
+          if ! git show-ref --verify --quiet refs/remotes/origin/Develop; then
+            BASE_BRANCH="develop"
+          fi
+          git fetch origin "$BASE_BRANCH:$BASE_BRANCH" 2>/dev/null || true
+
+          BASE_VERSION=$(git show "origin/$BASE_BRANCH:Cargo.toml" 2>/dev/null | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/' || echo "")
+          HEAD_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ -z "$BASE_VERSION" ]; then
+            echo "Could not read base version — skipping gate."
+            exit 0
+          fi
+
+          BREAKING=false
+          if [ "${PR_BREAKING_LABEL:-false}" = "true" ]; then
+            BREAKING=true
+          fi
+          chmod +x scripts/detect-breaking.sh scripts/check-version-bump.sh
+          if [ "$(scripts/detect-breaking.sh "origin/$BASE_BRANCH..HEAD")" = "true" ]; then
+            BREAKING=true
+          fi
+          echo "base=$BASE_VERSION head=$HEAD_VERSION breaking=$BREAKING"
+          scripts/check-version-bump.sh "$BASE_VERSION" "$HEAD_VERSION" "$BREAKING"
 
   auto-format:
     name: Auto-format Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+# Issue #251 — cut a semver git tag + GitHub release whenever the workspace
+# version changes on Develop, so downstream consumers (e.g. NEAT-AI-scorer) can
+# discover breaking changes through semantic versioning. This is independent of
+# the per-commit `wasm-bundle-<sha>` artifacts published by wasm-bundle.yml:
+# those address commits by SHA, these address releases by `v<major.minor.patch>`.
+
+name: Release (semver tag)
+
+on:
+  push:
+    branches: [Develop]
+    paths:
+      - "Cargo.toml"
+
+permissions:
+  contents: write # required to push the tag and create the release
+
+jobs:
+  release:
+    name: Tag and release on version bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Cut tag + release if the version is new
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Could not read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          echo "Workspace version: $VERSION (tag $TAG)"
+
+          # git tags are immutable identifiers; if this version was already
+          # released, there is nothing to do. Idempotent across re-runs.
+          if git ls-remote --tags --exit-code origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — nothing to release."
+            exit 0
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists — nothing to do."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --notes "Automated semver release for workspace version ${VERSION}. See RELEASING.md for the versioning policy (breaking ⇒ major-equivalent, i.e. minor pre-1.0). Decoupled from the wasm-bundle-<sha> artifacts."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,5 @@ Name tests after the behaviour or outcome (e.g. `relu_maps_negative_to_zero`), n
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).
+- **Versioning/release policy:** see **`RELEASING.md`** (Issue #251). A **breaking** change is a **major-equivalent** bump (pre-1.0: **minor**, `0.1.x → 0.2.0`); non-breaking is **patch**. Signal a break with the **`breaking-change`** PR label or a Conventional Commit `type!:` / `BREAKING CHANGE:` marker. The `version-increment` job bumps minor on a break; the `version-gate` job **fails** a break shipped on a patch-only bump; `release.yml` cuts a **`v<version>`** tag + GitHub release on `Develop`, decoupled from `wasm-bundle-<sha>`.
 - **`clippy::uninlined_format_args`** is not denied in CI until the test corpus is cleaned up; workspace lints still deny **`filter_next`** / **`collapsible_if`**.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.1.46"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ members = ["neat-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.46"
+# Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
+# (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
+# major-equivalent (minor) bump. See RELEASING.md.
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 |------|------|
 | `neat-core/` | Shared computation library; **140+** unit tests in `src/**/*.rs` plus integration tests in `neat-core/tests/` (>350 total). |
 | `Cargo.toml` | Virtual workspace root; `[workspace.package]` holds semver for release automation. |
+| `RELEASING.md` | Versioning/release policy (Issue #251): breaking ⇒ major-equivalent (minor pre-1.0) bump, non-breaking ⇒ patch; `v<version>` tags + releases on `Develop`. |
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
 | `neat-core/benches/` | Opt-in Criterion harnesses: `hot_paths` (core hot paths) and `parallel_scoring` (data-parallel scoring, needs `--features parallel`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,113 @@
+# Releasing NEAT-AI-core
+
+This document defines how `neat-core` is versioned and released so that
+downstream consumers (notably
+[NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer), which tracks
+the `neat-core` path dependency at head) can **discover breaking changes through
+semantic versioning** rather than being broken silently (Issue #251, part of the
+release-process redesign epic #248).
+
+## Versioning policy
+
+`neat-core` follows [Semantic Versioning](https://semver.org/). The single
+source of truth is `[workspace.package].version` in the root `Cargo.toml`; the
+`neat-core` crate inherits it via `version.workspace = true`.
+
+The repository is **pre-1.0**, so the *major-equivalent* slot is the **minor**:
+
+| Change kind  | Bump (pre-1.0)        | Bump (post-1.0) | Example                    |
+|--------------|-----------------------|-----------------|----------------------------|
+| Breaking     | minor (`0.1.x → 0.2.0`) | major (`1.x → 2.0.0`) | public type narrowing |
+| Non-breaking | patch (`0.1.4 → 0.1.5`) | patch           | new additive API, perf fix |
+
+A **breaking change is a major-equivalent bump**; everything else is a patch.
+
+### What counts as breaking
+
+A change is breaking if it can stop a downstream consumer that compiled and ran
+against the previous version from compiling or behaving correctly, for example:
+
+- Narrowing or changing a **public type**, including struct field types — e.g.
+  `SynapseData::from_index` changing from `u32` to `u16` (neat-core #177, the
+  change that motivated this policy).
+- Changing a **public function/method signature**, return type, or trait bound.
+- **Removing or renaming** any public item (function, type, field, module,
+  feature flag).
+- Changing the **serialised layout** or wire/binary format of data shared with
+  consumers (e.g. the `.bin` training-stream format).
+- Changing documented runtime **behaviour** in a way callers may rely on.
+
+Additive, backwards-compatible changes (new public items, internal refactors,
+performance work that preserves behaviour, doc fixes) are **non-breaking** and
+bump the patch.
+
+## How a version bump happens
+
+Bumping is automated by the `version-increment` job in
+`.github/workflows/ci.yml`, which runs on every pull request:
+
+- By default it bumps the **patch**.
+- When a **breaking signal** is present it bumps the **minor** (pre-1.0) instead,
+  via `scripts/next-version.sh`.
+
+### Signalling a breaking change
+
+Signal a breaking change in **either** of these ways:
+
+- Add the **`breaking-change` label** to the pull request; **or**
+- Use a [Conventional Commit](https://www.conventionalcommits.org/) breaking
+  marker in any commit on the PR — a `type!:` / `type(scope)!:` subject (e.g.
+  `perf(network)!: narrow from_index to u16`) or a `BREAKING CHANGE:` footer.
+
+`scripts/detect-breaking.sh` reads the commit markers; the label is read from the
+PR metadata. Either signal triggers the major-equivalent bump.
+
+## Enforcement: breaking cannot ship on a patch-only bump
+
+The `version-gate` job in `.github/workflows/ci.yml` is a **required check** that
+fails the PR if a breaking change is shipping on a patch-only (or no) bump. It
+compares the base-branch version against the head version using
+`scripts/check-version-bump.sh`:
+
+- a **breaking** PR must increase the minor (pre-1.0) or major (post-1.0);
+- a downgrade is always rejected;
+- a non-breaking PR may bump the patch (over-bumping is allowed).
+
+These scripts are pure and unit-tested under `tests/scripts/`
+(`next_version.bats`, `check_version_bump.bats`, `detect_breaking.bats`), so the
+policy logic is verified independently of CI.
+
+## Tags and GitHub releases
+
+On every push to `Develop`, the `release` job in `.github/workflows/release.yml`
+reads the workspace version and, if no `v<major.minor.patch>` tag/release exists
+yet, cuts a **git tag + GitHub release** named `v<version>` (e.g. `v0.2.0`). It is
+idempotent and **decoupled from the per-commit `wasm-bundle-<sha>` artifacts**:
+
+- `wasm-bundle-<sha>` releases address **commits by SHA** (immutable bundles).
+- `v<version>` releases address **versions** so consumers can pin and compare
+  semver and react to breaking bumps.
+
+## Retroactive decision for #177
+
+neat-core #177 (`SynapseData::from_index` `u32 → u16`) was breaking but shipped on
+patch bumps (`0.1.43 → 0.1.46`) with no signal, silently breaking the scorer. The
+decision is to **retro-bump**, not apply the policy forward-only: this PR sets the
+workspace version to **`0.2.0`** so the current breaking state is reflected by a
+`0.2.0`-class version, and the `release` workflow will cut `v0.2.0` on merge to
+`Develop`. The #177 `u16` narrowing itself is **not** reverted.
+
+## Release flow
+
+```mermaid
+flowchart TD
+    A[Open PR against Develop] --> B{Breaking signal?<br/>label or commit marker}
+    B -- "yes" --> C[version-increment:<br/>bump minor pre-1.0]
+    B -- "no" --> D[version-increment:<br/>bump patch]
+    C --> E[version-gate:<br/>check-version-bump.sh]
+    D --> E
+    E -- "breaking on patch-only" --> F[CI fails]
+    E -- "ok" --> G[Merge to Develop]
+    G --> H[release.yml:<br/>cut v&lt;version&gt; tag + GitHub release]
+    H --> I[Downstream discovers the bump]
+```

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# check-version-bump.sh — enforce the NEAT-AI-core breaking-change semver gate.
+#
+# Usage: check-version-bump.sh <base_version> <head_version> <is_breaking:true|false>
+#
+# Ensures a *breaking* change cannot ship on a patch-only bump (Issue #251):
+#   * a downgrade (head < base) is always rejected;
+#   * a breaking change requires a major-equivalent bump — pre-1.0 the MINOR
+#     must increase (0.1.x -> 0.2.0), post-1.0 the MAJOR must increase;
+#   * a non-breaking change only needs head >= base (over-bumping is allowed).
+#
+# Exits 0 when the bump satisfies the policy, non-zero (with a message) otherwise.
+set -euo pipefail
+
+die() {
+  echo "check-version-bump.sh: $1" >&2
+  exit 1
+}
+
+[ "$#" -eq 3 ] || die "usage: check-version-bump.sh <base_version> <head_version> <is_breaking:true|false>"
+
+base="${1#v}"
+head="${2#v}"
+breaking="$3"
+
+case "$breaking" in
+  true | false) ;;
+  *) die "is_breaking must be 'true' or 'false', got: $breaking" ;;
+esac
+
+for v in "$base" "$head"; do
+  if ! printf '%s' "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    die "malformed version (expected x.y.z): $v"
+  fi
+done
+
+IFS='.' read -r b_major b_minor b_patch <<<"$base"
+IFS='.' read -r h_major h_minor h_patch <<<"$head"
+
+# Numeric comparison helper: echoes -1, 0 or 1 for a<=>b on the (major,minor,patch) tuples.
+cmp_triple() {
+  local am=$1 an=$2 ap=$3 bm=$4 bn=$5 bp=$6
+  if [ "$am" -ne "$bm" ]; then [ "$am" -gt "$bm" ] && echo 1 || echo -1; return; fi
+  if [ "$an" -ne "$bn" ]; then [ "$an" -gt "$bn" ] && echo 1 || echo -1; return; fi
+  if [ "$ap" -ne "$bp" ]; then [ "$ap" -gt "$bp" ] && echo 1 || echo -1; return; fi
+  echo 0
+}
+
+order=$(cmp_triple "$h_major" "$h_minor" "$h_patch" "$b_major" "$b_minor" "$b_patch")
+
+if [ "$order" -lt 0 ]; then
+  die "version downgraded: $base -> $head"
+fi
+
+if [ "$breaking" = "true" ]; then
+  # Major-equivalent bump. Pre-1.0 (base major 0) the minor (or a move to >=1.0)
+  # must increase; post-1.0 the major must increase.
+  if [ "$b_major" -eq 0 ]; then
+    if [ "$h_major" -eq 0 ] && [ "$h_minor" -eq "$b_minor" ]; then
+      die "breaking change requires a major-equivalent bump (pre-1.0: minor), but $base -> $head is only a patch-level (or no) bump"
+    fi
+  else
+    if [ "$h_major" -eq "$b_major" ]; then
+      die "breaking change requires a major-equivalent bump (post-1.0: major), but $base -> $head does not increase the major"
+    fi
+  fi
+fi
+
+echo "check-version-bump.sh: OK ($base -> $head, breaking=$breaking)"

--- a/scripts/detect-breaking.sh
+++ b/scripts/detect-breaking.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# detect-breaking.sh — detect a breaking-change signal in a git commit range.
+#
+# Usage: detect-breaking.sh <git-range>
+#
+# Echoes "true" when any commit in <git-range> carries a Conventional Commit
+# breaking marker — a `type!:` / `type(scope)!:` subject, or a
+# `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer — otherwise "false".
+# (The CI jobs additionally OR in the `breaking-change` PR label.) See Issue #251.
+set -euo pipefail
+
+[ "$#" -eq 1 ] || {
+  echo "usage: detect-breaking.sh <git-range>" >&2
+  exit 2
+}
+range="$1"
+
+if git log --format='%s' "$range" | grep -Eq '^[a-zA-Z]+(\([^)]*\))?!:'; then
+  echo true
+  exit 0
+fi
+if git log --format='%B' "$range" | grep -Eq '(^|[[:space:]])BREAKING[ -]CHANGE:'; then
+  echo true
+  exit 0
+fi
+echo false

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# next-version.sh — compute the next semver per the NEAT-AI-core release policy.
+#
+# Usage: next-version.sh <current_version> <is_breaking:true|false>
+#
+# Policy (see RELEASING.md, Issue #251):
+#   * breaking change  -> major-equivalent bump
+#                         pre-1.0 (major == 0): bump MINOR, reset patch
+#                         post-1.0:             bump MAJOR, reset minor+patch
+#   * non-breaking     -> bump PATCH
+#
+# Prints the next version to stdout. Exits non-zero on bad input.
+set -euo pipefail
+
+die() {
+  echo "next-version.sh: $1" >&2
+  exit 1
+}
+
+[ "$#" -eq 2 ] || die "usage: next-version.sh <current_version> <is_breaking:true|false>"
+
+current="${1#v}" # tolerate a leading v
+breaking="$2"
+
+case "$breaking" in
+  true | false) ;;
+  *) die "is_breaking must be 'true' or 'false', got: $breaking" ;;
+esac
+
+# Strict x.y.z (digits only); reject pre-release/build metadata for clarity.
+if ! printf '%s' "$current" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  die "malformed version (expected x.y.z): $current"
+fi
+
+IFS='.' read -r major minor patch <<<"$current"
+
+if [ "$breaking" = "true" ]; then
+  if [ "$major" -eq 0 ]; then
+    minor=$((minor + 1))
+    patch=0
+  else
+    major=$((major + 1))
+    minor=0
+    patch=0
+  fi
+else
+  patch=$((patch + 1))
+fi
+
+echo "${major}.${minor}.${patch}"

--- a/tests/scripts/check_version_bump.bats
+++ b/tests/scripts/check_version_bump.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-version-bump.sh (Issue #251).
+#
+# The gate that ensures a *breaking* change cannot ship on a patch-only bump.
+# It compares the base-branch version against the head version and the breaking
+# signal, exiting non-zero when the bump is too small for a breaking change or
+# when the version was downgraded.
+#
+# These are "what" tests: they run the real script and assert on its exit code.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SCRIPT="${REPO_ROOT}/scripts/check-version-bump.sh"
+}
+
+@test "breaking change with a minor bump passes (pre-1.0)" {
+  run "$SCRIPT" "0.1.46" "0.2.0" true
+  [ "$status" -eq 0 ]
+}
+
+@test "breaking change with only a patch bump fails (pre-1.0)" {
+  run "$SCRIPT" "0.1.46" "0.1.47" true
+  [ "$status" -ne 0 ]
+}
+
+@test "breaking change with no version change fails" {
+  run "$SCRIPT" "0.1.46" "0.1.46" true
+  [ "$status" -ne 0 ]
+}
+
+@test "breaking change with a major bump passes (post-1.0)" {
+  run "$SCRIPT" "1.4.2" "2.0.0" true
+  [ "$status" -eq 0 ]
+}
+
+@test "breaking change with only a minor bump fails (post-1.0)" {
+  run "$SCRIPT" "1.4.2" "1.5.0" true
+  [ "$status" -ne 0 ]
+}
+
+@test "non-breaking change with a patch bump passes" {
+  run "$SCRIPT" "0.1.46" "0.1.47" false
+  [ "$status" -eq 0 ]
+}
+
+@test "non-breaking change with a minor bump passes (over-bumping is allowed)" {
+  run "$SCRIPT" "0.1.46" "0.2.0" false
+  [ "$status" -eq 0 ]
+}
+
+@test "non-breaking change with no version change passes" {
+  run "$SCRIPT" "0.1.46" "0.1.46" false
+  [ "$status" -eq 0 ]
+}
+
+@test "a downgrade is always rejected" {
+  run "$SCRIPT" "0.2.0" "0.1.47" false
+  [ "$status" -ne 0 ]
+}
+
+@test "a leading v is tolerated on both versions" {
+  run "$SCRIPT" "v0.1.46" "v0.2.0" true
+  [ "$status" -eq 0 ]
+}
+
+@test "missing arguments are rejected" {
+  run "$SCRIPT" "0.1.46" "0.2.0"
+  [ "$status" -ne 0 ]
+}
+
+@test "a malformed version is rejected" {
+  run "$SCRIPT" "0.1" "0.2.0" true
+  [ "$status" -ne 0 ]
+}

--- a/tests/scripts/detect_breaking.bats
+++ b/tests/scripts/detect_breaking.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Tests for scripts/detect-breaking.sh (Issue #251).
+#
+# These are "what" tests: they build a throwaway git history and assert on the
+# true/false the script prints for the commit range.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SCRIPT="${REPO_ROOT}/scripts/detect-breaking.sh"
+  WORK="$(mktemp -d)"
+  cd "$WORK"
+  git init -q
+  git config user.email "t@example.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "chore: base commit"
+  BASE="$(git rev-parse HEAD)"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+@test "plain non-breaking commits report false" {
+  git commit -q --allow-empty -m "feat: add a knob"
+  git commit -q --allow-empty -m "fix: correct a typo"
+  run "$SCRIPT" "${BASE}..HEAD"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "a type!: subject marker reports true" {
+  git commit -q --allow-empty -m "perf(network)!: narrow from_index u32 -> u16"
+  run "$SCRIPT" "${BASE}..HEAD"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "a BREAKING CHANGE footer reports true" {
+  printf 'feat: rework api\n\nBREAKING CHANGE: SynapseData layout changed\n' >msg.txt
+  git commit -q --allow-empty -F msg.txt
+  run "$SCRIPT" "${BASE}..HEAD"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "missing range argument is rejected" {
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/tests/scripts/next_version.bats
+++ b/tests/scripts/next_version.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for scripts/next-version.sh (Issue #251 — semver breaking-change signal).
+#
+# Policy (pre-1.0): a breaking change is a *major-equivalent* bump, which
+# pre-1.0 means the MINOR (0.1.x -> 0.2.0); a non-breaking change bumps the
+# PATCH (0.1.x -> 0.1.(x+1)). Post-1.0 a breaking change bumps the MAJOR.
+#
+# These are "what" tests: they run the real script and assert on the version
+# string it prints, not on its source text.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SCRIPT="${REPO_ROOT}/scripts/next-version.sh"
+}
+
+@test "non-breaking change bumps the patch (pre-1.0)" {
+  run "$SCRIPT" "0.1.46" false
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.47" ]
+}
+
+@test "breaking change bumps the minor pre-1.0 and resets patch" {
+  run "$SCRIPT" "0.1.46" true
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.2.0" ]
+}
+
+@test "breaking change bumps the major post-1.0 and resets minor+patch" {
+  run "$SCRIPT" "1.4.2" true
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.0.0" ]
+}
+
+@test "non-breaking change bumps the patch post-1.0" {
+  run "$SCRIPT" "1.4.2" false
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.4.3" ]
+}
+
+@test "a leading v on the input is tolerated" {
+  run "$SCRIPT" "v0.1.46" false
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.47" ]
+}
+
+@test "missing arguments are rejected" {
+  run "$SCRIPT" "0.1.46"
+  [ "$status" -ne 0 ]
+}
+
+@test "a malformed version is rejected" {
+  run "$SCRIPT" "1.2" false
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

neat-core gave **no signal** for breaking changes: it has no semver tags (only `wasm-bundle-<sha>`), and its CI auto-bumped the **patch** on every PR. So the **#177** breaking change (`SynapseData::from_index` `u32 → u16`) shipped as `0.1.43 → 0.1.46` and silently broke the downstream scorer.

This PR makes neat-core signal breaking changes through semantic versioning.

Companion to **stSoftwareAU/NEAT-AI-scorer#251** (part of epic stSoftwareAU/NEAT-AI-scorer#248).

## Changes

- **`RELEASING.md`** — versioning/release policy: breaking ⇒ major-equivalent bump (pre-1.0: **minor**, `0.1.x → 0.2.0`), non-breaking ⇒ **patch**. Documents what counts as breaking, how to signal it, enforcement, and the retro decision.
- **`scripts/next-version.sh`**, **`scripts/check-version-bump.sh`**, **`scripts/detect-breaking.sh`** — pure, unit-tested (bats) semver-policy helpers.
- **`ci.yml` `version-increment`** — now bumps the **minor** on a breaking signal (the `breaking-change` PR label, or a Conventional Commit `type!:` / `BREAKING CHANGE:` marker) instead of always the patch.
- **`ci.yml` `version-gate`** (new job) — **fails** a PR whose breaking change ships on a patch-only (or no) bump.
- **`release.yml`** (new workflow) — cuts a **`v<version>`** git tag + GitHub release on push to `Develop`, **decoupled from `wasm-bundle-<sha>`**; idempotent.
- **Retro-bump** workspace version `0.1.46 → 0.2.0` to reflect the #177 break (the `u16` narrowing is **not** reverted).

## Acceptance criteria (Issue #251)

- [x] Committed release/versioning policy: breaking ⇒ major-equivalent (minor pre-1.0), non-breaking ⇒ patch — `RELEASING.md`.
- [x] CI mechanism so a breaking change cannot ship on a patch-only bump — `version-gate` job + `check-version-bump.sh`.
- [x] Semver git tag + GitHub release on version bumps, decoupled from `wasm-bundle-<sha>` — `release.yml`.
- [x] Current breaking state (#177) reflected by a `0.2.0`-class version — workspace version `0.2.0`; `release.yml` cuts `v0.2.0` on merge.

## Test plan

- `bats tests/scripts/next_version.bats` · `check_version_bump.bats` · `detect_breaking.bats` — policy logic (all green).
- Full `bats tests/scripts` (146 tests) green, including SHA-pinning, actionlint, and script-injection workflow gates covering the two new/edited workflows.
- `actionlint`, `shellcheck`, `markdownlint-cli2`, `codespell` clean; `cargo check --workspace --locked` passes at `v0.2.0`.

> Note: not auto-merging — cutting the `v0.2.0` release is a human-gated step (the `release.yml` workflow performs it on merge to `Develop`).