### PR TITLE
[#227] Eliminate per-record output Vec allocation in scoring (use activate_into) (Issue #229)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -49,7 +49,7 @@ mod bench {
         records: &[Vec<f32>],
         num_outputs: usize,
         threads: usize,
-    ) -> Vec<Vec<f32>> {
+    ) -> Vec<f32> {
         let pool = ThreadPoolBuilder::new()
             .num_threads(threads)
             .build()

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -24,62 +24,76 @@
 //!
 //! Results are **identical** to the sequential path regardless of thread count:
 //!
-//! - Every record is scored by the same [`CompiledNetwork::activate`] call used
-//!   sequentially. `activate` overwrites every non-input activation each call,
-//!   so there is no cross-record state.
+//! - Every record is scored by the same [`CompiledNetwork::activate_into`] call
+//!   used sequentially. `activate_into` overwrites every non-input activation
+//!   each call, so there is no cross-record state.
 //! - No `&mut self` is shared across threads. `CompiledNetwork` is `Clone`, and
 //!   the clone carries the per-call scratch buffers (`activations`,
 //!   `hint_values_buffer`, the 4-way batch buffers). The immutable weights are
 //!   read through `&self`; each rayon worker initialises **its own** cloned
-//!   scratch context via `map_init` and owns its buffers for the duration.
-//! - Output order matches input order — `par_iter().map(...).collect()`
-//!   preserves indexed order.
+//!   scratch context via `for_each_init` and owns its buffers for the duration.
+//! - Output order matches input order — the flat output buffer is split into
+//!   disjoint per-record chunks by index (`par_chunks_mut(num_outputs)` zipped
+//!   with `par_iter()`), so record `i` always writes `[i * num_outputs ..]`.
+//!
+//! # Output layout (Issue #229)
+//!
+//! Both paths return one contiguous `Vec<f32>` of `records.len() * num_outputs`
+//! elements rather than a `Vec<Vec<f32>>`. Record `i`'s outputs occupy
+//! `[i * num_outputs .. (i + 1) * num_outputs]`. This flat buffer is written
+//! through [`CompiledNetwork::activate_into`], so the batch performs a **single**
+//! output allocation instead of one heap allocation per record.
 
 use crate::network::CompiledNetwork;
 
 impl CompiledNetwork {
-    /// Score every record sequentially, returning one output vector per record.
+    /// Score every record sequentially, returning a single flat output buffer.
+    ///
+    /// The result is one contiguous `Vec<f32>` of `records.len() * num_outputs`
+    /// elements: record `i`'s outputs occupy `[i * num_outputs .. (i + 1) *
+    /// num_outputs]`. Routing through [`CompiledNetwork::activate_into`] and
+    /// writing straight into pre-sized chunks removes the per-record output
+    /// `Vec` allocation that [`CompiledNetwork::activate`]'s `to_vec()` incurred
+    /// (Issue #229) — the whole batch now costs a **single** output allocation.
     ///
     /// Shared read-only weights (`&self`) plus a single owned scratch context
     /// (one clone of the network). This is the fallback used when the `parallel`
     /// feature is off or when building for `wasm32`, and the reference path the
     /// parallel results must match exactly.
-    ///
-    /// Each record is scored with [`CompiledNetwork::activate`]; the first
-    /// `num_outputs` … (`num_neurons - num_outputs ..`) activations are returned.
-    pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+    pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         let mut scratch = self.clone();
-        records
-            .iter()
-            .map(|record| scratch.activate(record, num_outputs))
-            .collect()
+        let mut outputs = vec![0.0f32; records.len() * num_outputs];
+        for (record, chunk) in records.iter().zip(outputs.chunks_exact_mut(num_outputs)) {
+            scratch.activate_into(record, chunk);
+        }
+        outputs
     }
 
-    /// Score every record across the `rayon` thread pool, returning one output
-    /// vector per record in input order.
+    /// Score every record across the `rayon` thread pool, writing into a single
+    /// flat output buffer in input order.
     ///
-    /// Each rayon worker initialises its own cloned scratch context via
-    /// `map_init`, so no `&mut self` is shared across threads: immutable weights
-    /// are read through `&self` while every worker owns its activation buffers.
-    /// Because each record is scored by the same [`CompiledNetwork::activate`]
-    /// used by [`CompiledNetwork::score_records`] and there is no cross-record
-    /// state, the results are identical to the sequential path.
+    /// Layout matches [`CompiledNetwork::score_records`]: record `i`'s outputs
+    /// live in `[i * num_outputs .. (i + 1) * num_outputs]`. Each rayon worker
+    /// initialises its own cloned scratch context via `for_each_init`, so no
+    /// `&mut self` is shared across threads: immutable weights are read through
+    /// `&self` while every worker owns its activation buffers and writes only its
+    /// own disjoint output chunk. Because each record is scored by the same
+    /// [`CompiledNetwork::activate_into`] used sequentially and there is no
+    /// cross-record state, the results are identical to the sequential path.
     ///
     /// Available with the `parallel` feature on native targets.
     #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
-    pub fn score_records_parallel(
-        &self,
-        records: &[Vec<f32>],
-        num_outputs: usize,
-    ) -> Vec<Vec<f32>> {
+    pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         use rayon::prelude::*;
-        records
-            .par_iter()
-            .map_init(
+        let mut outputs = vec![0.0f32; records.len() * num_outputs];
+        outputs
+            .par_chunks_mut(num_outputs)
+            .zip(records.par_iter())
+            .for_each_init(
                 || self.clone(),
-                |scratch, record| scratch.activate(record, num_outputs),
-            )
-            .collect()
+                |scratch, (chunk, record)| scratch.activate_into(record, chunk),
+            );
+        outputs
     }
 
     /// Sequential fallback for [`CompiledNetwork::score_records_parallel`] when
@@ -87,11 +101,7 @@ impl CompiledNetwork {
     /// `rayon` is unavailable). Same signature and identical results to the
     /// feature-on path — just single-threaded.
     #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
-    pub fn score_records_parallel(
-        &self,
-        records: &[Vec<f32>],
-        num_outputs: usize,
-    ) -> Vec<Vec<f32>> {
+    pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         self.score_records(records, num_outputs)
     }
 }

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -29,13 +29,15 @@ fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
 }
 
 /// Independent sequential reference: a fresh scratch clone scored one record at
