### PR TITLE
🟡 Comparison doc still lists topology export (#22) and Serialize round-trip (#30) as pending — both have landed (Issue #260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-260.md
+++ b/docs/archive/pr-summaries/pr-summary-260.md
@@ -1,0 +1,55 @@
+## Summary
+
+`docs/research/ikaruga-neat-ai-comparison.md` still framed two adoption
+candidates as *pending* work, but both have since landed on `Develop`. The
+research doc was therefore an anti-map: an agent triaging follow-ups would be
+sent to re-implement completed, tested features. This PR updates the two rows to
+**done** while keeping the historical analysis intact. Closes #260.
+
+Verified against current code before editing:
+
+- **Topology export (Issue #22)** — `neat-core/src/topology_export.rs` exists and
+  provides `to_dot` and `to_topology_json` from `CompiledNetwork` (module doc
+  cites Issue #22), tested in `neat-core/tests/topology_export.rs`.
+- **Serialize round-trip (Issue #30)** — `CreatureExport`, `NeuronExport` and
+  `SynapseExport` in `neat-core/src/creature.rs:35,54,69` all derive **both**
+  `Deserialize` and `Serialize`; the module doc states "derive both".
+
+## Changes
+
+- Module inventory line (`creature` row): now states the export structs derive
+  both `Deserialize` and `Serialize` (Issue #30 landed).
+- Candidate **#6 Topology visualisation**: 🎯 → ✅ adopted; "no export path" reworded
+  to reference the shipped `topology_export.rs`; "No new issue needed" → **done**.
+- Candidate **#8 Serialisation format**: 🎯 → ✅ adopted; "only `Deserialize`" reworded
+  to "both `Serialize` + `Deserialize`", status **done**.
+- Summary table rows 6 and 8: classification → ✅ adopted; `neat-core` columns
+  updated to reflect the shipped state; follow-up column marked "(landed)".
+- "Adoption candidates" list reframed from proposed work to shipped outcome.
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. Correctness was
+verified two ways:
+
+1. **Source of truth check** — grepped the current code to confirm both features
+   ship (`topology_export.rs` present with `to_dot`/`to_topology_json`;
+   `creature.rs` derives both traits).
+2. **Quality gate** — `./quality.sh < /dev/null` passes cleanly, including the
+   existing `topology_export.rs` tests
+   (`to_dot_method_callable_on_compiled_network`,
+   `to_topology_json_method_callable_on_compiled_network`) that exercise the very
+   code the doc now describes as landed:
+
+```
+test result: ok. 9 passed; 0 failed; ...
+✅ All quality checks passed!
+```
+
+## Test Plan
+
+No new tests: this is a stale-documentation fix, and no doc-consistency test
+references this file. The features the doc describes are already covered by
+existing tests — `neat-core/tests/topology_export.rs` (topology export, Issue
+#22) and the creature/serde tests (round-trip `Serialize`, Issue #30) — which
+continue to pass under `./quality.sh`.

--- a/docs/research/ikaruga-neat-ai-comparison.md
+++ b/docs/research/ikaruga-neat-ai-comparison.md
@@ -36,7 +36,7 @@ The `mame-neat` sibling crate mirrors this layout against MAME.
 | Module | Role |
 |--------|------|
 | `squash` | **38 activation variants** (Identity, ReLU, ReLU6, LeakyReLU, SELU, ELU, Logistic, Tanh, HardTanh, Softsign, Softplus, Swish, Mish, GELU, Sine, Cosine, Tan, ArcTan, Gaussian, BentIdentity, BipolarSigmoid, Bipolar, Step, Complement, Absolute, Square, Cube, Sqrt, StdInverse, Exponential, LogSigmoid, ISRU, Minimum, Maximum, If, Hypotenuse, HypotenuseV2, Mean). |
-| `creature` | `CreatureExport` / `NeuronExport` / `SynapseExport` — **`Deserialize` only** (no `Serialize`), plus `compile_creature` to `CompiledNetwork`. |
+| `creature` | `CreatureExport` / `NeuronExport` / `SynapseExport` — derive **both `Deserialize` and `Serialize`** (round-trip landed, Issue #30), plus `compile_creature` to `CompiledNetwork`. |
 | `network` | `CompiledNetwork`, `NeuronData`, `SynapseData` — compiled forward-pass evaluator. |
 | `topological_backprop` | Topologically ordered backprop loop (lifted from `wasm_activation` per #9). |
 | `topology_ops` | Cycle detection, reverse topological order, structural validation, batch validation. |
@@ -88,15 +88,15 @@ Ikaruga computes a topological order with DFS + cycle skip and iterates nodes se
 
 Ikaruga's `BatchEvaluator` imports `burn::tensor` but the batched path is still sequential `inputs.iter().map(…)`. Nothing to port.
 
-### 6. Topology visualisation — 🎯 worth adopting (data-only export, not the GUI)
+### 6. Topology visualisation — ✅ adopted (data-only export, not the GUI)
 
-Ikaruga ships an 855-line `network_view.rs` built on `egui`/`eframe`, live-coupled to `Arc<RwLock<VisualizationState>>`. It is **not headless** and does **not export** DOT, JSON, or any other machine-readable graph format. `neat-core` has **no export path** today.
+Ikaruga ships an 855-line `network_view.rs` built on `egui`/`eframe`, live-coupled to `Arc<RwLock<VisualizationState>>`. It is **not headless** and does **not export** DOT, JSON, or any other machine-readable graph format. At the time of research `neat-core` had no export path.
 
-The useful capability to pull forward is **deterministic topology export** (DOT and/or topology JSON) from `CompiledNetwork`, so downstream tools (Graphviz, web viewers, snapshot diffs) can render networks without linking a GUI stack into `neat-core`. The live `egui` renderer itself is out of scope — any interactive viewer belongs in [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore) or a sibling tool.
+The useful capability was **deterministic topology export** (DOT and/or topology JSON) from `CompiledNetwork`, so downstream tools (Graphviz, web viewers, snapshot diffs) can render networks without linking a GUI stack into `neat-core`. That has **landed**: `neat-core/src/topology_export.rs` provides `to_dot` and `to_topology_json` from `CompiledNetwork` (Issue #22), with tests in `neat-core/tests/topology_export.rs`. The live `egui` renderer itself remains out of scope — any interactive viewer belongs in [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore) or a sibling tool.
 
 - **Priority:** medium.
 - **Effort:** small (1 PR, ~300 LOC + tests).
-- **Tracked by:** existing open issue [#22 — Add CompiledNetwork topology export (DOT/JSON) for debugging and visualisation](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22). **No new issue needed.**
+- **Status:** **done** — shipped via issue [#22 — Add CompiledNetwork topology export (DOT/JSON) for debugging and visualisation](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22) (`neat-core/src/topology_export.rs`).
 
 ### 7. GPU acceleration (Burn + WGPU) — ⛔ out of scope
 
@@ -104,13 +104,15 @@ Ikaruga declares `burn = "0.16"` with WGPU, but `neural_net.rs` openly admits th
 
 No adoption. Record as **explicitly rejected** to avoid re-litigating.
 
-### 8. Serialisation format — 🎯 worth adopting (round-trip JSON on `CreatureExport`)
+### 8. Serialisation format — ✅ adopted (round-trip JSON on `CreatureExport`)
 
-Ikaruga derives both `Serialize` and `Deserialize` on its `Genome`, enabling full round-trip JSON persistence. `neat-core`'s `CreatureExport` currently derives **only** `Deserialize` — networks can be loaded but not written back out. For the topology-export work in #22, and for snapshot diffing, cache priming, and WASM bridging, a symmetric serialise path is worth adding. The JSON shape is fixed by the TypeScript `CreatureExport` contract, so there is no schema design required — only matching `Serialize` derives, `#[serde(rename = …)]` attributes, and a deterministic field ordering test.
+Ikaruga derives both `Serialize` and `Deserialize` on its `Genome`, enabling full round-trip JSON persistence. At the time of research `neat-core`'s `CreatureExport` derived **only** `Deserialize` — networks could be loaded but not written back out. For the topology-export work in #22, and for snapshot diffing, cache priming, and WASM bridging, a symmetric serialise path was worth adding. The JSON shape is fixed by the TypeScript `CreatureExport` contract, so there was no schema design required — only matching `Serialize` derives, `#[serde(rename = …)]` attributes, and a deterministic field ordering test.
+
+That has **landed**: `CreatureExport`, `NeuronExport`, and `SynapseExport` (`neat-core/src/creature.rs`) now derive both `Deserialize` and `Serialize`, so networks round-trip out to JSON as well as in (Issue #30).
 
 - **Priority:** medium.
 - **Effort:** small (~150 LOC + tests: round-trip, deterministic field order, numerical precision on f64 weights).
-- **Issue:** new follow-up issue created per this research.
+- **Status:** **done** — shipped via issue [#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30) (`neat-core/src/creature.rs`).
 
 ### 9. Emulator bridge / environment interface (TCP + Lua) — ⛔ out of scope
 
@@ -131,16 +133,18 @@ Ikaruga's `fitness.rs` (579 LOC) encodes per-game scoring heuristics. Fitness is
 | 3 | Population, tournament, crossover | `population.rs` 381 LOC | — | 🌐 parent repo | — |
 | 4 | NeatConfig JSON | `config.rs` | `TrainingDataConfig` only | 🌐 parent repo | — |
 | 5 | Feed-forward evaluation | 4 activations, no SIMD, no backprop | 38 activations + backprop + SIMD + PC | ✅ already richer | — |
-| 6 | Topology visualisation | 855-LOC egui GUI, no export | no export path | 🎯 adopt (data-only export) | [#22](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22) (existing) |
+| 6 | Topology visualisation | 855-LOC egui GUI, no export | `topology_export` (DOT/JSON) | ✅ adopted (data-only export) | [#22](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22) (landed) |
 | 7 | GPU (Burn + WGPU) | declared, unused | — | ⛔ out of scope (breaks WASM) | — |
-| 8 | Genome JSON round-trip | `Serialize` + `Deserialize` | `Deserialize` only | 🎯 adopt | [#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30) |
+| 8 | Genome JSON round-trip | `Serialize` + `Deserialize` | `Serialize` + `Deserialize` | ✅ adopted | [#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30) (landed) |
 | 9 | Emulator TCP + Lua bridge | 558 LOC + Lua scripts | — | ⛔ out of scope | — |
 | 10 | Fitness scoring | 579 LOC per game | — | ⛔ out of scope | — |
 
-## Adoption candidates (prioritised)
+## Adoption candidates (outcome)
 
-1. **CompiledNetwork topology export (DOT / topology JSON)** — medium priority, small effort. Already scoped in open issue **[#22](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22)**. No new issue needed.
-2. **`CreatureExport` round-trip JSON (`Serialize` on all three export types)** — medium priority, small effort. Tracked by follow-up issue **[#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30)** raised alongside this document.
+Both candidates identified by this research have since **shipped** on `Develop`:
+
+1. ✅ **CompiledNetwork topology export (DOT / topology JSON)** — **done**. Landed via issue **[#22](https://github.com/stSoftwareAU/NEAT-AI-core/issues/22)** as `neat-core/src/topology_export.rs` (`to_dot`, `to_topology_json`), tested in `neat-core/tests/topology_export.rs`.
+2. ✅ **`CreatureExport` round-trip JSON (`Serialize` on all three export types)** — **done**. Landed via issue **[#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30)**; `CreatureExport` / `NeuronExport` / `SynapseExport` in `neat-core/src/creature.rs` now derive both `Serialize` and `Deserialize`.
 
 Everything else is either already covered more completely by `neat-core`, owned by the parent NEAT-AI repo, or deliberately outside this crate's scope.
 


### PR DESCRIPTION
## Summary

`docs/research/ikaruga-neat-ai-comparison.md` still framed two adoption
candidates as *pending* work, but both have since landed on `Develop`. The
research doc was therefore an anti-map: an agent triaging follow-ups would be
sent to re-implement completed, tested features. This PR updates the two rows to
**done** while keeping the historical analysis intact. Closes #260.

Verified against current code before editing:

- **Topology export (Issue #22)** — `neat-core/src/topology_export.rs` exists and
  provides `to_dot` and `to_topology_json` from `CompiledNetwork` (module doc
  cites Issue #22), tested in `neat-core/tests/topology_export.rs`.
- **Serialize round-trip (Issue #30)** — `CreatureExport`, `NeuronExport` and
  `SynapseExport` in `neat-core/src/creature.rs:35,54,69` all derive **both**
  `Deserialize` and `Serialize`; the module doc states "derive both".

## Changes

- Module inventory line (`creature` row): now states the export structs derive
  both `Deserialize` and `Serialize` (Issue #30 landed).
- Candidate **#6 Topology visualisation**: 🎯 → ✅ adopted; "no export path" reworded
  to reference the shipped `topology_export.rs`; "No new issue needed" → **done**.
- Candidate **#8 Serialisation format**: 🎯 → ✅ adopted; "only `Deserialize`" reworded
  to "both `Serialize` + `Deserialize`", status **done**.
- Summary table rows 6 and 8: classification → ✅ adopted; `neat-core` columns
  updated to reflect the shipped state; follow-up column marked "(landed)".
- "Adoption candidates" list reframed from proposed work to shipped outcome.

## Evidence

Documentation-only change — no web interface to screenshot. Correctness was
verified two ways:

1. **Source of truth check** — grepped the current code to confirm both features
   ship (`topology_export.rs` present with `to_dot`/`to_topology_json`;
   `creature.rs` derives both traits).
2. **Quality gate** — `./quality.sh < /dev/null` passes cleanly, including the
   existing `topology_export.rs` tests
   (`to_dot_method_callable_on_compiled_network`,
   `to_topology_json_method_callable_on_compiled_network`) that exercise the very
   code the doc now describes as landed:

```
test result: ok. 9 passed; 0 failed; ...
✅ All quality checks passed!
```

## Test Plan

No new tests: this is a stale-documentation fix, and no doc-consistency test
references this file. The features the doc describes are already covered by
existing tests — `neat-core/tests/topology_export.rs` (topology export, Issue
#22) and the creature/serde tests (round-trip `Serialize`, Issue #30) — which
continue to pass under `./quality.sh`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrhr4ko7-f133a6`<!-- vibe-worker-issue-260 -->