### PR TITLE
docs(benches): fold #227 perf negative result and Tanh fixture caveat into bench docs (Issue #261)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-261.md
+++ b/docs/archive/pr-summaries/pr-summary-261.md
@@ -1,0 +1,69 @@
+## Summary
+
+Fold the two durable learnings from the #227 perf campaign — recorded so far
+only in the PR-summary archive — into the committed bench docs, so they are not
+lost and the committed numbers are read correctly. **Closes #261.**
+
+Two learnings were absorbed:
+
+1. **Fixture caveat — squash homogeneity.** The `production` / `production_2x`
+   Criterion fixtures build every neuron as `SquashType::Tanh`
+   (`neat-core/benches/common/mod.rs:168`). `BASELINE.md` documented
+   host/toolchain/record-count but never this squash homogeneity, letting a
+   reader over-read the committed `scoring`/`production` numbers. Real GRQ
+   creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
+   squash-vectorisation deltas are a **lower bound** and branch-prediction
+   levers are **unmeasurable**.
+2. **Optimisation lever learned (negative result, PR #245).** The #245 6–8%
+   single-core win was **not** the branch-misprediction the issue hypothesised
+   — on a homogeneous-`Tanh` fixture the predictor already nails the one-arm
+   squash `match`. The real lever was LLVM **failing to CSE** eight identical
+   `apply_get_range(squash)` range-lookups per neuron (intervening `NaN`/`±Inf`
+   branches blocked the merge), so 7 of 8 range matches per batch were
+   redundant. Rule preserved: hoist per-record range lookups; do not attribute
+   a perf delta to an unverified cause.
+
+### What changed
+
+- `neat-core/benches/BASELINE.md` — new **"Fixture caveat — squash homogeneity"**
+  section stating the fixtures are uniformly `Tanh`, so vectorisation deltas are
+  a lower bound and branch-prediction levers are unmeasurable here.
+- `neat-core/benches/README.md` — a fixture-caveat note under the shape table,
+  plus an **"Optimisation levers learned"** section recording the #245 range-CSE
+  finding and its corollary for future squash/scoring work.
+- `neat-core/tests/bench_fixtures.rs` — new "what" test
+  `production_fixture_squash_is_homogeneous_tanh` that asserts every neuron in
+  both production fixtures is `Tanh`, so the documented caveat is machine-checked
+  and any future change diversifying the fixture squash fails the test rather
+  than silently invalidating the docs.
+
+The `pr-summary-243/-245/-246.md` archives are retained: Issue #2173 makes
+`docs/archive/pr-summaries/` the permanent home for PR summaries, and the
+durable learnings they carried now also live in the bench docs.
+
+```mermaid
+flowchart LR
+    A["PR-summary archive<br/>(243 · 245 · 246)"] -->|absorb learnings| B["BASELINE.md<br/>Fixture caveat"]
+    A -->|absorb learnings| C["README.md<br/>Optimisation levers learned"]
+    D["common/mod.rs:168<br/>squash_type = Tanh"] -->|asserted by| E["bench_fixtures.rs<br/>homogeneous_tanh test"]
+    E -.guards.-> B
+    E -.guards.-> C
+```
+
+## Evidence
+
+Documentation + test change — no web interface to screenshot. The caveat's
+underlying fact is now machine-checked:
+
+- `cargo test -p neat-core --test bench_fixtures` — 10 passed, including the new
+  `production_fixture_squash_is_homogeneous_tanh`.
+- `./quality.sh` passes cleanly (markdownlint, fmt, clippy `-D warnings`, deny,
+  full workspace tests).
+
+## Test Plan
+
+- Added `neat-core/tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`
+  — builds the `production` and `production_2x` fixtures and asserts every
+  neuron's `squash_type` is `SquashType::Tanh`, locking the documented
+  homogeneity caveat.
+- Existing `bench_fixtures` tests remain unchanged and green.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -11,6 +11,26 @@ affected group against this file, with matching host/toolchain metadata.
 > fixtures are synthesised from a fixed-seed PRNG — the 3 MB production
 > `network.json` and the real training corpus are **not** committed.
 
+## Fixture caveat — squash homogeneity (Issue #261)
+
+Every neuron in the `production` / `production_2x` fixtures is uniformly
+`SquashType::Tanh` (`benches/common/mod.rs:168`), asserted by
+`tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`. Real
+GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so read every
+`scoring`/`production` A/B below with two corrections in mind:
+
+- **Squash-vectorisation deltas are a lower bound.** Varied-squash creatures
+  also convert scalar `libm` `Gelu`/`Mish` to the vectorised path, gaining at
+  least as much as the all-`Tanh` fixture shows.
+- **Branch-prediction levers are unmeasurable here.** A homogeneous squash means
+  the predictor already nails the one-arm `match`, so a branch-misprediction
+  optimisation shows no delta on this fixture — that is a fixture artefact, not
+  evidence the lever is worthless on real creatures.
+
+The real `GRQ-cluster/network.json` is not on the build host, so it cannot be
+A/B'd here directly; re-run against the pinned creature to confirm on the real
+varied-squash topology.
+
 ## Host / toolchain
 
 | Field | Value |

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -62,6 +62,37 @@ creatures" requirement. The deterministic builders live in
 `benches/common/mod.rs` and are exercised by the `bench_fixtures` integration
 test.
 
+> **Fixture caveat — squash is uniformly `Tanh` (Issue #261).** The `squash`
+> column above is not varied: every neuron in the `production` / `production_2x`
+> shapes is built with `SquashType::Tanh` (`benches/common/mod.rs:168`), locked
+> by `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`.
+> Real GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
+> squash-vectorisation deltas are a **lower bound** and branch-prediction levers
+> are **unmeasurable** (a homogeneous squash lets the predictor nail the
+> one-arm `match`). See [`BASELINE.md`](BASELINE.md) for the full caveat.
+
+## Optimisation levers learned (Issue #261)
+
+Durable negative/counter-intuitive results from the #227 perf campaign, kept
+here so the levers are **not re-attempted** and the numbers are read correctly.
+
+- **The per-record squash cost was the *range lookup*, not branch
+  misprediction (PR #245, 6–8% single-core win).** The #245 issue hypothesised
+  the win would come from eliminating a mispredicted squash `match`. It did not:
+  the fixture is homogeneous `Tanh`, so the predictor already nails that branch
+  (see the fixture caveat above). The real lever was LLVM **failing to CSE**
+  eight identical `apply_get_range(squash)` range-lookups per neuron — the
+  intervening `NaN`/`±Inf` branches blocked the merge, so 7 of every 8 range
+  `match`es per batch were redundant work. **Hoisting** the per-record range
+  lookup removed it. Rule: hoist per-record range lookups; do **not** attribute
+  a perf delta to an unverified cause (here, branch misprediction) — verify the
+  actual lever before recording it.
+- **Corollary for future squash/scoring work.** On a *varied*-squash creature
+  the eliminated misprediction would stack on top of the range-hoist gain, so
+  the committed homogeneous-`Tanh` numbers are a lower bound for production.
+  Chasing branch-misprediction *on this fixture* will measure nothing — validate
+  such levers against the real varied-squash creature, not the synthetic shape.
+
 ## Running
 
 ```bash

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -11,6 +11,7 @@ use common::{
     FanIn, NETWORKS, NetSpec, PRODUCTION_SCORING_RECORDS, build_backprop_data, build_inputs,
     build_network, build_records,
 };
+use neat_core::squash::SquashType;
 
 fn spec(label: &str) -> &'static NetSpec {
     NETWORKS
@@ -79,6 +80,26 @@ fn varied_fan_in_actually_varies_unlike_fixed_shapes() {
         assert!(
             tail.iter().all(|n| n.num_synapses as usize == f),
             "fixed shapes should keep a constant fan-in past the early ramp"
+        );
+    }
+}
+
+#[test]
+fn production_fixture_squash_is_homogeneous_tanh() {
+    // The BASELINE.md / README.md "Fixture caveat" (Issue #261) rests on the
+    // production/production_2x fixtures being uniformly `Tanh`. That homogeneity
+    // makes squash-vectorisation deltas a lower bound (real GRQ creatures also
+    // run scalar-`libm` Gelu/Mish) and makes branch-prediction levers
+    // unmeasurable on the fixture (the predictor already nails a one-arm match).
+    // If a future change diversifies the fixture squash, this test fails so the
+    // documented caveat is revisited rather than silently invalidated.
+    for label in ["production", "production_2x"] {
+        let net = build_network(spec(label), 0x5152_5354);
+        assert!(
+            net.neurons
+                .iter()
+                .all(|n| n.squash_type == SquashType::Tanh as u8),
+            "{label} fixture must be homogeneous Tanh — the bench-doc caveat depends on it"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fold the two durable learnings from the #227 perf campaign — recorded so far
only in the PR-summary archive — into the committed bench docs, so they are not
lost and the committed numbers are read correctly. **Closes #261.**

Two learnings were absorbed:

1. **Fixture caveat — squash homogeneity.** The `production` / `production_2x`
   Criterion fixtures build every neuron as `SquashType::Tanh`
   (`neat-core/benches/common/mod.rs:168`). `BASELINE.md` documented
   host/toolchain/record-count but never this squash homogeneity, letting a
   reader over-read the committed `scoring`/`production` numbers. Real GRQ
   creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
   squash-vectorisation deltas are a **lower bound** and branch-prediction
   levers are **unmeasurable**.
2. **Optimisation lever learned (negative result, PR #245).** The #245 6–8%
   single-core win was **not** the branch-misprediction the issue hypothesised
   — on a homogeneous-`Tanh` fixture the predictor already nails the one-arm
   squash `match`. The real lever was LLVM **failing to CSE** eight identical
   `apply_get_range(squash)` range-lookups per neuron (intervening `NaN`/`±Inf`
   branches blocked the merge), so 7 of 8 range matches per batch were
   redundant. Rule preserved: hoist per-record range lookups; do not attribute
   a perf delta to an unverified cause.

### What changed

- `neat-core/benches/BASELINE.md` — new **"Fixture caveat — squash homogeneity"**
  section stating the fixtures are uniformly `Tanh`, so vectorisation deltas are
  a lower bound and branch-prediction levers are unmeasurable here.
- `neat-core/benches/README.md` — a fixture-caveat note under the shape table,
  plus an **"Optimisation levers learned"** section recording the #245 range-CSE
  finding and its corollary for future squash/scoring work.
- `neat-core/tests/bench_fixtures.rs` — new "what" test
  `production_fixture_squash_is_homogeneous_tanh` that asserts every neuron in
  both production fixtures is `Tanh`, so the documented caveat is machine-checked
  and any future change diversifying the fixture squash fails the test rather
  than silently invalidating the docs.

The `pr-summary-243/-245/-246.md` archives are retained: Issue #2173 makes
`docs/archive/pr-summaries/` the permanent home for PR summaries, and the
durable learnings they carried now also live in the bench docs.

```mermaid
flowchart LR
    A["PR-summary archive<br/>(243 · 245 · 246)"] -->|absorb learnings| B["BASELINE.md<br/>Fixture caveat"]
    A -->|absorb learnings| C["README.md<br/>Optimisation levers learned"]
    D["common/mod.rs:168<br/>squash_type = Tanh"] -->|asserted by| E["bench_fixtures.rs<br/>homogeneous_tanh test"]
    E -.guards.-> B
    E -.guards.-> C
```

## Evidence

Documentation + test change — no web interface to screenshot. The caveat's
underlying fact is now machine-checked:

- `cargo test -p neat-core --test bench_fixtures` — 10 passed, including the new
  `production_fixture_squash_is_homogeneous_tanh`.
- `./quality.sh` passes cleanly (markdownlint, fmt, clippy `-D warnings`, deny,
  full workspace tests).

## Test Plan

- Added `neat-core/tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`
  — builds the `production` and `production_2x` fixtures and asserts every
  neuron's `squash_type` is `SquashType::Tanh`, locking the documented
  homogeneity caveat.
- Existing `bench_fixtures` tests remain unchanged and green.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrhysy0c-0f3c57`<!-- vibe-worker-issue-261 -->