### PR TITLE
bench(neat-core): exact production-topology Criterion baseline (Issue #286)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-286.md
+++ b/docs/archive/pr-summaries/pr-summary-286.md
@@ -1,0 +1,99 @@
+# Criterion baseline on the production topology (Issue #286)
+
+## Summary
+
+Established a reproducible **Criterion baseline on the exact production
+topology** — the committed `GRQ-cluster/network.json` shape of **1,666 non-input
+neurons, 21,513 synapses, 2,461 inputs** — so every later perf change in this
+crate has a dated before/after anchor. Measurement only, no optimisation
+(optimisation lands in the lane sub-issues that gate on these numbers).
+**Closes #286.**
+
+What changed:
+
+- **New `production_exact` fixture** in `neat-core/benches/common/mod.rs`. Unlike
+  the existing `production` shape (a ~13-average `FanIn::VariedAround`
+  approximation, ~21.7k synapses), the new shape uses a new
+  **`FanIn::ExactTotal(21_513)`** variant that distributes the synapses across
+  the 1,666 neurons as evenly as possible (12 or 13 each, Bresenham-interleaved),
+  so the fixture reproduces the real model **to the synapse**. Seeded and
+  deterministic.
+- The new variant is threaded through **both** deterministic builders —
+  `build_network` (forward/scoring) and `build_backprop_data` (backprop) — via a
+  pre-computed `exact_schedule`. The RNG-drawn shapes stay on their existing
+  `draw` path, so every committed `production`/`production_2x` baseline is
+  byte-for-byte unchanged.
+- `production_exact` is wired into the `hot_paths` groups (its label starts with
+  `production`, so the `scoring` group and the `production` regex filter pick it
+  up) and added to the `parallel_scoring` label list, covering **both lanes**:
+  the default single-thread path and the native `--features parallel` path.
+- **`BASELINE.md`** gains a dated (2026-07-18, rustc 1.97.0) production-exact
+  section with single-thread and parallel numbers, plus a per-creature scoring
+  latency mapped back to the project metric (**score improvement per wall-clock
+  hour**).
+
+### Fixture → baseline flow
+
+```mermaid
+flowchart LR
+    A["NetSpec production_exact<br/>1666 neurons / 21,513 synapses / 2461 inputs"] --> B["FanIn::ExactTotal(21_513)"]
+    B --> C["exact_schedule()<br/>Bresenham-even 12/13 fan-in"]
+    C --> D["build_network()"]
+    C --> E["build_backprop_data()"]
+    D --> F["hot_paths: forward / scoring<br/>parallel_scoring: 1 vs 12 cores"]
+    E --> G["hot_paths: backprop"]
+    F --> H["BASELINE.md — dated numbers"]
+    G --> H
+```
+
+## Evidence
+
+Backend/bench-only change — no web UI to screenshot. Evidence is the dated
+benchmark numbers recorded in `neat-core/benches/BASELINE.md` and the fixture
+tests that assert the exact topology.
+
+**Single-thread lane** (`cargo bench -p neat-core --bench hot_paths -- production_exact`):
+
+| Group | production_exact |
+| --- | --- |
+| `forward_pass` | 30.76 µs `[30.19, 31.35]` (~134 Melem/s) |
+| `batched_scoring/trace_batch_4way` | 122.65 µs `[120.98, 124.33]` |
+| `batched_scoring/mse_sum_8records` | 242.08 µs `[239.09, 244.99]` |
+| `backprop` | 214.14 µs `[210.46, 218.05]` (~19.3 Melem/s) |
+| `scoring` (4096 records) | 91.50 ms `[90.05, 92.96]` (44.8 Krecords/s) |
+
+**Parallel lane** (`cargo bench -p neat-core --features parallel --bench parallel_scoring -- production_exact`):
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production_exact` | 61.84 ms `[60.36, 63.38]` | 24.62 ms `[22.35, 26.98]` | 66.2 K → 166.4 K | 2.51× |
+
+Per-creature corpus pass (~2.24 M records/generation): ≈ **33.9 s** single-core,
+≈ **13.5 s** on 12 cores — the denominator of the project metric. The
+scoring-lane run-to-run variance (~62–92 ms single-core across invocations, a
+thermal artefact of the laptop-class M4 Pro) is documented honestly in
+`BASELINE.md`; the internally-consistent 2.51× parallel ratio is the
+authoritative anchor.
+
+## Test Plan
+
+New/updated tests in `neat-core/tests/bench_fixtures.rs` (run green via
+`cargo test -p neat-core --test bench_fixtures`, and compiled in PR CI by
+`cargo check/clippy --all-targets --all-features`):
+
+- `production_exact_matches_committed_grq_topology` — asserts exactly 2,461
+  inputs, 1,666 non-input neurons, 4,127 total, and **21,513** built synapses.
+- `production_exact_fan_in_is_evenly_spread_and_varies` — fan-in takes at most
+  two values (12/13) with a mean near the production ~13.
+- `production_exact_build_is_deterministic` — same seed reproduces identical
+  synapses and neurons (reproducibility guard).
+- `production_exact_backprop_data_has_exact_synapse_count` — regression test for
+  the backprop builder honouring the exact schedule (caught a real bug where
+  `build_backprop_data` fell through to `draw`, building a synapse-free network).
+- `production_exact_network_activates_to_finite_outputs` — forward pass produces
+  finite outputs.
+- `production_fixture_squash_is_homogeneous_tanh` — extended to cover the new
+  shape, keeping the documented squash-homogeneity caveat honest.
+
+No existing tests removed or modified in behaviour; existing
+`production`/`production_2x` fixtures and baselines are untouched.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -13,8 +13,8 @@ affected group against this file, with matching host/toolchain metadata.
 
 ## Fixture caveat — squash homogeneity (Issue #261)
 
-Every neuron in the `production` / `production_2x` fixtures is uniformly
-`SquashType::Tanh` (`benches/common/mod.rs:168`), asserted by
+Every neuron in the `production` / `production_2x` / `production_exact` fixtures
+is uniformly `SquashType::Tanh` (`benches/common/mod.rs`), asserted by
 `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`. Real
 GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so read every
 `scoring`/`production` A/B below with two corrections in mind:
@@ -104,6 +104,74 @@ Throughput highlights: `forward_pass` ≈ 126 Melem/s (production) / 123 Melem/s
 The single-core `parallel_scoring` figure (16.86 Krecords/s for `production`)
 matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both drive the same
 sequential `score_records` path, an internal consistency check on the fixture.
+
+## Production-exact topology baseline (Issue #286)
+
+Dated anchor for the **exact** committed `GRQ-cluster/network.json` topology —
+**1,666 non-input neurons, 21,513 synapses, 2,461 inputs** (4,127 total neurons,
+one output). Unlike the `production` shape's ~13-average `VariedAround` fan-in,
+the `production_exact` shape uses `FanIn::ExactTotal(21_513)`, which spreads the
+synapses across the 1,666 neurons as evenly as possible (12 or 13 each,
+Bresenham-interleaved) so the synapse count reproduces the real model to the
+synapse. Seeded synthesis is deterministic and asserted exact by
+`tests/bench_fixtures.rs::production_exact_matches_committed_grq_topology`.
+
+**Measured 2026-07-18** on the same GRQ host class, toolchain **rustc 1.97.0**
+(the earlier `production`/`production_2x` rows above were taken on rustc 1.96.0,
+so compare across sections only within a lane, not across toolchains).
+
+| Field | Value |
+| --- | --- |
+| Host | Apple M4 Pro — 12 cores (8P + 4E), 24 GB, macOS (arm64) |
+| Logical cores (`available_parallelism`) | 12 |
+| Toolchain | rustc 1.97.0 |
+| Criterion | 0.8.2 |
+| Build | `--release` (bench profile) |
+
+### Single-thread lane (`cargo bench -p neat-core --bench hot_paths -- production_exact`)
+
+| Group / benchmark | production_exact | Throughput |
+| --- | --- | --- |
+| `forward_pass` | 30.76 µs `[30.19, 31.35]` | ~134 Melem/s |
+| `batched_scoring/trace_batch_4way` | 122.65 µs `[120.98, 124.33]` | — |
+| `batched_scoring/mse_sum_8records` | 242.08 µs `[239.09, 244.99]` | — |
+| `backprop` | 214.14 µs `[210.46, 218.05]` | ~19.3 Melem/s |
+| `scoring` (4096 records) | 91.50 ms `[90.05, 92.96]` | 44.77 Krecords/s |
+
+### Parallel lane (`cargo bench -p neat-core --features parallel --bench parallel_scoring -- production_exact`)
+
+4096 records scored through one creature inside a fixed-size rayon pool.
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production_exact` | 61.84 ms `[60.36, 63.38]` | 24.62 ms `[22.35, 26.98]` | 66.23 K → 166.4 K | 2.51× |
+
+### Per-creature scoring latency → the project metric
+
+The project metric is **score improvement per wall-clock hour**, and per
+generation a single creature forward-passes the whole ~2.24 M-record corpus to
+compute its fitness (see the record-count calibration above). At the measured
+`production_exact` throughput that per-creature scoring pass costs:
+
+| Lane | records/s | Per-creature corpus pass (~2.24 M records) |
+| --- | --- | --- |
+| Single core | 66.2 K | ≈ **33.9 s** |
+| 12 cores | 166.4 K | ≈ **13.5 s** |
+
+That per-creature latency is the denominator of the metric: halving it doubles
+the creatures a fixed wall-clock budget can score, so it is the figure every
+lane sub-issue's optimisation is measured against.
+
+> **Scoring-lane variance (be honest about it).** The ~90 ms `hot_paths`
+> `scoring` figure and the ~62 ms `parallel_scoring` `1_core` figure exercise the
+> *same* sequential `score_records` path, so in principle they match — but they
+> were taken in separate `cargo bench` invocations and the ~90 ms → ~62 ms spread
+> is real run-to-run variance (thermal state on the laptop-class M4 Pro under a
+> ~90 ms single-shot benchmark with 100 iterations). Treat the **`parallel_scoring`
+> 1-core/12-core pair as the authoritative scoring anchor** — both were measured
+> in one invocation, so their 2.51× ratio is internally consistent — and read the
+> single-core scoring latency as ~62–92 ms (±~20%). A lane sub-issue must A/B
+> with `--save-baseline` inside a single invocation to stay inside this band.
 
 ## Reproducing
 

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -21,7 +21,7 @@ There are two bench targets:
 | `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
-| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x` |
+| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -52,6 +52,17 @@ can be misleading.
 | `large_5000` | 32 | 4968 | 5000 | 16 | 24 (fixed) | ~119k |
 | `production` | 2461 | 1673 | 4134 | 1 | ~13 (varied) | ~21.7k |
 | `production_2x` | 4922 | 3346 | 8268 | 2 | ~13 (varied) | ~43.5k |
+| `production_exact` | 2461 | 1666 | 4127 | 1 | ~12.9 (exact) | **21,513** |
+
+`production_exact` (Issue #286) pins the fixture to the committed
+`GRQ-cluster/network.json` topology — 1,666 non-input neurons, **exactly**
+21,513 synapses, 2,461 inputs — so the Criterion baseline is anchored to the
+real production model rather than `production`'s ~13-average approximation.
+Unlike the `VariedAround` shapes it uses `FanIn::ExactTotal`, which distributes
+the 21,513 synapses across the 1,666 neurons as evenly as possible (a Bresenham
+stride, so the two fan-in values — 12 and 13 — are interleaved, not clustered).
+Its label starts with `production`, so the `production` regex filter and the
+`scoring` group pick it up automatically.
 
 The `production` shape is synthesised from the seeded PRNG to match the real
 creature's dimensions — the 3 MB `network.json` is **not** committed. Fan-in for
@@ -64,7 +75,8 @@ test.
 
 > **Fixture caveat — squash is uniformly `Tanh` (Issue #261).** The `squash`
 > column above is not varied: every neuron in the `production` / `production_2x`
-> shapes is built with `SquashType::Tanh` (`benches/common/mod.rs:168`), locked
+> / `production_exact` shapes is built with `SquashType::Tanh`
+> (`benches/common/mod.rs`), locked
 > by `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`.
 > Real GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
 > squash-vectorisation deltas are a **lower bound** and branch-prediction levers
@@ -114,7 +126,8 @@ cargo bench -p neat-core --bench hot_paths -- production
 
 `parallel_scoring.rs` reports records/sec for scoring a batch through one
 creature on **a single core versus all available cores**, using the
-`production`/`production_2x` shapes. It scores inside a rayon pool of a fixed
+`production`/`production_2x`/`production_exact` shapes. It scores inside a rayon
+pool of a fixed
 size, so the 1-core and all-core measurements share one code path and differ
 only in pool size.
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -55,12 +55,21 @@ pub enum FanIn {
     /// the production creature's sparse average (~13). Used by the wide/shallow
     /// `production` shapes, which are gather-bound rather than dense.
     VariedAround(usize),
+    /// Distribute *exactly* this many synapses across the non-input neurons, as
+    /// evenly as possible. Used by the `production_exact` shape (Issue #286) so
+    /// the fixture reproduces the committed `GRQ-cluster/network.json` synapse
+    /// count to the synapse, not just its ~13 average. See
+    /// [`FanIn::exact_schedule`].
+    ExactTotal(usize),
 }
 
 impl FanIn {
     /// Number of incoming connections for a neuron that has `max_fan` strictly
     /// earlier neurons to draw from. Only [`FanIn::VariedAround`] consumes an
     /// RNG draw, so [`FanIn::Fixed`] shapes keep their exact prior sequence.
+    /// [`FanIn::ExactTotal`] is not drawn per-neuron — its per-neuron counts come
+    /// from [`FanIn::exact_schedule`] — so `draw` treats it as a no-connection
+    /// fallback that is never reached on the exact path.
     pub fn draw(self, rng: &mut Lcg, max_fan: usize) -> usize {
         let target = match self {
             FanIn::Fixed(f) => f,
@@ -68,8 +77,44 @@ impl FanIn {
                 let span = (2 * avg).saturating_sub(1).max(1);
                 1 + rng.next_below(span)
             }
+            FanIn::ExactTotal(_) => 0,
         };
         target.min(max_fan)
+    }
+
+    /// Pre-computed per-neuron fan-in schedule for variants whose total synapse
+    /// count is fixed exactly. Returns `None` for the RNG-drawn variants
+    /// ([`FanIn::Fixed`] / [`FanIn::VariedAround`]) so their existing draw
+    /// sequence — and therefore every committed baseline — is left untouched.
+    ///
+    /// [`FanIn::ExactTotal`] spreads `total` synapses as evenly as possible
+    /// across `num_non_inputs` neurons: each neuron gets `total / num_non_inputs`
+    /// synapses, and the `total % num_non_inputs` remainder is handed out
+    /// one-per-neuron using a Bresenham stride so the extra-synapse neurons are
+    /// interleaved across the range rather than clustered at the front. The
+    /// schedule therefore sums to **exactly** `total` by construction, with at
+    /// most two distinct fan-in values (`base` and `base + 1`).
+    pub fn exact_schedule(self, num_non_inputs: usize) -> Option<Vec<usize>> {
+        match self {
+            FanIn::ExactTotal(total) => {
+                if num_non_inputs == 0 {
+                    return Some(Vec::new());
+                }
+                let base = total / num_non_inputs;
+                let remainder = total % num_non_inputs;
+                let schedule = (0..num_non_inputs)
+                    .map(|n| {
+                        // Bresenham even distribution: exactly `remainder` neurons
+                        // across the whole range receive one extra synapse.
+                        let extra =
+                            (n + 1) * remainder / num_non_inputs - n * remainder / num_non_inputs;
+                        base + extra
+                    })
+                    .collect();
+                Some(schedule)
+            }
+            FanIn::Fixed(_) | FanIn::VariedAround(_) => None,
+        }
     }
 }
 
@@ -96,7 +141,11 @@ impl NetSpec {
 /// a huge input layer, a modest neuron count and a sparse ~13 average fan-in,
 /// which is gather-bound in a way the dense shapes are not. `production_2x`
 /// doubles neurons and synapses to cover #175's "or larger creatures" clause.
-pub const NETWORKS: [NetSpec; 5] = [
+/// `production_exact` (Issue #286) pins the fixture to the committed
+/// `GRQ-cluster/network.json` topology — 1,666 non-input neurons, 21,513
+/// synapses, 2,461 inputs — to the synapse, giving the Criterion baseline a
+/// reproducible production-topology anchor.
+pub const NETWORKS: [NetSpec; 6] = [
     NetSpec {
         label: "small_50",
         num_neurons: 50,
@@ -134,6 +183,18 @@ pub const NETWORKS: [NetSpec; 5] = [
         num_outputs: 2,
         fan_in: FanIn::VariedAround(13),
     },
+    NetSpec {
+        label: "production_exact",
+        // Exact GRQ-cluster/network.json topology (Issue #286): 2461 inputs +
+        // 1666 non-input neurons = 4127 total, exactly 21,513 synapses. Unlike
+        // `production`'s ~13-average VariedAround, ExactTotal pins the synapse
+        // count to the committed production model so the baseline is anchored to
+        // the real topology rather than an approximation of it.
+        num_neurons: 4127,
+        num_inputs: 2461,
+        num_outputs: 1,
+        fan_in: FanIn::ExactTotal(21_513),
+    },
 ];
 
 /// Build a deterministic feedforward [`CompiledNetwork`] from a [`NetSpec`].
@@ -146,12 +207,21 @@ pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
     let num_inputs = spec.num_inputs;
     let mut rng = Lcg::new(seed);
     let num_non_inputs = spec.num_non_inputs();
+    // `Some` only for exact-count shapes; the RNG-drawn shapes stay `None` so
+    // their per-neuron `draw` sequence — and every committed baseline — is
+    // byte-for-byte unchanged.
+    let schedule = spec.fan_in.exact_schedule(num_non_inputs);
     let mut neurons = Vec::with_capacity(num_non_inputs);
     let mut synapses = Vec::new();
 
     for n in 0..num_non_inputs {
         let global_idx = num_inputs + n;
-        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        let this_fan = match &schedule {
+            // Cap by strictly-earlier neurons for soundness; never truncates on
+            // the production_exact shape (num_inputs ≫ per-neuron fan-in).
+            Some(sched) => sched[n].min(global_idx),
+            None => spec.fan_in.draw(&mut rng, global_idx),
+        };
         let start_synapse = synapses.len() as u32;
         for _ in 0..this_fan {
             let from = rng.next_below(global_idx);
@@ -261,6 +331,10 @@ pub fn build_backprop_data(spec: &NetSpec, seed: u64) -> BackpropData {
     let num_inputs = spec.num_inputs;
     let num_outputs = spec.num_outputs;
     let mut rng = Lcg::new(seed);
+    // Exact-count shapes use a pre-computed schedule; RNG-drawn shapes stay
+    // `None` so their existing draw sequence is untouched (mirrors
+    // `build_network`).
+    let schedule = spec.fan_in.exact_schedule(spec.num_non_inputs());
     let mut neurons = Vec::with_capacity(num_neurons);
 
     // Input neurons first.
@@ -291,7 +365,10 @@ pub fn build_backprop_data(spec: &NetSpec, seed: u64) -> BackpropData {
             rng.next_signed(),
         ));
 
-        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        let this_fan = match &schedule {
+            Some(sched) => sched[global_idx - num_inputs].min(global_idx),
+            None => spec.fan_in.draw(&mut rng, global_idx),
+        };
         inward_starts[global_idx] = inward_indices.len() as u32;
         inward_counts[global_idx] = this_fan as u32;
         for _ in 0..this_fan {

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -58,7 +58,7 @@ mod bench {
         // Production-representative volume (Issue #228); see `PRODUCTION_SCORING_RECORDS`.
         const NUM_RECORDS: usize = PRODUCTION_SCORING_RECORDS;
 
-        for label in ["production", "production_2x"] {
+        for label in ["production", "production_2x", "production_exact"] {
             let s = spec(label);
             let net = build_network(s, 0x5EED);
             let records = build_records(net.num_inputs(), NUM_RECORDS);

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -38,6 +38,115 @@ fn production_shapes_are_registered_with_expected_dimensions() {
 }
 
 #[test]
+fn production_exact_matches_committed_grq_topology() {
+    // Issue #286: the `production_exact` fixture must reproduce the committed
+    // GRQ-cluster/network.json topology to the synapse — 1,666 non-input
+    // neurons, 21,513 synapses, 2,461 inputs — so the Criterion baseline is
+    // anchored to the real production model rather than a ~13-average estimate.
+    let spec = spec("production_exact");
+    assert_eq!(spec.num_inputs, 2461, "production inputs");
+    assert_eq!(spec.num_non_inputs(), 1666, "production non-input neurons");
+    assert_eq!(spec.num_neurons, 4127, "2461 inputs + 1666 neurons");
+    assert_eq!(spec.num_outputs, 1);
+
+    let net = build_network(spec, 0x5152_5354);
+    assert_eq!(
+        net.neurons.len(),
+        1666,
+        "one NeuronData per non-input neuron"
+    );
+    assert_eq!(net.num_inputs, 2461);
+    assert_eq!(net.num_neurons, 4127);
+    assert_eq!(
+        net.synapses.len(),
+        21_513,
+        "production_exact must build exactly 21,513 synapses"
+    );
+
+    // Per-neuron `num_synapses` must sum to the flat synapse buffer length.
+    let summed: usize = net.neurons.iter().map(|n| n.num_synapses as usize).sum();
+    assert_eq!(summed, 21_513);
+}
+
+#[test]
+fn production_exact_fan_in_is_evenly_spread_and_varies() {
+    // ExactTotal spreads 21,513 synapses across 1,666 neurons as evenly as
+    // possible, so the fan-in takes exactly two values (base and base+1) with a
+    // mean near the production ~13.
+    let net = build_network(spec("production_exact"), 0x5152_5354);
+    let distinct: std::collections::BTreeSet<u16> =
+        net.neurons.iter().map(|n| n.num_synapses).collect();
+    assert!(
+        distinct.len() > 1,
+        "exact fan-in should still vary, saw only {distinct:?}"
+    );
+    assert!(
+        distinct.len() <= 2,
+        "even distribution should use at most two fan-in values, saw {distinct:?}"
+    );
+    let avg_fan_in = net.synapses.len() as f64 / net.neurons.len() as f64;
+    assert!(
+        (12.0..=14.0).contains(&avg_fan_in),
+        "average fan-in {avg_fan_in} should sit near the production ~13"
+    );
+}
+
+#[test]
+fn production_exact_build_is_deterministic() {
+    // Seeded synthesis must reproduce byte-for-byte so the baseline numbers are
+    // reproducible (Issue #286 acceptance).
+    let a = build_network(spec("production_exact"), 0x5152_5354);
+    let b = build_network(spec("production_exact"), 0x5152_5354);
+    assert_eq!(a.synapses.len(), b.synapses.len());
+    assert!(
+        a.synapses
+            .iter()
+            .zip(&b.synapses)
+            .all(|(x, y)| x.weight == y.weight && x.from_index == y.from_index),
+        "same seed must reproduce identical synapses"
+    );
+    assert!(
+        a.neurons
+            .iter()
+            .zip(&b.neurons)
+            .all(|(x, y)| x.bias == y.bias && x.num_synapses == y.num_synapses),
+        "same seed must reproduce identical neurons"
+    );
+}
+
+#[test]
+fn production_exact_backprop_data_has_exact_synapse_count() {
+    // Regression: `build_backprop_data` must honour the ExactTotal schedule too,
+    // otherwise the exact shape falls through to `draw` (which returns 0 for
+    // ExactTotal) and the backprop bench runs on a synapse-free network.
+    let spec = spec("production_exact");
+    let data = build_backprop_data(spec, 0x1357_9BDF);
+    assert_eq!(data.neurons.len(), spec.num_neurons);
+    assert_eq!(data.reverse_topo_order.len(), spec.num_non_inputs());
+    assert_eq!(
+        data.synapses.len(),
+        21_513,
+        "backprop fixture must build the same 21,513 synapses as the forward fixture"
+    );
+    let summed: usize = data.inward_counts.iter().map(|&c| c as usize).sum();
+    assert_eq!(summed, 21_513);
+    assert_eq!(summed, data.inward_indices.len());
+}
+
+#[test]
+fn production_exact_network_activates_to_finite_outputs() {
+    let spec = spec("production_exact");
+    let mut net = build_network(spec, 0x5152_5354);
+    let inputs = build_inputs(spec.num_inputs, 0xA1B2_C3D4);
+    let out = net.activate(&inputs, spec.num_outputs);
+    assert_eq!(out.len(), spec.num_outputs);
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "production_exact forward pass must produce finite outputs"
+    );
+}
+
+#[test]
 fn build_network_matches_production_neuron_and_synapse_counts() {
     let prod = spec("production");
     let net = build_network(prod, 0x5152_5354);
@@ -93,7 +202,7 @@ fn production_fixture_squash_is_homogeneous_tanh() {
     // unmeasurable on the fixture (the predictor already nails a one-arm match).
     // If a future change diversifies the fixture squash, this test fails so the
     // documented caveat is revisited rather than silently invalidated.
-    for label in ["production", "production_2x"] {
+    for label in ["production", "production_2x", "production_exact"] {
         let net = build_network(spec(label), 0x5152_5354);
         assert!(
             net.neurons


### PR DESCRIPTION
# Criterion baseline on the production topology (Issue #286)

## Summary

Established a reproducible **Criterion baseline on the exact production
topology** — the committed `GRQ-cluster/network.json` shape of **1,666 non-input
neurons, 21,513 synapses, 2,461 inputs** — so every later perf change in this
crate has a dated before/after anchor. Measurement only, no optimisation
(optimisation lands in the lane sub-issues that gate on these numbers).
**Closes #286.**

What changed:

- **New `production_exact` fixture** in `neat-core/benches/common/mod.rs`. Unlike
  the existing `production` shape (a ~13-average `FanIn::VariedAround`
  approximation, ~21.7k synapses), the new shape uses a new
  **`FanIn::ExactTotal(21_513)`** variant that distributes the synapses across
  the 1,666 neurons as evenly as possible (12 or 13 each, Bresenham-interleaved),
  so the fixture reproduces the real model **to the synapse**. Seeded and
  deterministic.
- The new variant is threaded through **both** deterministic builders —
  `build_network` (forward/scoring) and `build_backprop_data` (backprop) — via a
  pre-computed `exact_schedule`. The RNG-drawn shapes stay on their existing
  `draw` path, so every committed `production`/`production_2x` baseline is
  byte-for-byte unchanged.
- `production_exact` is wired into the `hot_paths` groups (its label starts with
  `production`, so the `scoring` group and the `production` regex filter pick it
  up) and added to the `parallel_scoring` label list, covering **both lanes**:
  the default single-thread path and the native `--features parallel` path.
- **`BASELINE.md`** gains a dated (2026-07-18, rustc 1.97.0) production-exact
  section with single-thread and parallel numbers, plus a per-creature scoring
  latency mapped back to the project metric (**score improvement per wall-clock
  hour**).

### Fixture → baseline flow

```mermaid
flowchart LR
    A["NetSpec production_exact<br/>1666 neurons / 21,513 synapses / 2461 inputs"] --> B["FanIn::ExactTotal(21_513)"]
    B --> C["exact_schedule()<br/>Bresenham-even 12/13 fan-in"]
    C --> D["build_network()"]
    C --> E["build_backprop_data()"]
    D --> F["hot_paths: forward / scoring<br/>parallel_scoring: 1 vs 12 cores"]
    E --> G["hot_paths: backprop"]
    F --> H["BASELINE.md — dated numbers"]
    G --> H
```

## Evidence

Backend/bench-only change — no web UI to screenshot. Evidence is the dated
benchmark numbers recorded in `neat-core/benches/BASELINE.md` and the fixture
tests that assert the exact topology.

**Single-thread lane** (`cargo bench -p neat-core --bench hot_paths -- production_exact`):

| Group | production_exact |
| --- | --- |
| `forward_pass` | 30.76 µs `[30.19, 31.35]` (~134 Melem/s) |
| `batched_scoring/trace_batch_4way` | 122.65 µs `[120.98, 124.33]` |
| `batched_scoring/mse_sum_8records` | 242.08 µs `[239.09, 244.99]` |
| `backprop` | 214.14 µs `[210.46, 218.05]` (~19.3 Melem/s) |
| `scoring` (4096 records) | 91.50 ms `[90.05, 92.96]` (44.8 Krecords/s) |

**Parallel lane** (`cargo bench -p neat-core --features parallel --bench parallel_scoring -- production_exact`):

| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
| --- | --- | --- | --- | --- |
| `production_exact` | 61.84 ms `[60.36, 63.38]` | 24.62 ms `[22.35, 26.98]` | 66.2 K → 166.4 K | 2.51× |

Per-creature corpus pass (~2.24 M records/generation): ≈ **33.9 s** single-core,
≈ **13.5 s** on 12 cores — the denominator of the project metric. The
scoring-lane run-to-run variance (~62–92 ms single-core across invocations, a
thermal artefact of the laptop-class M4 Pro) is documented honestly in
`BASELINE.md`; the internally-consistent 2.51× parallel ratio is the
authoritative anchor.

## Test Plan

New/updated tests in `neat-core/tests/bench_fixtures.rs` (run green via
`cargo test -p neat-core --test bench_fixtures`, and compiled in PR CI by
`cargo check/clippy --all-targets --all-features`):

- `production_exact_matches_committed_grq_topology` — asserts exactly 2,461
  inputs, 1,666 non-input neurons, 4,127 total, and **21,513** built synapses.
- `production_exact_fan_in_is_evenly_spread_and_varies` — fan-in takes at most
  two values (12/13) with a mean near the production ~13.
- `production_exact_build_is_deterministic` — same seed reproduces identical
  synapses and neurons (reproducibility guard).
- `production_exact_backprop_data_has_exact_synapse_count` — regression test for
  the backprop builder honouring the exact schedule (caught a real bug where
  `build_backprop_data` fell through to `draw`, building a synapse-free network).
- `production_exact_network_activates_to_finite_outputs` — forward pass produces
  finite outputs.
- `production_fixture_squash_is_homogeneous_tanh` — extended to cover the new
  shape, keeping the documented squash-homogeneity caveat honest.

No existing tests removed or modified in behaviour; existing
`production`/`production_2x` fixtures and baselines are untouched.



## Milestone
This PR is part of the **#285 Suggest neat-core performance improvements for production learn/sampler runs** milestone and targets the `milestone/285-suggest-neat-core-performance-improvements-for` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrq0z80e-2476ad`<!-- vibe-worker-issue-286 -->