### PR TITLE
perf(neat-core): record-interleaved scoring gather, ~2.1x single-core (Issue #287)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-287.md
+++ b/docs/archive/pr-summaries/pr-summary-287.md
@@ -1,0 +1,111 @@
+# Optimise the wasm32 single-thread per-creature scoring hot path (Issue #287)
+
+## Summary
+
+Speeds up the single-thread record-scoring hot path (`score_records` →
+`score_batch_into`) — the lane NEAT-AI's per-creature `wasm32` workers drive —
+by switching the batched forward pass to a **record-interleaved activation
+layout**. Instead of eight separate per-lane activation buffers, one group of
+eight records is transposed into a single buffer where lane `l` of source
+neuron `n` lives at `inter[n * 8 + l]`, so all eight records for a synapse's
+source are **contiguous**. Each gather in the new `weighted_sum_interleaved_8`
+kernel is then one cache-line read (two adjacent 4-wide loads on NEON, one
+`_mm256_loadu_ps` on AVX2, one contiguous `f32x4` pair on wasm `simd128`)
+instead of eight scattered loads across eight buffers, and each neuron's eight
+outputs are a single contiguous store. This extends the #230 batched-SIMD
+approach to the gather/scatter itself; because the win is **layout-driven**, it
+applies identically to the native and `wasm32` builds.
+
+Networks that contain aggregate squashes (Minimum/Maximum/If/Hypotenuse/
+HypotenuseV2/Mean) keep the original per-lane path via an automatic dispatch;
+the all-standard-squash production topology takes the interleaved fast path.
+
+Closes #287.
+
+### What changed
+
+- `neat-core/src/simd_native.rs` — `weighted_sum_interleaved_8` (AVX2 / NEON /
+  scalar), mirroring the existing 8-record kernels and their `get_unchecked`
+  load-time-validation soundness contract (`from_index < num_neurons` ⇒
+  `from_index * 8 + 8 ≤ inter.len()`).
+- `neat-core/src/simd.rs` — the `wasm32` `simd128`/`relaxed-simd`
+  `weighted_sum_interleaved_8`, plus the native re-export.
+- `neat-core/src/batch_scoring.rs` — `BatchScratch` gains the interleaved
+  buffer; `score_batch_into` dispatches to `score_batch_interleaved` (fast path)
+  or the retained `score_batch_per_lane` (aggregate fallback). Full 8-record
+  groups run the interleaved kernel; the `records.len() % 8` tail runs the exact
+  single-record kernel so single-record scoring stays bit-for-bit identical to
+  `activate`.
+
+### Scope note — wasm32 target, native evidence gate
+
+The issue targets the `wasm32` scoring lane, but the repo's evidence gate
+(`neat-core/benches/hot_paths.rs`, `BASELINE.md`) is a native Criterion harness
+— the `wasm32` SIMD path is `cfg`'d out of the host build and cannot be A/B'd
+here. The optimisation therefore lives in the **shared, architecture-neutral**
+scoring structure so the identical layout change benefits both builds, and is
+measured on the native `production_exact` fixture the baseline anchors to. The
+`wasm32` and native builds and clippy both pass.
+
+## Evidence — before/after benchmark (Performance Task Workflow)
+
+Backend/CLI change with no web interface, so evidence is Criterion, not a
+screenshot. Fixture: `production_exact` (1,666 non-input neurons / 21,513
+synapses / 2,461 inputs), the exact committed GRQ-cluster topology.
+
+Separate `cargo bench` invocations drift on the laptop-class M4 Pro (the
+`BASELINE.md` thermal caveat), so the A/B was run as **alternating** old/new
+rounds of the *same* prebuilt bench binaries, capturing the **unchanged**
+`forward_pass` benchmark as a drift control. The control stayed flat, proving
+the `scoring` delta is the code change and not thermal drift.
+
+4 alternating rounds, rustc 1.97.0, `--release`, Criterion `--sample-size 60`
+(median ms):
+
+| Round | `scoring` OLD | `scoring` NEW | `forward_pass` OLD (control) | `forward_pass` NEW (control) |
+| --- | --- | --- | --- | --- |
+| 1 | 82.98 ms | 48.98 ms | 31.77 µs | 36.11 µs |
+| 2 | 104.35 ms | 49.73 ms | 35.74 µs | 35.03 µs |
+| 3 | 109.33 ms | 53.29 ms | 35.17 µs | 36.96 µs |
+| 4 | 108.85 ms | 40.30 ms | 35.92 µs | 30.74 µs |
+| **mean** | **101.4 ms** | **48.1 ms** | **34.65 µs** | **34.71 µs** |
+
+- `scoring/production_exact`: **101.4 ms → 48.1 ms, −52% (≈2.1× faster)**; every
+  round is far faster on the new path.
+- `forward_pass` control (the single-record `activate` path, untouched): flat
+  (34.65 vs 34.71 µs mean) → drift cancelled.
+
+At ~48 ms the per-creature ~2.24 M-record corpus pass drops from ≈33.9 s toward
+the low 20s of seconds on a single core — a direct gain on the score-per-hour
+metric. `BASELINE.md` is updated with this result and the methodology.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — 8 per-lane buffers"]
+        A["synapse from_index"] --> B0["act0[from]"] & B1["act1[from]"] & B7["… act7[from]"]
+        B0 & B1 & B7 --> C["8 scattered cache-line reads"]
+    end
+    subgraph after["After — record-interleaved"]
+        D["synapse from_index"] --> E["inter[from*8 .. from*8+8]"]
+        E --> F["1 contiguous cache-line read"]
+    end
+```
+
+## Test Plan
+
+- **New** `neat-core/tests/interleaved_scoring_parity.rs` — "what" tests
+  exercising both dispatch branches across the 8-record boundary (counts
+  1,7,8,9,16,17):
+  - `interleaved_fast_path_matches_reference_across_boundaries` — all-Tanh net
+    (fast path) matches the scalar `activate` reference within SIMD tolerance.
+  - `interleaved_single_record_is_bit_identical_to_activate` — single record is
+    bit-for-bit identical (exact tail path).
+  - `aggregate_fallback_path_matches_reference_across_boundaries` — Maximum net
+    (per-lane fallback) is exact.
+- Existing scoring parity/allocation suites pass unchanged:
+  `score_squash_simd_parity`, `mse_squash_simd_parity`, `parallel_scoring`
+  (incl. `single_record_matches_direct_activate`,
+  `sequential_and_parallel_are_bit_identical`), `scoring_allocations`
+  (no per-record allocation — `BatchScratch` allocates once).
+- `./quality.sh` passes: fmt, clippy (`-D warnings`, native + `wasm32`),
+  `cargo deny`, full `cargo test`, doc build, release build.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -173,6 +173,48 @@ lane sub-issue's optimisation is measured against.
 > single-core scoring latency as ~62–92 ms (±~20%). A lane sub-issue must A/B
 > with `--save-baseline` inside a single invocation to stay inside this band.
 
+## Record-interleaved scoring optimisation (Issue #287)
+
+The single-thread scoring hot path (`score_records` → `score_batch_into`, the
+same lane NEAT-AI's per-creature wasm32 workers drive) now transposes each
+group of eight records into a **record-interleaved** activation buffer:
+lane `l` of source neuron `n` lives at `inter[n * 8 + l]`, so all eight records
+for a synapse's source are contiguous. Each gather in
+`weighted_sum_interleaved_8` is then one cache-line read (two adjacent 4-wide
+loads on NEON / one `_mm256_loadu_ps` on AVX2 / one contiguous `f32x4` pair on
+wasm `simd128`) instead of eight scattered per-lane loads, and each neuron's
+eight outputs are a single contiguous store. This extends the #230 batched-SIMD
+approach to the gather itself; it is layout-driven, so the win is portable
+across the native and `wasm32` builds. Networks containing aggregate squashes
+(Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean) keep the original per-lane
+path; the all-standard-squash production topology takes the fast path.
+
+**Methodology (controls for the laptop thermal band above).** Because separate
+`cargo bench` invocations drift, the A/B was run as **alternating** old/new
+rounds of the *same* prebuilt bench binaries, capturing the unchanged
+`forward_pass` benchmark alongside `scoring` as a drift control. `forward_pass`
+stayed flat across old/new (34.65 µs vs 34.71 µs mean), confirming the `scoring`
+delta is the code change, not thermal drift.
+
+**Measured 2026-07-18**, GRQ host class (Apple M4 Pro), rustc 1.97.0,
+`--release`, 4 alternating rounds (Criterion `--sample-size 60`):
+
+| `production_exact` (median) | old | new | change |
+| --- | --- | --- | --- |
+| `scoring` (4096 records) mean of 4 rounds | 101.4 ms | 48.1 ms | **−52% (≈2.1×)** |
+| `forward_pass` control (unchanged) mean | 34.65 µs | 34.71 µs | flat |
+
+Every round showed the interleaved path far faster on `scoring` (old
+83/104/109/109 ms → new 49/50/53/40 ms). At the ~48 ms new scoring figure the
+per-creature ~2.24 M-record corpus pass (see the latency table above) drops from
+≈33.9 s toward the low-20s-of-seconds on a single core — a direct win on the
+score-per-hour metric. `forward_pass` (the single-record `activate` path) is
+untouched and unaffected. Numerics: full 8-record groups are bit-identical to
+the prior per-lane 8-record path (same FMA order); the `records.len() % 8` tail
+runs the exact single-record kernel, so single-record scoring stays
+bit-for-bit identical to `activate` (asserted by
+`tests/interleaved_scoring_parity.rs` and the existing scoring parity suite).
+
 ## Reproducing
 
 ```bash

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -43,27 +43,46 @@
 use crate::network::{CompiledNetwork, NeuronData, SynapseData};
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{
-    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
-    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
+    weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
+    weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
+    weighted_sum_simd_8records,
 };
 use crate::squash::{SquashType, apply_squash};
 use crate::squash_simd::{squash_x4, squash_x8};
 use crate::synapse_type::SynapseType;
 
-/// Reusable per-worker scratch: eight activation buffers, one per SIMD lane.
+/// Number of records processed per SIMD batch (one lane each).
+pub(crate) const SCORING_LANES: usize = 8;
+
+/// Reusable per-worker scratch for the batched scoring forward pass.
 ///
 /// Owning the buffers here lets the sequential path allocate once for a whole
 /// batch and the parallel path allocate once per rayon worker (via
 /// `for_each_init`), instead of once per chunk.
+///
+/// Two layouts are held so scoring can pick the cheaper gather per network
+/// (Issue #287):
+///
+/// - `inter` is the **record-interleaved** buffer used by the fast path when the
+///   network has no aggregate-squash neurons: lane `l` of neuron `n` lives at
+///   `inter[n * SCORING_LANES + l]`, so a synapse's eight records are contiguous
+///   and each gather reads one cache line instead of eight scattered buffers.
+/// - `acts` is the original eight-buffer (one-per-lane) layout, retained for the
+///   fallback path that scores networks containing aggregate squashes
+///   (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean), whose exact
+///   single-record kernels index a contiguous per-lane activation slice.
 pub struct BatchScratch {
     acts: [Vec<f32>; 8],
+    inter: Vec<f32>,
 }
 
 impl BatchScratch {
-    /// Allocate eight zeroed activation buffers sized to the network.
+    /// Allocate the zeroed activation buffers sized to the network: eight
+    /// per-lane buffers plus one interleaved buffer of `num_neurons * 8`.
     pub fn new(num_neurons: usize) -> Self {
         Self {
             acts: std::array::from_fn(|_| vec![0.0f32; num_neurons]),
+            inter: vec![0.0f32; num_neurons * SCORING_LANES],
         }
     }
 }
@@ -184,11 +203,165 @@ impl CompiledNetwork {
     ///
     /// Record `i` (0-based within `records`) writes its outputs to
     /// `out[i * num_outputs .. (i + 1) * num_outputs]`; `out` must be exactly
-    /// `records.len() * num_outputs` long. Records are grouped into 8s and
-    /// driven through [`weighted_sum_simd_8records`], then a 4-record group via
-    /// [`weighted_sum_simd_4records`], then a scalar tail — matching the
-    /// remainder handling of `mse_sum_batch_packed`.
+    /// `records.len() * num_outputs` long.
+    ///
+    /// Dispatches between two numerically-equivalent layouts (Issue #287):
+    ///
+    /// - **Interleaved fast path** ([`Self::score_batch_interleaved`]) when the
+    ///   network has no aggregate-squash neurons — the common case, including the
+    ///   all-standard-squash production topology. Records are transposed so each
+    ///   synapse gather reads one cache line.
+    /// - **Per-lane fallback** ([`Self::score_batch_per_lane`]) otherwise, which
+    ///   keeps aggregate squashes (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/
+    ///   Mean) on the exact single-record kernels.
+    ///
+    /// Both group records into 8s then a 4-record group then a scalar tail, and
+    /// both are bit-identical on the covered standard-squash neurons.
     pub(crate) fn score_batch_into(
+        &self,
+        scratch: &mut BatchScratch,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        if self.has_aggregate_squash() {
+            self.score_batch_per_lane(scratch, records, num_outputs, out);
+        } else {
+            self.score_batch_interleaved(scratch, records, num_outputs, out);
+        }
+    }
+
+    /// True when any non-constant neuron uses an aggregate squash whose exact
+    /// kernel needs a contiguous per-lane activation slice (so the interleaved
+    /// fast path does not apply). O(neurons); the scoring batch dwarfs it.
+    fn has_aggregate_squash(&self) -> bool {
+        self.neurons.iter().any(|neuron| {
+            !neuron.is_constant
+                && matches!(
+                    SquashType::from(neuron.squash_type),
+                    SquashType::Minimum
+                        | SquashType::Maximum
+                        | SquashType::If
+                        | SquashType::Hypotenuse
+                        | SquashType::HypotenuseV2
+                        | SquashType::Mean
+                )
+        })
+    }
+
+    /// Record-interleaved scoring fast path (Issue #287).
+    ///
+    /// Transposes each group of eight records into `scratch.inter`
+    /// (`inter[n * 8 + l]` = lane `l` of neuron `n`) so every synapse gather in
+    /// [`weighted_sum_interleaved_8`] reads one contiguous cache line rather than
+    /// eight scattered per-lane buffers, and each neuron's eight outputs are a
+    /// contiguous store. Full 8-record groups are bit-identical to the per-lane
+    /// 8-record path (same FMA order and vectorised squash); the trailing
+    /// `records.len() % 8` records run the exact single-record kernel
+    /// ([`neuron_activation_scalar`]) so they stay bit-for-bit identical to
+    /// `activate` — matching the per-lane fallback's scalar-tail guarantee. Only
+    /// called when [`Self::has_aggregate_squash`] is false, so the group path
+    /// needs no aggregate kernel.
+    fn score_batch_interleaved(
+        &self,
+        scratch: &mut BatchScratch,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        const L: usize = SCORING_LANES;
+        let num_inputs = self.num_inputs;
+        let num_neurons = self.num_neurons;
+        let output_start = num_neurons - num_outputs;
+        let n = records.len();
+
+        // `inter` (fast group path) and `acts[0]` (exact scalar tail) are disjoint
+        // fields, so borrow both at once.
+        let BatchScratch { acts, inter } = scratch;
+        let tail_act = &mut acts[0];
+
+        let mut base = 0usize;
+
+        // ---- full 8-record groups -------------------------------------------
+        while base + L <= n {
+            // Transpose L records into the interleaved buffer.
+            for l in 0..L {
+                let rec = &records[base + l];
+                let in_len = rec.len().min(num_inputs);
+                for i in 0..in_len {
+                    inter[i * L + l] = rec[i];
+                }
+                for i in in_len..num_inputs {
+                    inter[i * L + l] = 0.0;
+                }
+            }
+
+            // Forward pass, all L lanes at once.
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let out_base = (num_inputs + neuron_idx) * L;
+
+                if neuron.is_constant {
+                    let v = apply_limit_range(SquashType::Identity, neuron.bias);
+                    for slot in inter[out_base..out_base + L].iter_mut() {
+                        *slot = v;
+                    }
+                    continue;
+                }
+
+                let squash = SquashType::from(neuron.squash_type);
+                let start = neuron.start_synapse as usize;
+                let end = start + neuron.num_synapses as usize;
+                let sums =
+                    weighted_sum_interleaved_8(&self.synapses, inter, start, end, neuron.bias);
+
+                // Vectorised squash across all 8 lanes for the covered types
+                // (Issue #243); scalar inline fallback otherwise.
+                let squashed = squash_x8(squash, sums).unwrap_or_else(|| {
+                    let st = neuron.squash_type;
+                    sums.map(|s| inline_squash(st, squash, s))
+                });
+
+                // Resolve the output range once per neuron (Issue #245) and clamp
+                // all 8 lanes; the writes land in one contiguous cache line.
+                let (low, high) = apply_get_range(squash);
+                for l in 0..L {
+                    inter[out_base + l] = apply_limit_range_bounds(low, high, squashed[l]);
+                }
+            }
+
+            // Scatter each lane's outputs to the flat buffer.
+            for l in 0..L {
+                let dst = (base + l) * num_outputs;
+                for o in 0..num_outputs {
+                    out[dst + o] = inter[(output_start + o) * L + l];
+                }
+            }
+
+            base += L;
+        }
+
+        // ---- exact single-record tail (records.len() % 8) -------------------
+        // Bit-identical to `activate`, so a lone or partial trailing group keeps
+        // the strict single-record parity guarantee.
+        while base < n {
+            load_record(tail_act, &records[base], num_inputs);
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+                tail_act[actual_idx] = neuron_activation_scalar(&self.synapses, tail_act, neuron);
+            }
+            let dst = base * num_outputs;
+            out[dst..dst + num_outputs]
+                .copy_from_slice(&tail_act[output_start..output_start + num_outputs]);
+            base += 1;
+        }
+    }
+
+    /// Per-lane fallback scoring path — the original eight-buffer layout, kept
+    /// verbatim for networks containing aggregate squashes (Issue #287). Record
+    /// `i` writes `out[i * num_outputs ..]`; records are grouped into 8s
+    /// ([`weighted_sum_simd_8records`]), then a 4-record group
+    /// ([`weighted_sum_simd_4records`]), then a scalar tail.
+    fn score_batch_per_lane(
         &self,
         scratch: &mut BatchScratch,
         records: &[Vec<f32>],

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -454,6 +454,68 @@ pub fn weighted_sum_simd_8records(
     )
 }
 