-/// a time. Deliberately does not call `score_records`, so the parity assertion
-/// does not assume the two share an implementation.
-fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+/// a time via per-record `activate` (which still allocates its own output
+/// `Vec`), flattened to the flat `[record * num_outputs]` layout the scoring
+/// path now returns. Deliberately does not call `score_records`, so the parity
+/// assertion does not assume the two share an implementation.
+fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
     let mut scratch = net.clone();
     records
         .iter()
-        .map(|r| scratch.activate(r, num_outputs))
+        .flat_map(|r| scratch.activate(r, num_outputs))
         .collect()
 }
 
@@ -48,7 +50,7 @@ fn parallel_scoring_matches_sequential_on_production_fixture() {
     let expected = reference(&net, &records, s.num_outputs);
     let actual = net.score_records_parallel(&records, s.num_outputs);
 
-    assert_eq!(actual.len(), records.len());
+    assert_eq!(actual.len(), records.len() * s.num_outputs);
     assert_eq!(actual, expected, "parallel results must equal sequential");
 }
 
@@ -86,7 +88,11 @@ fn output_order_is_preserved() {
     // index-aligned reference.
     let expected = reference(&net, &records, s.num_outputs);
     let actual = net.score_records_parallel(&records, s.num_outputs);
-    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+    for (i, (a, e)) in actual
+        .chunks_exact(s.num_outputs)
+        .zip(expected.chunks_exact(s.num_outputs))
+        .enumerate()
+    {
         assert_eq!(a, e, "record {i} out of order or incorrect");
     }
 }
