### PR TITLE
🟡 Define README terms on first use: NEAT, creature, squash, Vibe Coder (Issue #262)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # NEAT-AI-core
 
-**Native shared Rust** for [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI): the **`neat-core`** crate (tests included) lives here as a Cargo workspace member.
+**Native shared Rust** for [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI) — an implementation of [**NEAT** (NeuroEvolution of Augmenting Topologies)](https://en.wikipedia.org/wiki/Neuroevolution_of_augmenting_topologies): the **`neat-core`** crate (tests included) lives here as a Cargo workspace member.
+
+## Glossary
+
+First-use definitions for the project's core terms, an acronym, and its
+internal automation name. Standard terms link out; the project's own
+vocabulary carries a plain-English gloss.
+
+- <a id="glossary-neat"></a>**NEAT** — [NeuroEvolution of Augmenting Topologies](https://en.wikipedia.org/wiki/Neuroevolution_of_augmenting_topologies), the algorithm that evolves both the weights *and* the topology of a neural network. NEAT-AI is a project built on this idea; this repo is its shared native core.
+- <a id="glossary-creature"></a>**creature** — the project's term for a single evolved individual: a [genome](https://en.wikipedia.org/wiki/Artificial_neural_network) compiled to a runnable network. Scoring pushes many records through one creature.
+- <a id="glossary-squash"></a>**squash** — a neuron's [activation function](https://en.wikipedia.org/wiki/Activation_function) (the non-linearity applied to its weighted input sum). "Standard-squash" neurons use the project's default activation.
+- <a id="glossary-vibe-coder"></a>**Vibe Coder** — the automated agent that raises the routine dependency-bump and quality PRs (it runs `bump-deps.sh` before `quality.sh` on every such PR).
 
 ## Test-driven development
 
@@ -21,7 +32,7 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 | `neat-core/benches/` | Opt-in Criterion harnesses: `hot_paths` (core hot paths) and `parallel_scoring` (data-parallel scoring, needs `--features parallel`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
 | `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
-| `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build (Vibe Coder hook). |
+| `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build ([Vibe Coder](#glossary-vibe-coder) hook). |
 | `.github/dependabot.yml` | Advisory-triggered security-update fast lane — raises a fix PR the moment a RustSec/OSV advisory lands, independent of the weekly bump. |
 | `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`). |
 | `LICENSE`, `.gitleaks.toml` | Inherited from NEAT-AI `Develop`. |
@@ -43,7 +54,7 @@ cargo bench -p neat-core --bench hot_paths
 |---------|---------|--------|
 | `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
 
-Scoring a production-size dataset pushes many records through one creature — an
+Scoring a production-size dataset pushes many records through one [creature](#glossary-creature) — an
 embarrassingly parallel workload *across records*. Both `score_records` and
 `score_records_parallel` drive the forward pass through the **8-record batched
 SIMD path** (Issue #230): records are grouped into 8s (then a 4-record group,
@@ -53,7 +64,7 @@ across the lanes. On the gather-bound production topology this cut single-core
 scoring time by **~39%** (see `docs/archive/pr-summaries/pr-summary-230.md`).
 With the `parallel` feature the throughput additionally scales with core count.
 
-Standard-squash neurons now sum **across records** rather than across synapses,
+Standard-[squash](#glossary-squash) neurons now sum **across records** rather than across synapses,
 so their `f32` results match the per-record `activate` reference within a small
 tolerance (SIMD re-association), while the sequential and parallel paths agree
 bit-for-bit. Output order always matches input order.

--- a/docs/archive/pr-summaries/pr-summary-262.md
+++ b/docs/archive/pr-summaries/pr-summary-262.md
@@ -1,0 +1,53 @@
+## Summary
+
+`README.md` is the declared source of truth but used several core terms
+without a first-use definition, so a newcomer (human or AI) could not ground
+them. This PR adds first-use definitions and links each first use to them.
+Closes #262.
+
+Changes:
+
+- **New Glossary section** near the top of `README.md`:
+  - **NEAT** — expanded to *NeuroEvolution of Augmenting Topologies* and linked
+    to Wikipedia. Also expanded inline on the very first mention in the intro.
+  - **creature** — glossed as the project's term for a single evolved
+    individual: a genome compiled to a runnable network.
+  - **squash** — glossed as a neuron's *activation function* (linked).
+  - **Vibe Coder** — glossed as the automated agent that raises the routine
+    dependency-bump and quality PRs (runs `bump-deps.sh` before `quality.sh`).
+- **Linked each first use** in the body (`creature`, `squash`, `Vibe Coder`)
+  back to its glossary anchor.
+
+Standard terms link out; the project's own vocabulary carries a plain-English
+gloss, per documentation check 7 (undefined terms, acronyms, playful names).
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. Verified with a new
+bats "what" test suite that reads the published README artefact and asserts each
+term is defined, plus the full existing gate:
+
+```
+$ bats tests/scripts/readme_glossary.bats
+1..6
+ok 1 README.md exists
+ok 2 NEAT is expanded to NeuroEvolution of Augmenting Topologies
+ok 3 creature is glossed as an evolved individual / genome
+ok 4 squash is glossed as an activation function
+ok 5 Vibe Coder is glossed as the automated PR agent
+ok 6 a Glossary section exists in README.md
+
+$ bats tests/scripts    # 178 tests, 0 failures
+$ npx markdownlint-cli2 README.md   # 0 error(s)
+$ codespell README.md               # clean
+```
+
+## Test Plan
+
+- Added `tests/scripts/readme_glossary.bats` — "what" tests that parse
+  `README.md` and assert on observable content:
+  - NEAT is expanded to *NeuroEvolution of Augmenting Topologies*.
+  - `creature`, `squash`, and `Vibe Coder` each carry a gloss.
+  - A Glossary section exists.
+- The suite failed against the pre-change README (5 of 6 failing) and passes
+  after the README update, confirming it exercises the fix.

--- a/tests/scripts/readme_glossary.bats
+++ b/tests/scripts/readme_glossary.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Tests that README.md defines its core terms on first use (Issue #262).
+#
+# Rationale: README.md is the declared source of truth. It uses an acronym
+# (NEAT), a domain object (creature), an activation term (squash), and a
+# playful internal name (Vibe Coder) without first-use definitions, so a
+# newcomer — human or AI — cannot ground them. This is documentation check 7
+# (undefined terms, acronyms, and playful names): standard terms should link
+# out, project terms should carry a plain-English gloss.
+#
+# These are "what" tests: they read the published README artefact and assert
+# on the observable outcome (each term is defined), not on how the definition
+# is phrased or laid out.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  README="${REPO_ROOT}/README.md"
+}
+
+@test "README.md exists" {
+  [ -f "$README" ]
+}
+
+@test "NEAT is expanded to NeuroEvolution of Augmenting Topologies" {
+  [ -f "$README" ]
+  # Match case-insensitively; the acronym must be spelled out at least once.
+  run grep -iq "NeuroEvolution of Augmenting Topologies" "$README"
+  [ "$status" -eq 0 ]
+}
+
+@test "creature is glossed as an evolved individual / genome" {
+  [ -f "$README" ]
+  run python3 - "$README" <<'PY'
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read().lower()
+# A gloss line for creature must mention it is an individual genome/network.
+if re.search(r"\*\*creature\*\*.*(genome|individual|network)", text):
+    sys.exit(0)
+sys.stderr.write("no plain-English gloss found for 'creature'\n")
+sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "squash is glossed as an activation function" {
+  [ -f "$README" ]
+  run python3 - "$README" <<'PY'
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read().lower()
+if re.search(r"\*\*squash\*\*.*activation function", text):
+    sys.exit(0)
+sys.stderr.write("no gloss found for 'squash' as an activation function\n")
+sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "Vibe Coder is glossed as the automated PR agent" {
+  [ -f "$README" ]
+  run python3 - "$README" <<'PY'
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read().lower()
+# The gloss must describe the Vibe Coder as an automated agent that raises PRs.
+if re.search(r"\*\*vibe coder\*\*.*(automat|agent).*pr", text):
+    sys.exit(0)
+sys.stderr.write("no gloss found for 'Vibe Coder' as the automated PR agent\n")
+sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "a Glossary section exists in README.md" {
+  [ -f "$README" ]
+  run grep -Eiq "^#+[[:space:]]+Glossary" "$README"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`README.md` is the declared source of truth but used several core terms
without a first-use definition, so a newcomer (human or AI) could not ground
them. This PR adds first-use definitions and links each first use to them.
Closes #262.

Changes:

- **New Glossary section** near the top of `README.md`:
  - **NEAT** — expanded to *NeuroEvolution of Augmenting Topologies* and linked
    to Wikipedia. Also expanded inline on the very first mention in the intro.
  - **creature** — glossed as the project's term for a single evolved
    individual: a genome compiled to a runnable network.
  - **squash** — glossed as a neuron's *activation function* (linked).
  - **Vibe Coder** — glossed as the automated agent that raises the routine
    dependency-bump and quality PRs (runs `bump-deps.sh` before `quality.sh`).
- **Linked each first use** in the body (`creature`, `squash`, `Vibe Coder`)
  back to its glossary anchor.

Standard terms link out; the project's own vocabulary carries a plain-English
gloss, per documentation check 7 (undefined terms, acronyms, playful names).

## Evidence

Documentation-only change — no web interface to screenshot. Verified with a new
bats "what" test suite that reads the published README artefact and asserts each
term is defined, plus the full existing gate:

```
$ bats tests/scripts/readme_glossary.bats
1..6
ok 1 README.md exists
ok 2 NEAT is expanded to NeuroEvolution of Augmenting Topologies
ok 3 creature is glossed as an evolved individual / genome
ok 4 squash is glossed as an activation function
ok 5 Vibe Coder is glossed as the automated PR agent
ok 6 a Glossary section exists in README.md

$ bats tests/scripts    # 178 tests, 0 failures
$ npx markdownlint-cli2 README.md   # 0 error(s)
$ codespell README.md               # clean
```

## Test Plan

- Added `tests/scripts/readme_glossary.bats` — "what" tests that parse
  `README.md` and assert on observable content:
  - NEAT is expanded to *NeuroEvolution of Augmenting Topologies*.
  - `creature`, `squash`, and `Vibe Coder` each carry a gloss.
  - A Glossary section exists.
- The suite failed against the pre-change README (5 of 6 failing) and passes
  after the README update, confirming it exercises the fix.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrhysy0c-0f3c57`<!-- vibe-worker-issue-262 -->