### PR TITLE
perf: hoist per-neuron squash range dispatch out of per-record loop (Issue #245)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-245.md
+++ b/docs/archive/pr-summaries/pr-summary-245.md
@@ -1,0 +1,112 @@
+## Summary
+
+Cuts squash-dispatch overhead in the batched scoring / MSE hot paths by
+**hoisting the per-neuron output-range dispatch out of the per-record inner
+loop** (Issue #245). Previously each standard-squash neuron clamped its 8 (then
+4) batch lanes by calling `apply_limit_range(squash, v)` **once per record** —
+and every one of those calls re-ran the 37-arm `apply_get_range` `match` to
+re-derive the same `(low, high)` bounds. The range only depends on the neuron's
+squash type, so it is now resolved **once per neuron** and every lane is clamped
+through a new bounds-only helper `apply_limit_range_bounds(low, high, v)`.
+
+This is a single dispatch-hoist variant (the issue asked for exactly one lever
+per PR): no SoA, no new SIMD squashes, numerics byte-for-byte unchanged.
+
+**Merge gate — `hot_paths scoring/production` improves ≥5%.** Clears the gate on
+both production shapes, confirmed across two independent A/B runs. `Closes #245.`
+
+### What changed
+
+- `neat-core/src/range.rs` — new `apply_limit_range_bounds(low, high, value)`;
+  `apply_limit_range` now delegates to it (single source of truth, identical
+  NaN/±Inf/clamp semantics).
+- `neat-core/src/batch_scoring.rs` — `score_batch_into` 8-way + 4-way standard
+  arms resolve `apply_get_range(squash)` once, clamp all lanes via the bounds
+  helper.
+- `neat-core/src/loss.rs` — same hoist in the `batch_8way_activation!` macro
+  (powers `mae`/`mape`/… `_sum_batch_packed`) and in `mse_sum_batch_4way` /
+  `mse_sum_batch_8way` (the `mse_sum_batch_packed` fast paths).
+- `neat-core/src/lib.rs` — re-export the new helper.
+
+```mermaid
+flowchart TD
+    subgraph before["Before — dispatch per record"]
+        A1["squash_x8(squash, sums)  (1× / neuron)"] --> B1["apply_limit_range(squash, lane0)"]
+        B1 --> C1["apply_get_range match #1"]
+        B1 --> D1["… lane1..lane7 →<br/>apply_get_range match #2..#8"]
+    end
+    subgraph after["After — dispatch per neuron (Issue #245)"]
+        A2["squash_x8(squash, sums)  (1× / neuron)"] --> E2["(low, high) = apply_get_range(squash)  (1× / neuron)"]
+        E2 --> F2["apply_limit_range_bounds(low, high, lane0..lane7)<br/>no per-lane match"]
+    end
+    before --> after
+```
+
+## Evidence
+
+Backend-only change (no web surface). Evidence is the seeded Criterion harness
+plus parity tests. Host: Apple M4 Pro, `--release` bench profile, machine
+otherwise idle; each A/B was measured **back-to-back** (stash original →
+`--save-baseline`, restore → `--baseline`) to minimise thermal drift.
+
+### Merge gate — `cargo bench -p neat-core --bench hot_paths -- scoring/production`
+
+| Benchmark | Before | After | Δ (median) | 95% CI |
+| --- | --- | --- | --- | --- |
+| `scoring/production` | 36.39 ms | 34.05 ms | **−6.4 %** | [−6.99 %, −5.87 %] |
+| `scoring/production_2x` | 87.98 ms | 80.53 ms | **−8.5 %** | [−8.97 %, −7.98 %] |
+
+`p = 0.00 < 0.05` on both. A first independent A/B run (different baseline
+capture) corroborated: `production` −8.1 %, `production_2x` −8.0 %.
+
+### Second gate — `cargo bench -p neat-core --features parallel --bench parallel_scoring`
+
+| Benchmark | Before | After | Δ (median) | 95% CI |
+| --- | --- | --- | --- | --- |
+| `score_records/production/1_core` | 22.12 ms | 21.06 ms | −4.8 % | [−5.5 %, −4.2 %] |
+| `score_records/production/10_cores` | 6.42 ms | 5.83 ms | **−9.1 %** | [−10.8 %, −7.5 %] |
+| `score_records/production_2x/1_core` | 68.00 ms | 64.71 ms | −4.8 % | [−5.3 %, −4.4 %] |
+| `score_records/production_2x/10_cores` | 18.04 ms | 16.81 ms | **−6.8 %** | [−7.9 %, −5.6 %] |
+
+The production-realistic multi-core path (`10_cores`) improves 6.8–9.1 %; the
+`1_core` rayon-pool configs improve ~4.8 % (`p < 0.05`).
+
+### Learning record
+
+- **Was the dispatch visible after the change?** Yes — a reproducible 6–8 %
+  single-core wall-clock cut, well above Criterion's ~±5 % noise band, with
+  tight non-overlapping CIs across two independent A/B runs.
+- **What the lever actually was.** The benchmark's production fixture is
+  **homogeneous `Tanh`** (`benches/common/mod.rs` builds every neuron as `Tanh`),
+  so the branch predictor already nails the squash `match` — the win is **not**
+  the branch-misprediction the issue hypothesised. It is the raw instruction
+  count of re-dispatching the *range* lookup **per record**: LLVM did not CSE the
+  8 identical `apply_get_range(squash)` calls across the inlined per-lane
+  `apply_limit_range` bodies (the intervening NaN/±Inf branches blocked the
+  merge), so 7 of every 8 range `match`es per neuron per batch were redundant
+  work. Hoisting them removed that work.
+- **What was *not* the lever.** The `squash_x8`/`squash_x4` kernel dispatch was
+  already once-per-neuron, so it was not on the per-record critical path; the
+  range clamp was the remaining per-record dispatch, and it was the whole gain.
+- **Implication for the original hypothesis.** On a *varied*-squash creature the
+  eliminated misprediction would stack on top of this, so the real production
+  gain is a lower bound of what the gated homogeneous fixture shows.
+
+## Test Plan
+
+- **New** `neat-core/tests/range.rs::limit_range_bounds_matches_apply_limit_range`
+  — asserts `apply_limit_range_bounds(low, high, v)` is **bit-identical**
+  (`to_bits()`) to `apply_limit_range(squash, v)` for all 37 squash types across
+  finite / ±Inf / NaN edge values. This pins the hoist's numeric equivalence.
+- **Existing, unchanged, still green** (regression guard for the numerics):
+  - `tests/score_squash_simd_parity.rs` (score path parity vs scalar reference,
+    all vectorised + non-vectorised squashes, across batch boundaries).
+  - `tests/mse_squash_simd_parity.rs` (4-way / 8-way / remainder MSE parity).
+  - `tests/range.rs` existing clamp/validate tests.
+- **Quality gate:** `cargo clippy --all-targets --all-features -D warnings`,
+  `cargo check`, `cargo test --workspace --all-features`, `cargo doc`, and
+  `cargo build --release` all pass. The unrelated pre-existing bats failures in
+  `tests/scripts/ci_workflow_quarantine.bats` (tests 48/49/50/54, about
+  `ci.yml`↔`bump-deps.sh` wiring) are untouched by this PR — those files are
+  byte-identical to `origin/Develop` — and are out of scope for this Rust perf
+  change.

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -41,7 +41,7 @@
 //! input order regardless of batching or thread count.
 
 use crate::network::{CompiledNetwork, NeuronData, SynapseData};
-use crate::range::apply_limit_range;
+use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
     weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
@@ -273,14 +273,18 @@ impl CompiledNetwork {
                             let st = neuron.squash_type;
                             sums.map(|s| inline_squash(st, squash, s))
                         });
