### PR TITLE
Validate synapse from_index at load to prevent out-of-bounds read (Issue #207)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-207.md
+++ b/docs/archive/pr-summaries/pr-summary-207.md
@@ -1,0 +1,70 @@
+# Fix: validate synapse `from_index` at load time (Issue #207)
+
+## Summary
+
+`CompiledNetwork::new` deserialised each synapse's `from_index` (`u16`) straight
+from the input bytes without ever checking it was a valid neuron index. During
+the forward pass the native SIMD kernels read the activation buffer (sized to
+exactly `num_neurons`) with **unchecked** indexing (`get_unchecked`) keyed on
+that `from_index`. A malformed or corrupted compiled-network buffer declaring a
+synapse with `from_index >= num_neurons` therefore caused an out-of-bounds read
+— undefined behaviour (heap information disclosure or a fault) on every
+`activate()` / `activate_into()` call.
+
+The fix validates the invariant **once, at deserialisation time**. After the
+parse loop, `CompiledNetwork::new` now returns a new typed error
+`NetworkError::InvalidSynapseIndex { from_index, num_neurons }` if any synapse
+references an index outside `0..num_neurons`. A network that loads successfully
+is guaranteed to have every `from_index` in range, so the existing
+`get_unchecked` calls become sound and the hot path is unchanged. The
+index-validity precondition is now documented in each affected kernel's
+`# Safety` / `// SAFETY:` block and in the `weighted_sum_simd` dispatcher.
+
+Closes #207.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+Rust test suite and the full local quality gate (fmt, clippy `-D warnings`,
+tests, doc all clean). The four failing checks in `quality.sh` are pre-existing
+`bats` tests asserting `ci.yml` invokes `bump-deps.sh` — unrelated files this PR
+does not touch.
+
+```mermaid
+flowchart TD
+    A[compiled .bin buffer] --> B["CompiledNetwork::new parses synapses"]
+    B --> C{"every from_index < num_neurons?"}
+    C -- no --> D["Err(NetworkError::InvalidSynapseIndex)"]
+    C -- yes --> E[network loaded]
+    E --> F["activate() → weighted_sum_simd"]
+    F --> G["get_unchecked(from_index) — now sound"]
+```
+
+## Test Plan
+
+Added `neat-core/src/network.rs` unit tests (Issue #207 block):
+
+- `new_rejects_out_of_range_from_index` — `from_index == num_neurons` (first
+  out-of-bounds value) is rejected with `InvalidSynapseIndex` carrying the
+  offending index and node count.
+- `new_rejects_far_out_of_range_from_index` — `from_index == u16::MAX` (top of
+  the attacker-controllable range) is rejected.
+- `new_accepts_max_valid_from_index` — the largest in-range index
+  (`num_neurons - 1`) still loads, proving the guard rejects only genuinely
+  out-of-bounds indices.
+- `activate_is_bounded_for_loaded_network` — a successfully loaded network runs
+  a full forward pass with a finite result, confirming no out-of-bounds access.
+
+All new tests fail to compile against the unfixed code (the
+`InvalidSynapseIndex` variant does not exist) and pass after the fix. Existing
+loader tests (`new_rejects_networks_exceeding_max_node_count`,
+`new_preserves_high_source_index`, etc.) remain green.
+
+## Security self-check
+
+- **Input validation**: the deserialiser now validates every source index
+  before the network can be activated — the core of this fix.
+- **Injection / secrets / auth**: not applicable; no new external surface,
+  secrets, or endpoints.
+- **Error handling**: returns a typed, non-leaking `NetworkError`; no internal
+  state exposed.

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -42,6 +42,20 @@ pub enum NetworkError {
         /// The declared node count that exceeded [`MAX_NODE_COUNT`].
         count: usize,
     },
+    /// A synapse references a source neuron index that is not a valid index into
+    /// the activation buffer (`from_index >= num_neurons`).
+    ///
+    /// Issue #207 - the forward pass reads activations with unchecked indexing
+    /// (`get_unchecked`) keyed on the deserialised `from_index`. Validating every
+    /// index at load time upholds the kernels' safety precondition, so a malformed
+    /// or corrupted buffer is rejected here rather than triggering an out-of-bounds
+    /// read (undefined behaviour) during activation.
+    InvalidSynapseIndex {
+        /// The out-of-range source index read from the buffer.
+        from_index: u16,
+        /// The network's node count; valid indices are `0..num_neurons`.
+        num_neurons: usize,
+    },
 }
 
 impl std::fmt::Display for NetworkError {
@@ -55,6 +69,16 @@ impl std::fmt::Display for NetworkError {
                     f,
                     "Network has {count} nodes, exceeding the maximum of {MAX_NODE_COUNT} \
                      addressable by a u16 source index"
+                )
+            }
+            NetworkError::InvalidSynapseIndex {
+                from_index,
+                num_neurons,
+            } => {
+                write!(
+                    f,
+                    "Synapse source index {from_index} is out of bounds for a network \
+                     with {num_neurons} nodes (valid indices are 0..{num_neurons})"
                 )
             }
         }
