### PR TITLE
chore(tests): remove unused manifest_dir helper (#200)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-200.md
+++ b/docs/archive/pr-summaries/pr-summary-200.md
@@ -1,0 +1,46 @@
+## Summary
+
+Removed the dead `manifest_dir` helper from the shared integration-test
+`common` module (`neat-core/tests/common/mod.rs`). The function was an
+exported test helper with **no caller anywhere in the repo** — it was
+silenced with `#[allow(dead_code)]` and a doc comment noting it was
+forward-looking scaffolding for fixtures that were never added. Its only
+dependency, `use std::path::PathBuf;`, became unused once the function
+was deleted, so that import was dropped too. Closes #200.
+
+## Evidence
+
+This is a test-only, CLI/library change with no web interface to
+screenshot.
+
+A full-repo reference search confirmed `manifest_dir` had no caller,
+qualified path, or glob re-export (only its own definition matched):
+
+```
+$ grep -rn "manifest_dir" --include="*.rs" .
+neat-core/tests/common/mod.rs:10:pub fn manifest_dir() -> PathBuf {
+```
+
+After removal, the `dead_code` lint no longer flags the symbol:
+
+```
+$ RUSTFLAGS="--force-warn dead_code" cargo check --workspace --all-targets --all-features
+# no warning for tests/common/mod.rs / manifest_dir
+```
+
+The rest of the `common` module (`minimal_creature_json`) is still used
+by the integration-test harnesses (`creature_compile.rs`,
+`integration.rs`, `tests/creature/*`, etc.), which continue to compile
+and pass under `cargo test --workspace` via `./quality.sh`.
+
+## Test Plan
+
+- No new test added: this is a pure dead-code removal. The guarantee is
+  enforced by the compiler's `dead_code` lint (verified above) and by the
+  existing integration-test suite, which exercises the surviving
+  `common::minimal_creature_json` helper and still compiles/passes.
+- Ran `./quality.sh < /dev/null`. The only failures (tests 43, 44, 45,
+  49 — concerning `ci.yml`/`bump-deps.sh` quarantine wiring) are
+  **pre-existing on the baseline** `Develop` branch and unrelated to this
+  change; verified by stashing the change and re-running. This change
+  introduces no new failures.

--- a/neat-core/tests/common/mod.rs
+++ b/neat-core/tests/common/mod.rs
@@ -3,14 +3,6 @@
 //! Layout matches [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery):
 //! `tests/common/mod.rs` plus `#[path = "../common/mod.rs"] mod common;` in subdirectory harnesses.
 
-use std::path::PathBuf;
-
-/// `neat-core` manifest directory (fixtures live under `tests/data/` when added).
-#[allow(dead_code)]
-pub fn manifest_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
 /// Minimal valid creature JSON for compile / activation smoke tests.
 pub fn minimal_creature_json() -> &'static str {
     r#"{


### PR DESCRIPTION
## Summary

Removed the dead `manifest_dir` helper from the shared integration-test
`common` module (`neat-core/tests/common/mod.rs`). The function was an
exported test helper with **no caller anywhere in the repo** — it was
silenced with `#[allow(dead_code)]` and a doc comment noting it was
forward-looking scaffolding for fixtures that were never added. Its only
dependency, `use std::path::PathBuf;`, became unused once the function
was deleted, so that import was dropped too. Closes #200.

## Evidence

This is a test-only, CLI/library change with no web interface to
screenshot.

A full-repo reference search confirmed `manifest_dir` had no caller,
qualified path, or glob re-export (only its own definition matched):

```
$ grep -rn "manifest_dir" --include="*.rs" .
neat-core/tests/common/mod.rs:10:pub fn manifest_dir() -> PathBuf {
```

After removal, the `dead_code` lint no longer flags the symbol:

```
$ RUSTFLAGS="--force-warn dead_code" cargo check --workspace --all-targets --all-features
# no warning for tests/common/mod.rs / manifest_dir
```

The rest of the `common` module (`minimal_creature_json`) is still used
by the integration-test harnesses (`creature_compile.rs`,
`integration.rs`, `tests/creature/*`, etc.), which continue to compile
and pass under `cargo test --workspace` via `./quality.sh`.

## Test Plan

- No new test added: this is a pure dead-code removal. The guarantee is
  enforced by the compiler's `dead_code` lint (verified above) and by the
  existing integration-test suite, which exercises the surviving
  `common::minimal_creature_json` helper and still compiles/passes.
- Ran `./quality.sh < /dev/null`. The only failures (tests 43, 44, 45,
  49 — concerning `ci.yml`/`bump-deps.sh` quarantine wiring) are
  **pre-existing on the baseline** `Develop` branch and unrelated to this
  change; verified by stashing the change and re-running. This change
  introduces no new failures.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqvuwdvy-966a54`<!-- vibe-worker-issue-200 -->