-                        act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                        act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                        act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                        act3[actual_idx] = apply_limit_range(squash, squashed[3]);
-                        act4[actual_idx] = apply_limit_range(squash, squashed[4]);
-                        act5[actual_idx] = apply_limit_range(squash, squashed[5]);
-                        act6[actual_idx] = apply_limit_range(squash, squashed[6]);
-                        act7[actual_idx] = apply_limit_range(squash, squashed[7]);
+                        // Issue #245: resolve the output range once per neuron
+                        // and clamp all 8 lanes through the bounds, so the range
+                        // `match` runs once instead of once per record.
+                        let (low, high) = apply_get_range(squash);
+                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
+                        act4[actual_idx] = apply_limit_range_bounds(low, high, squashed[4]);
+                        act5[actual_idx] = apply_limit_range_bounds(low, high, squashed[5]);
+                        act6[actual_idx] = apply_limit_range_bounds(low, high, squashed[6]);
+                        act7[actual_idx] = apply_limit_range_bounds(low, high, squashed[7]);
                     }
                 }
             }
@@ -356,10 +360,13 @@ impl CompiledNetwork {
                             let st = neuron.squash_type;
                             sums.map(|s| inline_squash(st, squash, s))
                         });
-                        act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                        act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                        act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                        act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                        // Issue #245: resolve the output range once per neuron
+                        // and clamp all 4 lanes through the bounds.
+                        let (low, high) = apply_get_range(squash);
+                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
                     }
                 }
             }

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -71,7 +71,9 @@ pub use loss::{
     mae_sum_batch_packed, mape_sum_batch_packed, mse_mean_record, mse_sum_batch_packed,
     msle_sum_batch_packed,
 };