+/// Issue #287 - record-interleaved 8-lane weighted sum for the batched scoring
+/// hot path.
+///
+/// `inter` is the transposed batch activation buffer: lane `l` of source neuron
+/// `n` lives at `inter[n * 8 + l]`, so all eight records for a synapse's source
+/// are contiguous. Each gather is then two adjacent 4-wide reads from one cache
+/// line instead of eight scattered per-lane loads, cutting gather traffic on the
+/// gather-bound production topology. Numerically identical to
+/// [`weighted_sum_simd_8records`]: same per-synapse FMA order, bias seeded into
+/// every lane.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+pub fn weighted_sum_interleaved_8(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    if end <= start {
+        return [bias; 8];
+    }
+
+    let mut acc03 = f32x4_splat(bias);
+    let mut acc47 = f32x4_splat(bias);
+
+    for i in start..end {
+        let synapse = &synapses[i];
+        let base = synapse.from_index as usize * 8;
+        let weights = f32x4_splat(synapse.weight);
+
+        // The eight lanes are contiguous, so these read one cache line.
+        let acts03 = f32x4(
+            inter[base],
+            inter[base + 1],
+            inter[base + 2],
+            inter[base + 3],
+        );
+        let acts47 = f32x4(
+            inter[base + 4],
+            inter[base + 5],
+            inter[base + 6],
+            inter[base + 7],
+        );
+
+        acc03 = f32x4_relaxed_madd(weights, acts03, acc03);
+        acc47 = f32x4_relaxed_madd(weights, acts47, acc47);
+    }
+
+    [
+        f32x4_extract_lane::<0>(acc03),
+        f32x4_extract_lane::<1>(acc03),
+        f32x4_extract_lane::<2>(acc03),
+        f32x4_extract_lane::<3>(acc03),
+        f32x4_extract_lane::<0>(acc47),
+        f32x4_extract_lane::<1>(acc47),
+        f32x4_extract_lane::<2>(acc47),
+        f32x4_extract_lane::<3>(acc47),
+    ]
+}
+
 // Native (non-wasm32) multi-record helpers now live in `simd_native.rs` and use
 // AVX2/FMA on x86_64, NEON on aarch64, falling back to scalar elsewhere.
 #[cfg(not(target_arch = "wasm32"))]
