### PR TITLE
[#230] Score records through the 8-record batched SIMD path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,25 @@ cargo bench -p neat-core --bench hot_paths
 | `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
 
 Scoring a production-size dataset pushes many records through one creature — an
-embarrassingly parallel workload *across records*. With the `parallel` feature
-the throughput scales with core count, while results stay **identical** to the
-sequential path (each record is scored by the same `activate`, with no
-cross-record state — each rayon worker owns a cloned scratch context):
+embarrassingly parallel workload *across records*. Both `score_records` and
+`score_records_parallel` drive the forward pass through the **8-record batched
+SIMD path** (Issue #230): records are grouped into 8s (then a 4-record group,
+then a scalar tail) and forwarded through `weighted_sum_simd_8records` /
+`weighted_sum_simd_4records`, loading each synapse weight once and applying it
+across the lanes. On the gather-bound production topology this cut single-core
+scoring time by **~39%** (see `docs/archive/pr-summaries/pr-summary-230.md`).
+With the `parallel` feature the throughput additionally scales with core count.
+
+Standard-squash neurons now sum **across records** rather than across synapses,
+so their `f32` results match the per-record `activate` reference within a small
+tolerance (SIMD re-association), while the sequential and parallel paths agree
+bit-for-bit. Output order always matches input order.
 
 ```rust
-// Off-feature / wasm: transparently runs sequentially.
+// Off-feature / wasm: transparently runs sequentially (still batched SIMD).
 let outputs = net.score_records(&records, num_outputs);
 
-// With `--features parallel` on native: scored across the rayon pool,
+// With `--features parallel` on native: batches scored across the rayon pool,
 // same results, in input order.
 let outputs = net.score_records_parallel(&records, num_outputs);
 ```
@@ -61,15 +70,18 @@ let outputs = net.score_records_parallel(&records, num_outputs);
 ```mermaid
 flowchart LR
     R[records] --> S{parallel feature?}
-    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
-    S -- on, native --> P[score_records_parallel]
-    P --> W1[worker 1<br/>cloned scratch]
-    P --> W2[worker 2<br/>cloned scratch]
-    P --> Wn[worker N<br/>cloned scratch]
-    W1 --> O[outputs in input order]
-    W2 --> O
-    Wn --> O
-    Q --> O
+    S -- off / wasm32 --> Q[score_records<br/>sequential, batched SIMD]
+    S -- on, native --> P[score_records_parallel<br/>rayon chunks]
+    P --> W1[worker 1<br/>own lane scratch]
+    P --> Wn[worker N<br/>own lane scratch]
+    subgraph B[batched forward per chunk]
+        direction TB
+        E8[8-record SIMD] --> E4[4-record SIMD] --> E1[scalar tail]
+    end
+    Q --> B
+    W1 --> B
+    Wn --> B
+    B --> O[outputs in input order]
 ```
 
 ```bash

--- a/docs/archive/pr-summaries/pr-summary-230.md
+++ b/docs/archive/pr-summaries/pr-summary-230.md
@@ -1,0 +1,104 @@
+# [#227] Score records through the 8-record batched SIMD path
+
+## Summary
+
+Route record scoring through the existing **8-record batched SIMD path** so the
+synapse gather + weighted-sum is amortised across 8 records instead of one at a
+time. The production topology is *wide, shallow, sparse, varied fan-in* —
+gather-bound — where the single-record forward pass re-reads each synapse's
+weight and metadata once **per record**. Batching loads each weight once and
+applies it across 8 (then 4) records via `weighted_sum_simd_8records` /
+`weighted_sum_simd_4records`, cutting gather traffic on the dominant
+standard-squash neurons.
+
+New module `neat-core/src/batch_scoring.rs` adds `CompiledNetwork::score_batch_into`
+plus a reusable `BatchScratch` (eight lane buffers). Both `score_records` and
+`score_records_parallel` now drive this batched forward pass; the parallel path
+splits records into fixed 64-record chunks (a multiple of the SIMD batch) so each
+rayon worker owns its own scratch and every record lands on the same primitive
+either way. Public signatures, the flat output layout, and the single output
+allocation (Issue #229) are unchanged.
+
+**Closes #230.**
+
+### Numerics
+
+- **Squash** uses the exact scalar inline branch of `activate_into` (Identity /
+  ReLU / Logistic / Tanh, else `apply_squash`) — no vectorised approximation —
+  so the squash itself is bit-identical.
+- **Standard-squash** neurons sum *across records* rather than across synapses,
+  re-associating the `f32` accumulation. Results therefore match the per-record
+  reference **within tolerance** (~1e-6 observed, `TOL = 1e-3`), not bit-for-bit
+  — the acceptance criteria explicitly allow SIMD reordering / `f32`
+  accumulation differences.
+- **Aggregate** squashes (Min/Max/If/Hypotenuse/HypotenuseV2/Mean) and the
+  **scalar tail** run the exact single-record path, so those neurons and those
+  records are bit-identical to the reference.
+- **Sequential and parallel paths agree bit-for-bit** (each record's result is
+  independent of its batch-mates, and the chunk size is a multiple of the SIMD
+  batch).
+
+```mermaid
+flowchart LR
+    R[records slice] --> B{group by lane}
+    B -- 8 at a time --> E8[weighted_sum_simd_8records<br/>weight loaded once, applied x8]
+    B -- next 4 --> E4[weighted_sum_simd_4records]
+    B -- remainder --> E1[scalar tail<br/>exact single-record path]
+    E8 --> O[flat outputs, input order]
+    E4 --> O
+    E1 --> O
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by benchmarks and
+the extended lane-parity test suite.
+
+### Benchmark (performance gate: merge only on ≥5% gain)
+
+`cargo bench -p neat-core --features parallel --bench parallel_scoring`
+(`--warm-up-time 1 --measurement-time 3 --sample-size 20`), Apple Silicon,
+2048 records/batch. Baseline = #227 `HEAD` (per-record `activate_into`); After =
+this branch.
+
+| Bench | Baseline | After | Change |
+|-------|---------:|------:|-------:|
+| `score_records/production/1_core` | 47.55 ms | 28.85 ms | **−39.3%** |
+| `score_records/production/10_cores` | 9.19 ms | 6.34 ms | **−32.1%** |
+| `score_records/production_2x/1_core` | 100.71 ms | 78.53 ms | **−22.0%** |
+| `score_records/production_2x/10_cores` | 18.97 ms | 15.96 ms | **−16.8%** |
+
+All four measurements clear the ≥5% gate; Criterion's own change detection
+reports `Performance has improved` (p < 0.05) on every one. The single-core
+numbers isolate the forward-pass lever (no rayon noise): scoring the gather-bound
+production creature is **~39% faster** per core.
+
+## Test Plan
+
+Extended `neat-core/tests/parallel_scoring.rs`:
+
+- Added `TOL` + `assert_close` and relaxed the four per-record-reference parity
+  tests (`parallel_scoring_matches_sequential_on_production_fixture`,
+  `parallel_scoring_matches_sequential_across_shapes`,
+  `score_records_matches_reference`, `output_order_is_preserved`) to the agreed
+  float tolerance where `f32` re-association requires it. `single_record_matches_direct_activate`
+  and `empty_records_yields_empty_output` stay **exact** (scalar/degenerate paths).
+- Added `tail_boundary_record_counts_match_reference` exercising counts
+  `0,1,2,3,4,5,7,8,9,12,15,16,17,24,31,33` — straddling every 8/4/scalar
+  boundary — asserting both exact output **length** (no record dropped or
+  duplicated) and per-record parity within tolerance.
+- Added `sequential_and_parallel_are_bit_identical` (counts 7,8,9,65,130,257
+  across three shapes) proving the two paths agree bit-for-bit.
+- `neat-core/tests/simd_weighted_sums.rs` and `network_activate_trace_batch.rs`
+  (unchanged) continue to guard the underlying SIMD primitives.
+
+Updated `neat-core/tests/scoring_allocations.rs` doc comments to describe the
+batched path (behaviour it directly tests); the no-per-record-allocation
+invariant still holds (one output buffer + one lane-scratch set, constant in
+record count).
+
+Full local gate green: `cargo fmt --check`, `cargo clippy --workspace
+--all-targets --all-features -D warnings`, `cargo test --workspace --lib --tests
+--all-features`, `cargo doc -D warnings`, `cargo build --release`, `cargo deny
+check`. Also verified the default (no-`parallel`) build and its
+`score_records_parallel` fallback.

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -1,0 +1,379 @@
+//! Batched record scoring through the 8-record SIMD path (Issue #230).
+//!
+//! The production topology is *wide, shallow, sparse, varied fan-in* —
+//! gather-bound (see `benches/README.md`). The single-record forward pass
+//! ([`CompiledNetwork::activate_into`]) re-reads each synapse's weight and
+//! metadata once **per record**. This module drives the forward pass through
+//! the existing across-records SIMD primitives
+//! ([`weighted_sum_simd_8records`] / [`weighted_sum_simd_4records`]), loading
+//! each synapse weight once and applying it across 8 (then 4) records. That
+//! amortises the weight load and synapse-index read across the batch, cutting
+//! gather traffic on the dominant standard-squash neurons.
+//!
+//! # Numerics
+//!
+//! Standard-squash neurons accumulate their weighted sum across records rather
+//! than across synapses, so the summation is re-associated relative to the
+//! single-record [`weighted_sum_simd`] kernel. In `f32` that yields results
+//! that match the per-record reference **within a small tolerance**, not
+//! bit-for-bit (Issue #230 acceptance criteria explicitly allow SIMD
+//! reordering / `f32` accumulation differences). Every other numeric step is
+//! identical to [`CompiledNetwork::activate_into`]:
+//!
+//! - The **squash** uses the same scalar inline branch (Identity / ReLU /
+//!   Logistic / Tanh, else `apply_squash`) — no vectorised approximation — so
+//!   the squash itself is bit-identical.
+//! - **Aggregate** squashes (Minimum, Maximum, If, Hypotenuse, HypotenuseV2,
+//!   Mean) and the **scalar tail** (`records.len() % 8` after the 4-way step)
+//!   run the exact single-record path via `neuron_activation_scalar`, so those
+//!   neurons and those records are bit-identical to the reference.
+//!
+//! # Determinism
+//!
+//! Weights are read through `&self`; all mutable state lives in a caller-owned
+//! [`BatchScratch`]. Record `i`'s outputs are always written to
+//! `out[i * num_outputs .. (i + 1) * num_outputs]`, so output order matches
+//! input order regardless of batching or thread count.
+
+use crate::network::{CompiledNetwork, NeuronData, SynapseData};
+use crate::range::apply_limit_range;
+use crate::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
+};
+use crate::squash::{SquashType, apply_squash};
+use crate::synapse_type::SynapseType;
+
+/// Reusable per-worker scratch: eight activation buffers, one per SIMD lane.
+///
+/// Owning the buffers here lets the sequential path allocate once for a whole
+/// batch and the parallel path allocate once per rayon worker (via
+/// `for_each_init`), instead of once per chunk.
+pub struct BatchScratch {
+    acts: [Vec<f32>; 8],
+}
+
+impl BatchScratch {
+    /// Allocate eight zeroed activation buffers sized to the network.
+    pub fn new(num_neurons: usize) -> Self {
+        Self {
+            acts: std::array::from_fn(|_| vec![0.0f32; num_neurons]),
+        }
+    }
+}
+
+/// Inline squash matching [`CompiledNetwork::activate_into`] exactly: the four
+/// hot types are branched directly, everything else defers to [`apply_squash`].
+#[inline]
+fn inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
+    match squash_type {
+        0 => sum,                        // IDENTITY
+        1 => sum.max(0.0),               // ReLU
+        6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
+        7 => sum.tanh(),                 // TANH
+        _ => apply_squash(squash, sum),  // Other (fallback)
+    }
+}
+
+/// Single-record activation for one neuron, byte-for-byte identical to the body
+/// of [`CompiledNetwork::activate_into`]. Reused for constant neurons, aggregate
+/// squashes and the scalar tail so those results exactly match the reference.
+#[inline]
+fn neuron_activation_scalar(synapses: &[SynapseData], act: &[f32], neuron: &NeuronData) -> f32 {
+    if neuron.is_constant {
+        return apply_limit_range(SquashType::Identity, neuron.bias);
+    }
+
+    let squash = SquashType::from(neuron.squash_type);
+    let start = neuron.start_synapse as usize;
+    let end = start + neuron.num_synapses as usize;
+
+    let activation = match squash {
+        SquashType::Minimum => {
+            let mut min_val = f32::INFINITY;
+            for s in &synapses[start..end] {
+                let val = act[s.from_index as usize] * s.weight;
+                if val < min_val {
+                    min_val = val;
+                }
+            }
+            if min_val == f32::INFINITY {
+                neuron.bias
+            } else {
+                min_val + neuron.bias
+            }
+        }
+        SquashType::Maximum => {
+            let mut max_val = f32::NEG_INFINITY;
+            for s in &synapses[start..end] {
+                let val = act[s.from_index as usize] * s.weight;
+                if val > max_val {
+                    max_val = val;
+                }
+            }
+            if max_val == f32::NEG_INFINITY {
+                neuron.bias
+            } else {
+                max_val + neuron.bias
+            }
+        }
+        SquashType::If => {
+            let mut condition_sum = 0.0f32;
+            let mut positive_sum = 0.0f32;
+            let mut negative_sum = 0.0f32;
+            for s in &synapses[start..end] {
+                let val = act[s.from_index as usize] * s.weight;
+                match SynapseType::from(s.synapse_type) {
+                    SynapseType::Condition => condition_sum += val,
+                    SynapseType::Negative => negative_sum += val,
+                    SynapseType::Positive | SynapseType::Standard => positive_sum += val,
+                }
+            }
+            if condition_sum > 0.0 {
+                positive_sum + neuron.bias
+            } else {
+                negative_sum + neuron.bias
+            }
+        }
+        SquashType::Hypotenuse => {
+            let sum_sq = weighted_sum_of_squares_simd(synapses, act, start, end);
+            sum_sq.sqrt() + neuron.bias
+        }
+        SquashType::HypotenuseV2 => {
+            let sum_sq = weighted_sum_of_squares_v2_simd(synapses, act, start, end, neuron.bias);
+            sum_sq.sqrt()
+        }
+        SquashType::Mean => {
+            let n = (end - start) as f32;
+            if n <= 0.0 {
+                neuron.bias
+            } else {
+                let sum = weighted_sum_no_bias_simd(synapses, act, start, end);
+                sum / n + neuron.bias
+            }
+        }
+        _ => {
+            let sum = weighted_sum_simd(synapses, act, start, end, neuron.bias);
+            inline_squash(neuron.squash_type, squash, sum)
+        }
+    };
+
+    apply_limit_range(squash, activation)
+}
+
+/// Copy record inputs into a lane buffer, matching [`CompiledNetwork::activate_into`]
+/// (which copies `min(len, num_inputs)` input values). Any input slot the record
+/// does not cover is zeroed so each record is scored statelessly — buffers are
+/// reused across batches, and every non-input neuron is overwritten during the
+/// forward pass, so no further reset is required.
+#[inline]
+fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
+    let in_len = record.len().min(num_inputs);
+    act[..in_len].copy_from_slice(&record[..in_len]);
+    act[in_len..num_inputs].fill(0.0);
+}
+
+impl CompiledNetwork {
+    /// Score a contiguous slice of records through the batched SIMD path.
+    ///
+    /// Record `i` (0-based within `records`) writes its outputs to
+    /// `out[i * num_outputs .. (i + 1) * num_outputs]`; `out` must be exactly
+    /// `records.len() * num_outputs` long. Records are grouped into 8s and
+    /// driven through [`weighted_sum_simd_8records`], then a 4-record group via
+    /// [`weighted_sum_simd_4records`], then a scalar tail — matching the
+    /// remainder handling of `mse_sum_batch_packed`.
+    pub(crate) fn score_batch_into(
+        &self,
+        scratch: &mut BatchScratch,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        let num_neurons = self.num_neurons;
+        let num_inputs = self.num_inputs;
+        let output_start = num_neurons - num_outputs;
+        let n = records.len();
+
+        let [act0, act1, act2, act3, act4, act5, act6, act7] = &mut scratch.acts;
+
+        let mut base = 0usize;
+
+        // ---- 8-record batches ------------------------------------------------
+        while base + 8 <= n {
+            load_record(act0, &records[base], num_inputs);
+            load_record(act1, &records[base + 1], num_inputs);
+            load_record(act2, &records[base + 2], num_inputs);
+            load_record(act3, &records[base + 3], num_inputs);
+            load_record(act4, &records[base + 4], num_inputs);
+            load_record(act5, &records[base + 5], num_inputs);
+            load_record(act6, &records[base + 6], num_inputs);
+            load_record(act7, &records[base + 7], num_inputs);
+
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+
+                if neuron.is_constant {
+                    let v = apply_limit_range(SquashType::Identity, neuron.bias);
+                    act0[actual_idx] = v;
+                    act1[actual_idx] = v;
+                    act2[actual_idx] = v;
+                    act3[actual_idx] = v;
+                    act4[actual_idx] = v;
+                    act5[actual_idx] = v;
+                    act6[actual_idx] = v;
+                    act7[actual_idx] = v;
+                    continue;
+                }
+
+                let squash = SquashType::from(neuron.squash_type);
+                match squash {
+                    SquashType::Minimum
+                    | SquashType::Maximum
+                    | SquashType::If
+                    | SquashType::Hypotenuse
+                    | SquashType::HypotenuseV2
+                    | SquashType::Mean => {
+                        // Aggregate squashes stay on the exact single-record path.
+                        act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
+                        act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
+                        act2[actual_idx] = neuron_activation_scalar(&self.synapses, act2, neuron);
+                        act3[actual_idx] = neuron_activation_scalar(&self.synapses, act3, neuron);
+                        act4[actual_idx] = neuron_activation_scalar(&self.synapses, act4, neuron);
+                        act5[actual_idx] = neuron_activation_scalar(&self.synapses, act5, neuron);
+                        act6[actual_idx] = neuron_activation_scalar(&self.synapses, act6, neuron);
+                        act7[actual_idx] = neuron_activation_scalar(&self.synapses, act7, neuron);
+                    }
+                    _ => {
+                        let start = neuron.start_synapse as usize;
+                        let end = start + neuron.num_synapses as usize;
+                        let (s0, s1, s2, s3, s4, s5, s6, s7) = weighted_sum_simd_8records(
+                            &self.synapses,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
+                            act4,
+                            act5,
+                            act6,
+                            act7,
+                            start,
+                            end,
+                            neuron.bias,
+                        );
+                        let st = neuron.squash_type;
+                        act0[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s0));
+                        act1[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s1));
+                        act2[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s2));
+                        act3[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s3));
+                        act4[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s4));
+                        act5[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s5));
+                        act6[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s6));
+                        act7[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s7));
+                    }
+                }
+            }
+
+            for r in 0..8 {
+                let src = match r {
+                    0 => &*act0,
+                    1 => &*act1,
+                    2 => &*act2,
+                    3 => &*act3,
+                    4 => &*act4,
+                    5 => &*act5,
+                    6 => &*act6,
+                    _ => &*act7,
+                };
+                let dst = (base + r) * num_outputs;
+                out[dst..dst + num_outputs]
+                    .copy_from_slice(&src[output_start..output_start + num_outputs]);
+            }
+
+            base += 8;
+        }
+
+        // ---- 4-record batch (0 or 1 of them) ---------------------------------
+        if base + 4 <= n {
+            load_record(act0, &records[base], num_inputs);
+            load_record(act1, &records[base + 1], num_inputs);
+            load_record(act2, &records[base + 2], num_inputs);
+            load_record(act3, &records[base + 3], num_inputs);
+
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+
+                if neuron.is_constant {
+                    let v = apply_limit_range(SquashType::Identity, neuron.bias);
+                    act0[actual_idx] = v;
+                    act1[actual_idx] = v;
+                    act2[actual_idx] = v;
+                    act3[actual_idx] = v;
+                    continue;
+                }
+
+                let squash = SquashType::from(neuron.squash_type);
+                match squash {
+                    SquashType::Minimum
+                    | SquashType::Maximum
+                    | SquashType::If
+                    | SquashType::Hypotenuse
+                    | SquashType::HypotenuseV2
+                    | SquashType::Mean => {
+                        act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
+                        act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
+                        act2[actual_idx] = neuron_activation_scalar(&self.synapses, act2, neuron);
+                        act3[actual_idx] = neuron_activation_scalar(&self.synapses, act3, neuron);
+                    }
+                    _ => {
+                        let start = neuron.start_synapse as usize;
+                        let end = start + neuron.num_synapses as usize;
+                        let (s0, s1, s2, s3) = weighted_sum_simd_4records(
+                            &self.synapses,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
+                            start,
+                            end,
+                            neuron.bias,
+                        );
+                        let st = neuron.squash_type;
+                        act0[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s0));
+                        act1[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s1));
+                        act2[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s2));
+                        act3[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s3));
+                    }
+                }
+            }
+
+            for r in 0..4 {
+                let src = match r {
+                    0 => &*act0,
+                    1 => &*act1,
+                    2 => &*act2,
+                    _ => &*act3,
+                };
+                let dst = (base + r) * num_outputs;
+                out[dst..dst + num_outputs]
+                    .copy_from_slice(&src[output_start..output_start + num_outputs]);
+            }
+
+            base += 4;
+        }
+
+        // ---- scalar tail (records.len() % 4) ---------------------------------
+        // Exact single-record path so tail records are bit-identical to the
+        // reference.
+        while base < n {
+            load_record(act0, &records[base], num_inputs);
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+                act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
+            }
+            let dst = base * num_outputs;
+            out[dst..dst + num_outputs]
+                .copy_from_slice(&act0[output_start..output_start + num_outputs]);
+            base += 1;
+        }
+    }
+}

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -9,6 +9,7 @@
 
 // Core computation modules
 pub mod accumulate;
+pub mod batch_scoring;
 pub mod creature;
 pub mod derivative;
 pub mod elastic_distribution;

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -44,28 +44,39 @@
 //! through [`CompiledNetwork::activate_into`], so the batch performs a **single**
 //! output allocation instead of one heap allocation per record.
 
+use crate::batch_scoring::BatchScratch;
 use crate::network::CompiledNetwork;
+
+/// Records per rayon task on the parallel path. A multiple of 8 so every task's
+/// interior runs full 8-record SIMD batches (only the final task's tail can be
+/// short), and small enough that a 2048-record batch splits into many chunks for
+/// work-stealing balance across cores.
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+const PARALLEL_CHUNK_RECORDS: usize = 64;
 
 impl CompiledNetwork {
     /// Score every record sequentially, returning a single flat output buffer.
     ///
     /// The result is one contiguous `Vec<f32>` of `records.len() * num_outputs`
     /// elements: record `i`'s outputs occupy `[i * num_outputs .. (i + 1) *
-    /// num_outputs]`. Routing through [`CompiledNetwork::activate_into`] and
-    /// writing straight into pre-sized chunks removes the per-record output
-    /// `Vec` allocation that [`CompiledNetwork::activate`]'s `to_vec()` incurred
-    /// (Issue #229) — the whole batch now costs a **single** output allocation.
+    /// num_outputs]`.
     ///
-    /// Shared read-only weights (`&self`) plus a single owned scratch context
-    /// (one clone of the network). This is the fallback used when the `parallel`
-    /// feature is off or when building for `wasm32`, and the reference path the
-    /// parallel results must match exactly.
+    /// The batch is driven through the across-records SIMD path (Issue #230):
+    /// records are grouped into 8s (then a 4-record group, then a scalar tail)
+    /// and forwarded through the batched `weighted_sum_simd_8records` /
+    /// `weighted_sum_simd_4records` kernels, loading each synapse weight once and
+    /// applying it across the lanes. The output layout and the single output
+    /// allocation (Issue #229) are unchanged; standard-squash results match the
+    /// per-record reference within a small `f32` tolerance (see
+    /// [`crate::batch_scoring`]).
+    ///
+    /// This is the fallback used when the `parallel` feature is off or when
+    /// building for `wasm32`, and the reference path the parallel results must
+    /// match exactly.
     pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
-        let mut scratch = self.clone();
         let mut outputs = vec![0.0f32; records.len() * num_outputs];
-        for (record, chunk) in records.iter().zip(outputs.chunks_exact_mut(num_outputs)) {
-            scratch.activate_into(record, chunk);
-        }
+        let mut scratch = BatchScratch::new(self.num_neurons);
+        self.score_batch_into(&mut scratch, records, num_outputs, &mut outputs);
         outputs
     }
 
@@ -73,13 +84,16 @@ impl CompiledNetwork {
     /// flat output buffer in input order.
     ///
     /// Layout matches [`CompiledNetwork::score_records`]: record `i`'s outputs
-    /// live in `[i * num_outputs .. (i + 1) * num_outputs]`. Each rayon worker
-    /// initialises its own cloned scratch context via `for_each_init`, so no
-    /// `&mut self` is shared across threads: immutable weights are read through
-    /// `&self` while every worker owns its activation buffers and writes only its
-    /// own disjoint output chunk. Because each record is scored by the same
-    /// [`CompiledNetwork::activate_into`] used sequentially and there is no
-    /// cross-record state, the results are identical to the sequential path.
+    /// live in `[i * num_outputs .. (i + 1) * num_outputs]`. Records are split
+    /// into fixed-size chunks (`PARALLEL_CHUNK_RECORDS`) across the rayon pool;
+    /// each worker initialises its own [`BatchScratch`] via `for_each_init` and
+    /// drives its chunk through the same batched forward pass
+    /// ([`CompiledNetwork::score_batch_into`]) the sequential path uses, writing
+    /// only its own disjoint output slice. No `&mut self` is shared: immutable
+    /// weights are read through `&self` while every worker owns its lane
+    /// buffers. Because each chunk boundary is a multiple of the batch size and
+    /// the forward pass carries no cross-record state, results are identical to
+    /// the sequential path regardless of thread count.
     ///
     /// Available with the `parallel` feature on native targets.
     #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
@@ -87,11 +101,13 @@ impl CompiledNetwork {
         use rayon::prelude::*;
         let mut outputs = vec![0.0f32; records.len() * num_outputs];
         outputs
-            .par_chunks_mut(num_outputs)
-            .zip(records.par_iter())
+            .par_chunks_mut(PARALLEL_CHUNK_RECORDS * num_outputs)
+            .zip(records.par_chunks(PARALLEL_CHUNK_RECORDS))
             .for_each_init(
-                || self.clone(),
-                |scratch, (chunk, record)| scratch.activate_into(record, chunk),
+                || BatchScratch::new(self.num_neurons),
+                |scratch, (out_chunk, rec_chunk)| {
+                    self.score_batch_into(scratch, rec_chunk, num_outputs, out_chunk)
+                },
             );
         outputs
     }

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -1,11 +1,19 @@
-//! Behavioural tests for data-parallel record scoring (Issue #179).
+//! Behavioural tests for data-parallel record scoring (Issue #179, #230).
 //!
 //! These assert on observable outcomes — the returned output vectors — rather
 //! than on threading mechanics. They run in both feature modes: with the
 //! `parallel` feature off, `score_records_parallel` is the sequential fallback;
 //! with `--features parallel` (as `quality.sh` runs via `--all-features`), the
-//! same assertions exercise the rayon path. Either way the contract is the same:
-//! results identical to the sequential reference, in input order.
+//! same assertions exercise the rayon path.
+//!
+//! Since Issue #230 the forward pass is driven through the across-records SIMD
+//! path (8-record / 4-record batches, scalar tail). Standard-squash neurons now
+//! sum across records rather than across synapses, so their `f32` results match
+//! the per-record reference **within [`TOL`]**, not bit-for-bit — the
+//! acceptance criteria explicitly allow SIMD reordering / `f32` accumulation
+//! differences. A genuine bug (cross-lane weight mix-up, dropped/duplicated
+//! record, mis-ordered output) differs by O(1), far above `TOL`. The scalar
+//! tail and the sequential-vs-parallel comparison remain **exact**.
 
 #[path = "../benches/common/mod.rs"]
 #[allow(dead_code)]
@@ -13,6 +21,39 @@ mod common;
 
 use common::{NETWORKS, NetSpec, build_inputs, build_network};
 use neat_core::network::CompiledNetwork;
+
+/// Absolute tolerance for the batched SIMD path vs the per-record reference.
+/// Outputs are bounded (Tanh + range-limit), so ~1e-6 reassociation noise sits
+/// well under this bound while any real lane/order bug (O(1) error) trips it.
+const TOL: f32 = 1e-3;
+
+/// Assert two flat output buffers agree within [`TOL`], reporting the worst
+/// element on failure so a real divergence is easy to spot.
+fn assert_close(actual: &[f32], expected: &[f32], ctx: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{ctx}: length mismatch ({} vs {})",
+        actual.len(),
+        expected.len()
+    );
+    let mut worst = 0.0f32;
+    let mut worst_at = 0usize;
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        let diff = (a - e).abs();
+        if diff > worst {
+            worst = diff;
+            worst_at = i;
+        }
+    }
+    assert!(
+        worst <= TOL,
+        "{ctx}: max abs diff {worst} at index {worst_at} exceeds tol {TOL} \
+         (actual={}, expected={})",
+        actual.get(worst_at).copied().unwrap_or(f32::NAN),
+        expected.get(worst_at).copied().unwrap_or(f32::NAN),
+    );
+}
 
 fn spec(label: &str) -> &'static NetSpec {
     NETWORKS
@@ -51,7 +92,7 @@ fn parallel_scoring_matches_sequential_on_production_fixture() {
     let actual = net.score_records_parallel(&records, s.num_outputs);
 
     assert_eq!(actual.len(), records.len() * s.num_outputs);
-    assert_eq!(actual, expected, "parallel results must equal sequential");
+    assert_close(&actual, &expected, "production fixture");
 }
 
 #[test]
@@ -64,7 +105,7 @@ fn parallel_scoring_matches_sequential_across_shapes() {
         let expected = reference(&net, &records, s.num_outputs);
         let actual = net.score_records_parallel(&records, s.num_outputs);
 
-        assert_eq!(actual, expected, "mismatch for shape {label}");
+        assert_close(&actual, &expected, &format!("shape {label}"));
     }
 }
 