-pub use range::{apply_get_range, apply_limit_range, apply_validate_range};
+pub use range::{
+    apply_get_range, apply_limit_range, apply_limit_range_bounds, apply_validate_range,
+};
 pub use safe_zone::{apply_safe_zone_adjustment, apply_safe_zone_adjustment_batch};
 pub use score_scan::{compute_score_components, scan_max_bias, scan_max_weight};
 pub use squash::apply_squash;

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -7,7 +7,7 @@
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
 use crate::network::CompiledNetwork;
-use crate::range::apply_limit_range;
+use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
 use crate::squash::{SquashType, apply_squash};
 use crate::squash_simd::{squash_x4, squash_x8};
@@ -228,14 +228,17 @@ macro_rules! batch_8way_activation {
                                 }
                             };
 
-                            act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                            act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                            act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                            act3[actual_idx] = apply_limit_range(squash, squashed[3]);
-                            act4[actual_idx] = apply_limit_range(squash, squashed[4]);
-                            act5[actual_idx] = apply_limit_range(squash, squashed[5]);
-                            act6[actual_idx] = apply_limit_range(squash, squashed[6]);
-                            act7[actual_idx] = apply_limit_range(squash, squashed[7]);
+                            // Issue #245: resolve the output range once per
+                            // neuron and clamp all 8 lanes through the bounds.
+                            let (low, high) = apply_get_range(squash);
+                            act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                            act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                            act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                            act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
+                            act4[actual_idx] = apply_limit_range_bounds(low, high, squashed[4]);
+                            act5[actual_idx] = apply_limit_range_bounds(low, high, squashed[5]);
+                            act6[actual_idx] = apply_limit_range_bounds(low, high, squashed[6]);
+                            act7[actual_idx] = apply_limit_range_bounds(low, high, squashed[7]);
                         }
                     }
                 }
@@ -434,10 +437,12 @@ macro_rules! batch_8way_activation {
                                     }
                                 };
 
-                                act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                                act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                                act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                                act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                                // Issue #245: resolve the range once per neuron.
+                                let (low, high) = apply_get_range(squash);
+                                act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                                act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                                act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                                act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
                             }
                         }
                     }
@@ -855,10 +860,12 @@ fn mse_sum_batch_4way(
                             }
                         };
 
-                        act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                        act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                        act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                        act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                        // Issue #245: resolve the output range once per neuron.
+                        let (low, high) = apply_get_range(squash);
+                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
                     }
                 }
             }
@@ -1219,14 +1226,17 @@ fn mse_sum_batch_8way(
                             }
                         };
 
-                        act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                        act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                        act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                        act3[actual_idx] = apply_limit_range(squash, squashed[3]);
-                        act4[actual_idx] = apply_limit_range(squash, squashed[4]);
-                        act5[actual_idx] = apply_limit_range(squash, squashed[5]);
-                        act6[actual_idx] = apply_limit_range(squash, squashed[6]);
-                        act7[actual_idx] = apply_limit_range(squash, squashed[7]);
+                        // Issue #245: resolve the output range once per neuron
+                        // and clamp all 8 lanes through the bounds.
+                        let (low, high) = apply_get_range(squash);
+                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
+                        act4[actual_idx] = apply_limit_range_bounds(low, high, squashed[4]);
+                        act5[actual_idx] = apply_limit_range_bounds(low, high, squashed[5]);
+                        act6[actual_idx] = apply_limit_range_bounds(low, high, squashed[6]);
+                        act7[actual_idx] = apply_limit_range_bounds(low, high, squashed[7]);
                     }
                 }
             }