@@ -287,6 +311,21 @@ impl CompiledNetwork {
                 num_synapses: num_synapse,
                 squash_type,
                 is_constant,
+            });
+        }
+
+        // Issue #207 - validate every source index against the node count before the
+        // network can be activated. The forward pass reads the activation buffer (sized
+        // to num_neurons) with unchecked indexing keyed on from_index; an out-of-range
+        // index would be an out-of-bounds read (undefined behaviour). Rejecting here
+        // upholds that precondition once, keeping the hot path unchanged.
+        if let Some(bad) = synapses
+            .iter()
+            .find(|s| s.from_index as usize >= num_neurons)
+        {
+            return Err(NetworkError::InvalidSynapseIndex {
+                from_index: bad.from_index,
+                num_neurons,
             });
         }
 
@@ -2177,5 +2216,62 @@ mod tests {
         let net = CompiledNetwork::new(&bytes).expect("network must load");
         assert_eq!(net.synapses.len(), 1);
         assert_eq!(net.synapses[0].from_index, high);
+    }
+
+    // ---- Issue #207: synapse from_index bounds validated at load ----
+
+    #[test]
+    fn new_rejects_out_of_range_from_index() {
+        // Issue #207 - a synapse whose from_index is >= num_neurons would drive an
+        // out-of-bounds read in the unchecked SIMD forward pass. The loader must
+        // reject it up front rather than deserialise an unsound network.
+        let num_neurons = 4u32;
+        let num_inputs = 3u32;
+        // Only indices 0..=3 are valid; 4 is one past the end of the buffer.
+        let bytes = serialise_single_synapse_network(num_neurons, num_inputs, num_neurons as u16);
+
+        match CompiledNetwork::new(&bytes) {
+            Err(NetworkError::InvalidSynapseIndex {
+                from_index,
+                num_neurons: n,
+            }) => {
+                assert_eq!(from_index, num_neurons as u16);
+                assert_eq!(n, num_neurons as usize);
+            }
+            Err(other) => panic!("expected InvalidSynapseIndex, got {other:?}"),
+            Ok(_) => panic!("expected InvalidSynapseIndex error, network loaded"),
+        }
+    }
+
+    #[test]
+    fn new_rejects_far_out_of_range_from_index() {
+        // Issue #207 - the maximum u16 index must also be rejected when it exceeds
+        // the node count, covering the top of the attacker-controllable range.
+        let bytes = serialise_single_synapse_network(4, 3, u16::MAX);
+        assert!(matches!(
+            CompiledNetwork::new(&bytes),
+            Err(NetworkError::InvalidSynapseIndex { .. })
+        ));
+    }
+
+    #[test]
+    fn new_accepts_max_valid_from_index() {
+        // Issue #207 - the largest in-range index (num_neurons - 1) must still load,
+        // proving the guard rejects only genuinely out-of-bounds indices.
+        let bytes = serialise_single_synapse_network(4, 3, 3);
+        let net = CompiledNetwork::new(&bytes).expect("in-range index must load");
+        assert_eq!(net.synapses[0].from_index, 3);
+    }
+
+    #[test]
+    fn activate_is_bounded_for_loaded_network() {
+        // Issue #207 - a network that loads successfully must never index past its
+        // activation buffer during a forward pass. Every valid from_index is < the
+        // buffer length (num_neurons), so activate() cannot read out of bounds.
+        let bytes = serialise_single_synapse_network(4, 3, 2);
+        let mut net = CompiledNetwork::new(&bytes).expect("network must load");
+        let out = net.activate(&[1.0, 2.0, 3.0], 1);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].is_finite());
     }
 }

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -84,6 +84,10 @@ mod x86 {
 
     /// # Safety
     /// Caller must ensure AVX2 is enabled (`is_x86_feature_detected!("avx2")`).
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into each activation buffer; the kernel reads
+    /// activations with `get_unchecked`. `CompiledNetwork::new` validates this at
+    /// load time.
     #[target_feature(enable = "avx2")]
     #[inline]
     pub unsafe fn weighted_sum_simd_8records_avx2(
@@ -130,6 +134,10 @@ mod x86 {
 
     /// # Safety
     /// Caller must ensure FMA is enabled (`is_x86_feature_detected!("fma")`).
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "fma")]
     #[inline]
     pub unsafe fn weighted_sum_simd_4records_fma(
@@ -171,6 +179,10 @@ mod x86 {
 
     /// # Safety
     /// Caller must ensure FMA is enabled (`is_x86_feature_detected!("fma")`).
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "fma")]
     #[inline]
     pub unsafe fn weighted_sum_fma(
@@ -213,6 +225,10 @@ mod x86 {
 
     /// # Safety
     /// Caller must ensure FMA is enabled (`is_x86_feature_detected!("fma")`).
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "fma")]
     #[inline]
     pub unsafe fn weighted_sum_of_squares_fma(
@@ -256,6 +272,10 @@ mod x86 {
 
     /// # Safety
     /// Caller must ensure FMA is enabled (`is_x86_feature_detected!("fma")`).
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "fma")]
     #[inline]
     pub unsafe fn weighted_sum_of_squares_v2_fma(
@@ -308,6 +328,10 @@ mod aarch64 {
 
     /// # Safety
     /// Caller must ensure NEON is available (typical on aarch64-apple-darwin / linux-aarch64).
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into each activation buffer; the kernel reads
+    /// activations with `get_unchecked`. `CompiledNetwork::new` validates this at
+    /// load time.
     #[target_feature(enable = "neon")]
     #[inline]
     pub unsafe fn weighted_sum_simd_8records_neon(
@@ -359,6 +383,10 @@ mod aarch64 {
 
     /// # Safety
     /// Caller must ensure NEON is available.
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "neon")]
     #[inline]
     pub unsafe fn weighted_sum_simd_4records_neon(
@@ -399,6 +427,10 @@ mod aarch64 {
 
     /// # Safety
     /// Caller must ensure NEON is available.
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "neon")]
     #[inline]
     pub unsafe fn weighted_sum_neon(
@@ -444,6 +476,10 @@ mod aarch64 {
 
     /// # Safety
     /// Caller must ensure NEON is available.
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "neon")]
     #[inline]
     pub unsafe fn weighted_sum_of_squares_neon(
@@ -490,6 +526,10 @@ mod aarch64 {
 
     /// # Safety
     /// Caller must ensure NEON is available.
+    /// Issue #207 - caller must also ensure every `synapse.from_index` in
+    /// `start..end` is a valid index into `activations` (`< activations.len()`);
+    /// the kernel reads activations with `get_unchecked`. `CompiledNetwork::new`
+    /// validates this at load time.
     #[target_feature(enable = "neon")]
     #[inline]
     pub unsafe fn weighted_sum_of_squares_v2_neon(
@@ -723,6 +763,12 @@ const SINGLE_RECORD_SIMD_MIN: usize = 4;
 ///
 /// Production forward-pass hot path. AVX2/FMA on x86_64, NEON on aarch64, scalar
 /// elsewhere and for counts below one SIMD lane.
+///
+/// Issue #207 - on the SIMD paths this delegates to `get_unchecked` kernels, so
+/// every `synapse.from_index` in `start..end` must be a valid index into
+/// `activations`. `CompiledNetwork::new` enforces this at load time
+/// (`NetworkError::InvalidSynapseIndex`), so callers holding a loaded network
+/// already satisfy the precondition.
 #[inline]
 pub fn weighted_sum_simd(
     synapses: &[SynapseData],


### PR DESCRIPTION
# Fix: validate synapse `from_index` at load time (Issue #207)

## Summary

`CompiledNetwork::new` deserialised each synapse's `from_index` (`u16`) straight
from the input bytes without ever checking it was a valid neuron index. During
the forward pass the native SIMD kernels read the activation buffer (sized to
exactly `num_neurons`) with **unchecked** indexing (`get_unchecked`) keyed on
that `from_index`. A malformed or corrupted compiled-network buffer declaring a
synapse with `from_index >= num_neurons` therefore caused an out-of-bounds read
— undefined behaviour (heap information disclosure or a fault) on every
`activate()` / `activate_into()` call.

The fix validates the invariant **once, at deserialisation time**. After the
parse loop, `CompiledNetwork::new` now returns a new typed error
`NetworkError::InvalidSynapseIndex { from_index, num_neurons }` if any synapse
references an index outside `0..num_neurons`. A network that loads successfully
is guaranteed to have every `from_index` in range, so the existing
`get_unchecked` calls become sound and the hot path is unchanged. The
index-validity precondition is now documented in each affected kernel's
`# Safety` / `// SAFETY:` block and in the `weighted_sum_simd` dispatcher.

Closes #207.

## Evidence

Backend/library change only — no web interface to screenshot. Verified via the
Rust test suite and the full local quality gate (fmt, clippy `-D warnings`,
tests, doc all clean). The four failing checks in `quality.sh` are pre-existing
`bats` tests asserting `ci.yml` invokes `bump-deps.sh` — unrelated files this PR
does not touch.

```mermaid
flowchart TD
    A[compiled .bin buffer] --> B["CompiledNetwork::new parses synapses"]
    B --> C{"every from_index < num_neurons?"}
    C -- no --> D["Err(NetworkError::InvalidSynapseIndex)"]
    C -- yes --> E[network loaded]
    E --> F["activate() → weighted_sum_simd"]
    F --> G["get_unchecked(from_index) — now sound"]
```

## Test Plan

Added `neat-core/src/network.rs` unit tests (Issue #207 block):

- `new_rejects_out_of_range_from_index` — `from_index == num_neurons` (first
  out-of-bounds value) is rejected with `InvalidSynapseIndex` carrying the
  offending index and node count.
- `new_rejects_far_out_of_range_from_index` — `from_index == u16::MAX` (top of
  the attacker-controllable range) is rejected.
- `new_accepts_max_valid_from_index` — the largest in-range index
  (`num_neurons - 1`) still loads, proving the guard rejects only genuinely
  out-of-bounds indices.
- `activate_is_bounded_for_loaded_network` — a successfully loaded network runs
  a full forward pass with a finite result, confirming no out-of-bounds access.

All new tests fail to compile against the unfixed code (the
`InvalidSynapseIndex` variant does not exist) and pass after the fix. Existing
loader tests (`new_rejects_networks_exceeding_max_node_count`,
`new_preserves_high_source_index`, etc.) remain green.

## Security self-check

- **Input validation**: the deserialiser now validates every source index
  before the network can be activated — the core of this fix.
- **Injection / secrets / auth**: not applicable; no new external surface,
  secrets, or endpoints.
- **Error handling**: returns a typed, non-leaking `NetworkError`; no internal
  state exposed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr38nd2m-ba0a95`<!-- vibe-worker-issue-207 -->