### PR TITLE
Milestone: #227 Speed up NEAT evolution on production-sized creatures (benchmark-gated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -171,18 +171,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -310,7 +310,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "neat-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "criterion",
  "rayon",
@@ -694,18 +694,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -44,16 +44,25 @@ cargo bench -p neat-core --bench hot_paths
 | `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
 
 Scoring a production-size dataset pushes many records through one creature — an
-embarrassingly parallel workload *across records*. With the `parallel` feature
-the throughput scales with core count, while results stay **identical** to the
-sequential path (each record is scored by the same `activate`, with no
-cross-record state — each rayon worker owns a cloned scratch context):
+embarrassingly parallel workload *across records*. Both `score_records` and
+`score_records_parallel` drive the forward pass through the **8-record batched
+SIMD path** (Issue #230): records are grouped into 8s (then a 4-record group,
+then a scalar tail) and forwarded through `weighted_sum_simd_8records` /
+`weighted_sum_simd_4records`, loading each synapse weight once and applying it
+across the lanes. On the gather-bound production topology this cut single-core
+scoring time by **~39%** (see `docs/archive/pr-summaries/pr-summary-230.md`).
+With the `parallel` feature the throughput additionally scales with core count.
+
+Standard-squash neurons now sum **across records** rather than across synapses,
+so their `f32` results match the per-record `activate` reference within a small
+tolerance (SIMD re-association), while the sequential and parallel paths agree
+bit-for-bit. Output order always matches input order.
 
 ```rust
-// Off-feature / wasm: transparently runs sequentially.
+// Off-feature / wasm: transparently runs sequentially (still batched SIMD).
 let outputs = net.score_records(&records, num_outputs);
 
-// With `--features parallel` on native: scored across the rayon pool,
+// With `--features parallel` on native: batches scored across the rayon pool,
 // same results, in input order.
 let outputs = net.score_records_parallel(&records, num_outputs);
 ```
@@ -61,15 +70,18 @@ let outputs = net.score_records_parallel(&records, num_outputs);
 ```mermaid
 flowchart LR
     R[records] --> S{parallel feature?}
-    S -- off / wasm32 --> Q[score_records<br/>one scratch clone, sequential]
-    S -- on, native --> P[score_records_parallel]
-    P --> W1[worker 1<br/>cloned scratch]
-    P --> W2[worker 2<br/>cloned scratch]
-    P --> Wn[worker N<br/>cloned scratch]
-    W1 --> O[outputs in input order]
-    W2 --> O
-    Wn --> O
-    Q --> O
+    S -- off / wasm32 --> Q[score_records<br/>sequential, batched SIMD]
+    S -- on, native --> P[score_records_parallel<br/>rayon chunks]
+    P --> W1[worker 1<br/>own lane scratch]
+    P --> Wn[worker N<br/>own lane scratch]
+    subgraph B[batched forward per chunk]
+        direction TB
+        E8[8-record SIMD] --> E4[4-record SIMD] --> E1[scalar tail]
+    end
+    Q --> B
+    W1 --> B
+    Wn --> B
+    B --> O[outputs in input order]
 ```
 
 ```bash

--- a/docs/archive/pr-summaries/pr-summary-228.md
+++ b/docs/archive/pr-summaries/pr-summary-228.md
@@ -1,0 +1,113 @@
+# Establish production-sized benchmark baseline and scoring fixtures (Issue #228)
+
+## Summary
+
+Establishes the documented, production-calibrated benchmark baseline that every
+optimisation under the #227 milestone is gated against. Closes #228.
+
+Production timings show fitness evaluation dominates (~95% of wall clock:
+2,901,473 ms of 3,042,879 ms over 32 generations). This is a **bench-only**
+change — no library behaviour is touched — that does three things:
+
+1. **Calibrates the scoring record count to production volume.**
+   `parallel_scoring.rs` scored an uncalibrated 2048-record token batch. It now
+   scores `PRODUCTION_SCORING_RECORDS = 4096` records — one GRQ-cluster training
+   shard's worth — with the derivation from committed telemetry
+   (`GRQ-cluster/performance.csv` / `result.json`) documented in `BASELINE.md`
+   and `benches/common/mod.rs`.
+2. **Adds a `scoring` group to `hot_paths.rs`** measuring single-core
+   `score_records` throughput at production record volume for `production` /
+   `production_2x`, reachable via `--bench hot_paths -- production`.
+3. **Commits `neat-core/benches/BASELINE.md`** with the production/production_2x
+   numbers for every hot-path group, plus host/CPU/toolchain metadata.
+
+The record count lives in `benches/common/mod.rs` as a single source of truth
+(`PRODUCTION_SCORING_RECORDS` + `build_records`), shared by both bench targets
+and the `bench_fixtures` test.
+
+### Record-count derivation (cross-checkable against #227)
+
+| Quantity | Value | Source |
+| --- | --- | --- |
+| Training corpus size | 22,097,375,712 bytes | `training_data_size_bytes` |
+| Training shards | 520 | `training_data_files` |
+| Per-record width | 2461 × 4 = 9844 bytes | `num_inputs` × `size_of::<f32>()` |
+| Whole-corpus records | ≈ 2.24 M | corpus / record width |
+| Records per shard | ≈ 4,317 | 2.24 M / 520 |
+| **Bench batch** | **4096** | one shard, rounded to 2¹² |
+
+Materialising the full ~2.24 M-record corpus (~21 GiB) is infeasible for a
+micro-benchmark, so the harness scores one shard (~40 MiB) — already far larger
+than any CPU cache, so records/sec extrapolates to the full corpus pass.
+
+## Evidence
+
+Backend/bench-only change — no web interface to screenshot. Evidence is the
+committed baseline numbers, captured on the Apple Silicon host class.
+
+**Host:** Apple M4 Pro (8P+4E, 12 logical), macOS 26.5.2 arm64, rustc 1.96.0,
+Criterion 0.8.2, `--release`.
+
+`hot_paths -- production` (single-thread):
+
+| Group / benchmark | production | production_2x |
+| --- | --- | --- |
+| `forward_pass` | 32.76 µs | 67.26 µs |
+| `batched_scoring/trace_batch_4way` | 80.17 µs | 199.18 µs |
+| `batched_scoring/mse_sum_8records` | 223.55 µs | 656.06 µs |
+| `backprop` | 153.87 µs | 368.19 µs |
+| `scoring` (4096 records) | 242.79 ms | 491.36 ms |
+
+`parallel_scoring --features parallel` (4096 records, 1 vs 12 cores):
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production` | 242.97 ms | 75.44 ms | 16.86 K → 54.30 K | 3.22× |
+| `production_2x` | 487.26 ms | 137.78 ms | 8.41 K → 29.73 K | 3.54× |
+
+Internal consistency check: single-core `parallel_scoring` (16.86 Krecords/s,
+`production`) matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both
+drive the same sequential `score_records` path.
+
+```mermaid
+flowchart LR
+    T["GRQ-cluster telemetry<br/>performance.csv / result.json"] --> D["Derive record count<br/>corpus / 520 shards ≈ 4.3k"]
+    D --> C["PRODUCTION_SCORING_RECORDS = 4096<br/>(common/mod.rs)"]
+    C --> H["hot_paths: scoring group"]
+    C --> P["parallel_scoring: 1 vs all cores"]
+    H --> B["BASELINE.md"]
+    P --> B
+    B --> O["Gates every #227 optimisation PR<br/>(before/after comparison)"]
+```
+
+## Test Plan
+
+Added behavioural ("what") tests to `neat-core/tests/bench_fixtures.rs`
+(exercising the shared fixtures via `#[path]`):
+
+- `build_records_produces_deterministic_distinct_batch_sized_to_inputs` — the
+  helper yields `count` records each of `num_inputs` length, reproducible under
+  a fixed seed (non-determinism guard) and distinct across the batch.
+- `production_scoring_record_count_is_production_representative` — the built
+  batch exceeds the prior 2048 token batch and stays memory-feasible (< 1 GiB)
+  at the widest shape.
+- `score_records_on_production_batch_yields_finite_ordered_outputs` — scoring a
+  production-shaped batch produces finite, correctly-shaped outputs.
+
+Verification run (all green):
+
+- `cargo test --workspace --lib --tests --all-features` — all pass, including
+  the 9 `bench_fixtures` tests and 7 `parallel_scoring` tests.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
+- `cargo bench -p neat-core --no-run --features parallel` — the required bench
+  compile smoke test (benches are `harness = false` / excluded from CI, so this
+  is the automated gate).
+- `cargo fmt --all --check`, `cargo doc`, `codespell` — clean.
+
+### Pre-existing failure noted
+
+`./quality.sh` exits early on 4 pre-existing `ci.yml` bats failures (tests
+48/49/50/54 about `bump-deps.sh` wiring) that are present on the clean base
+branch and unrelated to this change (which touches only `neat-core/benches/*`,
+`neat-core/tests/bench_fixtures.rs` and `docs/`). Every Rust stage `quality.sh`
+would run past that point was executed directly and passed.

