### PR TITLE
perf: wire squash_x8/x4 into score_batch_into + expand SIMD squash coverage (Issue #243)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "criterion",
  "rayon",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-243.md
+++ b/docs/archive/pr-summaries/pr-summary-243.md
@@ -1,0 +1,107 @@
+# PR Summary — Issue #243
+
+## Summary
+
+Wire the batched **scoring** hot path through the vectorised squash
+approximations, and broaden `squash_simd` coverage to the high-frequency
+production squash types that were still scalar. **Closes #243.**
+
+Production flamegraphs (NEAT-AI-scorer#296) showed `mse_sum_batch_packed` and
+the libm transcendental mix dominating evolution wall-clock, yet the #230
+scoring path (`score_batch_into` → `score_records` / `score_records_parallel`)
+still applied the squash **scalar, per lane** — so it never used the SIMD squash
+work #180 already paid for.
+
+Two changes:
+
+1. **`CompiledNetwork::score_batch_into`** now feeds its 8- and 4-record lane
+   sums through `squash_x8` / `squash_x4` (falling back to the scalar inline
+   squash for uncovered types), exactly the way `mse_sum_batch_packed` does.
+2. **`squash_simd`** gains branchless, auto-vectorisable lane implementations for
+   the production mix that was still scalar:
+   - *Cheap / algebraic (exact f32):* `Absolute`, `HardTanh`, `Relu6`,
+     `LeakyRelu`, `Bipolar`, `Softsign`, `BentIdentity`, `Isru`.
+   - *Transcendental (approximation reusing the existing `exp` / new `sin` /
+     `atan` cores):* `Gaussian`, `Swish`, `BipolarSigmoid`, `Elu`, `Selu`,
+     `Sine`, `Cosine`, `ArcTan`.
+
+Scalar `apply_squash` stays the correctness oracle: every added type is bounded
+within `SQUASH_SIMD_MAX_ABS_ERR` (5e-6) of it, asserted by range-sweep tests
+(same pattern the hot transcendentals already use). Uncovered types (e.g.
+`Identity`, `Relu`, `Softplus`, `Square`, `Cube`, aggregates) still return `None`
+and keep bit-identical scalar numerics.
+
+## Evidence
+
+### Benchmarks (performance gate)
+
+**Host:** Apple Silicon (GRQ-23, GRQ class), quiet machine, interleaved A/B via
+Criterion `--save-baseline before` / `--baseline before`.
+
+```bash
+cargo bench -p neat-core --bench hot_paths -- --save-baseline before 'production'
+# … change …
+cargo bench -p neat-core --bench hot_paths -- --baseline before 'scoring/production'
+```
+
+| Benchmark | Before | After | Change | CIs |
+|---|---:|---:|---:|---|
+| `scoring/production` | 59.94 ms | 36.91 ms | **−38.4 %** (thrpt +62 %) | non-overlapping, p < 0.05 |
+| `scoring/production_2x` | 155.0 ms | 86.83 ms | **−44.0 %** (thrpt +79 %) | non-overlapping, p < 0.05 |
+
+Both clear the **≥ 5 %** merge gate on `scoring/production` decisively with
+non-overlapping confidence intervals. The `scoring` benches build an all-`Tanh`
+production creature, so the win is the direct result of routing the squash
+through `squash_x8` instead of eight scalar `tanhf` calls per neuron.
+
+> Note: `forward_pass/*` is the single-record path (`activate_into`), which this
+> change does not touch; its numbers are unchanged bar measurement noise.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    R[records batch] --> B[score_batch_into]
+    B --> W[weighted_sum_simd_8/4records]
+    W --> S{squash_x8 / squash_x4}
+    S -->|covered type| V[vectorised lanes]
+    S -->|None| F[scalar inline_squash fallback]
+    V --> L[apply_limit_range]
+    F --> L
+    L --> O[out record*num_outputs]
+```
+
+### Correctness
+
+Backend/CLI change — no web UI to screenshot. Verified via tests:
+
+- `neat-core/tests/score_squash_simd_parity.rs` (new): scores distinct-per-record
+  batches through the public `score_records` and asserts parity with the scalar
+  per-record `activate` reference across every batch boundary (8-block, 4-block,
+  tail) for all 20 vectorised types **and** representative scalar-fallback types.
+- `squash_simd` range tests: each added type is swept over its realistic finite
+  window and asserted within `SQUASH_SIMD_MAX_ABS_ERR` of scalar `apply_squash`.
+- Existing `tests/parallel_scoring.rs` (incl. `--features parallel`) and
+  `tests/mse_squash_simd_parity.rs` stay green — the scoring/loss parity within
+  the agreed f32/SIMD tolerance (#227/#230) is preserved.
+
+`cargo fmt --check` and `cargo clippy --all-targets` are clean. `./quality.sh`
+has 4 pre-existing failures (tests 48–54, all about `ci.yml`/`bump-deps.sh`
+quarantine wiring) that also fail on the base branch `Develop` — unrelated to
+this change and out of scope.
+
+## Test Plan
+
+- **Added** `neat-core/tests/score_squash_simd_parity.rs`:
+  - `score_batch_matches_scalar_for_vectorised_squashes`
+  - `score_batch_matches_scalar_across_batch_boundaries`
+  - `score_batch_non_vectorised_squash_matches_scalar`
+- **Added** in `squash_simd.rs` unit tests:
+  - `issue_243_additions_within_tolerance_over_range` (per-type range sweep)
+  - `bipolar_matches_scalar_sign`
+  - Expanded `VECTORISED`, `all_four_lanes_match_scalar`, `x8_matches_x4`,
+    `extreme_inputs_are_finite` to cover all 20 types; refreshed
+    `non_vectorised_types_opt_out`.
+- **Ran** `cargo test -p neat-core` (all suites) and
+  `cargo test -p neat-core --features parallel --test parallel_scoring` — green.
+- **Ran** the Criterion A/B benchmark gate (table above).

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -20,9 +20,14 @@
 //! reordering / `f32` accumulation differences). Every other numeric step is
 //! identical to [`CompiledNetwork::activate_into`]:
 //!
-//! - The **squash** uses the same scalar inline branch (Identity / ReLU /
-//!   Logistic / Tanh, else `apply_squash`) — no vectorised approximation — so
-//!   the squash itself is bit-identical.
+//! - The **squash** for the covered types is evaluated across all 8 (then 4)
+//!   batch lanes at once through the vectorised `squash_x8` / `squash_x4`
+//!   approximations (Issue #243, mirroring `mse_sum_batch_packed`). Those
+//!   approximations stay within `SQUASH_SIMD_MAX_ABS_ERR` of scalar
+//!   `apply_squash`, so results match the per-record reference within the same
+//!   SIMD tolerance the batched weighted sums already introduce (Issue #230).
+//!   Every other type keeps the scalar inline branch (Identity / ReLU /
+//!   Logistic / Tanh, else `apply_squash`), so its squash stays bit-identical.
 //! - **Aggregate** squashes (Minimum, Maximum, If, Hypotenuse, HypotenuseV2,
 //!   Mean) and the **scalar tail** (`records.len() % 8` after the 4-way step)
 //!   run the exact single-record path via `neuron_activation_scalar`, so those
@@ -42,6 +47,7 @@ use crate::simd::{
     weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
 };
 use crate::squash::{SquashType, apply_squash};
+use crate::squash_simd::{squash_x4, squash_x8};
 use crate::synapse_type::SynapseType;
 
 /// Reusable per-worker scratch: eight activation buffers, one per SIMD lane.
@@ -260,15 +266,21 @@ impl CompiledNetwork {
                             end,
                             neuron.bias,
                         );
-                        let st = neuron.squash_type;
-                        act0[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s0));
-                        act1[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s1));
-                        act2[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s2));
-                        act3[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s3));
-                        act4[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s4));
-                        act5[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s5));
-                        act6[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s6));
-                        act7[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s7));
+                        // Vectorised squash across all 8 lanes for the covered
+                        // types (Issue #243); scalar inline fallback otherwise.
+                        let sums = [s0, s1, s2, s3, s4, s5, s6, s7];
+                        let squashed = squash_x8(squash, sums).unwrap_or_else(|| {
+                            let st = neuron.squash_type;
+                            sums.map(|s| inline_squash(st, squash, s))
+                        });
+                        act0[actual_idx] = apply_limit_range(squash, squashed[0]);
+                        act1[actual_idx] = apply_limit_range(squash, squashed[1]);
+                        act2[actual_idx] = apply_limit_range(squash, squashed[2]);
+                        act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                        act4[actual_idx] = apply_limit_range(squash, squashed[4]);
+                        act5[actual_idx] = apply_limit_range(squash, squashed[5]);
+                        act6[actual_idx] = apply_limit_range(squash, squashed[6]);
+                        act7[actual_idx] = apply_limit_range(squash, squashed[7]);
                     }
                 }
             }
@@ -337,11 +349,17 @@ impl CompiledNetwork {
                             end,
                             neuron.bias,
                         );
-                        let st = neuron.squash_type;
-                        act0[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s0));
-                        act1[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s1));
-                        act2[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s2));
-                        act3[actual_idx] = apply_limit_range(squash, inline_squash(st, squash, s3));
+                        // Vectorised squash across all 4 lanes for the covered
+                        // types (Issue #243); scalar inline fallback otherwise.
+                        let sums = [s0, s1, s2, s3];
+                        let squashed = squash_x4(squash, sums).unwrap_or_else(|| {
+                            let st = neuron.squash_type;
+                            sums.map(|s| inline_squash(st, squash, s))
+                        });
+                        act0[actual_idx] = apply_limit_range(squash, squashed[0]);
+                        act1[actual_idx] = apply_limit_range(squash, squashed[1]);
+                        act2[actual_idx] = apply_limit_range(squash, squashed[2]);
+                        act3[actual_idx] = apply_limit_range(squash, squashed[3]);
                     }
                 }
             }

--- a/neat-core/src/squash_simd.rs
+++ b/neat-core/src/squash_simd.rs
@@ -26,7 +26,10 @@
 //! scalar path, leaving their numerics unchanged. The scalar `apply_squash`
 //! remains the single source of truth for correctness.
 
-use crate::squash::{GELU_COEFF, SQRT_2_OVER_PI, SquashType};
+use crate::squash::{
+    GELU_COEFF, LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SOFTSIGN_LIMIT, SQRT_2_OVER_PI,
+    SquashType,
+};
 
 /// Documented maximum absolute error of the vectorised squashes versus the
 /// scalar [`apply_squash`](crate::squash::apply_squash) over the finite input range. Chosen tighter than the
@@ -156,19 +159,304 @@ fn mish_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
     out
 }
 
+/// Branchless single-lane `sin` approximation (Cephes `sinf` octant reduction).
+/// Accurate to ~1e-7 over the finite range where the argument reduction holds
+/// (`|x|` up to a few thousand); the value stays finite for any input. Shared by
+/// [`sine_lanes`] and [`cosine_lanes`].
+#[inline(always)]
+fn sin_approx(x: f32) -> f32 {
+    // 4/pi and the three-part high-precision pi/4 split (Cody–Waite).
+    const FOPI: f32 = 1.273_239_5;
+    const DP1: f32 = 0.785_156_25;
+    const DP2: f32 = 2.418_756_5e-4;
+    const DP3: f32 = 3.774_895e-8;
+
+    let sign_in = if x < 0.0 { -1.0_f32 } else { 1.0_f32 };
+    let mut xa = x.abs();
+    // Guard the integer reduction against overflow for extreme inputs; beyond
+    // this the periodic value is meaningless anyway, and callers only require a
+    // finite result there.
+    xa = xa.min(1.0e9);
+
+    let mut j = (FOPI * xa) as i32;
+    let mut y = j as f32;
+    if j & 1 != 0 {
+        j += 1;
+        y += 1.0;
+    }
+    j &= 7;
+    let mut sign = sign_in;
+    if j > 3 {
+        sign = -sign;
+        j -= 4;
+    }
+
+    let z = ((xa - y * DP1) - y * DP2) - y * DP3;
+    let zz = z * z;
+
+    let result = if j == 1 || j == 2 {
+        // cos polynomial on the reduced range.
+        let mut p = 2.443_315_7e-5;
+        p = p * zz - 1.388_731_6e-3;
+        p = p * zz + 4.166_664_6e-2;
+        1.0 - 0.5 * zz + p * zz * zz
+    } else {
+        // sin polynomial on the reduced range.
+        let mut p = -1.951_529_6e-4;
+        p = p * zz + 8.332_161e-3;
+        p = p * zz - 1.666_665_5e-1;
+        z + p * z * zz
+    };
+
+    sign * result
+}
+
+/// Branchless single-lane `atan` approximation (Cephes `atanf` range folding).
+/// Accurate to a few `1e-7` over the whole finite range; odd-symmetric and
+/// saturating to `±pi/2`.
+#[inline(always)]
+fn atan_approx(x: f32) -> f32 {
+    const TAN_3PI_8: f32 = 2.414_213_6; // tan(3*pi/8)
+    const TAN_PI_8: f32 = 0.414_213_57; // tan(pi/8)
+    const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+    const FRAC_PI_4: f32 = core::f32::consts::FRAC_PI_4;
+
+    let sign = if x < 0.0 { -1.0_f32 } else { 1.0_f32 };
+    let xa = x.abs();
+
+    // Fold |x| into [0, tan(pi/8)] and remember the added angle.
+    let (xr, y) = if xa > TAN_3PI_8 {
+        (-1.0 / xa, FRAC_PI_2)
+    } else if xa > TAN_PI_8 {
+        ((xa - 1.0) / (xa + 1.0), FRAC_PI_4)
+    } else {
+        (xa, 0.0)
+    };
+
+    let z = xr * xr;
+    let mut p = 8.053_744_5e-2;
+    p = p * z - 1.387_768_6e-1;
+    p = p * z + 1.997_771_1e-1;
+    p = p * z - 3.333_295e-1;
+    let poly = p * z * xr + xr;
+
+    sign * (y + poly)
+}
+
+/// `Absolute` (`|x|`) over a lane array — exact, branchless.
+#[inline]
+fn absolute_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = x[i].abs();
+    }
+    out
+}
+
+/// `HardTanh` (`clamp(x, -1, 1)`) over a lane array — exact, branchless.
+#[inline]
+fn hard_tanh_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = x[i].clamp(-1.0, 1.0);
+    }
+    out
+}
+
+/// `Relu6` (`clamp(x, 0, 6)`) over a lane array — exact, branchless.
+#[inline]
+fn relu6_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = x[i].clamp(0.0, 6.0);
+    }
+    out
+}
+
+/// `LeakyRelu` over a lane array — exact, branchless select.
+#[inline]
+fn leaky_relu_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        out[i] = if v >= 0.0 { v } else { LEAKY_RELU_ALPHA * v };
+    }
+    out
+}
+
+/// `Bipolar` (`x > 0 → 1, else -1`) over a lane array — exact, branchless.
+#[inline]
+fn bipolar_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = if x[i] > 0.0 { 1.0 } else { -1.0 };
+    }
+    out
+}
+
+/// `Softsign` (`x / (1 + |x|)`, clamped to the JS `±0.99` limit) over a lane
+/// array. Reproduces the scalar clamp bit-for-bit so numerics are unchanged.
+#[inline]
+fn softsign_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    // Same limit as scalar `apply_squash`: the next f32 below 0.99 so clamped
+    // values stay within the JS (f64) bounds.
+    let limit = f32::from_bits(SOFTSIGN_LIMIT.to_bits() - 1);
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        let y = v / (1.0 + v.abs());
+        out[i] = y.max(-limit).min(limit);
+    }
+    out
+}
+
+/// `BentIdentity` (`(sqrt(x^2 + 1) - 1) / 2 + x`) over a lane array — exact
+/// f32, branchless.
+#[inline]
+fn bent_identity_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        out[i] = ((v * v + 1.0).sqrt() - 1.0) / 2.0 + v;
+    }
+    out
+}
+
+/// `Isru` (`x / sqrt(1 + x^2)`) over a lane array — exact f32, branchless.
+#[inline]
+fn isru_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        out[i] = v / (1.0 + v * v).sqrt();
+    }
+    out
+}
+
+/// `Gaussian` (`exp(-x^2)`) over a lane array via [`exp_approx`].
+#[inline]
+fn gaussian_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        out[i] = exp_approx(-v * v);
+    }
+    out
+}
+
+/// `Swish` (`x / (1 + exp(-x))`) over a lane array via [`exp_approx`].
+#[inline]
+fn swish_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        out[i] = v / (1.0 + exp_approx(-v));
+    }
+    out
+}
+
+/// `BipolarSigmoid` (`2 / (1 + exp(-x)) - 1`) over a lane array.
+#[inline]
+fn bipolar_sigmoid_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = 2.0 / (1.0 + exp_approx(-x[i])) - 1.0;
+    }
+    out
+}
+
+/// `Elu` (`x > 0 → x, else exp(x) - 1`) over a lane array — branchless select.
+#[inline]
+fn elu_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let v = x[i];
+        out[i] = if v > 0.0 { v } else { exp_approx(v) - 1.0 };
+    }
+    out
+}
+
+/// `Selu` over a lane array — branchless select matching the scalar structure
+/// (`lambda * (x > 0 ? x : alpha*exp(x) - alpha)`), with the same `x <= 709`
+/// safety clamp the scalar path applies before the exponential.
+#[inline]
+fn selu_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        let sx = x[i].min(709.0);
+        let fx = if sx > 0.0 {
+            sx
+        } else {
+            SELU_ALPHA * exp_approx(sx) - SELU_ALPHA
+        };
+        out[i] = SELU_LAMBDA * fx;
+    }
+    out
+}
+
+/// `Sine` (`sin(x)`) over a lane array via [`sin_approx`].
+#[inline]
+fn sine_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = sin_approx(x[i]);
+    }
+    out
+}
+
+/// `Cosine` (`cos(x) = sin(x + pi/2)`) over a lane array via [`sin_approx`].
+#[inline]
+fn cosine_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    const FRAC_PI_2: f32 = core::f32::consts::FRAC_PI_2;
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = sin_approx(x[i] + FRAC_PI_2);
+    }
+    out
+}
+
+/// `ArcTan` (`atan(x)`) over a lane array via [`atan_approx`].
+#[inline]
+fn arctan_lanes<const N: usize>(x: [f32; N]) -> [f32; N] {
+    let mut out = [0.0_f32; N];
+    for i in 0..N {
+        out[i] = atan_approx(x[i]);
+    }
+    out
+}
+
 /// Vectorised squash dispatch over `N` lanes.
 ///
-/// Returns `Some([..])` for the hot transcendental squashes that have a
-/// lane-parallel approximation within [`SQUASH_SIMD_MAX_ABS_ERR`] of scalar
+/// Returns `Some([..])` for the squashes that have a lane-parallel
+/// approximation within [`SQUASH_SIMD_MAX_ABS_ERR`] of scalar
 /// [`apply_squash`](crate::squash::apply_squash); returns `None` for every other type so the caller keeps the
 /// existing scalar path (unchanged numerics).
 #[inline]
 fn squash_lanes<const N: usize>(squash: SquashType, x: [f32; N]) -> Option<[f32; N]> {
     match squash {
+        // Hot transcendental squashes (Issue #180).
         SquashType::Tanh => Some(tanh_lanes(x)),
         SquashType::Logistic => Some(logistic_lanes(x)),
         SquashType::Gelu => Some(gelu_lanes(x)),
         SquashType::Mish => Some(mish_lanes(x)),
+        // High-frequency production squashes (Issue #243). Cheap / algebraic:
+        SquashType::Absolute => Some(absolute_lanes(x)),
+        SquashType::HardTanh => Some(hard_tanh_lanes(x)),
+        SquashType::Relu6 => Some(relu6_lanes(x)),
+        SquashType::LeakyRelu => Some(leaky_relu_lanes(x)),
+        SquashType::Bipolar => Some(bipolar_lanes(x)),
+        SquashType::Softsign => Some(softsign_lanes(x)),
+        SquashType::BentIdentity => Some(bent_identity_lanes(x)),
+        SquashType::Isru => Some(isru_lanes(x)),
+        // High-frequency production squashes (Issue #243). Transcendental:
+        SquashType::Gaussian => Some(gaussian_lanes(x)),
+        SquashType::Swish => Some(swish_lanes(x)),
+        SquashType::BipolarSigmoid => Some(bipolar_sigmoid_lanes(x)),
+        SquashType::Elu => Some(elu_lanes(x)),
+        SquashType::Selu => Some(selu_lanes(x)),
+        SquashType::Sine => Some(sine_lanes(x)),
+        SquashType::Cosine => Some(cosine_lanes(x)),
+        SquashType::ArcTan => Some(arctan_lanes(x)),
         _ => None,
     }
 }
@@ -192,11 +480,56 @@ mod tests {
 
     /// Squash types with a vectorised implementation, and the others which must
     /// opt out (so the caller falls back to scalar with unchanged numerics).
-    const VECTORISED: [SquashType; 4] = [
+    const VECTORISED: [SquashType; 20] = [
         SquashType::Tanh,
         SquashType::Logistic,
         SquashType::Gelu,
         SquashType::Mish,
+        // Issue #243 additions.
+        SquashType::Absolute,
+        SquashType::HardTanh,
+        SquashType::Relu6,
+        SquashType::LeakyRelu,
+        SquashType::Bipolar,
+        SquashType::Softsign,
+        SquashType::BentIdentity,
+        SquashType::Isru,
+        SquashType::Gaussian,
+        SquashType::Swish,
+        SquashType::BipolarSigmoid,
+        SquashType::Elu,
+        SquashType::Selu,
+        SquashType::Sine,
+        SquashType::Cosine,
+        SquashType::ArcTan,
+    ];
+
+    /// Per-type finite sweep windows for the Issue #243 additions. Each window
+    /// covers the range the activation is realistically used over; the assert is
+    /// the same [`SQUASH_SIMD_MAX_ABS_ERR`] bound as the hot transcendentals.
+    /// Bipolar is a step function (exact away from the `x = 0` discontinuity) so
+    /// it is checked separately rather than swept across the jump.
+    const RANGE_CASES: [(SquashType, f32, f32); 18] = [
+        (SquashType::Absolute, -1.0e6, 1.0e6),
+        (SquashType::HardTanh, -10.0, 10.0),
+        (SquashType::Relu6, -10.0, 10.0),
+        (SquashType::LeakyRelu, -100.0, 100.0),
+        (SquashType::Softsign, -1.0e4, 1.0e4),
+        (SquashType::BentIdentity, -1.0e3, 1.0e3),
+        (SquashType::Isru, -1.0e3, 1.0e3),
+        (SquashType::Gaussian, -20.0, 20.0),
+        (SquashType::Swish, -30.0, 30.0),
+        (SquashType::BipolarSigmoid, -40.0, 40.0),
+        (SquashType::Elu, -40.0, 40.0),
+        (SquashType::Selu, -30.0, 30.0),
+        (SquashType::Sine, -50.0, 50.0),
+        (SquashType::Cosine, -50.0, 50.0),
+        (SquashType::ArcTan, -1.0e3, 1.0e3),
+        // Extra transcendental windows around the origin, where the curvature is
+        // highest and the approximation is most stressed.
+        (SquashType::Swish, -6.0, 6.0),
+        (SquashType::Sine, -6.3, 6.3),
+        (SquashType::Cosine, -6.3, 6.3),
     ];
 
     /// Max absolute error of a vectorised squash versus scalar `apply_squash`
@@ -251,6 +584,28 @@ mod tests {
     }
 
     #[test]
+    fn issue_243_additions_within_tolerance_over_range() {
+        for (squash, lo, hi) in RANGE_CASES {
+            let err = max_abs_err(squash, lo, hi, 40_000);
+            assert!(
+                err <= SQUASH_SIMD_MAX_ABS_ERR,
+                "{squash:?} max abs err {err} over [{lo}, {hi}] exceeds {SQUASH_SIMD_MAX_ABS_ERR}"
+            );
+        }
+    }
+
+    #[test]
+    fn bipolar_matches_scalar_sign() {
+        // Bipolar is a step at x = 0; away from the jump the vectorised path must
+        // reproduce the scalar sign exactly.
+        for &x in &[-100.0_f32, -1.0, -1e-3, 1e-3, 1.0, 100.0] {
+            let want = apply_squash(SquashType::Bipolar, x);
+            let got = squash_x4(SquashType::Bipolar, [x, x, x, x]).unwrap()[0];
+            assert_eq!(want, got, "Bipolar({x}): want {want}, got {got}");
+        }
+    }
+
+    #[test]
     fn all_four_lanes_match_scalar() {
         // The same value in every lane must reproduce the scalar result; distinct
         // values per lane must each match their own scalar squash.
@@ -291,9 +646,16 @@ mod tests {
         for squash in [
             SquashType::Identity,
             SquashType::Relu,
-            SquashType::Sine,
-            SquashType::Gaussian,
             SquashType::Softplus,
+            SquashType::Tan,
+            SquashType::Square,
+            SquashType::Cube,
+            SquashType::Sqrt,
+            SquashType::Exponential,
+            SquashType::LogSigmoid,
+            SquashType::StdInverse,
+            SquashType::Complement,
+            SquashType::Step,
             SquashType::Minimum,
         ] {
             assert!(

--- a/neat-core/tests/score_squash_simd_parity.rs
+++ b/neat-core/tests/score_squash_simd_parity.rs
@@ -1,0 +1,209 @@
+//! Parity guard for the SIMD squash wiring in the batched scoring path
+//! (Issue #243). `CompiledNetwork::score_batch_into` now feeds its per-lane
+//! sums through the vectorised `squash_x8` / `squash_x4` approximations for the
+//! covered squash types (Tanh / Logistic / Gelu / Mish from #180 plus the
+//! high-frequency production types added by #243), falling back to the scalar
+//! inline squash for every other type.
+//!
+//! These are "what" tests: they build a real forward network, score a batch of
+//! distinct records through the public `score_records` entry point, and assert
+//! the result matches the scalar single-record `activate` reference within the
+//! documented SIMD tolerance. Distinct per-record inputs mean a lane
+//! transposition in the wiring would break the parity, so the tests double as a
+//! regression guard for the batching itself.
+
+use neat_core::squash::SquashType;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Build a small forward network: `num_inputs` inputs fully connected into two
+/// hidden neurons and one output neuron, every non-input neuron using `squash`.
+fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.3 - 0.11 * (i as f32) + 0.07 * (h as f32),
+                from_index: i as u16,
+                synapse_type: 0,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    let hidden0 = num_inputs as u16;
+    let hidden1 = num_inputs as u16 + 1;
+    synapses.push(SynapseData {
+        weight: 0.6,
+        from_index: hidden0,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.4,
+        from_index: hidden1,
+        synapse_type: 0,
+    });
+    neurons.push(NeuronData {
+        bias: 0.01,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Deterministic distinct input records that exercise the squash curves across
+/// their negative/positive ranges (so a lane mix-up would surface).
+fn build_records(num_records: usize, num_inputs: usize) -> Vec<Vec<f32>> {
+    (0..num_records)
+        .map(|r| {
+            (0..num_inputs)
+                .map(|i| -1.5 + 0.37 * (r as f32) - 0.21 * (i as f32))
+                .collect()
+        })
+        .collect()
+}
+
+/// Scalar single-record reference: score each record via `activate` (the scalar
+/// forward pass) and flatten to the `[record * num_outputs]` layout that
+/// `score_records` returns. Deliberately independent of `score_records`.
+fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
+    let mut scratch = net.clone();
+    records
+        .iter()
+        .flat_map(|r| scratch.activate(r, num_outputs))
+        .collect()
+}
+
+/// Per-element tolerance: each vectorised activation is within
+/// `SQUASH_SIMD_MAX_ABS_ERR` (5e-6) of scalar, and the batched weighted sums
+/// add ~1e-6 of reassociation noise; 1e-3 stays far below any scoring-decision
+/// threshold while a real lane/order bug (an O(1) error) still trips it.
+const TOL: f32 = 1e-3;
+
+fn assert_parity(squash: SquashType, num_records: usize) {
+    let num_inputs = 4;
+    let num_outputs = 1;
+    let net = build_network(num_inputs, squash);
+    let records = build_records(num_records, num_inputs);
+
+    let expected = reference(&net, &records, num_outputs);
+    let actual = net.score_records(&records, num_outputs);
+
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{squash:?} n={num_records}: length mismatch"
+    );
+    let mut worst = 0.0f32;
+    let mut worst_at = 0usize;
+    for (i, (a, e)) in actual.iter().zip(&expected).enumerate() {
+        let diff = (a - e).abs();
+        if diff > worst {
+            worst = diff;
+            worst_at = i;
+        }
+    }
+    assert!(
+        worst <= TOL,
+        "{squash:?} n={num_records}: max abs diff {worst} at {worst_at} exceeds {TOL} \
+         (actual={}, expected={})",
+        actual[worst_at],
+        expected[worst_at]
+    );
+}
+
+/// The full set of squash types the scoring path now vectorises. Record counts
+/// straddle every batch boundary: 8-record block, 4-record block, and the
+/// scalar tail (`% 4`).
+const VECTORISED: [SquashType; 20] = [
+    SquashType::Tanh,
+    SquashType::Logistic,
+    SquashType::Gelu,
+    SquashType::Mish,
+    SquashType::Absolute,
+    SquashType::HardTanh,
+    SquashType::Relu6,
+    SquashType::LeakyRelu,
+    SquashType::Bipolar,
+    SquashType::Softsign,
+    SquashType::BentIdentity,
+    SquashType::Isru,
+    SquashType::Gaussian,
+    SquashType::Swish,
+    SquashType::BipolarSigmoid,
+    SquashType::Elu,
+    SquashType::Selu,
+    SquashType::Sine,
+    SquashType::Cosine,
+    SquashType::ArcTan,
+];
+
+#[test]
+fn score_batch_matches_scalar_for_vectorised_squashes() {
+    // 13 records = one 8-record block + one 4-record block + one tail record,
+    // so every code path in `score_batch_into` is exercised per type.
+    for squash in VECTORISED {
+        assert_parity(squash, 13);
+    }
+}
+
+#[test]
+fn score_batch_matches_scalar_across_batch_boundaries() {
+    // Counts that land exactly on / just past each block boundary.
+    for squash in VECTORISED {
+        for n in [1usize, 3, 4, 7, 8, 11, 16] {
+            assert_parity(squash, n);
+        }
+    }
+}
+
+#[test]
+fn score_batch_non_vectorised_squash_matches_scalar() {
+    // Types that keep the scalar fallback must still match after the wiring.
+    for squash in [
+        SquashType::Identity,
+        SquashType::Relu,
+        SquashType::Softplus,
+        SquashType::Square,
+        SquashType::Cube,
+    ] {
+        for n in [5usize, 8, 13] {
+            assert_parity(squash, n);
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary — Issue #243

## Summary

Wire the batched **scoring** hot path through the vectorised squash
approximations, and broaden `squash_simd` coverage to the high-frequency
production squash types that were still scalar. **Closes #243.**

Production flamegraphs (NEAT-AI-scorer#296) showed `mse_sum_batch_packed` and
the libm transcendental mix dominating evolution wall-clock, yet the #230
scoring path (`score_batch_into` → `score_records` / `score_records_parallel`)
still applied the squash **scalar, per lane** — so it never used the SIMD squash
work #180 already paid for.

Two changes:

1. **`CompiledNetwork::score_batch_into`** now feeds its 8- and 4-record lane
   sums through `squash_x8` / `squash_x4` (falling back to the scalar inline
   squash for uncovered types), exactly the way `mse_sum_batch_packed` does.
2. **`squash_simd`** gains branchless, auto-vectorisable lane implementations for
   the production mix that was still scalar:
   - *Cheap / algebraic (exact f32):* `Absolute`, `HardTanh`, `Relu6`,
     `LeakyRelu`, `Bipolar`, `Softsign`, `BentIdentity`, `Isru`.
   - *Transcendental (approximation reusing the existing `exp` / new `sin` /
     `atan` cores):* `Gaussian`, `Swish`, `BipolarSigmoid`, `Elu`, `Selu`,
     `Sine`, `Cosine`, `ArcTan`.

Scalar `apply_squash` stays the correctness oracle: every added type is bounded
within `SQUASH_SIMD_MAX_ABS_ERR` (5e-6) of it, asserted by range-sweep tests
(same pattern the hot transcendentals already use). Uncovered types (e.g.
`Identity`, `Relu`, `Softplus`, `Square`, `Cube`, aggregates) still return `None`
and keep bit-identical scalar numerics.

## Evidence

### Benchmarks (performance gate)

**Host:** Apple Silicon (GRQ-23, GRQ class), quiet machine, interleaved A/B via
Criterion `--save-baseline before` / `--baseline before`.

```bash
cargo bench -p neat-core --bench hot_paths -- --save-baseline before 'production'
# … change …
cargo bench -p neat-core --bench hot_paths -- --baseline before 'scoring/production'
```

| Benchmark | Before | After | Change | CIs |
|---|---:|---:|---:|---|
| `scoring/production` | 59.94 ms | 36.91 ms | **−38.4 %** (thrpt +62 %) | non-overlapping, p < 0.05 |
| `scoring/production_2x` | 155.0 ms | 86.83 ms | **−44.0 %** (thrpt +79 %) | non-overlapping, p < 0.05 |

Both clear the **≥ 5 %** merge gate on `scoring/production` decisively with
non-overlapping confidence intervals. The `scoring` benches build an all-`Tanh`
production creature, so the win is the direct result of routing the squash
through `squash_x8` instead of eight scalar `tanhf` calls per neuron.

> Note: `forward_pass/*` is the single-record path (`activate_into`), which this
> change does not touch; its numbers are unchanged bar measurement noise.

### Data flow

```mermaid
flowchart LR
    R[records batch] --> B[score_batch_into]
    B --> W[weighted_sum_simd_8/4records]
    W --> S{squash_x8 / squash_x4}
    S -->|covered type| V[vectorised lanes]
    S -->|None| F[scalar inline_squash fallback]
    V --> L[apply_limit_range]
    F --> L
    L --> O[out record*num_outputs]
```

### Correctness

Backend/CLI change — no web UI to screenshot. Verified via tests:

- `neat-core/tests/score_squash_simd_parity.rs` (new): scores distinct-per-record
  batches through the public `score_records` and asserts parity with the scalar
  per-record `activate` reference across every batch boundary (8-block, 4-block,
  tail) for all 20 vectorised types **and** representative scalar-fallback types.
- `squash_simd` range tests: each added type is swept over its realistic finite
  window and asserted within `SQUASH_SIMD_MAX_ABS_ERR` of scalar `apply_squash`.
- Existing `tests/parallel_scoring.rs` (incl. `--features parallel`) and
  `tests/mse_squash_simd_parity.rs` stay green — the scoring/loss parity within
  the agreed f32/SIMD tolerance (#227/#230) is preserved.

`cargo fmt --check` and `cargo clippy --all-targets` are clean. `./quality.sh`
has 4 pre-existing failures (tests 48–54, all about `ci.yml`/`bump-deps.sh`
quarantine wiring) that also fail on the base branch `Develop` — unrelated to
this change and out of scope.

## Test Plan

- **Added** `neat-core/tests/score_squash_simd_parity.rs`:
  - `score_batch_matches_scalar_for_vectorised_squashes`
  - `score_batch_matches_scalar_across_batch_boundaries`
  - `score_batch_non_vectorised_squash_matches_scalar`
- **Added** in `squash_simd.rs` unit tests:
  - `issue_243_additions_within_tolerance_over_range` (per-type range sweep)
  - `bipolar_matches_scalar_sign`
  - Expanded `VECTORISED`, `all_four_lanes_match_scalar`, `x8_matches_x4`,
    `extreme_inputs_are_finite` to cover all 20 types; refreshed
    `non_vectorised_types_opt_out`.
- **Ran** `cargo test -p neat-core` (all suites) and
  `cargo test -p neat-core --features parallel --test parallel_scoring` — green.
- **Ran** the Criterion A/B benchmark gate (table above).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrdeot1b-57dde0`<!-- vibe-worker-issue-243 -->