### PR TITLE
Establish production-sized benchmark baseline and scoring fixtures (Issue #228)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-228.md
+++ b/docs/archive/pr-summaries/pr-summary-228.md
@@ -1,0 +1,113 @@
+# Establish production-sized benchmark baseline and scoring fixtures (Issue #228)
+
+## Summary
+
+Establishes the documented, production-calibrated benchmark baseline that every
+optimisation under the #227 milestone is gated against. Closes #228.
+
+Production timings show fitness evaluation dominates (~95% of wall clock:
+2,901,473 ms of 3,042,879 ms over 32 generations). This is a **bench-only**
+change — no library behaviour is touched — that does three things:
+
+1. **Calibrates the scoring record count to production volume.**
+   `parallel_scoring.rs` scored an uncalibrated 2048-record token batch. It now
+   scores `PRODUCTION_SCORING_RECORDS = 4096` records — one GRQ-cluster training
+   shard's worth — with the derivation from committed telemetry
+   (`GRQ-cluster/performance.csv` / `result.json`) documented in `BASELINE.md`
+   and `benches/common/mod.rs`.
+2. **Adds a `scoring` group to `hot_paths.rs`** measuring single-core
+   `score_records` throughput at production record volume for `production` /
+   `production_2x`, reachable via `--bench hot_paths -- production`.
+3. **Commits `neat-core/benches/BASELINE.md`** with the production/production_2x
+   numbers for every hot-path group, plus host/CPU/toolchain metadata.
+
+The record count lives in `benches/common/mod.rs` as a single source of truth
+(`PRODUCTION_SCORING_RECORDS` + `build_records`), shared by both bench targets
+and the `bench_fixtures` test.
+
+### Record-count derivation (cross-checkable against #227)
+
+| Quantity | Value | Source |
+| --- | --- | --- |
+| Training corpus size | 22,097,375,712 bytes | `training_data_size_bytes` |
+| Training shards | 520 | `training_data_files` |
+| Per-record width | 2461 × 4 = 9844 bytes | `num_inputs` × `size_of::<f32>()` |
+| Whole-corpus records | ≈ 2.24 M | corpus / record width |
+| Records per shard | ≈ 4,317 | 2.24 M / 520 |
+| **Bench batch** | **4096** | one shard, rounded to 2¹² |
+
+Materialising the full ~2.24 M-record corpus (~21 GiB) is infeasible for a
+micro-benchmark, so the harness scores one shard (~40 MiB) — already far larger
+than any CPU cache, so records/sec extrapolates to the full corpus pass.
+
+## Evidence
+
+Backend/bench-only change — no web interface to screenshot. Evidence is the
+committed baseline numbers, captured on the Apple Silicon host class.
+
+**Host:** Apple M4 Pro (8P+4E, 12 logical), macOS 26.5.2 arm64, rustc 1.96.0,
+Criterion 0.8.2, `--release`.
+
+`hot_paths -- production` (single-thread):
+
+| Group / benchmark | production | production_2x |
+| --- | --- | --- |
+| `forward_pass` | 32.76 µs | 67.26 µs |
+| `batched_scoring/trace_batch_4way` | 80.17 µs | 199.18 µs |
+| `batched_scoring/mse_sum_8records` | 223.55 µs | 656.06 µs |
+| `backprop` | 153.87 µs | 368.19 µs |
+| `scoring` (4096 records) | 242.79 ms | 491.36 ms |
+
+`parallel_scoring --features parallel` (4096 records, 1 vs 12 cores):
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production` | 242.97 ms | 75.44 ms | 16.86 K → 54.30 K | 3.22× |
+| `production_2x` | 487.26 ms | 137.78 ms | 8.41 K → 29.73 K | 3.54× |
+
+Internal consistency check: single-core `parallel_scoring` (16.86 Krecords/s,
+`production`) matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both
+drive the same sequential `score_records` path.
+
+```mermaid
+flowchart LR
+    T["GRQ-cluster telemetry<br/>performance.csv / result.json"] --> D["Derive record count<br/>corpus / 520 shards ≈ 4.3k"]
+    D --> C["PRODUCTION_SCORING_RECORDS = 4096<br/>(common/mod.rs)"]
+    C --> H["hot_paths: scoring group"]
+    C --> P["parallel_scoring: 1 vs all cores"]
+    H --> B["BASELINE.md"]
+    P --> B
+    B --> O["Gates every #227 optimisation PR<br/>(before/after comparison)"]
+```
+
+## Test Plan
+
+Added behavioural ("what") tests to `neat-core/tests/bench_fixtures.rs`
+(exercising the shared fixtures via `#[path]`):
+
+- `build_records_produces_deterministic_distinct_batch_sized_to_inputs` — the
+  helper yields `count` records each of `num_inputs` length, reproducible under
+  a fixed seed (non-determinism guard) and distinct across the batch.
+- `production_scoring_record_count_is_production_representative` — the built
+  batch exceeds the prior 2048 token batch and stays memory-feasible (< 1 GiB)
+  at the widest shape.
+- `score_records_on_production_batch_yields_finite_ordered_outputs` — scoring a
+  production-shaped batch produces finite, correctly-shaped outputs.
+
+Verification run (all green):
+
+- `cargo test --workspace --lib --tests --all-features` — all pass, including
+  the 9 `bench_fixtures` tests and 7 `parallel_scoring` tests.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
+- `cargo bench -p neat-core --no-run --features parallel` — the required bench
+  compile smoke test (benches are `harness = false` / excluded from CI, so this
+  is the automated gate).
+- `cargo fmt --all --check`, `cargo doc`, `codespell` — clean.
+
+### Pre-existing failure noted
+
+`./quality.sh` exits early on 4 pre-existing `ci.yml` bats failures (tests
+48/49/50/54 about `bump-deps.sh` wiring) that are present on the clean base
+branch and unrelated to this change (which touches only `neat-core/benches/*`,
+`neat-core/tests/bench_fixtures.rs` and `docs/`). Every Rust stage `quality.sh`
+would run past that point was executed directly and passed.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -1,0 +1,110 @@
+# neat-core benchmark baseline (Issue #228)
+
+Documented baseline for the production-sized hot-path and scoring benchmarks.
+Every optimisation under the #227 milestone (per-record allocation, 8-record
+batched scoring, gather locality, prefetch, rayon granularity) is gated against
+these numbers: an optimisation PR must cite a before/after comparison for the
+affected group against this file, with matching host/toolchain metadata.
+
+> **Bench-only baseline.** The benchmarks are `harness = false` and excluded
+> from CI, so nothing here affects library behaviour or CI runtime. The
+> fixtures are synthesised from a fixed-seed PRNG — the 3 MB production
+> `network.json` and the real training corpus are **not** committed.
+
+## Host / toolchain
+
+| Field | Value |
+| --- | --- |
+| Host class | Apple Silicon (GRQ host class) |
+| CPU | Apple M4 Pro — 12 cores (8 performance + 4 efficiency) |
+| Logical cores (`available_parallelism`) | 12 |
+| RAM | 24 GB |
+| OS | macOS 26.5.2 (arm64) |
+| Toolchain | rustc 1.96.0 (ac68faa20 2026-05-25) |
+| Criterion | 0.8.2 |
+| Build | `--release` (bench profile, optimised) |
+
+Re-running the seeded synthesis on the same host reproduces the same fixtures;
+numbers should stay within Criterion's normal noise band (~±5%). A larger
+deviation on the same host indicates the fixed-seed setup is broken.
+
+## Production record-count calibration
+
+`parallel_scoring` and the `hot_paths` `scoring` group score
+`PRODUCTION_SCORING_RECORDS = 4096` records per iteration (defined in
+`benches/common/mod.rs`), replacing the prior uncalibrated 2048-record token
+batch. Derivation, from the committed GRQ-cluster telemetry
+(`GRQ-cluster/performance.csv`, the 32-generation production run whose totals
+match `result.json`: `generations = 32`, `total_time_ms = 3,042,879`,
+`fitnessMs = 2,901,473` — ~95% of wall clock):
+
+| Quantity | Value | Source |
+| --- | --- | --- |
+| Training corpus size | 22,097,375,712 bytes | `training_data_size_bytes` |
+| Training shards | 520 | `training_data_files` |
+| Per-record width | 2461 × 4 = 9844 bytes | `num_inputs` × `size_of::<f32>()` |
+| Whole-corpus records | ≈ 2.24 million | 22,097,375,712 / 9844 |
+| Records per shard | ≈ 4,317 | 2,244,755 / 520 |
+| **Bench batch** | **4096** | one shard, rounded down to 2¹² |
+
+A single creature forward-passes the whole ~2.24 M-record corpus per generation
+to compute its fitness. Materialising all of it (~21 GiB at production width) is
+infeasible for a micro-benchmark, so the harness scores **one production
+shard's worth** (~40 MiB at ~9.8 KiB/record). That batch already far exceeds any
+CPU cache, so its memory-traffic behaviour is production-representative, and
+records/sec extrapolates directly to the full corpus pass (throughput is
+size-invariant once pool/allocation overhead is amortised).
+
+## `hot_paths` — single-thread (`cargo bench -p neat-core --bench hot_paths -- production`)
+
+Times are Criterion's `[lower estimate upper]`; the median estimate is the
+comparison point.
+
+| Group / benchmark | production | production_2x |
+| --- | --- | --- |
+| `forward_pass` | 32.76 µs `[32.18, 33.34]` | 67.26 µs `[65.53, 69.10]` |
+| `batched_scoring/trace_batch_4way` | 80.17 µs `[78.46, 81.99]` | 199.18 µs `[194.54, 204.15]` |
+| `batched_scoring/mse_sum_8records` | 223.55 µs `[213.63, 234.10]` | 656.06 µs `[640.07, 672.17]` |
+| `backprop` | 153.87 µs `[150.97, 156.84]` | 368.19 µs `[361.57, 375.62]` |
+| `scoring` (4096 records) | 242.79 ms `[240.03, 245.76]` | 491.36 ms `[487.31, 495.73]` |
+
+Throughput highlights: `forward_pass` ≈ 126 Melem/s (production) / 123 Melem/s
+(production_2x); `backprop` ≈ 26.9 Melem/s / 22.5 Melem/s; single-core
+`scoring` ≈ 16.9 Krecords/s / 8.34 Krecords/s.
+
+## `parallel_scoring` — 1 core vs all cores (`cargo bench -p neat-core --bench parallel_scoring --features parallel`)
+
+4096 records scored through one creature inside a fixed-size rayon pool.
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production` | 242.97 ms `[240.75, 245.23]` | 75.44 ms `[73.05, 78.03]` | 16.86 K → 54.30 K | 3.22× |
+| `production_2x` | 487.26 ms `[484.49, 490.09]` | 137.78 ms `[133.86, 141.99]` | 8.41 K → 29.73 K | 3.54× |
+
+The single-core `parallel_scoring` figure (16.86 Krecords/s for `production`)
+matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both drive the same
+sequential `score_records` path, an internal consistency check on the fixture.
+
+## Reproducing
+
+```bash
+# Single-thread hot paths at production scale (forward_pass, batched_scoring,
+# backprop, scoring for production / production_2x).
+cargo bench -p neat-core --bench hot_paths -- production
+
+# Data-parallel scoring throughput (1 core vs all cores).
+cargo bench -p neat-core --bench parallel_scoring --features parallel
+
+# Bench compile smoke test (the only automated gate, since benches are
+# harness = false and excluded from CI).
+cargo bench -p neat-core --no-run --features parallel
+```
+
+To compare a candidate optimisation, save this state as a Criterion baseline
+first, then re-run after the change:
+
+```bash
+cargo bench -p neat-core --bench hot_paths -- --save-baseline before
+# … apply change …
+cargo bench -p neat-core --bench hot_paths -- --baseline before
+```

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -14,15 +14,22 @@ There are two bench targets:
 
 ## What is measured
 
-`hot_paths.rs` covers the four hottest paths in the crate:
+`hot_paths.rs` covers the hottest paths in the crate:
 
 | Group | Function(s) under test | Sizes |
 | --- | --- | --- |
 | `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
+| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
+
+The `scoring` group (Issue #228) pushes a full production-sized record batch
+through one creature via `score_records`, so `hot_paths` reports single-core
+scoring throughput at production record volume alongside the parallel harness.
+It covers only the gather-bound `production` shapes and is reachable with the
+`production` filter (`--bench hot_paths -- production`).
 
 Networks and inputs are built **once** outside the timed closure from a
 fixed-seed PRNG with fixed topologies, and `criterion::black_box` guards inputs
@@ -80,14 +87,27 @@ creature on **a single core versus all available cores**, using the
 size, so the 1-core and all-core measurements share one code path and differ
 only in pool size.
 
+The batch is `PRODUCTION_SCORING_RECORDS` records (defined in
+`benches/common/mod.rs` and shared with the `hot_paths` `scoring` group). That
+count is **calibrated to production record volume** — one GRQ-cluster training
+shard, ~4.3k records — rather than an arbitrary token batch. The derivation is
+documented in [`BASELINE.md`](BASELINE.md).
+
 ```bash
 # Requires the `parallel` feature (rayon, native targets only).
 cargo bench -p neat-core --features parallel --bench parallel_scoring
 ```
 
 The `production` filter is a regex over benchmark ids, so it matches both the
-`production` and `production_2x` shapes in `forward_pass`, `batched_scoring` and
-`backprop`.
+`production` and `production_2x` shapes in `forward_pass`, `batched_scoring`,
+`backprop` and `scoring`.
+
+## Documented baseline (Issue #228)
+
+[`BASELINE.md`](BASELINE.md) records the committed production/production_2x
+numbers for every hot-path group, with host/CPU/toolchain metadata. Every
+optimisation under the #227 milestone must cite a before/after comparison
+against it for the affected group.
 
 ## Comparing before vs after a change
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -207,6 +207,41 @@ pub fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
     (0..n).map(|_| rng.next_signed()).collect()
 }
 