--- a/docs/archive/pr-summaries/pr-summary-230.md
+++ b/docs/archive/pr-summaries/pr-summary-230.md
@@ -1,0 +1,104 @@
+# [#227] Score records through the 8-record batched SIMD path
+
+## Summary
+
+Route record scoring through the existing **8-record batched SIMD path** so the
+synapse gather + weighted-sum is amortised across 8 records instead of one at a
+time. The production topology is *wide, shallow, sparse, varied fan-in* —
+gather-bound — where the single-record forward pass re-reads each synapse's
+weight and metadata once **per record**. Batching loads each weight once and
+applies it across 8 (then 4) records via `weighted_sum_simd_8records` /
+`weighted_sum_simd_4records`, cutting gather traffic on the dominant
+standard-squash neurons.
+
+New module `neat-core/src/batch_scoring.rs` adds `CompiledNetwork::score_batch_into`
+plus a reusable `BatchScratch` (eight lane buffers). Both `score_records` and
+`score_records_parallel` now drive this batched forward pass; the parallel path
+splits records into fixed 64-record chunks (a multiple of the SIMD batch) so each
+rayon worker owns its own scratch and every record lands on the same primitive
+either way. Public signatures, the flat output layout, and the single output
+allocation (Issue #229) are unchanged.
+
+**Closes #230.**
+
+### Numerics
+
+- **Squash** uses the exact scalar inline branch of `activate_into` (Identity /
+  ReLU / Logistic / Tanh, else `apply_squash`) — no vectorised approximation —
+  so the squash itself is bit-identical.
+- **Standard-squash** neurons sum *across records* rather than across synapses,
+  re-associating the `f32` accumulation. Results therefore match the per-record
+  reference **within tolerance** (~1e-6 observed, `TOL = 1e-3`), not bit-for-bit
+  — the acceptance criteria explicitly allow SIMD reordering / `f32`
+  accumulation differences.
+- **Aggregate** squashes (Min/Max/If/Hypotenuse/HypotenuseV2/Mean) and the
+  **scalar tail** run the exact single-record path, so those neurons and those
+  records are bit-identical to the reference.
+- **Sequential and parallel paths agree bit-for-bit** (each record's result is
+  independent of its batch-mates, and the chunk size is a multiple of the SIMD
+  batch).
+
+```mermaid
+flowchart LR
+    R[records slice] --> B{group by lane}
+    B -- 8 at a time --> E8[weighted_sum_simd_8records<br/>weight loaded once, applied x8]
+    B -- next 4 --> E4[weighted_sum_simd_4records]
+    B -- remainder --> E1[scalar tail<br/>exact single-record path]
+    E8 --> O[flat outputs, input order]
+    E4 --> O
+    E1 --> O
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by benchmarks and
+the extended lane-parity test suite.
+
+### Benchmark (performance gate: merge only on ≥5% gain)
+
+`cargo bench -p neat-core --features parallel --bench parallel_scoring`
+(`--warm-up-time 1 --measurement-time 3 --sample-size 20`), Apple Silicon,
+2048 records/batch. Baseline = #227 `HEAD` (per-record `activate_into`); After =
+this branch.
+
+| Bench | Baseline | After | Change |
+|-------|---------:|------:|-------:|
+| `score_records/production/1_core` | 47.55 ms | 28.85 ms | **−39.3%** |
+| `score_records/production/10_cores` | 9.19 ms | 6.34 ms | **−32.1%** |
+| `score_records/production_2x/1_core` | 100.71 ms | 78.53 ms | **−22.0%** |
+| `score_records/production_2x/10_cores` | 18.97 ms | 15.96 ms | **−16.8%** |
+
+All four measurements clear the ≥5% gate; Criterion's own change detection
+reports `Performance has improved` (p < 0.05) on every one. The single-core
+numbers isolate the forward-pass lever (no rayon noise): scoring the gather-bound
+production creature is **~39% faster** per core.
+
+## Test Plan
+
+Extended `neat-core/tests/parallel_scoring.rs`:
+
+- Added `TOL` + `assert_close` and relaxed the four per-record-reference parity
+  tests (`parallel_scoring_matches_sequential_on_production_fixture`,
+  `parallel_scoring_matches_sequential_across_shapes`,
+  `score_records_matches_reference`, `output_order_is_preserved`) to the agreed
+  float tolerance where `f32` re-association requires it. `single_record_matches_direct_activate`
+  and `empty_records_yields_empty_output` stay **exact** (scalar/degenerate paths).
+- Added `tail_boundary_record_counts_match_reference` exercising counts
+  `0,1,2,3,4,5,7,8,9,12,15,16,17,24,31,33` — straddling every 8/4/scalar
+  boundary — asserting both exact output **length** (no record dropped or
+  duplicated) and per-record parity within tolerance.
+- Added `sequential_and_parallel_are_bit_identical` (counts 7,8,9,65,130,257
+  across three shapes) proving the two paths agree bit-for-bit.
+- `neat-core/tests/simd_weighted_sums.rs` and `network_activate_trace_batch.rs`
+  (unchanged) continue to guard the underlying SIMD primitives.
+
+Updated `neat-core/tests/scoring_allocations.rs` doc comments to describe the
+batched path (behaviour it directly tests); the no-per-record-allocation
+invariant still holds (one output buffer + one lane-scratch set, constant in
+record count).
+
+Full local gate green: `cargo fmt --check`, `cargo clippy --workspace
+--all-targets --all-features -D warnings`, `cargo test --workspace --lib --tests
+--all-features`, `cargo doc -D warnings`, `cargo build --release`, `cargo deny
+check`. Also verified the default (no-`parallel`) build and its
+`score_records_parallel` fallback.

--- a/docs/archive/pr-summaries/pr-summary-237.md
+++ b/docs/archive/pr-summaries/pr-summary-237.md
@@ -1,0 +1,75 @@
+# PR Summary — Issue #237
+
+## Summary
+
+`neat-core/tests/bench_fixtures.rs::score_records_on_production_batch_yields_finite_ordered_outputs`
+failed to compile on `milestone/227`. Issue #229 changed
+`CompiledNetwork::score_records` to return a **flat** `Vec<f32>` in the
+`[record * num_outputs]` layout (dropping the per-record `Vec`), but the
+bench_fixtures test still treated the result as `Vec<Vec<f32>>` rows —
+calling `.len()` and `.flatten()` on `&f32`. Because bench_fixtures is a
+`--tests` target, this broke `cargo test --workspace --lib --tests
+--all-features`, blocking the whole CI test build and `quality.sh` on the
+milestone branch.
+
+The fix updates the assertions to the flat layout, mirroring
+`tests/parallel_scoring.rs`: assert the flat length is
+`records.len() * prod.num_outputs` and that every element is finite.
+
+Fixes #237.
+
+### Base branch
+
+This PR targets **`milestone/227-speed-up-neat-evolution-on-production-sized-cr`**,
+not `Develop`. The flat `score_records` layout (#229) and the offending test
+exist **only** on the milestone branch — `Develop` still returns
+`Vec<Vec<f32>>` and does not contain this test — so the compile break, and its
+fix, belong on the milestone branch.
+
+```mermaid
+flowchart LR
+    A["#229: score_records → flat Vec&lt;f32&gt;"] --> B["bench_fixtures still<br/>treats output as rows"]
+    B --> C["E0599 / E0277:<br/>--tests target won't compile"]
+    C --> D["CI test build + quality.sh<br/>blocked on milestone/227"]
+    D --> E["#237 fix: assert flat<br/>length + finiteness"]
+    E --> F["cargo test compiles &amp; passes"]
+```
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+**Before (clean milestone base):**
+
+```
+error[E0599]: no method named `len` found for reference `&f32`
+  --> neat-core/tests/bench_fixtures.rs:197
+error[E0277]: `&f32` is not an iterator
+  --> neat-core/tests/bench_fixtures.rs:199
+error: could not compile `neat-core` (test "bench_fixtures") due to 3 previous errors
+```
+
+**After:**
+
+```
+running 9 tests
+test score_records_on_production_batch_yields_finite_ordered_outputs ... ok
+...
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+## Test Plan
+
+- `cargo test --test bench_fixtures --all-features` — compiles and all 9 tests
+  pass, including the previously-broken
+  `score_records_on_production_batch_yields_finite_ordered_outputs`.
+- The reproduction: the same command failed to compile against the unmodified
+  milestone base with E0599/E0277; it compiles and passes after the change.
+
+## Out of scope
+
+`./quality.sh` reports four pre-existing failures unrelated to this change
+(BATS 48/49/50/54, concerning `ci.yml` / `bump-deps.sh` dependency-quarantine
+wiring). These fail identically on the clean milestone base **without** this
+change and are not caused by, nor within the scope of, this compile-break fix.
+This PR touches only `neat-core/tests/bench_fixtures.rs`.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -1,0 +1,110 @@
+# neat-core benchmark baseline (Issue #228)
+
+Documented baseline for the production-sized hot-path and scoring benchmarks.
+Every optimisation under the #227 milestone (per-record allocation, 8-record
+batched scoring, gather locality, prefetch, rayon granularity) is gated against
+these numbers: an optimisation PR must cite a before/after comparison for the
+affected group against this file, with matching host/toolchain metadata.
+
+> **Bench-only baseline.** The benchmarks are `harness = false` and excluded
+> from CI, so nothing here affects library behaviour or CI runtime. The
+> fixtures are synthesised from a fixed-seed PRNG — the 3 MB production
+> `network.json` and the real training corpus are **not** committed.
+
+## Host / toolchain
+
+| Field | Value |
+| --- | --- |
+| Host class | Apple Silicon (GRQ host class) |
+| CPU | Apple M4 Pro — 12 cores (8 performance + 4 efficiency) |
+| Logical cores (`available_parallelism`) | 12 |
+| RAM | 24 GB |
+| OS | macOS 26.5.2 (arm64) |
+| Toolchain | rustc 1.96.0 (ac68faa20 2026-05-25) |
+| Criterion | 0.8.2 |
+| Build | `--release` (bench profile, optimised) |
+
+Re-running the seeded synthesis on the same host reproduces the same fixtures;
+numbers should stay within Criterion's normal noise band (~±5%). A larger
+deviation on the same host indicates the fixed-seed setup is broken.
+
+## Production record-count calibration
+
+`parallel_scoring` and the `hot_paths` `scoring` group score
+`PRODUCTION_SCORING_RECORDS = 4096` records per iteration (defined in
+`benches/common/mod.rs`), replacing the prior uncalibrated 2048-record token
+batch. Derivation, from the committed GRQ-cluster telemetry
+(`GRQ-cluster/performance.csv`, the 32-generation production run whose totals
+match `result.json`: `generations = 32`, `total_time_ms = 3,042,879`,
+`fitnessMs = 2,901,473` — ~95% of wall clock):
+
+| Quantity | Value | Source |
+| --- | --- | --- |
+| Training corpus size | 22,097,375,712 bytes | `training_data_size_bytes` |
+| Training shards | 520 | `training_data_files` |
+| Per-record width | 2461 × 4 = 9844 bytes | `num_inputs` × `size_of::<f32>()` |
+| Whole-corpus records | ≈ 2.24 million | 22,097,375,712 / 9844 |
+| Records per shard | ≈ 4,317 | 2,244,755 / 520 |
+| **Bench batch** | **4096** | one shard, rounded down to 2¹² |
+
+A single creature forward-passes the whole ~2.24 M-record corpus per generation
+to compute its fitness. Materialising all of it (~21 GiB at production width) is
+infeasible for a micro-benchmark, so the harness scores **one production
+shard's worth** (~40 MiB at ~9.8 KiB/record). That batch already far exceeds any
+CPU cache, so its memory-traffic behaviour is production-representative, and
+records/sec extrapolates directly to the full corpus pass (throughput is
+size-invariant once pool/allocation overhead is amortised).
+
+## `hot_paths` — single-thread (`cargo bench -p neat-core --bench hot_paths -- production`)
+
+Times are Criterion's `[lower estimate upper]`; the median estimate is the
+comparison point.
+
+| Group / benchmark | production | production_2x |
+| --- | --- | --- |
+| `forward_pass` | 32.76 µs `[32.18, 33.34]` | 67.26 µs `[65.53, 69.10]` |
+| `batched_scoring/trace_batch_4way` | 80.17 µs `[78.46, 81.99]` | 199.18 µs `[194.54, 204.15]` |
+| `batched_scoring/mse_sum_8records` | 223.55 µs `[213.63, 234.10]` | 656.06 µs `[640.07, 672.17]` |
+| `backprop` | 153.87 µs `[150.97, 156.84]` | 368.19 µs `[361.57, 375.62]` |
+| `scoring` (4096 records) | 242.79 ms `[240.03, 245.76]` | 491.36 ms `[487.31, 495.73]` |
+
+Throughput highlights: `forward_pass` ≈ 126 Melem/s (production) / 123 Melem/s
+(production_2x); `backprop` ≈ 26.9 Melem/s / 22.5 Melem/s; single-core
+`scoring` ≈ 16.9 Krecords/s / 8.34 Krecords/s.
+
+## `parallel_scoring` — 1 core vs all cores (`cargo bench -p neat-core --bench parallel_scoring --features parallel`)
+
+4096 records scored through one creature inside a fixed-size rayon pool.
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production` | 242.97 ms `[240.75, 245.23]` | 75.44 ms `[73.05, 78.03]` | 16.86 K → 54.30 K | 3.22× |
+| `production_2x` | 487.26 ms `[484.49, 490.09]` | 137.78 ms `[133.86, 141.99]` | 8.41 K → 29.73 K | 3.54× |
+
+The single-core `parallel_scoring` figure (16.86 Krecords/s for `production`)
+matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both drive the same
+sequential `score_records` path, an internal consistency check on the fixture.
+
+## Reproducing
+
+```bash
+# Single-thread hot paths at production scale (forward_pass, batched_scoring,
+# backprop, scoring for production / production_2x).
+cargo bench -p neat-core --bench hot_paths -- production
+
+# Data-parallel scoring throughput (1 core vs all cores).
+cargo bench -p neat-core --bench parallel_scoring --features parallel
+
+# Bench compile smoke test (the only automated gate, since benches are
+# harness = false and excluded from CI).
+cargo bench -p neat-core --no-run --features parallel
+```
+
+To compare a candidate optimisation, save this state as a Criterion baseline
+first, then re-run after the change:
+
+```bash
+cargo bench -p neat-core --bench hot_paths -- --save-baseline before
+# … apply change …
+cargo bench -p neat-core --bench hot_paths -- --baseline before
+```

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -14,15 +14,22 @@ There are two bench targets:
 
 ## What is measured
 
-`hot_paths.rs` covers the four hottest paths in the crate:
+`hot_paths.rs` covers the hottest paths in the crate:
 
 | Group | Function(s) under test | Sizes |
 | --- | --- | --- |
 | `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
+| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
+
+The `scoring` group (Issue #228) pushes a full production-sized record batch
+through one creature via `score_records`, so `hot_paths` reports single-core
+scoring throughput at production record volume alongside the parallel harness.
+It covers only the gather-bound `production` shapes and is reachable with the
+`production` filter (`--bench hot_paths -- production`).
 
 Networks and inputs are built **once** outside the timed closure from a
 fixed-seed PRNG with fixed topologies, and `criterion::black_box` guards inputs
@@ -80,14 +87,27 @@ creature on **a single core versus all available cores**, using the
 size, so the 1-core and all-core measurements share one code path and differ
 only in pool size.
 
+The batch is `PRODUCTION_SCORING_RECORDS` records (defined in
+`benches/common/mod.rs` and shared with the `hot_paths` `scoring` group). That
+count is **calibrated to production record volume** — one GRQ-cluster training
+shard, ~4.3k records — rather than an arbitrary token batch. The derivation is
+documented in [`BASELINE.md`](BASELINE.md).
+
 ```bash
 # Requires the `parallel` feature (rayon, native targets only).
 cargo bench -p neat-core --features parallel --bench parallel_scoring
 ```
 
 The `production` filter is a regex over benchmark ids, so it matches both the
-`production` and `production_2x` shapes in `forward_pass`, `batched_scoring` and
-`backprop`.
+`production` and `production_2x` shapes in `forward_pass`, `batched_scoring`,
+`backprop` and `scoring`.
+
+## Documented baseline (Issue #228)
+
+[`BASELINE.md`](BASELINE.md) records the committed production/production_2x
+numbers for every hot-path group, with host/CPU/toolchain metadata. Every
+optimisation under the #227 milestone must cite a before/after comparison
+against it for the affected group.
 
 ## Comparing before vs after a change
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -207,6 +207,41 @@ pub fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
     (0..n).map(|_| rng.next_signed()).collect()
 }
 
+/// Production-representative record count for the scoring throughput benches
+/// (Issue #228), calibrated to the committed GRQ-cluster telemetry rather than
+/// an arbitrary token batch.
+///
+/// Derivation (from `GRQ-cluster/performance.csv`, the 32-generation production
+/// run whose totals match `result.json`):
+///
+/// - `training_data_size_bytes` = 22,097,375,712 across
+///   `training_data_files` = 520 shards.
+/// - Per-record width = `num_inputs * size_of::<f32>()` = 2461 * 4 = 9844 bytes.
+/// - Whole-corpus records ≈ 22,097,375,712 / 9844 ≈ **2.24 million** — the count
+///   a single creature forward-passes per generation to compute its fitness.
+/// - Per training shard ≈ 2,244,755 / 520 ≈ **4,317 records** — the natural
+///   granularity the streaming scorer holds in flight.
+///
+/// Materialising the whole 2.24 M-record corpus in memory (~21 GiB at
+/// production width) is infeasible for a micro-benchmark, so the harness scores
+/// **one production shard's worth**, rounded down to the nearest power of two
+/// (4096). At ~9.8 KiB/record this batch is ~40 MiB — already far larger than
+/// any CPU cache, so its memory-traffic behaviour is production-representative,
+/// and records/sec extrapolates directly to the full corpus pass (throughput is
+/// size-invariant once the pool/allocation overhead is amortised). This is 2x
+/// the prior token batch of 2048.
+pub const PRODUCTION_SCORING_RECORDS: usize = 4096;
+
+/// Build `count` distinct input records of length `num_inputs`, each drawn from
+/// the fixed-seed PRNG with a per-record seed so the batch is reproducible yet
+/// not a degenerate run of identical rows. Shared by the `parallel_scoring` and
+/// `hot_paths` scoring groups so both measure the same synthesised workload.
+pub fn build_records(num_inputs: usize, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| build_inputs(num_inputs, 0x5C0E_0000 + i as u64))
+        .collect()
+}
+
 /// Owned backing storage for a `PropagateInput`; built once outside the loop.
 pub struct BackpropData {
     pub neurons: Vec<NeuronInput>,

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -30,7 +30,10 @@ use neat_core::unsquash::apply_unsquash;
 /// integration test (Issue #176) so the production-scale builders are exercised
 /// by a real `cargo test` run as well as the harness.
 mod common;
-use common::{Lcg, NETWORKS, build_backprop_data, build_inputs, build_network};
+use common::{
+    Lcg, NETWORKS, PRODUCTION_SCORING_RECORDS, build_backprop_data, build_inputs, build_network,
+    build_records,
+};
 
 /// Forward pass — `CompiledNetwork::activate` across representative sizes.
 fn bench_forward_pass(c: &mut Criterion) {
@@ -129,6 +132,37 @@ fn bench_backprop(c: &mut Criterion) {
                 black_box(out);
             });
         });