@@ -466,6 +528,7 @@ mod simd_native;
 // kernels and run on the primary `activate()` forward-pass hot path.
 #[cfg(not(target_arch = "wasm32"))]
 pub use simd_native::{
-    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
-    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
+    weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
+    weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
+    weighted_sum_simd_8records,
 };

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -77,6 +77,33 @@ fn weighted_sum_simd_4records_scalar(
     (sum0, sum1, sum2, sum3)
 }
 
+/// Scalar fallback for the record-interleaved 8-lane weighted sum (Issue #287).
+///
+/// `inter` is the transposed batch activation buffer: lane `l` of neuron `n`
+/// lives at `inter[n * 8 + l]`, so all eight records for a source neuron are
+/// contiguous. This mirrors [`weighted_sum_simd_8records_scalar`] numerically —
+/// same per-synapse FMA order, bias seeded into every lane — so the covered
+/// scoring path is bit-identical whichever gather layout is used.
+#[inline]
+fn weighted_sum_interleaved_8_scalar(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    let mut acc = [bias; 8];
+    for synapse in synapses.iter().take(end).skip(start) {
+        let base = synapse.from_index as usize * 8;
+        let w = synapse.weight;
+        let chunk = &inter[base..base + 8];
+        for l in 0..8 {
+            acc[l] += chunk[l] * w;
+        }
+    }
+    acc
+}
+
 #[cfg(target_arch = "x86_64")]
 mod x86 {
     use super::SynapseData;
@@ -130,6 +157,46 @@ mod x86 {
         (
             out[0], out[1], out[2], out[3], out[4], out[5], out[6], out[7],
         )
+    }
+
+    /// Record-interleaved 8-lane weighted sum (Issue #287).
+    ///
+    /// `inter` holds the transposed batch: the eight records for source neuron
+    /// `n` are contiguous at `inter[n * 8 .. n * 8 + 8]`, so each synapse gather
+    /// is a single `_mm256_loadu_ps` from one cache line instead of eight
+    /// scattered scalar loads — the whole point of the layout change.
+    ///
+    /// # Safety
+    /// Caller must ensure AVX2 is enabled (`is_x86_feature_detected!("avx2")`).
+    /// Issue #287 - `inter.len()` must be `num_neurons * 8` and every
+    /// `synapse.from_index` in `start..end` must be `< num_neurons`, so
+    /// `from_index * 8 + 8 <= inter.len()`; `CompiledNetwork::new` validates the
+    /// synapse index range at load time. The 8-wide read is then in bounds.
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub unsafe fn weighted_sum_interleaved_8_avx2(
+        synapses: &[SynapseData],
+        inter: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> [f32; 8] {
+        let mut acc = _mm256_set1_ps(bias);
+        let ptr = inter.as_ptr();
+        for i in start..end {
+            let synapse = unsafe { synapses.get_unchecked(i) };
+            let base = synapse.from_index as usize * 8;
+            let w = synapse.weight;
+            // SAFETY: base + 8 <= inter.len() by the load-time index validation
+            // documented above; the unaligned 8-wide load is in bounds.
+            let acts = unsafe { _mm256_loadu_ps(ptr.add(base)) };
+            let ws = _mm256_set1_ps(w);
+            // `_mm256_fmadd_ps` needs `fma` (mirrors the 8records kernel above).
+            acc = unsafe { _mm256_fmadd_ps(ws, acts, acc) };
+        }
+        let mut out = [0.0_f32; 8];
+        unsafe { _mm256_storeu_ps(out.as_mut_ptr(), acc) };
+        out
     }
 
     /// # Safety
@@ -379,6 +446,49 @@ mod aarch64 {
         (
             o03[0], o03[1], o03[2], o03[3], o47[0], o47[1], o47[2], o47[3],
         )
+    }
+
+    /// Record-interleaved 8-lane weighted sum (Issue #287).
+    ///
+    /// `inter` holds the transposed batch: the eight records for source neuron
+    /// `n` are contiguous at `inter[n * 8 .. n * 8 + 8]`, so each synapse gather
+    /// is two adjacent `vld1q_f32` loads from one cache line instead of eight
+    /// scattered scalar loads staged through a stack array.
+    ///
+    /// # Safety
+    /// Caller must ensure NEON is available (typical on aarch64-apple-darwin /
+    /// linux-aarch64). Issue #287 - `inter.len()` must be `num_neurons * 8` and
+    /// every `synapse.from_index` in `start..end` must be `< num_neurons`, so
+    /// `from_index * 8 + 8 <= inter.len()`; `CompiledNetwork::new` validates the
+    /// synapse index range at load time, making the two 4-wide reads in bounds.
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub unsafe fn weighted_sum_interleaved_8_neon(
+        synapses: &[SynapseData],
+        inter: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> [f32; 8] {
+        let mut acc03 = vdupq_n_f32(bias);
+        let mut acc47 = vdupq_n_f32(bias);
+        let ptr = inter.as_ptr();
+        for i in start..end {
+            let synapse = unsafe { synapses.get_unchecked(i) };
+            let base = synapse.from_index as usize * 8;
+            let w = synapse.weight;
+            // SAFETY: base + 8 <= inter.len() by the load-time index validation
+            // documented above; both 4-wide reads are in bounds.
+            let a03 = unsafe { vld1q_f32(ptr.add(base)) };
+            let a47 = unsafe { vld1q_f32(ptr.add(base + 4)) };
+            let vw = vdupq_n_f32(w);
+            acc03 = vfmaq_f32(acc03, vw, a03);
+            acc47 = vfmaq_f32(acc47, vw, a47);
+        }
+        let mut out = [0.0_f32; 8];
+        unsafe { vst1q_f32(out.as_mut_ptr(), acc03) };
+        unsafe { vst1q_f32(out.as_mut_ptr().add(4), acc47) };
+        out
     }
 
     /// # Safety
@@ -631,6 +741,49 @@ pub fn weighted_sum_simd_8records(
     weighted_sum_simd_8records_scalar(
         synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
     )
+}
+
+/// Record-interleaved 8-lane weighted sum (Issue #287): AVX2+FMA on x86_64,
+/// NEON on aarch64, else scalar. `inter` is the transposed batch buffer
+/// (`inter[n * 8 + l]` = lane `l` of neuron `n`), so each synapse gather touches
+/// one cache line instead of eight scattered per-lane buffers.
+#[inline]
+pub fn weighted_sum_interleaved_8(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    if end <= start {
+        return [bias; 8];
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: the `is_x86_feature_detected!("avx2")` guard proves AVX2 is
+            // available, satisfying the `#[target_feature(enable = "avx2")]`
+            // precondition on `weighted_sum_interleaved_8_avx2`.
+            return unsafe {
+                x86::weighted_sum_interleaved_8_avx2(synapses, inter, start, end, bias)
+            };
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: the `is_aarch64_feature_detected!("neon")` guard proves NEON
+            // is available, satisfying the `#[target_feature(enable = "neon")]`
+            // precondition on `weighted_sum_interleaved_8_neon`.
+            return unsafe {
+                aarch64::weighted_sum_interleaved_8_neon(synapses, inter, start, end, bias)
+            };
+        }
+    }
+
+    weighted_sum_interleaved_8_scalar(synapses, inter, start, end, bias)
 }
 
 /// 4-record weighted sum: FMA+SSE on x86_64, NEON on aarch64, else scalar.

--- a/neat-core/tests/interleaved_scoring_parity.rs
+++ b/neat-core/tests/interleaved_scoring_parity.rs
@@ -1,0 +1,155 @@
+//! Parity guard for the record-interleaved scoring fast path (Issue #287).
+//!
+//! `CompiledNetwork::score_batch_into` dispatches between a record-interleaved
+//! layout (fast path, taken when the network has no aggregate-squash neurons)
+//! and the original per-lane layout (fallback, taken when it does). These are
+//! "what" tests: they build real forward networks, score batches through the
+//! public `score_records` entry point, and assert the flat output matches the
+//! scalar single-record `activate` reference — so a lane transposition, a
+//! dropped tail record, or a wrong dispatch would surface as a parity break.
+//!
+//! Record counts straddle the 8-record group boundary (1, 7, 8, 9, 16, 17) so
+//! both the vectorised group path and the exact single-record tail are covered.
+
+use neat_core::squash::SquashType;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Build a two-hidden-plus-one-output feedforward network where every non-input
+/// neuron uses `squash`. `num_inputs` inputs fully connect into each hidden
+/// neuron; both hiddens feed the output.
+fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.25 - 0.09 * (i as f32) + 0.05 * (h as f32),
+                from_index: i as u16,
+                synapse_type: 0,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.03 * (h as f32) - 0.01,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    let hidden0 = num_inputs as u16;
+    let hidden1 = num_inputs as u16 + 1;
+    synapses.push(SynapseData {
+        weight: 0.7,
+        from_index: hidden0,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.5,
+        from_index: hidden1,
+        synapse_type: 0,
+    });
+    neurons.push(NeuronData {
+        bias: 0.02,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Deterministic distinct input records so a lane mix-up cannot hide.
+fn records(num_inputs: usize, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|r| {
+            (0..num_inputs)
+                .map(|i| ((r * 7 + i * 3) as f32 * 0.017).sin() * 0.9)
+                .collect()
+        })
+        .collect()
+}
+
+/// Reference outputs from the scalar single-record `activate` path.
+fn reference(net: &CompiledNetwork, recs: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
+    let mut scratch = net.clone();
+    let mut out = Vec::with_capacity(recs.len() * num_outputs);
+    for rec in recs {
+        out.extend_from_slice(&scratch.activate(rec, num_outputs));
+    }
+    out
+}
+
+const COUNTS: [usize; 6] = [1, 7, 8, 9, 16, 17];
+/// SIMD tolerance the batched vectorised squash/weighted-sum already carries
+/// (Issue #230 / #243); the exact single-record tail is well within it.
+const TOL: f32 = 2e-3;
+
+#[test]
+fn interleaved_fast_path_matches_reference_across_boundaries() {
+    // All-Tanh network → no aggregate neurons → interleaved fast path.
+    let num_inputs = 12;
+    let net = build_network(num_inputs, SquashType::Tanh);
+    for &count in &COUNTS {
+        let recs = records(num_inputs, count);
+        let got = net.score_records(&recs, 1);
+        let want = reference(&net, &recs, 1);
+        assert_eq!(got.len(), want.len(), "count {count}: length mismatch");
+        for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+            assert!(
+                (g - w).abs() <= TOL,
+                "count {count} record {i}: interleaved {g} vs reference {w}"
+            );
+        }
+    }
+}
+
+#[test]
+fn interleaved_single_record_is_bit_identical_to_activate() {
+    // A single record runs the exact scalar tail, so it must match bit-for-bit.
+    let num_inputs = 12;
+    let net = build_network(num_inputs, SquashType::Tanh);
+    let recs = records(num_inputs, 1);
+    assert_eq!(net.score_records(&recs, 1), reference(&net, &recs, 1));
+}
+
+#[test]
+fn aggregate_fallback_path_matches_reference_across_boundaries() {
+    // A Maximum network has aggregate neurons → forces the per-lane fallback,
+    // whose exact single-record kernels are bit-identical to the reference.
+    let num_inputs = 12;
+    let net = build_network(num_inputs, SquashType::Maximum);
+    for &count in &COUNTS {
+        let recs = records(num_inputs, count);
+        let got = net.score_records(&recs, 1);
+        let want = reference(&net, &recs, 1);
+        assert_eq!(got, want, "count {count}: aggregate fallback must be exact");
+    }
+}


### PR DESCRIPTION
# Optimise the wasm32 single-thread per-creature scoring hot path (Issue #287)

## Summary

Speeds up the single-thread record-scoring hot path (`score_records` →
`score_batch_into`) — the lane NEAT-AI's per-creature `wasm32` workers drive —
by switching the batched forward pass to a **record-interleaved activation
layout**. Instead of eight separate per-lane activation buffers, one group of
eight records is transposed into a single buffer where lane `l` of source
neuron `n` lives at `inter[n * 8 + l]`, so all eight records for a synapse's
source are **contiguous**. Each gather in the new `weighted_sum_interleaved_8`
kernel is then one cache-line read (two adjacent 4-wide loads on NEON, one
`_mm256_loadu_ps` on AVX2, one contiguous `f32x4` pair on wasm `simd128`)
instead of eight scattered loads across eight buffers, and each neuron's eight
outputs are a single contiguous store. This extends the #230 batched-SIMD
approach to the gather/scatter itself; because the win is **layout-driven**, it
applies identically to the native and `wasm32` builds.

Networks that contain aggregate squashes (Minimum/Maximum/If/Hypotenuse/
HypotenuseV2/Mean) keep the original per-lane path via an automatic dispatch;
the all-standard-squash production topology takes the interleaved fast path.

Closes #287.

### What changed

- `neat-core/src/simd_native.rs` — `weighted_sum_interleaved_8` (AVX2 / NEON /
  scalar), mirroring the existing 8-record kernels and their `get_unchecked`
  load-time-validation soundness contract (`from_index < num_neurons` ⇒
  `from_index * 8 + 8 ≤ inter.len()`).
- `neat-core/src/simd.rs` — the `wasm32` `simd128`/`relaxed-simd`
  `weighted_sum_interleaved_8`, plus the native re-export.
- `neat-core/src/batch_scoring.rs` — `BatchScratch` gains the interleaved
  buffer; `score_batch_into` dispatches to `score_batch_interleaved` (fast path)
  or the retained `score_batch_per_lane` (aggregate fallback). Full 8-record
  groups run the interleaved kernel; the `records.len() % 8` tail runs the exact
  single-record kernel so single-record scoring stays bit-for-bit identical to
  `activate`.

### Scope note — wasm32 target, native evidence gate

The issue targets the `wasm32` scoring lane, but the repo's evidence gate
(`neat-core/benches/hot_paths.rs`, `BASELINE.md`) is a native Criterion harness
— the `wasm32` SIMD path is `cfg`'d out of the host build and cannot be A/B'd
here. The optimisation therefore lives in the **shared, architecture-neutral**
scoring structure so the identical layout change benefits both builds, and is
measured on the native `production_exact` fixture the baseline anchors to. The
`wasm32` and native builds and clippy both pass.

## Evidence — before/after benchmark (Performance Task Workflow)

Backend/CLI change with no web interface, so evidence is Criterion, not a
screenshot. Fixture: `production_exact` (1,666 non-input neurons / 21,513
synapses / 2,461 inputs), the exact committed GRQ-cluster topology.

Separate `cargo bench` invocations drift on the laptop-class M4 Pro (the
`BASELINE.md` thermal caveat), so the A/B was run as **alternating** old/new
rounds of the *same* prebuilt bench binaries, capturing the **unchanged**
`forward_pass` benchmark as a drift control. The control stayed flat, proving
the `scoring` delta is the code change and not thermal drift.

4 alternating rounds, rustc 1.97.0, `--release`, Criterion `--sample-size 60`
(median ms):

| Round | `scoring` OLD | `scoring` NEW | `forward_pass` OLD (control) | `forward_pass` NEW (control) |
| --- | --- | --- | --- | --- |
| 1 | 82.98 ms | 48.98 ms | 31.77 µs | 36.11 µs |
| 2 | 104.35 ms | 49.73 ms | 35.74 µs | 35.03 µs |
| 3 | 109.33 ms | 53.29 ms | 35.17 µs | 36.96 µs |
| 4 | 108.85 ms | 40.30 ms | 35.92 µs | 30.74 µs |
| **mean** | **101.4 ms** | **48.1 ms** | **34.65 µs** | **34.71 µs** |

- `scoring/production_exact`: **101.4 ms → 48.1 ms, −52% (≈2.1× faster)**; every
  round is far faster on the new path.
- `forward_pass` control (the single-record `activate` path, untouched): flat
  (34.65 vs 34.71 µs mean) → drift cancelled.

At ~48 ms the per-creature ~2.24 M-record corpus pass drops from ≈33.9 s toward
the low 20s of seconds on a single core — a direct gain on the score-per-hour
metric. `BASELINE.md` is updated with this result and the methodology.

```mermaid
flowchart LR
    subgraph before["Before — 8 per-lane buffers"]
        A["synapse from_index"] --> B0["act0[from]"] & B1["act1[from]"] & B7["… act7[from]"]
        B0 & B1 & B7 --> C["8 scattered cache-line reads"]
    end
    subgraph after["After — record-interleaved"]
        D["synapse from_index"] --> E["inter[from*8 .. from*8+8]"]
        E --> F["1 contiguous cache-line read"]
    end
```

## Test Plan

- **New** `neat-core/tests/interleaved_scoring_parity.rs` — "what" tests
  exercising both dispatch branches across the 8-record boundary (counts
  1,7,8,9,16,17):
  - `interleaved_fast_path_matches_reference_across_boundaries` — all-Tanh net
    (fast path) matches the scalar `activate` reference within SIMD tolerance.
  - `interleaved_single_record_is_bit_identical_to_activate` — single record is
    bit-for-bit identical (exact tail path).
  - `aggregate_fallback_path_matches_reference_across_boundaries` — Maximum net
    (per-lane fallback) is exact.
- Existing scoring parity/allocation suites pass unchanged:
  `score_squash_simd_parity`, `mse_squash_simd_parity`, `parallel_scoring`
  (incl. `single_record_matches_direct_activate`,
  `sequential_and_parallel_are_bit_identical`), `scoring_allocations`
  (no per-record allocation — `BatchScratch` allocates once).
- `./quality.sh` passes: fmt, clippy (`-D warnings`, native + `wasm32`),
  `cargo deny`, full `cargo test`, doc build, release build.



## Milestone
This PR is part of the **#285 Suggest neat-core performance improvements for production learn/sampler runs** milestone and targets the `milestone/285-suggest-neat-core-performance-improvements-for` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrq7mm68-6cf000`<!-- vibe-worker-issue-287 -->