@@ -1401,10 +1411,12 @@ fn mse_sum_batch_8way(
                                 }
                             };
 
-                            act0[actual_idx] = apply_limit_range(squash, squashed[0]);
-                            act1[actual_idx] = apply_limit_range(squash, squashed[1]);
-                            act2[actual_idx] = apply_limit_range(squash, squashed[2]);
-                            act3[actual_idx] = apply_limit_range(squash, squashed[3]);
+                            // Issue #245: resolve the range once per neuron.
+                            let (low, high) = apply_get_range(squash);
+                            act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
+                            act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
+                            act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
+                            act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
                         }
                     }
                 }

--- a/neat-core/src/range.rs
+++ b/neat-core/src/range.rs
@@ -104,20 +104,21 @@ pub fn apply_validate_range(squash_type: SquashType, activation: f32) -> bool {
     activation >= low && activation <= high
 }
 
-/// Clamp a value to the valid range for an activation function
-/// Issue #1142 - WASM Migration Phase 10
+/// Clamp a value to an already-resolved `(low, high)` activation range.
 ///
-/// Returns the value clamped to the valid range.
-/// Infinity values are clamped to the bounds.
-/// NaN returns 0.0 as a safe default.
+/// This is the range-independent core of [`apply_limit_range`]: it takes the
+/// bounds directly instead of re-deriving them from a [`SquashType`] via
+/// [`apply_get_range`]. The batched scoring paths resolve the range **once per
+/// neuron** and then clamp every lane through this helper (Issue #245), so the
+/// per-record inner loop no longer re-runs the 37-arm range `match` for each of
+/// the 8 (then 4) records. `NaN` maps to `0.0` and infinities clamp to the
+/// finite bounds, byte-for-byte identical to [`apply_limit_range`].
 #[inline(always)]