+    }
+    group.finish();
+}
+
+/// Scoring throughput — a full production-shaped record batch pushed through
+/// one creature via `score_records` (Issue #228). Sized to
+/// [`PRODUCTION_SCORING_RECORDS`] so the single-core scoring figure in
+/// `hot_paths` is measured at production record volume, matching the
+/// `parallel_scoring` harness. Only the production shapes are gather-bound in
+/// the way real scoring is, so this group covers just `production` /
+/// `production_2x` and is reachable via `--bench hot_paths -- production`.
+fn bench_scoring(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scoring");
+    for spec in NETWORKS
+        .iter()
+        .filter(|s| s.label.starts_with("production"))
+    {
+        let net = build_network(spec, 0x5EED);
+        let records = build_records(net.num_inputs(), PRODUCTION_SCORING_RECORDS);
+        let num_outputs = spec.num_outputs;
+        group.throughput(Throughput::Elements(PRODUCTION_SCORING_RECORDS as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(spec.label),
+            &records,
+            |b, records| {
+                b.iter(|| {
+                    let out = net.score_records(black_box(records), black_box(num_outputs));
+                    black_box(out);
+                });
+            },
+        );
     }
     group.finish();
 }
@@ -309,6 +343,7 @@ criterion_group!(
     bench_forward_pass,
     bench_batched_scoring,
     bench_backprop,
+    bench_scoring,
     bench_activation_primitives,
 );
 criterion_main!(benches);

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -22,7 +22,9 @@ mod common;
 
 #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
 mod bench {
-    use super::common::{NETWORKS, NetSpec, build_inputs, build_network};
+    use super::common::{
+        NETWORKS, NetSpec, PRODUCTION_SCORING_RECORDS, build_network, build_records,
+    };
     use criterion::{Criterion, Throughput, criterion_group};
     use neat_core::network::CompiledNetwork;
     use rayon::ThreadPoolBuilder;
@@ -33,12 +35,6 @@ mod bench {
             .iter()
             .find(|s| s.label == label)
             .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
-    }
-
-    fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
-        (0..count)
-            .map(|i| build_inputs(net.num_inputs(), 0x5C0E_0000 + i as u64))
-            .collect()
     }
 
     /// Score `records` inside a rayon pool of exactly `threads` workers, so the
@@ -59,12 +55,13 @@ mod bench {
 
     pub fn bench_parallel_scoring(c: &mut Criterion) {
         let all_cores = std::thread::available_parallelism().map_or(1, |n| n.get());
-        const NUM_RECORDS: usize = 2048;
+        // Production-representative volume (Issue #228); see `PRODUCTION_SCORING_RECORDS`.
+        const NUM_RECORDS: usize = PRODUCTION_SCORING_RECORDS;
 
         for label in ["production", "production_2x"] {
             let s = spec(label);
             let net = build_network(s, 0x5EED);
-            let records = build_records(&net, NUM_RECORDS);
+            let records = build_records(net.num_inputs(), NUM_RECORDS);
             let num_outputs = s.num_outputs;
 
             let mut group = c.benchmark_group(format!("score_records/{label}"));

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -49,7 +49,7 @@ mod bench {
         records: &[Vec<f32>],
         num_outputs: usize,
         threads: usize,
-    ) -> Vec<Vec<f32>> {
+    ) -> Vec<f32> {
         let pool = ThreadPoolBuilder::new()
             .num_threads(threads)
             .build()

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -1,0 +1,379 @@
+//! Batched record scoring through the 8-record SIMD path (Issue #230).
+//!
+//! The production topology is *wide, shallow, sparse, varied fan-in* —
+//! gather-bound (see `benches/README.md`). The single-record forward pass
+//! ([`CompiledNetwork::activate_into`]) re-reads each synapse's weight and
+//! metadata once **per record**. This module drives the forward pass through
+//! the existing across-records SIMD primitives
+//! ([`weighted_sum_simd_8records`] / [`weighted_sum_simd_4records`]), loading
+//! each synapse weight once and applying it across 8 (then 4) records. That
+//! amortises the weight load and synapse-index read across the batch, cutting
+//! gather traffic on the dominant standard-squash neurons.
+//!
+//! # Numerics
+//!
+//! Standard-squash neurons accumulate their weighted sum across records rather
+//! than across synapses, so the summation is re-associated relative to the
+//! single-record [`weighted_sum_simd`] kernel. In `f32` that yields results
+//! that match the per-record reference **within a small tolerance**, not
+//! bit-for-bit (Issue #230 acceptance criteria explicitly allow SIMD
+//! reordering / `f32` accumulation differences). Every other numeric step is
+//! identical to [`CompiledNetwork::activate_into`]:
+//!
+//! - The **squash** uses the same scalar inline branch (Identity / ReLU /
+//!   Logistic / Tanh, else `apply_squash`) — no vectorised approximation — so
+//!   the squash itself is bit-identical.
+//! - **Aggregate** squashes (Minimum, Maximum, If, Hypotenuse, HypotenuseV2,
+//!   Mean) and the **scalar tail** (`records.len() % 8` after the 4-way step)
+//!   run the exact single-record path via `neuron_activation_scalar`, so those
+//!   neurons and those records are bit-identical to the reference.
+//!
+//! # Determinism
+//!
+//! Weights are read through `&self`; all mutable state lives in a caller-owned
+//! [`BatchScratch`]. Record `i`'s outputs are always written to
+//! `out[i * num_outputs .. (i + 1) * num_outputs]`, so output order matches
+//! input order regardless of batching or thread count.
+
+use crate::network::{CompiledNetwork, NeuronData, SynapseData};
+use crate::range::apply_limit_range;
+use crate::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
+};
+use crate::squash::{SquashType, apply_squash};
+use crate::synapse_type::SynapseType;
+
+/// Reusable per-worker scratch: eight activation buffers, one per SIMD lane.
+///
+/// Owning the buffers here lets the sequential path allocate once for a whole
+/// batch and the parallel path allocate once per rayon worker (via
+/// `for_each_init`), instead of once per chunk.
+pub struct BatchScratch {
+    acts: [Vec<f32>; 8],
+}
+
+impl BatchScratch {
+    /// Allocate eight zeroed activation buffers sized to the network.
+    pub fn new(num_neurons: usize) -> Self {
+        Self {
+            acts: std::array::from_fn(|_| vec![0.0f32; num_neurons]),
+        }
+    }
+}
+
+/// Inline squash matching [`CompiledNetwork::activate_into`] exactly: the four
+/// hot types are branched directly, everything else defers to [`apply_squash`].
+#[inline]
+fn inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
+    match squash_type {
+        0 => sum,                        // IDENTITY
+        1 => sum.max(0.0),               // ReLU
+        6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
+        7 => sum.tanh(),                 // TANH
+        _ => apply_squash(squash, sum),  // Other (fallback)
+    }
+}
+
+/// Single-record activation for one neuron, byte-for-byte identical to the body
+/// of [`CompiledNetwork::activate_into`]. Reused for constant neurons, aggregate
+/// squashes and the scalar tail so those results exactly match the reference.
+#[inline]
+fn neuron_activation_scalar(synapses: &[SynapseData], act: &[f32], neuron: &NeuronData) -> f32 {
+    if neuron.is_constant {
+        return apply_limit_range(SquashType::Identity, neuron.bias);
+    }
+
+    let squash = SquashType::from(neuron.squash_type);
+    let start = neuron.start_synapse as usize;
+    let end = start + neuron.num_synapses as usize;
+
+    let activation = match squash {
+        SquashType::Minimum => {
+            let mut min_val = f32::INFINITY;
+            for s in &synapses[start..end] {
+                let val = act[s.from_index as usize] * s.weight;
+                if val < min_val {
+                    min_val = val;
+                }
+            }
+            if min_val == f32::INFINITY {
+                neuron.bias
+            } else {
+                min_val + neuron.bias
+            }
+        }
+        SquashType::Maximum => {
+            let mut max_val = f32::NEG_INFINITY;
+            for s in &synapses[start..end] {
+                let val = act[s.from_index as usize] * s.weight;
+                if val > max_val {
+                    max_val = val;
+                }
+            }
+            if max_val == f32::NEG_INFINITY {
+                neuron.bias
+            } else {
+                max_val + neuron.bias
+            }
+        }
+        SquashType::If => {
+            let mut condition_sum = 0.0f32;
+            let mut positive_sum = 0.0f32;
+            let mut negative_sum = 0.0f32;
+            for s in &synapses[start..end] {
+                let val = act[s.from_index as usize] * s.weight;
+                match SynapseType::from(s.synapse_type) {
+                    SynapseType::Condition => condition_sum += val,
+                    SynapseType::Negative => negative_sum += val,
+                    SynapseType::Positive | SynapseType::Standard => positive_sum += val,
+                }
+            }
+            if condition_sum > 0.0 {
+                positive_sum + neuron.bias
+            } else {
+                negative_sum + neuron.bias
+            }
+        }
+        SquashType::Hypotenuse => {
+            let sum_sq = weighted_sum_of_squares_simd(synapses, act, start, end);
+            sum_sq.sqrt() + neuron.bias
+        }
+        SquashType::HypotenuseV2 => {
+            let sum_sq = weighted_sum_of_squares_v2_simd(synapses, act, start, end, neuron.bias);
+            sum_sq.sqrt()
+        }
+        SquashType::Mean => {
+            let n = (end - start) as f32;
+            if n <= 0.0 {
+                neuron.bias
+            } else {
+                let sum = weighted_sum_no_bias_simd(synapses, act, start, end);
+                sum / n + neuron.bias
+            }
+        }
+        _ => {
+            let sum = weighted_sum_simd(synapses, act, start, end, neuron.bias);
+            inline_squash(neuron.squash_type, squash, sum)
+        }
+    };
+
+    apply_limit_range(squash, activation)
+}
+
+/// Copy record inputs into a lane buffer, matching [`CompiledNetwork::activate_into`]
+/// (which copies `min(len, num_inputs)` input values). Any input slot the record
+/// does not cover is zeroed so each record is scored statelessly — buffers are
+/// reused across batches, and every non-input neuron is overwritten during the
+/// forward pass, so no further reset is required.
+#[inline]
+fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
+    let in_len = record.len().min(num_inputs);
+    act[..in_len].copy_from_slice(&record[..in_len]);
+    act[in_len..num_inputs].fill(0.0);
+}
+
+impl CompiledNetwork {
+    /// Score a contiguous slice of records through the batched SIMD path.
+    ///
+    /// Record `i` (0-based within `records`) writes its outputs to
+    /// `out[i * num_outputs .. (i + 1) * num_outputs]`; `out` must be exactly
+    /// `records.len() * num_outputs` long. Records are grouped into 8s and
+    /// driven through [`weighted_sum_simd_8records`], then a 4-record group via
+    /// [`weighted_sum_simd_4records`], then a scalar tail — matching the
+    /// remainder handling of `mse_sum_batch_packed`.
+    pub(crate) fn score_batch_into(
+        &self,
+        scratch: &mut BatchScratch,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        let num_neurons = self.num_neurons;
+        let num_inputs = self.num_inputs;
+        let output_start = num_neurons - num_outputs;
+        let n = records.len();
+
+        let [act0, act1, act2, act3, act4, act5, act6, act7] = &mut scratch.acts;
+
+        let mut base = 0usize;
+
+        // ---- 8-record batches ------------------------------------------------
+        while base + 8 <= n {
+            load_record(act0, &records[base], num_inputs);
+            load_record(act1, &records[base + 1], num_inputs);
+            load_record(act2, &records[base + 2], num_inputs);
+            load_record(act3, &records[base + 3], num_inputs);
+            load_record(act4, &records[base + 4], num_inputs);
+            load_record(act5, &records[base + 5], num_inputs);
+            load_record(act6, &records[base + 6], num_inputs);
+            load_record(act7, &records[base + 7], num_inputs);
+
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+
+                if neuron.is_constant {
+                    let v = apply_limit_range(SquashType::Identity, neuron.bias);
+                    act0[actual_idx] = v;
+                    act1[actual_idx] = v;
+                    act2[actual_idx] = v;
+                    act3[actual_idx] = v;
+                    act4[actual_idx] = v;
+                    act5[actual_idx] = v;
+                    act6[actual_idx] = v;
+                    act7[actual_idx] = v;
+                    continue;
+                }
+
+                let squash = SquashType::from(neuron.squash_type);
+                match squash {
+                    SquashType::Minimum
+                    | SquashType::Maximum
+                    | SquashType::If
+                    | SquashType::Hypotenuse
+                    | SquashType::HypotenuseV2
+                    | SquashType::Mean => {
+                        // Aggregate squashes stay on the exact single-record path.
+                        act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
+                        act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
+                        act2[actual_idx] = neuron_activation_scalar(&self.synapses, act2, neuron);
+                        act3[actual_idx] = neuron_activation_scalar(&self.synapses, act3, neuron);
+                        act4[actual_idx] = neuron_activation_scalar(&self.synapses, act4, neuron);
+                        act5[actual_idx] = neuron_activation_scalar(&self.synapses, act5, neuron);
+                        act6[actual_idx] = neuron_activation_scalar(&self.synapses, act6, neuron);
+                        act7[actual_idx] = neuron_activation_scalar(&self.synapses, act7, neuron);
+                    }
+                    _ => {
+                        let start = neuron.start_synapse as usize;
+                        let end = start + neuron.num_synapses as usize;
+                        let (s0, s1, s2, s3, s4, s5, s6, s7) = weighted_sum_simd_8records(
+                            &self.synapses,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
+                            act4,
+                            act5,
+                            act6,
+                            act7,
+                            start,
+                            end,
+                            neuron.bias,
+                        );
+                        let st = neuron.squash_type;
+                        act0[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s0));
+                        act1[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s1));
+                        act2[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s2));
+                        act3[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s3));
+                        act4[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s4));
+                        act5[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s5));
+                        act6[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s6));
+                        act7[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s7));
+                    }
+                }
+            }
+
+            for r in 0..8 {
+                let src = match r {
+                    0 => &*act0,
+                    1 => &*act1,
+                    2 => &*act2,
+                    3 => &*act3,
+                    4 => &*act4,
+                    5 => &*act5,
+                    6 => &*act6,
+                    _ => &*act7,
+                };
+                let dst = (base + r) * num_outputs;
+                out[dst..dst + num_outputs]
+                    .copy_from_slice(&src[output_start..output_start + num_outputs]);
+            }
+
+            base += 8;
+        }
+
+        // ---- 4-record batch (0 or 1 of them) ---------------------------------
+        if base + 4 <= n {
+            load_record(act0, &records[base], num_inputs);
+            load_record(act1, &records[base + 1], num_inputs);
+            load_record(act2, &records[base + 2], num_inputs);
+            load_record(act3, &records[base + 3], num_inputs);
+
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+
+                if neuron.is_constant {
+                    let v = apply_limit_range(SquashType::Identity, neuron.bias);
+                    act0[actual_idx] = v;
+                    act1[actual_idx] = v;
+                    act2[actual_idx] = v;
+                    act3[actual_idx] = v;
+                    continue;
+                }
+
+                let squash = SquashType::from(neuron.squash_type);
+                match squash {
+                    SquashType::Minimum
+                    | SquashType::Maximum
+                    | SquashType::If
+                    | SquashType::Hypotenuse
+                    | SquashType::HypotenuseV2
+                    | SquashType::Mean => {
+                        act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
+                        act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
+                        act2[actual_idx] = neuron_activation_scalar(&self.synapses, act2, neuron);
+                        act3[actual_idx] = neuron_activation_scalar(&self.synapses, act3, neuron);
+                    }
+                    _ => {
+                        let start = neuron.start_synapse as usize;
+                        let end = start + neuron.num_synapses as usize;
+                        let (s0, s1, s2, s3) = weighted_sum_simd_4records(
+                            &self.synapses,
+                            act0,
+                            act1,
+                            act2,
+                            act3,
+                            start,
+                            end,
+                            neuron.bias,
+                        );
+                        let st = neuron.squash_type;
+                        act0[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s0));
+                        act1[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s1));
+                        act2[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s2));
+                        act3[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s3));
+                    }
+                }
+            }
+
+            for r in 0..4 {
+                let src = match r {
+                    0 => &*act0,
+                    1 => &*act1,
+                    2 => &*act2,
+                    _ => &*act3,
+                };
+                let dst = (base + r) * num_outputs;
+                out[dst..dst + num_outputs]
+                    .copy_from_slice(&src[output_start..output_start + num_outputs]);
+            }
+
+            base += 4;
+        }
+
+        // ---- scalar tail (records.len() % 4) ---------------------------------
+        // Exact single-record path so tail records are bit-identical to the
+        // reference.
+        while base < n {
+            load_record(act0, &records[base], num_inputs);
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+                act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
+            }
+            let dst = base * num_outputs;
+            out[dst..dst + num_outputs]
+                .copy_from_slice(&act0[output_start..output_start + num_outputs]);
+            base += 1;
+        }
+    }
+}

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -9,6 +9,7 @@
 
 // Core computation modules
 pub mod accumulate;