+/// Production-representative record count for the scoring throughput benches
+/// (Issue #228), calibrated to the committed GRQ-cluster telemetry rather than
+/// an arbitrary token batch.
+///
+/// Derivation (from `GRQ-cluster/performance.csv`, the 32-generation production
+/// run whose totals match `result.json`):
+///
+/// - `training_data_size_bytes` = 22,097,375,712 across
+///   `training_data_files` = 520 shards.
+/// - Per-record width = `num_inputs * size_of::<f32>()` = 2461 * 4 = 9844 bytes.
+/// - Whole-corpus records ≈ 22,097,375,712 / 9844 ≈ **2.24 million** — the count
+///   a single creature forward-passes per generation to compute its fitness.
+/// - Per training shard ≈ 2,244,755 / 520 ≈ **4,317 records** — the natural
+///   granularity the streaming scorer holds in flight.
+///
+/// Materialising the whole 2.24 M-record corpus in memory (~21 GiB at
+/// production width) is infeasible for a micro-benchmark, so the harness scores
+/// **one production shard's worth**, rounded down to the nearest power of two
+/// (4096). At ~9.8 KiB/record this batch is ~40 MiB — already far larger than
+/// any CPU cache, so its memory-traffic behaviour is production-representative,
+/// and records/sec extrapolates directly to the full corpus pass (throughput is
+/// size-invariant once the pool/allocation overhead is amortised). This is 2x
+/// the prior token batch of 2048.
+pub const PRODUCTION_SCORING_RECORDS: usize = 4096;
+
+/// Build `count` distinct input records of length `num_inputs`, each drawn from
+/// the fixed-seed PRNG with a per-record seed so the batch is reproducible yet
+/// not a degenerate run of identical rows. Shared by the `parallel_scoring` and
+/// `hot_paths` scoring groups so both measure the same synthesised workload.
+pub fn build_records(num_inputs: usize, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| build_inputs(num_inputs, 0x5C0E_0000 + i as u64))
+        .collect()
+}
+
 /// Owned backing storage for a `PropagateInput`; built once outside the loop.
 pub struct BackpropData {
     pub neurons: Vec<NeuronInput>,

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -30,7 +30,10 @@ use neat_core::unsquash::apply_unsquash;
 /// integration test (Issue #176) so the production-scale builders are exercised
 /// by a real `cargo test` run as well as the harness.
 mod common;
-use common::{Lcg, NETWORKS, build_backprop_data, build_inputs, build_network};
+use common::{
+    Lcg, NETWORKS, PRODUCTION_SCORING_RECORDS, build_backprop_data, build_inputs, build_network,
+    build_records,
+};
 
 /// Forward pass — `CompiledNetwork::activate` across representative sizes.
 fn bench_forward_pass(c: &mut Criterion) {
@@ -129,6 +132,37 @@ fn bench_backprop(c: &mut Criterion) {
                 black_box(out);
             });
         });