@@ -98,10 +104,10 @@ fn each_output_has_num_outputs_elements() {
     let records = build_records(&net, 16);
 
     let out = net.score_records_parallel(&records, s.num_outputs);
-    assert_eq!(out.len(), 16);
-    for row in &out {
-        assert_eq!(row.len(), s.num_outputs);
-    }
+    // Flat buffer: 16 records each contributing exactly num_outputs elements.
+    assert_eq!(out.len(), 16 * s.num_outputs);
+    assert_eq!(out.chunks_exact(s.num_outputs).count(), 16);
+    assert!(out.chunks_exact(s.num_outputs).remainder().is_empty());
 }
 
 #[test]
@@ -124,5 +130,6 @@ fn single_record_matches_direct_activate() {
     let direct = scratch.activate(&record, s.num_outputs);
     let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
 
-    assert_eq!(via_parallel, vec![direct]);
+    // Single record: the flat buffer is exactly that record's outputs.
+    assert_eq!(via_parallel, direct);
 }

--- a/neat-core/tests/scoring_allocations.rs
+++ b/neat-core/tests/scoring_allocations.rs
@@ -1,0 +1,98 @@
+//! Allocation-count regression for the record-scoring hot path (Issue #229).
+//!
+//! `score_records` now routes every record through
+//! [`CompiledNetwork::activate_into`], writing into one pre-sized flat buffer
+//! instead of allocating a fresh output `Vec` per record via `activate`'s
+//! `to_vec()`. This test proves the batch performs **no per-record output
+//! allocation**: a counting global allocator records how many allocations
+//! happen while scoring, and the count must not scale with the record count.
+//!
+//! A revert to the old `to_vec()`-per-record path would allocate ~one `Vec` per
+//! record, so scoring 10× the records would allocate ~10× more — the delta
+//! assertion below would then fail loudly instead of silently regressing
+//! throughput.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{NETWORKS, NetSpec, build_inputs, build_network};
+use neat_core::network::CompiledNetwork;
+
+/// Global allocator that forwards to the system allocator while counting every
+/// allocation. Only the count is observed; the delta between two scoring calls
+/// with different record counts reveals per-record allocation.
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: forwarding an unchanged layout to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr`/`layout` came from `System.alloc` above.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| build_inputs(net.num_inputs(), 0xA110_0000 + i as u64))
+        .collect()
+}
+
+/// Allocation count consumed by scoring `records` (records/network built
+/// beforehand so only the scoring call is measured).
+fn allocs_for(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> usize {
+    let before = ALLOC_COUNT.load(Ordering::Relaxed);
+    let out = net.score_records(records, num_outputs);
+    // Keep the result alive across the measurement so its allocation is counted.
+    std::hint::black_box(&out);
+    let after = ALLOC_COUNT.load(Ordering::Relaxed);
+    after - before
+}
+
+#[test]
+fn score_records_has_no_per_record_output_allocation() {
+    let s = spec("production");
+    let net = build_network(s, 0x0A11_0C);
+
+    let small = build_records(&net, 100);
+    let large = build_records(&net, 1000);
+
+    // Warm up any one-off lazy initialisation so it is not counted below.
+    std::hint::black_box(net.score_records(&small, s.num_outputs));
+
+    let small_allocs = allocs_for(&net, &small, s.num_outputs);
+    let large_allocs = allocs_for(&net, &large, s.num_outputs);
+
+    // Per-record allocation would make scoring 10× the records allocate ~900
+    // extra times; the flat-buffer path allocates a constant handful (one output
+    // buffer + one scratch clone) regardless of record count. A generous
+    // threshold distinguishes "constant" from "grows with records" without being
+    // brittle to allocator/test-harness noise.
+    let delta = large_allocs.saturating_sub(small_allocs);
+    assert!(
+        delta < 50,
+        "scoring 10× records allocated {large_allocs} vs {small_allocs} \
+         (delta {delta}); expected a constant count — per-record output \
+         allocation has regressed"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #229.


## Milestone
This PR is part of the **#227 Speed up NEAT evolution on production-sized creatures (benchmark-gated)** milestone and targets the `milestone/227-speed-up-neat-evolution-on-production-sized-cr` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr9h0h0i-dfe4e1`<!-- vibe-worker-issue-229 -->