+pub mod batch_scoring;
 pub mod creature;
 pub mod derivative;
 pub mod elastic_distribution;

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -44,28 +44,39 @@
 //! through [`CompiledNetwork::activate_into`], so the batch performs a **single**
 //! output allocation instead of one heap allocation per record.
 
+use crate::batch_scoring::BatchScratch;
 use crate::network::CompiledNetwork;
+
+/// Records per rayon task on the parallel path. A multiple of 8 so every task's
+/// interior runs full 8-record SIMD batches (only the final task's tail can be
+/// short), and small enough that a 2048-record batch splits into many chunks for
+/// work-stealing balance across cores.
+#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+const PARALLEL_CHUNK_RECORDS: usize = 64;
 
 impl CompiledNetwork {
     /// Score every record sequentially, returning a single flat output buffer.
     ///
     /// The result is one contiguous `Vec<f32>` of `records.len() * num_outputs`
     /// elements: record `i`'s outputs occupy `[i * num_outputs .. (i + 1) *
-    /// num_outputs]`. Routing through [`CompiledNetwork::activate_into`] and
-    /// writing straight into pre-sized chunks removes the per-record output
-    /// `Vec` allocation that [`CompiledNetwork::activate`]'s `to_vec()` incurred
-    /// (Issue #229) — the whole batch now costs a **single** output allocation.
+    /// num_outputs]`.
     ///
-    /// Shared read-only weights (`&self`) plus a single owned scratch context
-    /// (one clone of the network). This is the fallback used when the `parallel`
-    /// feature is off or when building for `wasm32`, and the reference path the
-    /// parallel results must match exactly.
+    /// The batch is driven through the across-records SIMD path (Issue #230):
+    /// records are grouped into 8s (then a 4-record group, then a scalar tail)
+    /// and forwarded through the batched `weighted_sum_simd_8records` /
+    /// `weighted_sum_simd_4records` kernels, loading each synapse weight once and
+    /// applying it across the lanes. The output layout and the single output
+    /// allocation (Issue #229) are unchanged; standard-squash results match the
+    /// per-record reference within a small `f32` tolerance (see
+    /// [`crate::batch_scoring`]).
+    ///
+    /// This is the fallback used when the `parallel` feature is off or when
+    /// building for `wasm32`, and the reference path the parallel results must
+    /// match exactly.
     pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
-        let mut scratch = self.clone();
         let mut outputs = vec![0.0f32; records.len() * num_outputs];
-        for (record, chunk) in records.iter().zip(outputs.chunks_exact_mut(num_outputs)) {
-            scratch.activate_into(record, chunk);
-        }
+        let mut scratch = BatchScratch::new(self.num_neurons);
+        self.score_batch_into(&mut scratch, records, num_outputs, &mut outputs);
         outputs
     }
 
