### PR TITLE
docs(neat-core): document public API items and enable missing_docs lint (Issue #209)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ opt-level = 3
 # every unsafe operation must sit in an explicit `unsafe { … }` block.
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
+# Issue #209 - require a `///` summary on every exported item so the public
+# API surface stays documented on docs.rs. Promote to "deny" once stable.
+missing_docs = "warn"
 
 [workspace.lints.clippy]
 collapsible_if = "deny"

--- a/docs/archive/pr-summaries/pr-summary-209.md
+++ b/docs/archive/pr-summaries/pr-summary-209.md
@@ -1,0 +1,62 @@
+## Summary
+
+Enabled the `missing_docs` Rust lint on the workspace and documented the
+remaining undocumented public API items in `neat-core`, so the crate's public
+surface stays fully documented on docs.rs and CI catches new gaps. Closes #209.
+
+The lint is added to `[workspace.lints.rust]` as `missing_docs = "warn"`; because
+`quality.sh` (and CI) build with `RUSTFLAGS="-D warnings"` and docs with
+`RUSTDOCFLAGS="-D warnings"`, an undocumented `pub` item now fails the build.
+
+Enabling the lint surfaced the *actual* undocumented items (the line numbers in
+the issue were stale — the listed `network.rs`/`creature.rs`/`accumulate.rs`
+items already carry `///` docs). The real gaps were:
+
+- `neat-core/src/squash.rs` — all 38 `SquashType` activation-function variants.
+- `neat-core/src/propagate_codec.rs` — the 11 public fields of `DecodedPropagate`.
+- `neat-core/src/training_data.rs` — the struct/variant fields of
+  `TrainingDataError` (`InvalidFileSize`, `InvalidConfig`).
+
+Each item received a concise one-line `///` summary. Per the Rust API Guidelines
+(C-EXAMPLE), a runnable `# Examples` doctest was added to the public
+`apply_squash` function.
+
+The lint is set to `"warn"` (rather than `"deny"`) so the value applies via the
+`-D warnings` gate today while leaving room to promote it to `"deny"` in the lint
+table once the surface is proven stable — matching the issue's suggested rollout.
+
+```mermaid
+flowchart LR
+    A["pub item added"] --> B{"has /// doc?"}
+    B -- no --> C["missing_docs warns"]
+    C --> D["-D warnings → build fails"]
+    B -- yes --> E["build passes / docs.rs"]
+```
+
+## Evidence
+
+Backend/library-only change — no web interface to screenshot. Verified via the
+Rust toolchain:
+
+- `cargo check --workspace --all-targets --all-features` with `RUSTFLAGS="-D warnings"`:
+  **0** `missing documentation` errors (was 53 before the docs were added).
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`: builds cleanly.
+- `cargo test --doc --workspace`: 2 passed (includes the new `apply_squash` doctest).
+- `cargo test --workspace --lib --tests --all-features`: all existing tests pass.
+
+Note: `quality.sh` also runs a `tests/scripts` bats suite that has **4
+pre-existing failures** about `ci.yml`/`bump-deps.sh` (`not ok 43/44/45/49`).
+These reproduce on the untouched base branch (`git stash` → `bats tests/scripts`)
+and are unrelated to this documentation/lint change, which touches no workflow or
+shell files.
+
+## Test Plan
+
+- Added `apply_squash` `# Examples` doctest in `neat-core/src/squash.rs`,
+  asserting ReLU maps negatives to `0.0`, passes positives through, and Identity
+  returns the input unchanged — run by `cargo test --doc`.
+- The `missing_docs` lint itself is the regression guard: with `-D warnings`, any
+  future undocumented `pub` item fails `cargo check`/`cargo doc` in CI.
+- Re-ran the full Rust gate (build, clippy, check, lib/integration tests,
+  doctests, doc) — all green.

--- a/neat-core/src/propagate_codec.rs
+++ b/neat-core/src/propagate_codec.rs
@@ -50,16 +50,27 @@ pub const PER_SYNAPSE_OUT_F64S: usize = 7;
 /// fields to construct a [`PropagateInput`] for `propagate_topological_loop`.
 #[derive(Debug, Clone)]
 pub struct DecodedPropagate {
+    /// Decoded per-neuron inputs (bias, squash type, ...).
     pub neurons: Vec<NeuronInput>,
+    /// Decoded per-synapse inputs (source index, weight).
     pub synapses: Vec<SynapseInput>,
+    /// Start offset into `inward_indices` for each neuron.
     pub inward_starts: Vec<u32>,
+    /// Number of inward synapses for each neuron.
     pub inward_counts: Vec<u32>,
+    /// Flattened inward synapse indices for all neurons.
     pub inward_indices: Vec<u32>,
+    /// Neuron indices in reverse topological order.
     pub reverse_topo_order: Vec<u32>,
+    /// Expected output values used to compute the loss.
     pub expected: Vec<f32>,
+    /// Number of input neurons.
     pub input_count: u32,
+    /// Number of output neurons.
     pub output_count: u32,
+    /// Planck constant used to regularise gradients.
     pub plank_constant: f32,
+    /// Whether gradients are normalised during back-propagation.
     pub normalise_gradients: bool,
 }
 

--- a/neat-core/src/squash.rs
+++ b/neat-core/src/squash.rs
@@ -36,46 +36,84 @@ pub const CUBE_OUTPUT_CLAMP: f64 = 1e6;
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SquashType {
+    /// Identity — passes the input through unchanged.
     Identity = 0,
+    /// Rectified Linear Unit — `max(0, x)`.
     Relu = 1,
+    /// ReLU clamped to a maximum of 6 — `min(max(0, x), 6)`.
     Relu6 = 2,
+    /// Leaky ReLU — small negative slope for `x < 0`.
     LeakyRelu = 3,
+    /// Scaled Exponential Linear Unit (self-normalising).
     Selu = 4,
+    /// Exponential Linear Unit.
     Elu = 5,
+    /// Logistic sigmoid — output in `(0, 1)`.
     Logistic = 6,
+    /// Hyperbolic tangent — output in `(-1, 1)`.
     Tanh = 7,
+    /// Hard tanh — tanh clamped linearly to `[-1, 1]`.
     HardTanh = 8,
+    /// Softsign — `x / (1 + |x|)`.
     Softsign = 9,
+    /// Softplus — smooth approximation of ReLU, `ln(1 + e^x)`.
     Softplus = 10,
+    /// Swish — `x * sigmoid(x)`.
     Swish = 11,
+    /// Mish — `x * tanh(softplus(x))`.
     Mish = 12,
+    /// Gaussian Error Linear Unit (tanh approximation).
     Gelu = 13,
+    /// Sine of the input.
     Sine = 14,
+    /// Cosine of the input.
     Cosine = 15,
+    /// Tangent of the input (clamped near its asymptotes).
     Tan = 16,
+    /// Inverse tangent (arctangent) of the input.
     ArcTan = 17,
+    /// Gaussian bell curve — `e^(-x^2)`.
     Gaussian = 18,
+    /// Bent identity — `(sqrt(x^2 + 1) - 1) / 2 + x`.
     BentIdentity = 19,
+    /// Bipolar sigmoid — logistic scaled to `(-1, 1)`.
     BipolarSigmoid = 20,
+    /// Bipolar sign — `-1` for `x <= 0`, `+1` otherwise.
     Bipolar = 21,
+    /// Step — `0` for `x < 0`, `1` otherwise.
     Step = 22,
+    /// Complement — `1 - x`.
     Complement = 23,
+    /// Absolute value — `|x|`.
     Absolute = 24,
+    /// Square — `x^2` (clamped for stability).
     Square = 25,
+    /// Cube — `x^3` (clamped for stability).
     Cube = 26,
+    /// Square root of the input.
     Sqrt = 27,
+    /// Standard inverse — `1 / x` guarded against division by zero.
     StdInverse = 28,
+    /// Exponential — `e^x` (clamped for stability).
     Exponential = 29,
+    /// Log-sigmoid — `ln(sigmoid(x))`.
     LogSigmoid = 30,
+    /// Inverse Square Root Unit.
     Isru = 31,
     // Aggregate functions (Issue #1125)
+    /// Aggregate minimum of the weighted inputs.
     Minimum = 32,
+    /// Aggregate maximum of the weighted inputs.
     Maximum = 33,
+    /// Conditional aggregate — gate-style selection over inputs.
     If = 34,
     // Deprecated aggregate functions (implemented for WASM parity, remove when possible)
-    Hypotenuse = 35,   // HYPOT: hypot(weighted_inputs) + bias
+    /// Deprecated: hypotenuse of the weighted inputs, then add bias.
+    Hypotenuse = 35, // HYPOT: hypot(weighted_inputs) + bias
+    /// Deprecated: hypotenuse of `bias + weighted_inputs`.
     HypotenuseV2 = 36, // HYPOTv2: hypot(bias + weighted_inputs)
-    Mean = 37,         // MEAN: (sum of weighted_inputs) / n + bias
+    /// Deprecated: mean of the weighted inputs, then add bias.
+    Mean = 37, // MEAN: (sum of weighted_inputs) / n + bias
 }
 
 impl From<u8> for SquashType {
@@ -125,7 +163,19 @@ impl From<u8> for SquashType {
     }
 }
 
-/// Apply a squash function to a value
+/// Apply a squash (activation) function to a value.
+///
+/// # Examples
+///
+/// ```
+/// use neat_core::squash::{apply_squash, SquashType};
+///
+/// // ReLU maps negatives to zero and passes positives through.
+/// assert_eq!(apply_squash(SquashType::Relu, -2.0), 0.0);
+/// assert_eq!(apply_squash(SquashType::Relu, 3.0), 3.0);
+/// // Identity returns the input unchanged.
+/// assert_eq!(apply_squash(SquashType::Identity, 1.5), 1.5);
+/// ```
 #[inline(always)]
 pub fn apply_squash(squash_type: SquashType, x: f32) -> f32 {
     match squash_type {

--- a/neat-core/src/training_data.rs
+++ b/neat-core/src/training_data.rs
@@ -62,12 +62,18 @@ pub enum TrainingDataError {
     Io(io::Error),
     /// A file's size is not an exact multiple of the record size.
     InvalidFileSize {
+        /// Path of the offending file.
         path: PathBuf,
+        /// Actual size of the file in bytes.
         file_size: u64,
+        /// Expected size of a single record in bytes.
         record_size: usize,
     },
     /// The configuration specifies zero inputs or zero outputs.
-    InvalidConfig { message: String },
+    InvalidConfig {
+        /// Human-readable description of the invalid configuration.
+        message: String,
+    },
 }
 
 impl std::fmt::Display for TrainingDataError {


### PR DESCRIPTION
## Summary

Enabled the `missing_docs` Rust lint on the workspace and documented the
remaining undocumented public API items in `neat-core`, so the crate's public
surface stays fully documented on docs.rs and CI catches new gaps. Closes #209.

The lint is added to `[workspace.lints.rust]` as `missing_docs = "warn"`; because
`quality.sh` (and CI) build with `RUSTFLAGS="-D warnings"` and docs with
`RUSTDOCFLAGS="-D warnings"`, an undocumented `pub` item now fails the build.

Enabling the lint surfaced the *actual* undocumented items (the line numbers in
the issue were stale — the listed `network.rs`/`creature.rs`/`accumulate.rs`
items already carry `///` docs). The real gaps were:

- `neat-core/src/squash.rs` — all 38 `SquashType` activation-function variants.
- `neat-core/src/propagate_codec.rs` — the 11 public fields of `DecodedPropagate`.
- `neat-core/src/training_data.rs` — the struct/variant fields of
  `TrainingDataError` (`InvalidFileSize`, `InvalidConfig`).

Each item received a concise one-line `///` summary. Per the Rust API Guidelines
(C-EXAMPLE), a runnable `# Examples` doctest was added to the public
`apply_squash` function.

The lint is set to `"warn"` (rather than `"deny"`) so the value applies via the
`-D warnings` gate today while leaving room to promote it to `"deny"` in the lint
table once the surface is proven stable — matching the issue's suggested rollout.

```mermaid
flowchart LR
    A["pub item added"] --> B{"has /// doc?"}
    B -- no --> C["missing_docs warns"]
    C --> D["-D warnings → build fails"]
    B -- yes --> E["build passes / docs.rs"]
```

## Evidence

Backend/library-only change — no web interface to screenshot. Verified via the
Rust toolchain:

- `cargo check --workspace --all-targets --all-features` with `RUSTFLAGS="-D warnings"`:
  **0** `missing documentation` errors (was 53 before the docs were added).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`: builds cleanly.
- `cargo test --doc --workspace`: 2 passed (includes the new `apply_squash` doctest).
- `cargo test --workspace --lib --tests --all-features`: all existing tests pass.

Note: `quality.sh` also runs a `tests/scripts` bats suite that has **4
pre-existing failures** about `ci.yml`/`bump-deps.sh` (`not ok 43/44/45/49`).
These reproduce on the untouched base branch (`git stash` → `bats tests/scripts`)
and are unrelated to this documentation/lint change, which touches no workflow or
shell files.

## Test Plan

- Added `apply_squash` `# Examples` doctest in `neat-core/src/squash.rs`,
  asserting ReLU maps negatives to `0.0`, passes positives through, and Identity
  returns the input unchanged — run by `cargo test --doc`.
- The `missing_docs` lint itself is the regression guard: with `-D warnings`, any
  future undocumented `pub` item fails `cargo check`/`cargo doc` in CI.
- Re-ran the full Rust gate (build, clippy, check, lib/integration tests,
  doctests, doc) — all green.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr3iewtc-5cad3a`<!-- vibe-worker-issue-209 -->