+    }
+    group.finish();
+}
+
+/// Scoring throughput — a full production-shaped record batch pushed through
+/// one creature via `score_records` (Issue #228). Sized to
+/// [`PRODUCTION_SCORING_RECORDS`] so the single-core scoring figure in
+/// `hot_paths` is measured at production record volume, matching the
+/// `parallel_scoring` harness. Only the production shapes are gather-bound in
+/// the way real scoring is, so this group covers just `production` /
+/// `production_2x` and is reachable via `--bench hot_paths -- production`.
+fn bench_scoring(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scoring");
+    for spec in NETWORKS
+        .iter()
+        .filter(|s| s.label.starts_with("production"))
+    {
+        let net = build_network(spec, 0x5EED);
+        let records = build_records(net.num_inputs(), PRODUCTION_SCORING_RECORDS);
+        let num_outputs = spec.num_outputs;
+        group.throughput(Throughput::Elements(PRODUCTION_SCORING_RECORDS as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(spec.label),
+            &records,
+            |b, records| {
+                b.iter(|| {
+                    let out = net.score_records(black_box(records), black_box(num_outputs));
+                    black_box(out);
+                });
+            },
+        );
     }
     group.finish();
 }
@@ -309,6 +343,7 @@ criterion_group!(
     bench_forward_pass,
     bench_batched_scoring,
     bench_backprop,
+    bench_scoring,
     bench_activation_primitives,
 );
 criterion_main!(benches);

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -22,7 +22,9 @@ mod common;
 
 #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
 mod bench {
-    use super::common::{NETWORKS, NetSpec, build_inputs, build_network};
+    use super::common::{
+        NETWORKS, NetSpec, PRODUCTION_SCORING_RECORDS, build_network, build_records,
+    };
     use criterion::{Criterion, Throughput, criterion_group};
     use neat_core::network::CompiledNetwork;
     use rayon::ThreadPoolBuilder;
@@ -33,12 +35,6 @@ mod bench {
             .iter()
             .find(|s| s.label == label)
             .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
-    }
-
-    fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
-        (0..count)
-            .map(|i| build_inputs(net.num_inputs(), 0x5C0E_0000 + i as u64))
-            .collect()
     }
 
     /// Score `records` inside a rayon pool of exactly `threads` workers, so the
@@ -59,12 +55,13 @@ mod bench {
 
     pub fn bench_parallel_scoring(c: &mut Criterion) {
         let all_cores = std::thread::available_parallelism().map_or(1, |n| n.get());
-        const NUM_RECORDS: usize = 2048;
+        // Production-representative volume (Issue #228); see `PRODUCTION_SCORING_RECORDS`.
+        const NUM_RECORDS: usize = PRODUCTION_SCORING_RECORDS;
 
         for label in ["production", "production_2x"] {
             let s = spec(label);
             let net = build_network(s, 0x5EED);
-            let records = build_records(&net, NUM_RECORDS);
+            let records = build_records(net.num_inputs(), NUM_RECORDS);
             let num_outputs = s.num_outputs;
 
             let mut group = c.benchmark_group(format!("score_records/{label}"));

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -7,7 +7,10 @@
 #[allow(dead_code)]
 mod common;
 
-use common::{FanIn, NETWORKS, NetSpec, build_backprop_data, build_inputs, build_network};
+use common::{
+    FanIn, NETWORKS, NetSpec, PRODUCTION_SCORING_RECORDS, build_backprop_data, build_inputs,
+    build_network, build_records,
+};
 
 fn spec(label: &str) -> &'static NetSpec {
     NETWORKS
@@ -131,4 +134,69 @@ fn backprop_data_has_consistent_inward_adjacency_at_production_scale() {
     let summed: usize = data.inward_counts.iter().map(|&c| c as usize).sum();
     assert_eq!(summed, data.synapses.len());
     assert_eq!(summed, data.inward_indices.len());
+}
+
+#[test]
+fn build_records_produces_deterministic_distinct_batch_sized_to_inputs() {
+    let prod = spec("production");
+    let a = build_records(prod.num_inputs, 64);
+    let b = build_records(prod.num_inputs, 64);
+
+    // One record per requested count, each a full input vector.
+    assert_eq!(a.len(), 64);
+    assert!(
+        a.iter().all(|r| r.len() == prod.num_inputs),
+        "each record must be a full production-width input vector"
+    );
+
+    // Fixed-seed synthesis must reproduce byte-for-byte (non-determinism guard).
+    assert_eq!(a, b, "seeded record synthesis must be reproducible");
+
+    // Per-record seed ⇒ distinct rows, so throughput is not measured on a
+    // degenerate all-identical batch.
+    assert_ne!(a[0], a[1], "records should differ across the batch");
+}
+
+#[test]
+fn production_scoring_record_count_is_production_representative() {
+    // Build the actual batch the scoring benches time — calibrated to one
+    // production training shard (~corpus/520 ≈ 4.3k records).
+    let widest = spec("production_2x");
+    let batch = build_records(widest.num_inputs, PRODUCTION_SCORING_RECORDS);
+
+    // Well above the prior 2048 token batch, so records/sec reflects
+    // steady-state scoring rather than warm-up.
+    assert_eq!(batch.len(), PRODUCTION_SCORING_RECORDS);
+    assert!(
+        batch.len() > 2048,
+        "scoring batch must be production-sized, not a token batch"
+    );
+
+    // Memory-feasible on the Apple Silicon host class: even the widest shape's
+    // batch stays well under 1 GiB so the harness can materialise it.
+    let bytes: usize = batch
+        .iter()
+        .map(|r| r.len() * std::mem::size_of::<f32>())
+        .sum();
+    assert!(
+        bytes < (1usize << 30),
+        "production batch ({bytes} bytes) must fit comfortably in RAM"
+    );
+}
+
+#[test]
+fn score_records_on_production_batch_yields_finite_ordered_outputs() {
+    let prod = spec("production");
+    let net = build_network(prod, 0x5EED);
+    // A small production-shaped batch keeps the debug test fast while still
+    // exercising the exact fixture path the scoring benches time.
+    let records = build_records(net.num_inputs(), 96);
+
+    let out = net.score_records(&records, prod.num_outputs);
+    assert_eq!(out.len(), records.len());
+    assert!(out.iter().all(|row| row.len() == prod.num_outputs));
+    assert!(
+        out.iter().flatten().all(|v| v.is_finite()),
+        "production scoring must produce finite outputs"
+    );
 }


### PR DESCRIPTION
# Establish production-sized benchmark baseline and scoring fixtures (Issue #228)

## Summary

Establishes the documented, production-calibrated benchmark baseline that every
optimisation under the #227 milestone is gated against. Closes #228.

Production timings show fitness evaluation dominates (~95% of wall clock:
2,901,473 ms of 3,042,879 ms over 32 generations). This is a **bench-only**
change — no library behaviour is touched — that does three things:

1. **Calibrates the scoring record count to production volume.**
   `parallel_scoring.rs` scored an uncalibrated 2048-record token batch. It now
   scores `PRODUCTION_SCORING_RECORDS = 4096` records — one GRQ-cluster training
   shard's worth — with the derivation from committed telemetry
   (`GRQ-cluster/performance.csv` / `result.json`) documented in `BASELINE.md`
   and `benches/common/mod.rs`.
2. **Adds a `scoring` group to `hot_paths.rs`** measuring single-core
   `score_records` throughput at production record volume for `production` /
   `production_2x`, reachable via `--bench hot_paths -- production`.
3. **Commits `neat-core/benches/BASELINE.md`** with the production/production_2x
   numbers for every hot-path group, plus host/CPU/toolchain metadata.

The record count lives in `benches/common/mod.rs` as a single source of truth
(`PRODUCTION_SCORING_RECORDS` + `build_records`), shared by both bench targets
and the `bench_fixtures` test.

### Record-count derivation (cross-checkable against #227)

| Quantity | Value | Source |
| --- | --- | --- |
| Training corpus size | 22,097,375,712 bytes | `training_data_size_bytes` |
| Training shards | 520 | `training_data_files` |
| Per-record width | 2461 × 4 = 9844 bytes | `num_inputs` × `size_of::<f32>()` |
| Whole-corpus records | ≈ 2.24 M | corpus / record width |
| Records per shard | ≈ 4,317 | 2.24 M / 520 |
| **Bench batch** | **4096** | one shard, rounded to 2¹² |

Materialising the full ~2.24 M-record corpus (~21 GiB) is infeasible for a
micro-benchmark, so the harness scores one shard (~40 MiB) — already far larger
than any CPU cache, so records/sec extrapolates to the full corpus pass.

## Evidence

Backend/bench-only change — no web interface to screenshot. Evidence is the
committed baseline numbers, captured on the Apple Silicon host class.

**Host:** Apple M4 Pro (8P+4E, 12 logical), macOS 26.5.2 arm64, rustc 1.96.0,
Criterion 0.8.2, `--release`.

`hot_paths -- production` (single-thread):

| Group / benchmark | production | production_2x |
| --- | --- | --- |
| `forward_pass` | 32.76 µs | 67.26 µs |
| `batched_scoring/trace_batch_4way` | 80.17 µs | 199.18 µs |
| `batched_scoring/mse_sum_8records` | 223.55 µs | 656.06 µs |
| `backprop` | 153.87 µs | 368.19 µs |
| `scoring` (4096 records) | 242.79 ms | 491.36 ms |

`parallel_scoring --features parallel` (4096 records, 1 vs 12 cores):

| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
| --- | --- | --- | --- | --- |
| `production` | 242.97 ms | 75.44 ms | 16.86 K → 54.30 K | 3.22× |
| `production_2x` | 487.26 ms | 137.78 ms | 8.41 K → 29.73 K | 3.54× |

Internal consistency check: single-core `parallel_scoring` (16.86 Krecords/s,
`production`) matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both
drive the same sequential `score_records` path.

```mermaid
flowchart LR
    T["GRQ-cluster telemetry<br/>performance.csv / result.json"] --> D["Derive record count<br/>corpus / 520 shards ≈ 4.3k"]
    D --> C["PRODUCTION_SCORING_RECORDS = 4096<br/>(common/mod.rs)"]
    C --> H["hot_paths: scoring group"]
    C --> P["parallel_scoring: 1 vs all cores"]
    H --> B["BASELINE.md"]
    P --> B
    B --> O["Gates every #227 optimisation PR<br/>(before/after comparison)"]
```

## Test Plan

Added behavioural ("what") tests to `neat-core/tests/bench_fixtures.rs`
(exercising the shared fixtures via `#[path]`):

- `build_records_produces_deterministic_distinct_batch_sized_to_inputs` — the
  helper yields `count` records each of `num_inputs` length, reproducible under
  a fixed seed (non-determinism guard) and distinct across the batch.
- `production_scoring_record_count_is_production_representative` — the built
  batch exceeds the prior 2048 token batch and stays memory-feasible (< 1 GiB)
  at the widest shape.
- `score_records_on_production_batch_yields_finite_ordered_outputs` — scoring a
  production-shaped batch produces finite, correctly-shaped outputs.

Verification run (all green):

- `cargo test --workspace --lib --tests --all-features` — all pass, including
  the 9 `bench_fixtures` tests and 7 `parallel_scoring` tests.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo bench -p neat-core --no-run --features parallel` — the required bench
  compile smoke test (benches are `harness = false` / excluded from CI, so this
  is the automated gate).
- `cargo fmt --all --check`, `cargo doc`, `codespell` — clean.

### Pre-existing failure noted

`./quality.sh` exits early on 4 pre-existing `ci.yml` bats failures (tests
48/49/50/54 about `bump-deps.sh` wiring) that are present on the clean base
branch and unrelated to this change (which touches only `neat-core/benches/*`,
`neat-core/tests/bench_fixtures.rs` and `docs/`). Every Rust stage `quality.sh`
would run past that point was executed directly and passed.



## Milestone
This PR is part of the **#227 Speed up NEAT evolution on production-sized creatures (benchmark-gated)** milestone and targets the `milestone/227-speed-up-neat-evolution-on-production-sized-cr` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr9g4vub-2051b8`<!-- vibe-worker-issue-228 -->