@@ -73,13 +84,16 @@ impl CompiledNetwork {
     /// flat output buffer in input order.
     ///
     /// Layout matches [`CompiledNetwork::score_records`]: record `i`'s outputs
-    /// live in `[i * num_outputs .. (i + 1) * num_outputs]`. Each rayon worker
-    /// initialises its own cloned scratch context via `for_each_init`, so no
-    /// `&mut self` is shared across threads: immutable weights are read through
-    /// `&self` while every worker owns its activation buffers and writes only its
-    /// own disjoint output chunk. Because each record is scored by the same
-    /// [`CompiledNetwork::activate_into`] used sequentially and there is no
-    /// cross-record state, the results are identical to the sequential path.
+    /// live in `[i * num_outputs .. (i + 1) * num_outputs]`. Records are split
+    /// into fixed-size chunks (`PARALLEL_CHUNK_RECORDS`) across the rayon pool;
+    /// each worker initialises its own [`BatchScratch`] via `for_each_init` and
+    /// drives its chunk through the same batched forward pass
+    /// ([`CompiledNetwork::score_batch_into`]) the sequential path uses, writing
+    /// only its own disjoint output slice. No `&mut self` is shared: immutable
+    /// weights are read through `&self` while every worker owns its lane
+    /// buffers. Because each chunk boundary is a multiple of the batch size and
+    /// the forward pass carries no cross-record state, results are identical to
+    /// the sequential path regardless of thread count.
     ///
     /// Available with the `parallel` feature on native targets.
     #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
@@ -87,11 +101,13 @@ impl CompiledNetwork {
         use rayon::prelude::*;
         let mut outputs = vec![0.0f32; records.len() * num_outputs];
         outputs
-            .par_chunks_mut(num_outputs)
-            .zip(records.par_iter())
+            .par_chunks_mut(PARALLEL_CHUNK_RECORDS * num_outputs)
+            .zip(records.par_chunks(PARALLEL_CHUNK_RECORDS))
             .for_each_init(
-                || self.clone(),
-                |scratch, (chunk, record)| scratch.activate_into(record, chunk),
+                || BatchScratch::new(self.num_neurons),
+                |scratch, (out_chunk, rec_chunk)| {
+                    self.score_batch_into(scratch, rec_chunk, num_outputs, out_chunk)
+                },
             );
         outputs
     }

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -24,62 +24,76 @@
 //!
 //! Results are **identical** to the sequential path regardless of thread count:
 //!
-//! - Every record is scored by the same [`CompiledNetwork::activate`] call used
-//!   sequentially. `activate` overwrites every non-input activation each call,
-//!   so there is no cross-record state.
+//! - Every record is scored by the same [`CompiledNetwork::activate_into`] call
+//!   used sequentially. `activate_into` overwrites every non-input activation
+//!   each call, so there is no cross-record state.
 //! - No `&mut self` is shared across threads. `CompiledNetwork` is `Clone`, and
 //!   the clone carries the per-call scratch buffers (`activations`,
 //!   `hint_values_buffer`, the 4-way batch buffers). The immutable weights are
 //!   read through `&self`; each rayon worker initialises **its own** cloned
-//!   scratch context via `map_init` and owns its buffers for the duration.
-//! - Output order matches input order — `par_iter().map(...).collect()`
-//!   preserves indexed order.
+//!   scratch context via `for_each_init` and owns its buffers for the duration.
+//! - Output order matches input order — the flat output buffer is split into
+//!   disjoint per-record chunks by index (`par_chunks_mut(num_outputs)` zipped
+//!   with `par_iter()`), so record `i` always writes `[i * num_outputs ..]`.
+//!
+//! # Output layout (Issue #229)
+//!
+//! Both paths return one contiguous `Vec<f32>` of `records.len() * num_outputs`
+//! elements rather than a `Vec<Vec<f32>>`. Record `i`'s outputs occupy
+//! `[i * num_outputs .. (i + 1) * num_outputs]`. This flat buffer is written
+//! through [`CompiledNetwork::activate_into`], so the batch performs a **single**
+//! output allocation instead of one heap allocation per record.
 
 use crate::network::CompiledNetwork;
 
 impl CompiledNetwork {
-    /// Score every record sequentially, returning one output vector per record.
+    /// Score every record sequentially, returning a single flat output buffer.
+    ///
+    /// The result is one contiguous `Vec<f32>` of `records.len() * num_outputs`
+    /// elements: record `i`'s outputs occupy `[i * num_outputs .. (i + 1) *
+    /// num_outputs]`. Routing through [`CompiledNetwork::activate_into`] and
+    /// writing straight into pre-sized chunks removes the per-record output
+    /// `Vec` allocation that [`CompiledNetwork::activate`]'s `to_vec()` incurred
+    /// (Issue #229) — the whole batch now costs a **single** output allocation.
     ///
     /// Shared read-only weights (`&self`) plus a single owned scratch context
     /// (one clone of the network). This is the fallback used when the `parallel`
     /// feature is off or when building for `wasm32`, and the reference path the
     /// parallel results must match exactly.
-    ///
-    /// Each record is scored with [`CompiledNetwork::activate`]; the first
-    /// `num_outputs` … (`num_neurons - num_outputs ..`) activations are returned.
-    pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+    pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         let mut scratch = self.clone();
-        records
-            .iter()
-            .map(|record| scratch.activate(record, num_outputs))
-            .collect()
+        let mut outputs = vec![0.0f32; records.len() * num_outputs];
+        for (record, chunk) in records.iter().zip(outputs.chunks_exact_mut(num_outputs)) {
+            scratch.activate_into(record, chunk);
+        }
+        outputs
     }
 
-    /// Score every record across the `rayon` thread pool, returning one output
-    /// vector per record in input order.
+    /// Score every record across the `rayon` thread pool, writing into a single
+    /// flat output buffer in input order.
     ///
-    /// Each rayon worker initialises its own cloned scratch context via
-    /// `map_init`, so no `&mut self` is shared across threads: immutable weights
-    /// are read through `&self` while every worker owns its activation buffers.
-    /// Because each record is scored by the same [`CompiledNetwork::activate`]
-    /// used by [`CompiledNetwork::score_records`] and there is no cross-record
-    /// state, the results are identical to the sequential path.
+    /// Layout matches [`CompiledNetwork::score_records`]: record `i`'s outputs
+    /// live in `[i * num_outputs .. (i + 1) * num_outputs]`. Each rayon worker
+    /// initialises its own cloned scratch context via `for_each_init`, so no
+    /// `&mut self` is shared across threads: immutable weights are read through
+    /// `&self` while every worker owns its activation buffers and writes only its
+    /// own disjoint output chunk. Because each record is scored by the same
+    /// [`CompiledNetwork::activate_into`] used sequentially and there is no
+    /// cross-record state, the results are identical to the sequential path.
     ///
     /// Available with the `parallel` feature on native targets.
     #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
-    pub fn score_records_parallel(
-        &self,
-        records: &[Vec<f32>],
-        num_outputs: usize,
-    ) -> Vec<Vec<f32>> {
+    pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         use rayon::prelude::*;
-        records
-            .par_iter()
-            .map_init(
+        let mut outputs = vec![0.0f32; records.len() * num_outputs];
+        outputs
+            .par_chunks_mut(num_outputs)
+            .zip(records.par_iter())
+            .for_each_init(
                 || self.clone(),
-                |scratch, record| scratch.activate(record, num_outputs),
-            )
-            .collect()
+                |scratch, (chunk, record)| scratch.activate_into(record, chunk),
+            );
+        outputs
     }
 
     /// Sequential fallback for [`CompiledNetwork::score_records_parallel`] when
@@ -87,11 +101,7 @@ impl CompiledNetwork {
     /// `rayon` is unavailable). Same signature and identical results to the
     /// feature-on path — just single-threaded.
     #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
-    pub fn score_records_parallel(
-        &self,
-        records: &[Vec<f32>],
-        num_outputs: usize,
-    ) -> Vec<Vec<f32>> {
+    pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         self.score_records(records, num_outputs)
     }
 }

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -7,7 +7,10 @@
 #[allow(dead_code)]
 mod common;
 
-use common::{FanIn, NETWORKS, NetSpec, build_backprop_data, build_inputs, build_network};
+use common::{
+    FanIn, NETWORKS, NetSpec, PRODUCTION_SCORING_RECORDS, build_backprop_data, build_inputs,
+    build_network, build_records,
+};
 
 fn spec(label: &str) -> &'static NetSpec {
     NETWORKS
@@ -131,4 +134,69 @@ fn backprop_data_has_consistent_inward_adjacency_at_production_scale() {
     let summed: usize = data.inward_counts.iter().map(|&c| c as usize).sum();
     assert_eq!(summed, data.synapses.len());
     assert_eq!(summed, data.inward_indices.len());
+}
+
+#[test]
+fn build_records_produces_deterministic_distinct_batch_sized_to_inputs() {
+    let prod = spec("production");
+    let a = build_records(prod.num_inputs, 64);
+    let b = build_records(prod.num_inputs, 64);
+
+    // One record per requested count, each a full input vector.
+    assert_eq!(a.len(), 64);
+    assert!(
+        a.iter().all(|r| r.len() == prod.num_inputs),
+        "each record must be a full production-width input vector"
+    );
+
+    // Fixed-seed synthesis must reproduce byte-for-byte (non-determinism guard).
+    assert_eq!(a, b, "seeded record synthesis must be reproducible");
+
+    // Per-record seed ⇒ distinct rows, so throughput is not measured on a
+    // degenerate all-identical batch.
+    assert_ne!(a[0], a[1], "records should differ across the batch");
+}
+
+#[test]
+fn production_scoring_record_count_is_production_representative() {
+    // Build the actual batch the scoring benches time — calibrated to one
+    // production training shard (~corpus/520 ≈ 4.3k records).
+    let widest = spec("production_2x");
+    let batch = build_records(widest.num_inputs, PRODUCTION_SCORING_RECORDS);
+
+    // Well above the prior 2048 token batch, so records/sec reflects
+    // steady-state scoring rather than warm-up.
+    assert_eq!(batch.len(), PRODUCTION_SCORING_RECORDS);
+    assert!(
+        batch.len() > 2048,
+        "scoring batch must be production-sized, not a token batch"
+    );
+
+    // Memory-feasible on the Apple Silicon host class: even the widest shape's
+    // batch stays well under 1 GiB so the harness can materialise it.
+    let bytes: usize = batch
+        .iter()
+        .map(|r| r.len() * std::mem::size_of::<f32>())
+        .sum();
+    assert!(
+        bytes < (1usize << 30),
+        "production batch ({bytes} bytes) must fit comfortably in RAM"
+    );
+}
+
+#[test]
+fn score_records_on_production_batch_yields_finite_ordered_outputs() {
+    let prod = spec("production");
+    let net = build_network(prod, 0x5EED);
+    // A small production-shaped batch keeps the debug test fast while still
+    // exercising the exact fixture path the scoring benches time.
+    let records = build_records(net.num_inputs(), 96);
+
+    let out = net.score_records(&records, prod.num_outputs);
+    assert_eq!(out.len(), records.len());
+    assert!(out.iter().all(|row| row.len() == prod.num_outputs));
+    assert!(
+        out.iter().flatten().all(|v| v.is_finite()),
+        "production scoring must produce finite outputs"
+    );
 }

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -192,11 +192,12 @@ fn score_records_on_production_batch_yields_finite_ordered_outputs() {
     // exercising the exact fixture path the scoring benches time.
     let records = build_records(net.num_inputs(), 96);
 
+    // `score_records` returns a flat `[record * num_outputs]` buffer (Issue #229),
+    // so assert on the flat length and finiteness rather than per-record rows.
     let out = net.score_records(&records, prod.num_outputs);
-    assert_eq!(out.len(), records.len());
-    assert!(out.iter().all(|row| row.len() == prod.num_outputs));
+    assert_eq!(out.len(), records.len() * prod.num_outputs);
     assert!(
-        out.iter().flatten().all(|v| v.is_finite()),
+        out.iter().all(|v| v.is_finite()),
         "production scoring must produce finite outputs"
     );
 }

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -1,11 +1,19 @@
-//! Behavioural tests for data-parallel record scoring (Issue #179).
+//! Behavioural tests for data-parallel record scoring (Issue #179, #230).
 //!
 //! These assert on observable outcomes — the returned output vectors — rather
 //! than on threading mechanics. They run in both feature modes: with the
 //! `parallel` feature off, `score_records_parallel` is the sequential fallback;
 //! with `--features parallel` (as `quality.sh` runs via `--all-features`), the
-//! same assertions exercise the rayon path. Either way the contract is the same:
-//! results identical to the sequential reference, in input order.
+//! same assertions exercise the rayon path.
+//!
+//! Since Issue #230 the forward pass is driven through the across-records SIMD
+//! path (8-record / 4-record batches, scalar tail). Standard-squash neurons now
+//! sum across records rather than across synapses, so their `f32` results match
+//! the per-record reference **within [`TOL`]**, not bit-for-bit — the
+//! acceptance criteria explicitly allow SIMD reordering / `f32` accumulation
+//! differences. A genuine bug (cross-lane weight mix-up, dropped/duplicated
+//! record, mis-ordered output) differs by O(1), far above `TOL`. The scalar
+//! tail and the sequential-vs-parallel comparison remain **exact**.
 
 #[path = "../benches/common/mod.rs"]
 #[allow(dead_code)]
@@ -13,6 +21,39 @@ mod common;
 
 use common::{NETWORKS, NetSpec, build_inputs, build_network};
 use neat_core::network::CompiledNetwork;
+
+/// Absolute tolerance for the batched SIMD path vs the per-record reference.
+/// Outputs are bounded (Tanh + range-limit), so ~1e-6 reassociation noise sits
+/// well under this bound while any real lane/order bug (O(1) error) trips it.
+const TOL: f32 = 1e-3;
+
+/// Assert two flat output buffers agree within [`TOL`], reporting the worst
+/// element on failure so a real divergence is easy to spot.
+fn assert_close(actual: &[f32], expected: &[f32], ctx: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{ctx}: length mismatch ({} vs {})",
+        actual.len(),
+        expected.len()
+    );
+    let mut worst = 0.0f32;
+    let mut worst_at = 0usize;
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        let diff = (a - e).abs();
+        if diff > worst {
+            worst = diff;
+            worst_at = i;
+        }
+    }
+    assert!(
+        worst <= TOL,
+        "{ctx}: max abs diff {worst} at index {worst_at} exceeds tol {TOL} \
+         (actual={}, expected={})",
+        actual.get(worst_at).copied().unwrap_or(f32::NAN),
+        expected.get(worst_at).copied().unwrap_or(f32::NAN),
+    );
+}
 
 fn spec(label: &str) -> &'static NetSpec {
     NETWORKS