@@ -75,7 +116,11 @@ fn score_records_matches_reference() {
     let records = build_records(&net, 64);
 
     let expected = reference(&net, &records, s.num_outputs);
-    assert_eq!(net.score_records(&records, s.num_outputs), expected);
+    assert_close(
+        &net.score_records(&records, s.num_outputs),
+        &expected,
+        "score_records medium_500",
+    );
 }
 
 #[test]
@@ -85,7 +130,7 @@ fn output_order_is_preserved() {
     let records = build_records(&net, 200);
 
     // Each record is distinct, so a re-ordered result would not match the
-    // index-aligned reference.
+    // index-aligned reference within tolerance (a swap is an O(1) error).
     let expected = reference(&net, &records, s.num_outputs);
     let actual = net.score_records_parallel(&records, s.num_outputs);
     for (i, (a, e)) in actual
@@ -93,7 +138,7 @@ fn output_order_is_preserved() {
         .zip(expected.chunks_exact(s.num_outputs))
         .enumerate()
     {
-        assert_eq!(a, e, "record {i} out of order or incorrect");
+        assert_close(a, e, &format!("record {i} out of order or incorrect"));
     }
 }
 
@@ -130,6 +175,65 @@ fn single_record_matches_direct_activate() {
     let direct = scratch.activate(&record, s.num_outputs);
     let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
 
-    // Single record: the flat buffer is exactly that record's outputs.
+    // Single record: it runs the scalar tail, which is the exact single-record
+    // path — so the flat buffer is bit-for-bit that record's outputs.
     assert_eq!(via_parallel, direct);
+}
+
+/// Issue #230 — exercise the 8 / 4 / scalar tail boundaries. The remainder path
+/// is where a batched rewrite most likely silently drops or duplicates records,
+/// so we assert both the exact output length (no record lost or added) and
+/// per-record parity with the reference across counts straddling every boundary.
+#[test]
+fn tail_boundary_record_counts_match_reference() {
+    let s = spec("production");
+    let net = build_network(s, 0x0BAD_C0DE);
+
+    for &count in &[0usize, 1, 2, 3, 4, 5, 7, 8, 9, 12, 15, 16, 17, 24, 31, 33] {
+        let records = build_records(&net, count);
+        let expected = reference(&net, &records, s.num_outputs);
+
+        let seq = net.score_records(&records, s.num_outputs);
+        let par = net.score_records_parallel(&records, s.num_outputs);
+
+        assert_eq!(
+            seq.len(),
+            count * s.num_outputs,
+            "seq length for count {count}"
+        );
+        assert_eq!(
+            par.len(),
+            count * s.num_outputs,
+            "par length for count {count}"
+        );
+        assert_close(&seq, &expected, &format!("score_records count {count}"));
+        assert_close(
+            &par,
+            &expected,
+            &format!("score_records_parallel count {count}"),
+        );
+    }
+}
+
+/// The sequential and parallel paths run the identical batched forward pass and
+/// each record's result is independent of its batch-mates; the parallel chunk
+/// size is a multiple of the SIMD batch, so every record lands on the same
+/// primitive (8-way / 4-way / scalar) either way. They must therefore agree
+/// **bit-for-bit**, even though each only matches the per-record reference
+/// within tolerance.
+#[test]
+fn sequential_and_parallel_are_bit_identical() {
+    for label in ["small_50", "medium_500", "production"] {
+        let s = spec(label);
+        let net = build_network(s, 0x5AFE_5EED);
+        for &count in &[7usize, 8, 9, 65, 130, 257] {
+            let records = build_records(&net, count);
+            let seq = net.score_records(&records, s.num_outputs);
+            let par = net.score_records_parallel(&records, s.num_outputs);
+            assert_eq!(
+                seq, par,
+                "seq vs parallel diverged for {label} count {count}"
+            );
+        }
+    }
 }

--- a/neat-core/tests/scoring_allocations.rs
+++ b/neat-core/tests/scoring_allocations.rs
@@ -1,11 +1,12 @@
-//! Allocation-count regression for the record-scoring hot path (Issue #229).
+//! Allocation-count regression for the record-scoring hot path (Issue #229, #230).
 //!
-//! `score_records` now routes every record through
-//! [`CompiledNetwork::activate_into`], writing into one pre-sized flat buffer
-//! instead of allocating a fresh output `Vec` per record via `activate`'s
-//! `to_vec()`. This test proves the batch performs **no per-record output
-//! allocation**: a counting global allocator records how many allocations
-//! happen while scoring, and the count must not scale with the record count.
+//! `score_records` drives every record through the batched SIMD forward pass
+//! ([`CompiledNetwork::score_batch_into`], Issue #230), writing into one
+//! pre-sized flat buffer instead of allocating a fresh output `Vec` per record
+//! via `activate`'s `to_vec()`. This test proves the batch performs **no
+//! per-record output allocation**: a counting global allocator records how many
+//! allocations happen while scoring, and the count must not scale with the
+//! record count.
 //!
 //! A revert to the old `to_vec()`-per-record path would allocate ~one `Vec` per
 //! record, so scoring 10× the records would allocate ~10× more — the delta
@@ -72,7 +73,7 @@ fn allocs_for(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -
 #[test]
 fn score_records_has_no_per_record_output_allocation() {
     let s = spec("production");
-    let net = build_network(s, 0x0A11_0C);
+    let net = build_network(s, 0x000A_110C);
 
     let small = build_records(&net, 100);
     let large = build_records(&net, 1000);
@@ -85,7 +86,7 @@ fn score_records_has_no_per_record_output_allocation() {
 
     // Per-record allocation would make scoring 10× the records allocate ~900
     // extra times; the flat-buffer path allocates a constant handful (one output
-    // buffer + one scratch clone) regardless of record count. A generous
+    // buffer + one set of lane scratch buffers) regardless of record count. A generous
     // threshold distinguishes "constant" from "grows with records" without being
     // brittle to allocator/test-harness noise.
     let delta = large_allocs.saturating_sub(small_allocs);


### PR DESCRIPTION
# [#227] Score records through the 8-record batched SIMD path

## Summary

Route record scoring through the existing **8-record batched SIMD path** so the
synapse gather + weighted-sum is amortised across 8 records instead of one at a
time. The production topology is *wide, shallow, sparse, varied fan-in* —
gather-bound — where the single-record forward pass re-reads each synapse's
weight and metadata once **per record**. Batching loads each weight once and
applies it across 8 (then 4) records via `weighted_sum_simd_8records` /
`weighted_sum_simd_4records`, cutting gather traffic on the dominant
standard-squash neurons.

New module `neat-core/src/batch_scoring.rs` adds `CompiledNetwork::score_batch_into`
plus a reusable `BatchScratch` (eight lane buffers). Both `score_records` and
`score_records_parallel` now drive this batched forward pass; the parallel path
splits records into fixed 64-record chunks (a multiple of the SIMD batch) so each
rayon worker owns its own scratch and every record lands on the same primitive
either way. Public signatures, the flat output layout, and the single output
allocation (Issue #229) are unchanged.

**Closes #230.**

### Numerics

- **Squash** uses the exact scalar inline branch of `activate_into` (Identity /
  ReLU / Logistic / Tanh, else `apply_squash`) — no vectorised approximation —
  so the squash itself is bit-identical.
- **Standard-squash** neurons sum *across records* rather than across synapses,
  re-associating the `f32` accumulation. Results therefore match the per-record
  reference **within tolerance** (~1e-6 observed, `TOL = 1e-3`), not bit-for-bit
  — the acceptance criteria explicitly allow SIMD reordering / `f32`
  accumulation differences.
- **Aggregate** squashes (Min/Max/If/Hypotenuse/HypotenuseV2/Mean) and the
  **scalar tail** run the exact single-record path, so those neurons and those
  records are bit-identical to the reference.
- **Sequential and parallel paths agree bit-for-bit** (each record's result is
  independent of its batch-mates, and the chunk size is a multiple of the SIMD
  batch).

```mermaid
flowchart LR
    R[records slice] --> B{group by lane}
    B -- 8 at a time --> E8[weighted_sum_simd_8records<br/>weight loaded once, applied x8]
    B -- next 4 --> E4[weighted_sum_simd_4records]
    B -- remainder --> E1[scalar tail<br/>exact single-record path]
    E8 --> O[flat outputs, input order]
    E4 --> O
    E1 --> O
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by benchmarks and
the extended lane-parity test suite.

### Benchmark (performance gate: merge only on ≥5% gain)

`cargo bench -p neat-core --features parallel --bench parallel_scoring`
(`--warm-up-time 1 --measurement-time 3 --sample-size 20`), Apple Silicon,
2048 records/batch. Baseline = #227 `HEAD` (per-record `activate_into`); After =
this branch.

| Bench | Baseline | After | Change |
|-------|---------:|------:|-------:|
| `score_records/production/1_core` | 47.55 ms | 28.85 ms | **−39.3%** |
| `score_records/production/10_cores` | 9.19 ms | 6.34 ms | **−32.1%** |
| `score_records/production_2x/1_core` | 100.71 ms | 78.53 ms | **−22.0%** |
| `score_records/production_2x/10_cores` | 18.97 ms | 15.96 ms | **−16.8%** |

All four measurements clear the ≥5% gate; Criterion's own change detection
reports `Performance has improved` (p < 0.05) on every one. The single-core
numbers isolate the forward-pass lever (no rayon noise): scoring the gather-bound
production creature is **~39% faster** per core.

## Test Plan

Extended `neat-core/tests/parallel_scoring.rs`:

- Added `TOL` + `assert_close` and relaxed the four per-record-reference parity
  tests (`parallel_scoring_matches_sequential_on_production_fixture`,
  `parallel_scoring_matches_sequential_across_shapes`,
  `score_records_matches_reference`, `output_order_is_preserved`) to the agreed
  float tolerance where `f32` re-association requires it. `single_record_matches_direct_activate`
  and `empty_records_yields_empty_output` stay **exact** (scalar/degenerate paths).
- Added `tail_boundary_record_counts_match_reference` exercising counts
  `0,1,2,3,4,5,7,8,9,12,15,16,17,24,31,33` — straddling every 8/4/scalar
  boundary — asserting both exact output **length** (no record dropped or
  duplicated) and per-record parity within tolerance.
- Added `sequential_and_parallel_are_bit_identical` (counts 7,8,9,65,130,257
  across three shapes) proving the two paths agree bit-for-bit.
- `neat-core/tests/simd_weighted_sums.rs` and `network_activate_trace_batch.rs`
  (unchanged) continue to guard the underlying SIMD primitives.

Updated `neat-core/tests/scoring_allocations.rs` doc comments to describe the
batched path (behaviour it directly tests); the no-per-record-allocation
invariant still holds (one output buffer + one lane-scratch set, constant in
record count).

Full local gate green: `cargo fmt --check`, `cargo clippy --workspace
--all-targets --all-features -D warnings`, `cargo test --workspace --lib --tests
--all-features`, `cargo doc -D warnings`, `cargo build --release`, `cargo deny
check`. Also verified the default (no-`parallel`) build and its
`score_records_parallel` fallback.



## Milestone
This PR is part of the **#227 Speed up NEAT evolution on production-sized creatures (benchmark-gated)** milestone and targets the `milestone/227-speed-up-neat-evolution-on-production-sized-cr` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr9h0h0i-dfe4e1`<!-- vibe-worker-issue-230 -->