-pub fn apply_limit_range(squash_type: SquashType, value: f32) -> f32 {
+pub fn apply_limit_range_bounds(low: f32, high: f32, value: f32) -> f32 {
     // Handle NaN - return 0 as a safe default
     if value.is_nan() {
         return 0.0;
     }
-
-    let (low, high) = apply_get_range(squash_type);
 
     // Handle infinities by clamping to bounds
     if value == f32::INFINITY {
@@ -129,6 +130,18 @@ pub fn apply_limit_range(squash_type: SquashType, value: f32) -> f32 {
 
     // Clamp to range
     value.max(low).min(high)
+}
+
+/// Clamp a value to the valid range for an activation function
+/// Issue #1142 - WASM Migration Phase 10
+///
+/// Returns the value clamped to the valid range.
+/// Infinity values are clamped to the bounds.
+/// NaN returns 0.0 as a safe default.
+#[inline(always)]
+pub fn apply_limit_range(squash_type: SquashType, value: f32) -> f32 {
+    let (low, high) = apply_get_range(squash_type);
+    apply_limit_range_bounds(low, high, value)
 }
 
 /// Clamp an `f64` value to the valid output range of `squash_type`.

--- a/neat-core/tests/range.rs
+++ b/neat-core/tests/range.rs
@@ -1,7 +1,83 @@
 //! Range validation tests (moved from `src/range.rs`).
 
-use neat_core::range::apply_limit_range_f64;
+use neat_core::range::{apply_limit_range_bounds, apply_limit_range_f64};
 use neat_core::{SquashType, apply_get_range, apply_limit_range, apply_validate_range};
+
+/// Every squash type, so the hoisted-bounds helper can be checked against the
+/// squash-dispatching [`apply_limit_range`] for all 37 ranges (Issue #245).
+const ALL_SQUASH: [SquashType; 37] = [
+    SquashType::Identity,
+    SquashType::Logistic,
+    SquashType::Tanh,
+    SquashType::Relu,
+    SquashType::LeakyRelu,
+    SquashType::Sine,
+    SquashType::Cosine,
+    SquashType::Tan,
+    SquashType::ArcTan,
+    SquashType::Gaussian,
+    SquashType::BentIdentity,
+    SquashType::Bipolar,
+    SquashType::BipolarSigmoid,
+    SquashType::HardTanh,
+    SquashType::Absolute,
+    SquashType::Relu6,
+    SquashType::Selu,
+    SquashType::Gelu,
+    SquashType::Swish,
+    SquashType::Mish,
+    SquashType::Elu,
+    SquashType::Softsign,
+    SquashType::Softplus,
+    SquashType::Square,
+    SquashType::Cube,
+    SquashType::Sqrt,
+    SquashType::Exponential,
+    SquashType::LogSigmoid,
+    SquashType::StdInverse,
+    SquashType::Complement,
+    SquashType::Step,
+    SquashType::Isru,
+    SquashType::Minimum,
+    SquashType::Maximum,
+    SquashType::If,
+    SquashType::Hypotenuse,
+    SquashType::HypotenuseV2,
+];
+
+#[test]
+fn limit_range_bounds_matches_apply_limit_range() {
+    // The Issue #245 hoist resolves `(low, high)` once per neuron and clamps
+    // every lane through `apply_limit_range_bounds`. That must be byte-for-byte
+    // identical to the per-value `apply_limit_range` for every squash type and
+    // every edge value, or the batched scoring numerics would change.
+    let values = [
+        0.0f32,
+        -0.5,
+        0.5,
+        1.5,
+        -1.5,
+        6.5,
+        -6.5,
+        1e6,
+        -1e6,
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::NAN,
+    ];
+    for squash in ALL_SQUASH {
+        let (low, high) = apply_get_range(squash);
+        for &v in &values {
+            let want = apply_limit_range(squash, v);
+            let got = apply_limit_range_bounds(low, high, v);
+            assert_eq!(
+                want.to_bits(),
+                got.to_bits(),
+                "{squash:?} value {v}: apply_limit_range={want} but bounds helper={got}"
+            );
+        }
+    }
+}
 
 #[test]
 fn test_get_range_bounded() {


### PR DESCRIPTION
## Summary

Cuts squash-dispatch overhead in the batched scoring / MSE hot paths by
**hoisting the per-neuron output-range dispatch out of the per-record inner
loop** (Issue #245). Previously each standard-squash neuron clamped its 8 (then
4) batch lanes by calling `apply_limit_range(squash, v)` **once per record** —
and every one of those calls re-ran the 37-arm `apply_get_range` `match` to
re-derive the same `(low, high)` bounds. The range only depends on the neuron's
squash type, so it is now resolved **once per neuron** and every lane is clamped
through a new bounds-only helper `apply_limit_range_bounds(low, high, v)`.

This is a single dispatch-hoist variant (the issue asked for exactly one lever
per PR): no SoA, no new SIMD squashes, numerics byte-for-byte unchanged.

**Merge gate — `hot_paths scoring/production` improves ≥5%.** Clears the gate on
both production shapes, confirmed across two independent A/B runs. `Closes #245.`

### What changed

- `neat-core/src/range.rs` — new `apply_limit_range_bounds(low, high, value)`;
  `apply_limit_range` now delegates to it (single source of truth, identical
  NaN/±Inf/clamp semantics).
- `neat-core/src/batch_scoring.rs` — `score_batch_into` 8-way + 4-way standard
  arms resolve `apply_get_range(squash)` once, clamp all lanes via the bounds
  helper.
- `neat-core/src/loss.rs` — same hoist in the `batch_8way_activation!` macro
  (powers `mae`/`mape`/… `_sum_batch_packed`) and in `mse_sum_batch_4way` /
  `mse_sum_batch_8way` (the `mse_sum_batch_packed` fast paths).
- `neat-core/src/lib.rs` — re-export the new helper.

```mermaid
flowchart TD
    subgraph before["Before — dispatch per record"]
        A1["squash_x8(squash, sums)  (1× / neuron)"] --> B1["apply_limit_range(squash, lane0)"]
        B1 --> C1["apply_get_range match #1"]
        B1 --> D1["… lane1..lane7 →<br/>apply_get_range match #2..#8"]
    end
    subgraph after["After — dispatch per neuron (Issue #245)"]
        A2["squash_x8(squash, sums)  (1× / neuron)"] --> E2["(low, high) = apply_get_range(squash)  (1× / neuron)"]
        E2 --> F2["apply_limit_range_bounds(low, high, lane0..lane7)<br/>no per-lane match"]
    end
    before --> after
```

## Evidence

Backend-only change (no web surface). Evidence is the seeded Criterion harness
plus parity tests. Host: Apple M4 Pro, `--release` bench profile, machine
otherwise idle; each A/B was measured **back-to-back** (stash original →
`--save-baseline`, restore → `--baseline`) to minimise thermal drift.

### Merge gate — `cargo bench -p neat-core --bench hot_paths -- scoring/production`

| Benchmark | Before | After | Δ (median) | 95% CI |
| --- | --- | --- | --- | --- |
| `scoring/production` | 36.39 ms | 34.05 ms | **−6.4 %** | [−6.99 %, −5.87 %] |
| `scoring/production_2x` | 87.98 ms | 80.53 ms | **−8.5 %** | [−8.97 %, −7.98 %] |

`p = 0.00 < 0.05` on both. A first independent A/B run (different baseline
capture) corroborated: `production` −8.1 %, `production_2x` −8.0 %.

### Second gate — `cargo bench -p neat-core --features parallel --bench parallel_scoring`

| Benchmark | Before | After | Δ (median) | 95% CI |
| --- | --- | --- | --- | --- |
| `score_records/production/1_core` | 22.12 ms | 21.06 ms | −4.8 % | [−5.5 %, −4.2 %] |
| `score_records/production/10_cores` | 6.42 ms | 5.83 ms | **−9.1 %** | [−10.8 %, −7.5 %] |
| `score_records/production_2x/1_core` | 68.00 ms | 64.71 ms | −4.8 % | [−5.3 %, −4.4 %] |
| `score_records/production_2x/10_cores` | 18.04 ms | 16.81 ms | **−6.8 %** | [−7.9 %, −5.6 %] |

The production-realistic multi-core path (`10_cores`) improves 6.8–9.1 %; the
`1_core` rayon-pool configs improve ~4.8 % (`p < 0.05`).

### Learning record

- **Was the dispatch visible after the change?** Yes — a reproducible 6–8 %
  single-core wall-clock cut, well above Criterion's ~±5 % noise band, with
  tight non-overlapping CIs across two independent A/B runs.
- **What the lever actually was.** The benchmark's production fixture is
  **homogeneous `Tanh`** (`benches/common/mod.rs` builds every neuron as `Tanh`),
  so the branch predictor already nails the squash `match` — the win is **not**
  the branch-misprediction the issue hypothesised. It is the raw instruction
  count of re-dispatching the *range* lookup **per record**: LLVM did not CSE the
  8 identical `apply_get_range(squash)` calls across the inlined per-lane
  `apply_limit_range` bodies (the intervening NaN/±Inf branches blocked the
  merge), so 7 of every 8 range `match`es per neuron per batch were redundant
  work. Hoisting them removed that work.
- **What was *not* the lever.** The `squash_x8`/`squash_x4` kernel dispatch was
  already once-per-neuron, so it was not on the per-record critical path; the
  range clamp was the remaining per-record dispatch, and it was the whole gain.
- **Implication for the original hypothesis.** On a *varied*-squash creature the
  eliminated misprediction would stack on top of this, so the real production
  gain is a lower bound of what the gated homogeneous fixture shows.

## Test Plan

- **New** `neat-core/tests/range.rs::limit_range_bounds_matches_apply_limit_range`
  — asserts `apply_limit_range_bounds(low, high, v)` is **bit-identical**
  (`to_bits()`) to `apply_limit_range(squash, v)` for all 37 squash types across
  finite / ±Inf / NaN edge values. This pins the hoist's numeric equivalence.
- **Existing, unchanged, still green** (regression guard for the numerics):
  - `tests/score_squash_simd_parity.rs` (score path parity vs scalar reference,
    all vectorised + non-vectorised squashes, across batch boundaries).
  - `tests/mse_squash_simd_parity.rs` (4-way / 8-way / remainder MSE parity).
  - `tests/range.rs` existing clamp/validate tests.
- **Quality gate:** `cargo clippy --all-targets --all-features -D warnings`,
  `cargo check`, `cargo test --workspace --all-features`, `cargo doc`, and
  `cargo build --release` all pass. The unrelated pre-existing bats failures in
  `tests/scripts/ci_workflow_quarantine.bats` (tests 48/49/50/54, about
  `ci.yml`↔`bump-deps.sh` wiring) are untouched by this PR — those files are
  byte-identical to `origin/Develop` — and are out of scope for this Rust perf
  change.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrdjo5ue-faef7a`<!-- vibe-worker-issue-245 -->