@@ -51,7 +92,7 @@ fn parallel_scoring_matches_sequential_on_production_fixture() {
     let actual = net.score_records_parallel(&records, s.num_outputs);
 
     assert_eq!(actual.len(), records.len() * s.num_outputs);
-    assert_eq!(actual, expected, "parallel results must equal sequential");
+    assert_close(&actual, &expected, "production fixture");
 }
 
 #[test]
@@ -64,7 +105,7 @@ fn parallel_scoring_matches_sequential_across_shapes() {
         let expected = reference(&net, &records, s.num_outputs);
         let actual = net.score_records_parallel(&records, s.num_outputs);
 
-        assert_eq!(actual, expected, "mismatch for shape {label}");
+        assert_close(&actual, &expected, &format!("shape {label}"));
     }
 }
 
@@ -75,7 +116,11 @@ fn score_records_matches_reference() {
     let records = build_records(&net, 64);
 
     let expected = reference(&net, &records, s.num_outputs);
-    assert_eq!(net.score_records(&records, s.num_outputs), expected);
+    assert_close(
+        &net.score_records(&records, s.num_outputs),
+        &expected,
+        "score_records medium_500",
+    );
 }
 
 #[test]
@@ -85,7 +130,7 @@ fn output_order_is_preserved() {
     let records = build_records(&net, 200);
 
     // Each record is distinct, so a re-ordered result would not match the
-    // index-aligned reference.
+    // index-aligned reference within tolerance (a swap is an O(1) error).
     let expected = reference(&net, &records, s.num_outputs);
     let actual = net.score_records_parallel(&records, s.num_outputs);
     for (i, (a, e)) in actual
@@ -93,7 +138,7 @@ fn output_order_is_preserved() {
         .zip(expected.chunks_exact(s.num_outputs))
         .enumerate()
     {
-        assert_eq!(a, e, "record {i} out of order or incorrect");
+        assert_close(a, e, &format!("record {i} out of order or incorrect"));
     }
 }
 
@@ -130,6 +175,65 @@ fn single_record_matches_direct_activate() {
     let direct = scratch.activate(&record, s.num_outputs);
     let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
 
-    // Single record: the flat buffer is exactly that record's outputs.
+    // Single record: it runs the scalar tail, which is the exact single-record
+    // path — so the flat buffer is bit-for-bit that record's outputs.
     assert_eq!(via_parallel, direct);
+}
+
+/// Issue #230 — exercise the 8 / 4 / scalar tail boundaries. The remainder path
+/// is where a batched rewrite most likely silently drops or duplicates records,
+/// so we assert both the exact output length (no record lost or added) and
+/// per-record parity with the reference across counts straddling every boundary.
+#[test]
+fn tail_boundary_record_counts_match_reference() {
+    let s = spec("production");
+    let net = build_network(s, 0x0BAD_C0DE);
+
+    for &count in &[0usize, 1, 2, 3, 4, 5, 7, 8, 9, 12, 15, 16, 17, 24, 31, 33] {
+        let records = build_records(&net, count);
+        let expected = reference(&net, &records, s.num_outputs);
+
+        let seq = net.score_records(&records, s.num_outputs);
+        let par = net.score_records_parallel(&records, s.num_outputs);
+
+        assert_eq!(
+            seq.len(),
+            count * s.num_outputs,
+            "seq length for count {count}"
+        );
+        assert_eq!(
+            par.len(),
+            count * s.num_outputs,
+            "par length for count {count}"
+        );
+        assert_close(&seq, &expected, &format!("score_records count {count}"));
+        assert_close(
+            &par,
+            &expected,
+            &format!("score_records_parallel count {count}"),
+        );
+    }
+}
+
+/// The sequential and parallel paths run the identical batched forward pass and
+/// each record's result is independent of its batch-mates; the parallel chunk
+/// size is a multiple of the SIMD batch, so every record lands on the same
+/// primitive (8-way / 4-way / scalar) either way. They must therefore agree
+/// **bit-for-bit**, even though each only matches the per-record reference
+/// within tolerance.
+#[test]
+fn sequential_and_parallel_are_bit_identical() {
+    for label in ["small_50", "medium_500", "production"] {
+        let s = spec(label);
+        let net = build_network(s, 0x5AFE_5EED);
+        for &count in &[7usize, 8, 9, 65, 130, 257] {
+            let records = build_records(&net, count);
+            let seq = net.score_records(&records, s.num_outputs);
+            let par = net.score_records_parallel(&records, s.num_outputs);
+            assert_eq!(
+                seq, par,
+                "seq vs parallel diverged for {label} count {count}"
+            );
+        }
+    }
 }

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -29,13 +29,15 @@ fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
 }
 
 /// Independent sequential reference: a fresh scratch clone scored one record at
-/// a time. Deliberately does not call `score_records`, so the parity assertion
-/// does not assume the two share an implementation.
-fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<Vec<f32>> {
+/// a time via per-record `activate` (which still allocates its own output
+/// `Vec`), flattened to the flat `[record * num_outputs]` layout the scoring
+/// path now returns. Deliberately does not call `score_records`, so the parity
+/// assertion does not assume the two share an implementation.
+fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
     let mut scratch = net.clone();
     records
         .iter()
-        .map(|r| scratch.activate(r, num_outputs))
+        .flat_map(|r| scratch.activate(r, num_outputs))
         .collect()
 }
 
@@ -48,7 +50,7 @@ fn parallel_scoring_matches_sequential_on_production_fixture() {
     let expected = reference(&net, &records, s.num_outputs);
     let actual = net.score_records_parallel(&records, s.num_outputs);
 
-    assert_eq!(actual.len(), records.len());
+    assert_eq!(actual.len(), records.len() * s.num_outputs);
     assert_eq!(actual, expected, "parallel results must equal sequential");
 }
 
@@ -86,7 +88,11 @@ fn output_order_is_preserved() {
     // index-aligned reference.
     let expected = reference(&net, &records, s.num_outputs);
     let actual = net.score_records_parallel(&records, s.num_outputs);
-    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+    for (i, (a, e)) in actual
+        .chunks_exact(s.num_outputs)
+        .zip(expected.chunks_exact(s.num_outputs))
+        .enumerate()
+    {
         assert_eq!(a, e, "record {i} out of order or incorrect");
     }
 }
@@ -98,10 +104,10 @@ fn each_output_has_num_outputs_elements() {
     let records = build_records(&net, 16);
 
     let out = net.score_records_parallel(&records, s.num_outputs);
-    assert_eq!(out.len(), 16);
-    for row in &out {
-        assert_eq!(row.len(), s.num_outputs);
-    }
+    // Flat buffer: 16 records each contributing exactly num_outputs elements.
+    assert_eq!(out.len(), 16 * s.num_outputs);
+    assert_eq!(out.chunks_exact(s.num_outputs).count(), 16);
+    assert!(out.chunks_exact(s.num_outputs).remainder().is_empty());
 }
 
 #[test]
@@ -124,5 +130,6 @@ fn single_record_matches_direct_activate() {
     let direct = scratch.activate(&record, s.num_outputs);
     let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
 
-    assert_eq!(via_parallel, vec![direct]);
+    // Single record: the flat buffer is exactly that record's outputs.
+    assert_eq!(via_parallel, direct);
 }

--- a/neat-core/tests/scoring_allocations.rs
+++ b/neat-core/tests/scoring_allocations.rs
@@ -1,0 +1,98 @@
+//! Allocation-count regression for the record-scoring hot path (Issue #229).
+//!
+//! `score_records` now routes every record through
+//! [`CompiledNetwork::activate_into`], writing into one pre-sized flat buffer
+//! instead of allocating a fresh output `Vec` per record via `activate`'s
+//! `to_vec()`. This test proves the batch performs **no per-record output
+//! allocation**: a counting global allocator records how many allocations
+//! happen while scoring, and the count must not scale with the record count.
+//!
+//! A revert to the old `to_vec()`-per-record path would allocate ~one `Vec` per
+//! record, so scoring 10× the records would allocate ~10× more — the delta
+//! assertion below would then fail loudly instead of silently regressing
+//! throughput.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{NETWORKS, NetSpec, build_inputs, build_network};
+use neat_core::network::CompiledNetwork;
+
+/// Global allocator that forwards to the system allocator while counting every
+/// allocation. Only the count is observed; the delta between two scoring calls
+/// with different record counts reveals per-record allocation.
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: forwarding an unchanged layout to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr`/`layout` came from `System.alloc` above.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| build_inputs(net.num_inputs(), 0xA110_0000 + i as u64))
+        .collect()
+}
+
+/// Allocation count consumed by scoring `records` (records/network built
+/// beforehand so only the scoring call is measured).
+fn allocs_for(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> usize {
+    let before = ALLOC_COUNT.load(Ordering::Relaxed);
+    let out = net.score_records(records, num_outputs);
+    // Keep the result alive across the measurement so its allocation is counted.
+    std::hint::black_box(&out);
+    let after = ALLOC_COUNT.load(Ordering::Relaxed);
+    after - before
+}
+
+#[test]
+fn score_records_has_no_per_record_output_allocation() {
+    let s = spec("production");
+    let net = build_network(s, 0x0A11_0C);
+
+    let small = build_records(&net, 100);
+    let large = build_records(&net, 1000);
+
+    // Warm up any one-off lazy initialisation so it is not counted below.
+    std::hint::black_box(net.score_records(&small, s.num_outputs));
+
+    let small_allocs = allocs_for(&net, &small, s.num_outputs);
+    let large_allocs = allocs_for(&net, &large, s.num_outputs);
+
+    // Per-record allocation would make scoring 10× the records allocate ~900
+    // extra times; the flat-buffer path allocates a constant handful (one output
+    // buffer + one scratch clone) regardless of record count. A generous
+    // threshold distinguishes "constant" from "grows with records" without being
+    // brittle to allocator/test-harness noise.
+    let delta = large_allocs.saturating_sub(small_allocs);
+    assert!(
+        delta < 50,
+        "scoring 10× records allocated {large_allocs} vs {small_allocs} \
+         (delta {delta}); expected a constant count — per-record output \
+         allocation has regressed"
+    );
+}

--- a/neat-core/tests/scoring_allocations.rs
+++ b/neat-core/tests/scoring_allocations.rs
@@ -1,11 +1,12 @@
-//! Allocation-count regression for the record-scoring hot path (Issue #229).
+//! Allocation-count regression for the record-scoring hot path (Issue #229, #230).
 //!
-//! `score_records` now routes every record through
-//! [`CompiledNetwork::activate_into`], writing into one pre-sized flat buffer
-//! instead of allocating a fresh output `Vec` per record via `activate`'s
-//! `to_vec()`. This test proves the batch performs **no per-record output
-//! allocation**: a counting global allocator records how many allocations
-//! happen while scoring, and the count must not scale with the record count.
+//! `score_records` drives every record through the batched SIMD forward pass
+//! ([`CompiledNetwork::score_batch_into`], Issue #230), writing into one
+//! pre-sized flat buffer instead of allocating a fresh output `Vec` per record
+//! via `activate`'s `to_vec()`. This test proves the batch performs **no
+//! per-record output allocation**: a counting global allocator records how many
+//! allocations happen while scoring, and the count must not scale with the
+//! record count.
 //!
 //! A revert to the old `to_vec()`-per-record path would allocate ~one `Vec` per
 //! record, so scoring 10× the records would allocate ~10× more — the delta
@@ -72,7 +73,7 @@ fn allocs_for(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -
 #[test]
 fn score_records_has_no_per_record_output_allocation() {
     let s = spec("production");
-    let net = build_network(s, 0x0A11_0C);
+    let net = build_network(s, 0x000A_110C);
 
     let small = build_records(&net, 100);
     let large = build_records(&net, 1000);
@@ -85,7 +86,7 @@ fn score_records_has_no_per_record_output_allocation() {
 
     // Per-record allocation would make scoring 10× the records allocate ~900
     // extra times; the flat-buffer path allocates a constant handful (one output
-    // buffer + one scratch clone) regardless of record count. A generous
+    // buffer + one set of lane scratch buffers) regardless of record count. A generous
     // threshold distinguishes "constant" from "grows with records" without being
     // brittle to allocator/test-harness noise.
     let delta = large_allocs.saturating_sub(small_allocs);


### PR DESCRIPTION
## Milestone: #227 Speed up NEAT evolution on production-sized creatures (benchmark-gated)

This PR merges the completed milestone branch into Develop.
Closes #238

### Issues addressed
- #233: [#227] Experiment: chunked rayon scheduling in score_records_parallel
- #232: [#227] Experiment: software-prefetch the activation gather on aarch64
- #231: [#227] Experiment: order each neuron's synapses by from_index for gather locality
- #230: [#227] Score records through the 8-record batched SIMD path
- #229: [#227] Eliminate per-record output Vec allocation in scoring (use activate_into)
- #228: [#227] Establish production-sized benchmark baseline and scoring fixtures

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.