### PR TITLE
Milestone: #285 Suggest neat-core performance improvements for production learn/sampler runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ across the lanes. On the gather-bound production topology this cut single-core
 scoring time by **~39%** (see `docs/archive/pr-summaries/pr-summary-230.md`).
 With the `parallel` feature the throughput additionally scales with core count.
 
+On the exact committed production topology the native lane beats the wasm32 lane
+**1.78×** per core (NEON + FMA vs `simd128` + relaxed-madd) and **4.75×** at 12
+cores versus a single-threaded wasm32 creature — so where the native `rust_scorer`
+is built, production per-creature scoring should use `score_records_parallel`.
+See the native-vs-wasm32 decision, numbers, and the generation-end idle-core
+"win zone" in [`neat-core/benches/BASELINE.md`](neat-core/benches/BASELINE.md)
+(Issue #288).
+
 Standard-[squash](#glossary-squash) neurons now sum **across records** rather than across synapses,
 so their `f32` results match the per-record `activate` reference within a small
 tolerance (SIMD re-association), while the sequential and parallel paths agree

--- a/docs/archive/pr-summaries/pr-summary-286.md
+++ b/docs/archive/pr-summaries/pr-summary-286.md
@@ -1,0 +1,99 @@
+# Criterion baseline on the production topology (Issue #286)
+
+## Summary
+
+Established a reproducible **Criterion baseline on the exact production
+topology** — the committed `GRQ-cluster/network.json` shape of **1,666 non-input
+neurons, 21,513 synapses, 2,461 inputs** — so every later perf change in this
+crate has a dated before/after anchor. Measurement only, no optimisation
+(optimisation lands in the lane sub-issues that gate on these numbers).
+**Closes #286.**
+
+What changed:
+
+- **New `production_exact` fixture** in `neat-core/benches/common/mod.rs`. Unlike
+  the existing `production` shape (a ~13-average `FanIn::VariedAround`
+  approximation, ~21.7k synapses), the new shape uses a new
+  **`FanIn::ExactTotal(21_513)`** variant that distributes the synapses across
+  the 1,666 neurons as evenly as possible (12 or 13 each, Bresenham-interleaved),
+  so the fixture reproduces the real model **to the synapse**. Seeded and
+  deterministic.
+- The new variant is threaded through **both** deterministic builders —
+  `build_network` (forward/scoring) and `build_backprop_data` (backprop) — via a
+  pre-computed `exact_schedule`. The RNG-drawn shapes stay on their existing
+  `draw` path, so every committed `production`/`production_2x` baseline is
+  byte-for-byte unchanged.
+- `production_exact` is wired into the `hot_paths` groups (its label starts with
+  `production`, so the `scoring` group and the `production` regex filter pick it
+  up) and added to the `parallel_scoring` label list, covering **both lanes**:
+  the default single-thread path and the native `--features parallel` path.
+- **`BASELINE.md`** gains a dated (2026-07-18, rustc 1.97.0) production-exact
+  section with single-thread and parallel numbers, plus a per-creature scoring
+  latency mapped back to the project metric (**score improvement per wall-clock
+  hour**).
+
+### Fixture → baseline flow
+
+```mermaid
+flowchart LR
+    A["NetSpec production_exact<br/>1666 neurons / 21,513 synapses / 2461 inputs"] --> B["FanIn::ExactTotal(21_513)"]
+    B --> C["exact_schedule()<br/>Bresenham-even 12/13 fan-in"]
+    C --> D["build_network()"]
+    C --> E["build_backprop_data()"]
+    D --> F["hot_paths: forward / scoring<br/>parallel_scoring: 1 vs 12 cores"]
+    E --> G["hot_paths: backprop"]
+    F --> H["BASELINE.md — dated numbers"]
+    G --> H
+```
+
+## Evidence
+
+Backend/bench-only change — no web UI to screenshot. Evidence is the dated
+benchmark numbers recorded in `neat-core/benches/BASELINE.md` and the fixture
+tests that assert the exact topology.
+
+**Single-thread lane** (`cargo bench -p neat-core --bench hot_paths -- production_exact`):
+
+| Group | production_exact |
+| --- | --- |
+| `forward_pass` | 30.76 µs `[30.19, 31.35]` (~134 Melem/s) |
+| `batched_scoring/trace_batch_4way` | 122.65 µs `[120.98, 124.33]` |
+| `batched_scoring/mse_sum_8records` | 242.08 µs `[239.09, 244.99]` |
+| `backprop` | 214.14 µs `[210.46, 218.05]` (~19.3 Melem/s) |
+| `scoring` (4096 records) | 91.50 ms `[90.05, 92.96]` (44.8 Krecords/s) |
+
+**Parallel lane** (`cargo bench -p neat-core --features parallel --bench parallel_scoring -- production_exact`):
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production_exact` | 61.84 ms `[60.36, 63.38]` | 24.62 ms `[22.35, 26.98]` | 66.2 K → 166.4 K | 2.51× |
+
+Per-creature corpus pass (~2.24 M records/generation): ≈ **33.9 s** single-core,
+≈ **13.5 s** on 12 cores — the denominator of the project metric. The
+scoring-lane run-to-run variance (~62–92 ms single-core across invocations, a
+thermal artefact of the laptop-class M4 Pro) is documented honestly in
+`BASELINE.md`; the internally-consistent 2.51× parallel ratio is the
+authoritative anchor.
+
+## Test Plan
+
+New/updated tests in `neat-core/tests/bench_fixtures.rs` (run green via
+`cargo test -p neat-core --test bench_fixtures`, and compiled in PR CI by
+`cargo check/clippy --all-targets --all-features`):
+
+- `production_exact_matches_committed_grq_topology` — asserts exactly 2,461
+  inputs, 1,666 non-input neurons, 4,127 total, and **21,513** built synapses.
+- `production_exact_fan_in_is_evenly_spread_and_varies` — fan-in takes at most
+  two values (12/13) with a mean near the production ~13.
+- `production_exact_build_is_deterministic` — same seed reproduces identical
+  synapses and neurons (reproducibility guard).
+- `production_exact_backprop_data_has_exact_synapse_count` — regression test for
+  the backprop builder honouring the exact schedule (caught a real bug where
+  `build_backprop_data` fell through to `draw`, building a synapse-free network).
+- `production_exact_network_activates_to_finite_outputs` — forward pass produces
+  finite outputs.
+- `production_fixture_squash_is_homogeneous_tanh` — extended to cover the new
+  shape, keeping the documented squash-homogeneity caveat honest.
+
+No existing tests removed or modified in behaviour; existing
+`production`/`production_2x` fixtures and baselines are untouched.

--- a/docs/archive/pr-summaries/pr-summary-287.md
+++ b/docs/archive/pr-summaries/pr-summary-287.md
@@ -1,0 +1,111 @@
+# Optimise the wasm32 single-thread per-creature scoring hot path (Issue #287)
+
+## Summary
+
+Speeds up the single-thread record-scoring hot path (`score_records` →
+`score_batch_into`) — the lane NEAT-AI's per-creature `wasm32` workers drive —
+by switching the batched forward pass to a **record-interleaved activation
+layout**. Instead of eight separate per-lane activation buffers, one group of
+eight records is transposed into a single buffer where lane `l` of source
+neuron `n` lives at `inter[n * 8 + l]`, so all eight records for a synapse's
+source are **contiguous**. Each gather in the new `weighted_sum_interleaved_8`
+kernel is then one cache-line read (two adjacent 4-wide loads on NEON, one
+`_mm256_loadu_ps` on AVX2, one contiguous `f32x4` pair on wasm `simd128`)
+instead of eight scattered loads across eight buffers, and each neuron's eight
+outputs are a single contiguous store. This extends the #230 batched-SIMD
+approach to the gather/scatter itself; because the win is **layout-driven**, it
+applies identically to the native and `wasm32` builds.
+
+Networks that contain aggregate squashes (Minimum/Maximum/If/Hypotenuse/
+HypotenuseV2/Mean) keep the original per-lane path via an automatic dispatch;
+the all-standard-squash production topology takes the interleaved fast path.
+
+Closes #287.
+
+### What changed
+
+- `neat-core/src/simd_native.rs` — `weighted_sum_interleaved_8` (AVX2 / NEON /
+  scalar), mirroring the existing 8-record kernels and their `get_unchecked`
+  load-time-validation soundness contract (`from_index < num_neurons` ⇒
+  `from_index * 8 + 8 ≤ inter.len()`).
+- `neat-core/src/simd.rs` — the `wasm32` `simd128`/`relaxed-simd`
+  `weighted_sum_interleaved_8`, plus the native re-export.
+- `neat-core/src/batch_scoring.rs` — `BatchScratch` gains the interleaved
+  buffer; `score_batch_into` dispatches to `score_batch_interleaved` (fast path)
+  or the retained `score_batch_per_lane` (aggregate fallback). Full 8-record
+  groups run the interleaved kernel; the `records.len() % 8` tail runs the exact
+  single-record kernel so single-record scoring stays bit-for-bit identical to
+  `activate`.
+
+### Scope note — wasm32 target, native evidence gate
+
+The issue targets the `wasm32` scoring lane, but the repo's evidence gate
+(`neat-core/benches/hot_paths.rs`, `BASELINE.md`) is a native Criterion harness
+— the `wasm32` SIMD path is `cfg`'d out of the host build and cannot be A/B'd
+here. The optimisation therefore lives in the **shared, architecture-neutral**
+scoring structure so the identical layout change benefits both builds, and is
+measured on the native `production_exact` fixture the baseline anchors to. The
+`wasm32` and native builds and clippy both pass.
+
+## Evidence — before/after benchmark (Performance Task Workflow)
+
+Backend/CLI change with no web interface, so evidence is Criterion, not a
+screenshot. Fixture: `production_exact` (1,666 non-input neurons / 21,513
+synapses / 2,461 inputs), the exact committed GRQ-cluster topology.
+
+Separate `cargo bench` invocations drift on the laptop-class M4 Pro (the
+`BASELINE.md` thermal caveat), so the A/B was run as **alternating** old/new
+rounds of the *same* prebuilt bench binaries, capturing the **unchanged**
+`forward_pass` benchmark as a drift control. The control stayed flat, proving
+the `scoring` delta is the code change and not thermal drift.
+
+4 alternating rounds, rustc 1.97.0, `--release`, Criterion `--sample-size 60`
+(median ms):
+
+| Round | `scoring` OLD | `scoring` NEW | `forward_pass` OLD (control) | `forward_pass` NEW (control) |
+| --- | --- | --- | --- | --- |
+| 1 | 82.98 ms | 48.98 ms | 31.77 µs | 36.11 µs |
+| 2 | 104.35 ms | 49.73 ms | 35.74 µs | 35.03 µs |
+| 3 | 109.33 ms | 53.29 ms | 35.17 µs | 36.96 µs |
+| 4 | 108.85 ms | 40.30 ms | 35.92 µs | 30.74 µs |
+| **mean** | **101.4 ms** | **48.1 ms** | **34.65 µs** | **34.71 µs** |
+
+- `scoring/production_exact`: **101.4 ms → 48.1 ms, −52% (≈2.1× faster)**; every
+  round is far faster on the new path.
+- `forward_pass` control (the single-record `activate` path, untouched): flat
+  (34.65 vs 34.71 µs mean) → drift cancelled.
+
+At ~48 ms the per-creature ~2.24 M-record corpus pass drops from ≈33.9 s toward
+the low 20s of seconds on a single core — a direct gain on the score-per-hour
+metric. `BASELINE.md` is updated with this result and the methodology.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — 8 per-lane buffers"]
+        A["synapse from_index"] --> B0["act0[from]"] & B1["act1[from]"] & B7["… act7[from]"]
+        B0 & B1 & B7 --> C["8 scattered cache-line reads"]
+    end
+    subgraph after["After — record-interleaved"]
+        D["synapse from_index"] --> E["inter[from*8 .. from*8+8]"]
+        E --> F["1 contiguous cache-line read"]
+    end
+```
+
+## Test Plan
+
+- **New** `neat-core/tests/interleaved_scoring_parity.rs` — "what" tests
+  exercising both dispatch branches across the 8-record boundary (counts
+  1,7,8,9,16,17):
+  - `interleaved_fast_path_matches_reference_across_boundaries` — all-Tanh net
+    (fast path) matches the scalar `activate` reference within SIMD tolerance.
+  - `interleaved_single_record_is_bit_identical_to_activate` — single record is
+    bit-for-bit identical (exact tail path).
+  - `aggregate_fallback_path_matches_reference_across_boundaries` — Maximum net
+    (per-lane fallback) is exact.
+- Existing scoring parity/allocation suites pass unchanged:
+  `score_squash_simd_parity`, `mse_squash_simd_parity`, `parallel_scoring`
+  (incl. `single_record_matches_direct_activate`,
+  `sequential_and_parallel_are_bit_identical`), `scoring_allocations`
+  (no per-record allocation — `BatchScratch` allocates once).
+- `./quality.sh` passes: fmt, clippy (`-D warnings`, native + `wasm32`),
+  `cargo deny`, full `cargo test`, doc build, release build.

--- a/docs/archive/pr-summaries/pr-summary-288.md
+++ b/docs/archive/pr-summaries/pr-summary-288.md
@@ -1,0 +1,83 @@
+## Summary
+
+Benchmarked the native `--features parallel` (rayon, #179) scoring lane against
+the wasm32 single-thread lane on the production topology, and recorded the
+native-vs-wasm32 decision in `neat-core/benches/BASELINE.md`. **The native lane
+wins decisively**, so this is a **positive result**: production per-creature
+scoring should route to `CompiledNetwork::score_records_parallel` wherever the
+native `rust_scorer` is built. Closes #288.
+
+The core-side deliverable the issue owns — a clean native scoring entry point
+with a wasm32 fallback (`score_records_parallel`, sequential/wasm32 fallback via
+`cfg`) — already exists from #179 and is guarded by the parity suite; this issue
+proves it pays off at production scale and records the numbers. Cross-repo
+production wiring is out of scope here and tracked in NEAT-AI #3399 (WorkerPool
+idle-tail) and GRQ #3400 (flags), per the issue's one-root-cause-one-repo rule.
+
+This is a benchmark + decision change (no Rust behaviour changed), so it follows
+the Performance Task Workflow: before (wasm32) / after (native) numbers are
+included and show a measurable win.
+
+## Evidence
+
+Measured 2026-07-18, Apple M4 Pro (8P + 4E, 12 logical cores), rustc 1.97.0,
+`--release`, 4096 records (one production shard) through one creature.
+
+- **Native**: `cargo bench -p neat-core --features parallel --bench parallel_scoring`
+  (Criterion, `--sample-size 30`), median estimate.
+- **wasm32**: `wasm-pack build --target nodejs --release` of a throwaway harness
+  reusing the committed `benches/common` fixtures and calling the identical
+  `score_records` (simd128 + relaxed-simd, `wasm-opt`), timed under Node (median
+  of 20). Harness source + commands are committed in BASELINE.md → Reproducing.
+
+| Shape | wasm32 1-thread | native 1 core | native 12 cores |
+| --- | --- | --- | --- |
+| `production` | 125.4 ms · 32.7 K rec/s | 45.96 ms · 89.1 K rec/s | 15.47 ms · 264.8 K rec/s |
+| `production_2x` | 207.8 ms · 19.7 K rec/s | 102.7 ms · 39.9 K rec/s | 32.52 ms · 126.0 K rec/s |
+| `production_exact` | 83.40 ms · 49.1 K rec/s | 46.77 ms · 87.6 K rec/s | 17.56 ms · 233.3 K rec/s |
+
+On the exact committed topology (`production_exact`, 1,666 neurons / 21,513
+synapses / 2,461 inputs):
+
+- native **1.78×** wasm32 per core (NEON + FMA vs simd128 + relaxed-madd — pure codegen)
+- native **4.75×** wasm32 at 12 cores (the production reality: one native creature
+  uses idle cores a single-threaded wasm32 creature cannot)
+
+Per-creature ~2.24 M-record corpus pass (the score-per-hour metric's
+denominator): wasm32 ≈ 45.6 s → native single core ≈ 25.6 s → native 12 cores
+≈ 9.6 s.
+
+```mermaid
+flowchart TB
+    R[records for one creature] --> Q{native rust_scorer built<br/>and parallel feature on?}
+    Q -- no: wasm32 / off --> W[score_records<br/>sequential, simd128]
+    Q -- yes --> P[score_records_parallel<br/>rayon across idle cores]
+    subgraph WZ[generation-end tail = win zone]
+        direction TB
+        I[fewer creatures than cores<br/>cores go idle]
+        I --> P
+    end
+    W --> O[outputs, input order]
+    P --> O
+```
+
+Native wins on two stacked axes: a per-core codegen advantage that applies to
+every creature, and an idle-core advantage that pays off in the generation-end
+tail (the **per-creature parallelism win zone**), where a single remaining
+creature spreads its record batch across cores the wasm32 lane leaves idle. Full
+numbers, win-zone characterisation, and honesty caveats (12-core variance,
+squash-homogeneous fixture, wasm32 codegen ceiling) are in
+`neat-core/benches/BASELINE.md`.
+
+## Test Plan
+
+No Rust behaviour changed; the native path and its wasm32 fallback are already
+guarded by the existing parity suite, re-run green with `--features parallel`:
+
+- `neat-core/tests/parallel_scoring.rs` — all 9 tests pass, including
+  `parallel_scoring_matches_sequential_on_production_fixture` and
+  `sequential_and_parallel_are_bit_identical` (the issue's correctness gate).
+- `cargo bench -p neat-core --features parallel --bench parallel_scoring --no-run`
+  — bench compile smoke test (the only automated bench gate).
+- Docs validated with `markdownlint-cli2` (0 errors) and `codespell` (clean).
+- `./quality.sh` run clean (fmt/clippy/deny/tests/doc/release).

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -13,8 +13,8 @@ affected group against this file, with matching host/toolchain metadata.
 
 ## Fixture caveat — squash homogeneity (Issue #261)
 
-Every neuron in the `production` / `production_2x` fixtures is uniformly
-`SquashType::Tanh` (`benches/common/mod.rs:168`), asserted by
+Every neuron in the `production` / `production_2x` / `production_exact` fixtures
+is uniformly `SquashType::Tanh` (`benches/common/mod.rs`), asserted by
 `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`. Real
 GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so read every
 `scoring`/`production` A/B below with two corrections in mind:
@@ -104,6 +104,74 @@ Throughput highlights: `forward_pass` ≈ 126 Melem/s (production) / 123 Melem/s
 The single-core `parallel_scoring` figure (16.86 Krecords/s for `production`)
 matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both drive the same
 sequential `score_records` path, an internal consistency check on the fixture.
+
+## Production-exact topology baseline (Issue #286)
+
+Dated anchor for the **exact** committed `GRQ-cluster/network.json` topology —
+**1,666 non-input neurons, 21,513 synapses, 2,461 inputs** (4,127 total neurons,
+one output). Unlike the `production` shape's ~13-average `VariedAround` fan-in,
+the `production_exact` shape uses `FanIn::ExactTotal(21_513)`, which spreads the
+synapses across the 1,666 neurons as evenly as possible (12 or 13 each,
+Bresenham-interleaved) so the synapse count reproduces the real model to the
+synapse. Seeded synthesis is deterministic and asserted exact by
+`tests/bench_fixtures.rs::production_exact_matches_committed_grq_topology`.
+
+**Measured 2026-07-18** on the same GRQ host class, toolchain **rustc 1.97.0**
+(the earlier `production`/`production_2x` rows above were taken on rustc 1.96.0,
+so compare across sections only within a lane, not across toolchains).
+
+| Field | Value |
+| --- | --- |
+| Host | Apple M4 Pro — 12 cores (8P + 4E), 24 GB, macOS (arm64) |
+| Logical cores (`available_parallelism`) | 12 |
+| Toolchain | rustc 1.97.0 |
+| Criterion | 0.8.2 |
+| Build | `--release` (bench profile) |
+
+### Single-thread lane (`cargo bench -p neat-core --bench hot_paths -- production_exact`)
+
+| Group / benchmark | production_exact | Throughput |
+| --- | --- | --- |
+| `forward_pass` | 30.76 µs `[30.19, 31.35]` | ~134 Melem/s |
+| `batched_scoring/trace_batch_4way` | 122.65 µs `[120.98, 124.33]` | — |
+| `batched_scoring/mse_sum_8records` | 242.08 µs `[239.09, 244.99]` | — |
+| `backprop` | 214.14 µs `[210.46, 218.05]` | ~19.3 Melem/s |
+| `scoring` (4096 records) | 91.50 ms `[90.05, 92.96]` | 44.77 Krecords/s |
+
+### Parallel lane (`cargo bench -p neat-core --features parallel --bench parallel_scoring -- production_exact`)
+
+4096 records scored through one creature inside a fixed-size rayon pool.
+
+| Shape | 1 core | 12 cores | records/s (1 → 12) | Speed-up |
+| --- | --- | --- | --- | --- |
+| `production_exact` | 61.84 ms `[60.36, 63.38]` | 24.62 ms `[22.35, 26.98]` | 66.23 K → 166.4 K | 2.51× |
+
+### Per-creature scoring latency → the project metric
+
+The project metric is **score improvement per wall-clock hour**, and per
+generation a single creature forward-passes the whole ~2.24 M-record corpus to
+compute its fitness (see the record-count calibration above). At the measured
+`production_exact` throughput that per-creature scoring pass costs:
+
+| Lane | records/s | Per-creature corpus pass (~2.24 M records) |
+| --- | --- | --- |
+| Single core | 66.2 K | ≈ **33.9 s** |
+| 12 cores | 166.4 K | ≈ **13.5 s** |
+
+That per-creature latency is the denominator of the metric: halving it doubles
+the creatures a fixed wall-clock budget can score, so it is the figure every
+lane sub-issue's optimisation is measured against.
+
+> **Scoring-lane variance (be honest about it).** The ~90 ms `hot_paths`
+> `scoring` figure and the ~62 ms `parallel_scoring` `1_core` figure exercise the
+> *same* sequential `score_records` path, so in principle they match — but they
+> were taken in separate `cargo bench` invocations and the ~90 ms → ~62 ms spread
+> is real run-to-run variance (thermal state on the laptop-class M4 Pro under a
+> ~90 ms single-shot benchmark with 100 iterations). Treat the **`parallel_scoring`
+> 1-core/12-core pair as the authoritative scoring anchor** — both were measured
+> in one invocation, so their 2.51× ratio is internally consistent — and read the
+> single-core scoring latency as ~62–92 ms (±~20%). A lane sub-issue must A/B
+> with `--save-baseline` inside a single invocation to stay inside this band.
 
 ## Reproducing
 

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -173,6 +173,48 @@ lane sub-issue's optimisation is measured against.
 > single-core scoring latency as ~62–92 ms (±~20%). A lane sub-issue must A/B
 > with `--save-baseline` inside a single invocation to stay inside this band.
 
+## Record-interleaved scoring optimisation (Issue #287)
+
+The single-thread scoring hot path (`score_records` → `score_batch_into`, the
+same lane NEAT-AI's per-creature wasm32 workers drive) now transposes each
+group of eight records into a **record-interleaved** activation buffer:
+lane `l` of source neuron `n` lives at `inter[n * 8 + l]`, so all eight records
+for a synapse's source are contiguous. Each gather in
+`weighted_sum_interleaved_8` is then one cache-line read (two adjacent 4-wide
+loads on NEON / one `_mm256_loadu_ps` on AVX2 / one contiguous `f32x4` pair on
+wasm `simd128`) instead of eight scattered per-lane loads, and each neuron's
+eight outputs are a single contiguous store. This extends the #230 batched-SIMD
+approach to the gather itself; it is layout-driven, so the win is portable
+across the native and `wasm32` builds. Networks containing aggregate squashes
+(Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean) keep the original per-lane
+path; the all-standard-squash production topology takes the fast path.
+
+**Methodology (controls for the laptop thermal band above).** Because separate
+`cargo bench` invocations drift, the A/B was run as **alternating** old/new
+rounds of the *same* prebuilt bench binaries, capturing the unchanged
+`forward_pass` benchmark alongside `scoring` as a drift control. `forward_pass`
+stayed flat across old/new (34.65 µs vs 34.71 µs mean), confirming the `scoring`
+delta is the code change, not thermal drift.
+
+**Measured 2026-07-18**, GRQ host class (Apple M4 Pro), rustc 1.97.0,
+`--release`, 4 alternating rounds (Criterion `--sample-size 60`):
+
+| `production_exact` (median) | old | new | change |
+| --- | --- | --- | --- |
+| `scoring` (4096 records) mean of 4 rounds | 101.4 ms | 48.1 ms | **−52% (≈2.1×)** |
+| `forward_pass` control (unchanged) mean | 34.65 µs | 34.71 µs | flat |
+
+Every round showed the interleaved path far faster on `scoring` (old
+83/104/109/109 ms → new 49/50/53/40 ms). At the ~48 ms new scoring figure the
+per-creature ~2.24 M-record corpus pass (see the latency table above) drops from
+≈33.9 s toward the low-20s-of-seconds on a single core — a direct win on the
+score-per-hour metric. `forward_pass` (the single-record `activate` path) is
+untouched and unaffected. Numerics: full 8-record groups are bit-identical to
+the prior per-lane 8-record path (same FMA order); the `records.len() % 8` tail
+runs the exact single-record kernel, so single-record scoring stays
+bit-for-bit identical to `activate` (asserted by
+`tests/interleaved_scoring_parity.rs` and the existing scoring parity suite).
+
 ## Reproducing
 
 ```bash

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -215,6 +215,114 @@ runs the exact single-record kernel, so single-record scoring stays
 bit-for-bit identical to `activate` (asserted by
 `tests/interleaved_scoring_parity.rs` and the existing scoring parity suite).
 
+## Native (`--features parallel`) vs wasm32 scoring lane — decision (Issue #288)
+
+The `parallel` feature (rayon, #179) has always compiled the native
+`CompiledNetwork::score_records_parallel` entry point but was never A/B'd
+against the wasm32 lane at production scale, so production never routed
+per-creature scoring to it. This section quantifies the trade-off and records
+the decision.
+
+**Verdict: route production per-creature scoring to the native rayon lane where
+the native `rust_scorer` is built.** Native beats wasm32 on the production
+fixture on both axes — per-core codegen (NEON + FMA vs simd128 + relaxed-madd)
+and, decisively, by using idle cores the single-threaded wasm32 lane cannot.
+This is a **positive result**; the core-side native path
+(`score_records_parallel` with its sequential/wasm32 fallback) is ready, and the
+production wiring is raised
+cross-repo (NEAT-AI #3399 WorkerPool idle-tail, GRQ #3400 flags) per the issue's
+one-root-cause-one-repo rule — this issue owns only the neat-core native path,
+benchmark, and this decision.
+
+### The two lanes being compared
+
+Both lanes drive the **same** `score_records` forward pass (the #287
+record-interleaved batched-SIMD gather); they differ only in codegen and thread
+count:
+
+- **wasm32 single-thread** — the algorithm as compiled to `wasm32-unknown-unknown`
+  with `simd128` + `relaxed-simd` (`f32x4_relaxed_madd`), `wasm-opt`-optimised,
+  run in Node. This is the production wasm codegen the `wasm_activation` bundle
+  ships. In NEAT-AI the WorkerPool runs one creature per worker with no wasm
+  threads, so a single creature's scoring is single-threaded — this row is its
+  ceiling.
+- **native** — the same source compiled for `aarch64-apple-darwin` (AVX2/FMA on
+  x86, NEON on ARM), scored through a fixed-size rayon pool of 1 or 12 workers
+  via `score_records_parallel`.
+
+### Measured 2026-07-18 — GRQ host class
+
+Apple M4 Pro (8P + 4E, 12 logical cores), 24 GB, macOS (arm64), rustc 1.97.0,
+`--release`. 4096 records (one production shard; see the record-count
+calibration above) scored through one creature.
+
+- **Native**: `cargo bench -p neat-core --features parallel --bench parallel_scoring`
+  (Criterion, `--sample-size 30`), median estimate.
+- **wasm32**: `wasm-pack build --target nodejs --release` of a throwaway harness
+  that reuses the committed `benches/common` fixtures and calls the identical
+  `score_records`, driven by `node` timing `score_once()` (median of 20, after a
+  5-iteration warm-up). Harness source and commands under **Reproducing** below.
+
+| Shape | wasm32 1-thread | native 1 core | native 12 cores |
+| --- | --- | --- | --- |
+| `production` | 125.4 ms · 32.7 K rec/s | 45.96 ms · 89.1 K rec/s | 15.47 ms · 264.8 K rec/s |
+| `production_2x` | 207.8 ms · 19.7 K rec/s | 102.7 ms · 39.9 K rec/s | 32.52 ms · 126.0 K rec/s |
+| `production_exact` | 83.40 ms · 49.1 K rec/s | 46.77 ms · 87.6 K rec/s | 17.56 ms · 233.3 K rec/s |
+
+Native-over-wasm32 speed-ups on the exact committed topology
+(`production_exact`, 1,666 neurons / 21,513 synapses / 2,461 inputs):
+
+| Comparison | production_exact | Interpretation |
+| --- | --- | --- |
+| native 1 core ÷ wasm32 1-thread | **1.78×** | pure codegen: NEON + FMA vs simd128 + relaxed-madd |
+| native 12 cores ÷ wasm32 1-thread | **4.75×** | the production reality — one creature on native uses cores wasm32 cannot |
+| native 12 cores ÷ native 1 core | 2.66× | rayon per-creature scaling across 8P + 4E |
+
+The codegen delta ranges 1.78–2.73× across the three shapes; the full native
+12-core-vs-wasm32 delta ranges 4.75–8.10×.
+
+### The per-creature parallelism win zone
+
+The project metric is **score improvement per wall-clock hour**, whose
+denominator is the per-creature ~2.24 M-record corpus pass. At the
+`production_exact` throughputs above that pass costs:
+
+| Lane | records/s | Per-creature corpus pass (~2.24 M records) |
+| --- | --- | --- |
+| wasm32 single-thread | 49.1 K | ≈ **45.6 s** |
+| native single core | 87.6 K | ≈ **25.6 s** |
+| native 12 cores | 233.3 K | ≈ **9.6 s** |
+
+Two distinct wins stack:
+
+1. **Codegen win (whole generation).** Native's ~1.8× per-core advantage applies
+   to *every* creature regardless of core occupancy — it is not tail-specific.
+2. **Idle-core win (the tail).** NEAT-AI's WorkerPool saturates cores while
+   un-scored creatures outnumber cores, but at the **generation-end tail** fewer
+   creatures than cores remain and cores go idle. wasm32 workers are
+   single-threaded per creature, so that idle time is wasted; native
+   `score_records_parallel` lets each remaining creature spread its record batch
+   across the idle cores. This tail is the **per-creature parallelism win zone**
+   — where native rayon converts otherwise-idle cores into throughput.
+
+### Honesty caveats
+
+- **12-core variance.** The all-core medians were taken at `--sample-size 30` on
+  a laptop-class 8P + 4E part; run-to-run spread is wide (Criterion flagged the
+  all-core groups as noisy). The parallel scaling is sub-linear (2.66–3.16×, not
+  12×) because the ~40 MiB batch is memory-bandwidth-bound and the 4 efficiency
+  cores are slower than the 8 performance cores. The **single-thread codegen
+  delta is stable and by itself justifies native**; the parallel scaling is the
+  bonus that pays off most in the idle-tail.
+- **Fixture squash homogeneity.** As above (Issue #261) the fixtures are
+  all-`Tanh`; real `Gelu`/`Mish` creatures run scalar `libm` on wasm32, which
+  the native SIMD/`libm` split widens further — so the native advantage here is
+  a lower bound, not an upper one.
+- **wasm32 lane is a codegen ceiling, not the production wasm scorer.** This
+  measures the shared `score_records` compiled to wasm32. NEAT-AI's production
+  wasm path additionally pays JS↔wasm orchestration per record, so the real
+  wasm32 scoring lane is no faster than this row — reinforcing the verdict.
+
 ## Reproducing
 
 ```bash
@@ -237,4 +345,72 @@ first, then re-run after the change:
 cargo bench -p neat-core --bench hot_paths -- --save-baseline before
 # … apply change …
 cargo bench -p neat-core --bench hot_paths -- --baseline before
+```
+
+### wasm32 scoring anchor (Issue #288)
+
+Criterion is native-only, so the wasm32 row in the native-vs-wasm32 decision is
+measured with a throwaway `wasm-pack` harness that reuses the committed
+`benches/common` fixtures and calls the identical `CompiledNetwork::score_records`.
+`score_records` is a plain `pub` method (not feature- or target-gated), so the
+wasm32 build scores the same production topology through the same code path,
+compiled with `simd128` + `relaxed-simd` and `wasm-opt`-optimised — the
+production `wasm_activation` bundle's codegen. Create a scratch crate outside the
+workspace:
+
+```toml
+# Cargo.toml
+[package]
+name = "wasmbench288"
+version = "0.0.0"
+edition = "2024"
+[lib]
+crate-type = ["cdylib"]
+[dependencies]
+neat-core = { path = "/abs/path/to/NEAT-AI-core/neat-core" }
+wasm-bindgen = "0.2.126"
+[profile.release]
+opt-level = 3
+lto = true
+```
+
+```rust
+// src/lib.rs
+use std::cell::RefCell;
+use wasm_bindgen::prelude::*;
+#[path = "/abs/path/to/NEAT-AI-core/neat-core/benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+use common::{NETWORKS, PRODUCTION_SCORING_RECORDS, build_network, build_records};
+use neat_core::network::CompiledNetwork;
+thread_local! {
+    static ST: RefCell<Option<(CompiledNetwork, Vec<Vec<f32>>, usize)>> =
+        const { RefCell::new(None) };
+}
+#[wasm_bindgen]
+pub fn setup(code: u32) {
+    let label = ["production", "production_2x", "production_exact"][code as usize];
+    let s = NETWORKS.iter().find(|s| s.label == label).unwrap();
+    let net = build_network(s, 0x5EED);
+    let recs = build_records(net.num_inputs(), PRODUCTION_SCORING_RECORDS);
+    ST.with(|c| *c.borrow_mut() = Some((net, recs, s.num_outputs)));
+}
+#[wasm_bindgen]
+pub fn score_once() -> f32 {
+    ST.with(|c| {
+        let b = c.borrow();
+        let (net, recs, no) = b.as_ref().unwrap();
+        net.score_records(recs, *no).iter().sum()
+    })
+}
+```
+
+```bash
+wasm-pack build --target nodejs --release --out-dir pkg
+# Node: setup(code) once, then time score_once() (median of ~20, warm up first),
+# records/sec = PRODUCTION_SCORING_RECORDS / median_seconds.
+node -e 'import("./pkg/wasmbench288.js").then(m=>{m.setup(2);
+  for(let i=0;i<5;i++)m.score_once();
+  const t=[];for(let i=0;i<20;i++){const a=performance.now();m.score_once();t.push(performance.now()-a);}
+  t.sort((x,y)=>x-y);console.log("median ms",t[10].toFixed(2));})'
 ```

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -21,7 +21,7 @@ There are two bench targets:
 | `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
-| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x` |
+| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -52,6 +52,17 @@ can be misleading.
 | `large_5000` | 32 | 4968 | 5000 | 16 | 24 (fixed) | ~119k |
 | `production` | 2461 | 1673 | 4134 | 1 | ~13 (varied) | ~21.7k |
 | `production_2x` | 4922 | 3346 | 8268 | 2 | ~13 (varied) | ~43.5k |
+| `production_exact` | 2461 | 1666 | 4127 | 1 | ~12.9 (exact) | **21,513** |
+
+`production_exact` (Issue #286) pins the fixture to the committed
+`GRQ-cluster/network.json` topology — 1,666 non-input neurons, **exactly**
+21,513 synapses, 2,461 inputs — so the Criterion baseline is anchored to the
+real production model rather than `production`'s ~13-average approximation.
+Unlike the `VariedAround` shapes it uses `FanIn::ExactTotal`, which distributes
+the 21,513 synapses across the 1,666 neurons as evenly as possible (a Bresenham
+stride, so the two fan-in values — 12 and 13 — are interleaved, not clustered).
+Its label starts with `production`, so the `production` regex filter and the
+`scoring` group pick it up automatically.
 
 The `production` shape is synthesised from the seeded PRNG to match the real
 creature's dimensions — the 3 MB `network.json` is **not** committed. Fan-in for
@@ -64,7 +75,8 @@ test.
 
 > **Fixture caveat — squash is uniformly `Tanh` (Issue #261).** The `squash`
 > column above is not varied: every neuron in the `production` / `production_2x`
-> shapes is built with `SquashType::Tanh` (`benches/common/mod.rs:168`), locked
+> / `production_exact` shapes is built with `SquashType::Tanh`
+> (`benches/common/mod.rs`), locked
 > by `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`.
 > Real GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
 > squash-vectorisation deltas are a **lower bound** and branch-prediction levers
@@ -114,7 +126,8 @@ cargo bench -p neat-core --bench hot_paths -- production
 
 `parallel_scoring.rs` reports records/sec for scoring a batch through one
 creature on **a single core versus all available cores**, using the
-`production`/`production_2x` shapes. It scores inside a rayon pool of a fixed
+`production`/`production_2x`/`production_exact` shapes. It scores inside a rayon
+pool of a fixed
 size, so the 1-core and all-core measurements share one code path and differ
 only in pool size.
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -55,12 +55,21 @@ pub enum FanIn {
     /// the production creature's sparse average (~13). Used by the wide/shallow
     /// `production` shapes, which are gather-bound rather than dense.
     VariedAround(usize),
+    /// Distribute *exactly* this many synapses across the non-input neurons, as
+    /// evenly as possible. Used by the `production_exact` shape (Issue #286) so
+    /// the fixture reproduces the committed `GRQ-cluster/network.json` synapse
+    /// count to the synapse, not just its ~13 average. See
+    /// [`FanIn::exact_schedule`].
+    ExactTotal(usize),
 }
 
 impl FanIn {
     /// Number of incoming connections for a neuron that has `max_fan` strictly
     /// earlier neurons to draw from. Only [`FanIn::VariedAround`] consumes an
     /// RNG draw, so [`FanIn::Fixed`] shapes keep their exact prior sequence.
+    /// [`FanIn::ExactTotal`] is not drawn per-neuron — its per-neuron counts come
+    /// from [`FanIn::exact_schedule`] — so `draw` treats it as a no-connection
+    /// fallback that is never reached on the exact path.
     pub fn draw(self, rng: &mut Lcg, max_fan: usize) -> usize {
         let target = match self {
             FanIn::Fixed(f) => f,
@@ -68,8 +77,44 @@ impl FanIn {
                 let span = (2 * avg).saturating_sub(1).max(1);
                 1 + rng.next_below(span)
             }
+            FanIn::ExactTotal(_) => 0,
         };
         target.min(max_fan)
+    }
+
+    /// Pre-computed per-neuron fan-in schedule for variants whose total synapse
+    /// count is fixed exactly. Returns `None` for the RNG-drawn variants
+    /// ([`FanIn::Fixed`] / [`FanIn::VariedAround`]) so their existing draw
+    /// sequence — and therefore every committed baseline — is left untouched.
+    ///
+    /// [`FanIn::ExactTotal`] spreads `total` synapses as evenly as possible
+    /// across `num_non_inputs` neurons: each neuron gets `total / num_non_inputs`
+    /// synapses, and the `total % num_non_inputs` remainder is handed out
+    /// one-per-neuron using a Bresenham stride so the extra-synapse neurons are
+    /// interleaved across the range rather than clustered at the front. The
+    /// schedule therefore sums to **exactly** `total` by construction, with at
+    /// most two distinct fan-in values (`base` and `base + 1`).
+    pub fn exact_schedule(self, num_non_inputs: usize) -> Option<Vec<usize>> {
+        match self {
+            FanIn::ExactTotal(total) => {
+                if num_non_inputs == 0 {
+                    return Some(Vec::new());
+                }
+                let base = total / num_non_inputs;
+                let remainder = total % num_non_inputs;
+                let schedule = (0..num_non_inputs)
+                    .map(|n| {
+                        // Bresenham even distribution: exactly `remainder` neurons
+                        // across the whole range receive one extra synapse.
+                        let extra =
+                            (n + 1) * remainder / num_non_inputs - n * remainder / num_non_inputs;
+                        base + extra
+                    })
+                    .collect();
+                Some(schedule)
+            }
+            FanIn::Fixed(_) | FanIn::VariedAround(_) => None,
+        }
     }
 }
 
@@ -96,7 +141,11 @@ impl NetSpec {
 /// a huge input layer, a modest neuron count and a sparse ~13 average fan-in,
 /// which is gather-bound in a way the dense shapes are not. `production_2x`
 /// doubles neurons and synapses to cover #175's "or larger creatures" clause.
-pub const NETWORKS: [NetSpec; 5] = [
+/// `production_exact` (Issue #286) pins the fixture to the committed
+/// `GRQ-cluster/network.json` topology — 1,666 non-input neurons, 21,513
+/// synapses, 2,461 inputs — to the synapse, giving the Criterion baseline a
+/// reproducible production-topology anchor.
+pub const NETWORKS: [NetSpec; 6] = [
     NetSpec {
         label: "small_50",
         num_neurons: 50,
@@ -134,6 +183,18 @@ pub const NETWORKS: [NetSpec; 5] = [
         num_outputs: 2,
         fan_in: FanIn::VariedAround(13),
     },
+    NetSpec {
+        label: "production_exact",
+        // Exact GRQ-cluster/network.json topology (Issue #286): 2461 inputs +
+        // 1666 non-input neurons = 4127 total, exactly 21,513 synapses. Unlike
+        // `production`'s ~13-average VariedAround, ExactTotal pins the synapse
+        // count to the committed production model so the baseline is anchored to
+        // the real topology rather than an approximation of it.
+        num_neurons: 4127,
+        num_inputs: 2461,
+        num_outputs: 1,
+        fan_in: FanIn::ExactTotal(21_513),
+    },
 ];
 
 /// Build a deterministic feedforward [`CompiledNetwork`] from a [`NetSpec`].
@@ -146,12 +207,21 @@ pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
     let num_inputs = spec.num_inputs;
     let mut rng = Lcg::new(seed);
     let num_non_inputs = spec.num_non_inputs();
+    // `Some` only for exact-count shapes; the RNG-drawn shapes stay `None` so
+    // their per-neuron `draw` sequence — and every committed baseline — is
+    // byte-for-byte unchanged.
+    let schedule = spec.fan_in.exact_schedule(num_non_inputs);
     let mut neurons = Vec::with_capacity(num_non_inputs);
     let mut synapses = Vec::new();
 
     for n in 0..num_non_inputs {
         let global_idx = num_inputs + n;
-        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        let this_fan = match &schedule {
+            // Cap by strictly-earlier neurons for soundness; never truncates on
+            // the production_exact shape (num_inputs ≫ per-neuron fan-in).
+            Some(sched) => sched[n].min(global_idx),
+            None => spec.fan_in.draw(&mut rng, global_idx),
+        };
         let start_synapse = synapses.len() as u32;
         for _ in 0..this_fan {
             let from = rng.next_below(global_idx);
@@ -261,6 +331,10 @@ pub fn build_backprop_data(spec: &NetSpec, seed: u64) -> BackpropData {
     let num_inputs = spec.num_inputs;
     let num_outputs = spec.num_outputs;
     let mut rng = Lcg::new(seed);
+    // Exact-count shapes use a pre-computed schedule; RNG-drawn shapes stay
+    // `None` so their existing draw sequence is untouched (mirrors
+    // `build_network`).
+    let schedule = spec.fan_in.exact_schedule(spec.num_non_inputs());
     let mut neurons = Vec::with_capacity(num_neurons);
 
     // Input neurons first.
@@ -291,7 +365,10 @@ pub fn build_backprop_data(spec: &NetSpec, seed: u64) -> BackpropData {
             rng.next_signed(),
         ));
 
-        let this_fan = spec.fan_in.draw(&mut rng, global_idx);
+        let this_fan = match &schedule {
+            Some(sched) => sched[global_idx - num_inputs].min(global_idx),
+            None => spec.fan_in.draw(&mut rng, global_idx),
+        };
         inward_starts[global_idx] = inward_indices.len() as u32;
         inward_counts[global_idx] = this_fan as u32;
         for _ in 0..this_fan {

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -58,7 +58,7 @@ mod bench {
         // Production-representative volume (Issue #228); see `PRODUCTION_SCORING_RECORDS`.
         const NUM_RECORDS: usize = PRODUCTION_SCORING_RECORDS;
 
-        for label in ["production", "production_2x"] {
+        for label in ["production", "production_2x", "production_exact"] {
             let s = spec(label);
             let net = build_network(s, 0x5EED);
             let records = build_records(net.num_inputs(), NUM_RECORDS);

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -43,27 +43,46 @@
 use crate::network::{CompiledNetwork, NeuronData, SynapseData};
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{
-    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
-    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
+    weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
+    weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
+    weighted_sum_simd_8records,
 };
 use crate::squash::{SquashType, apply_squash};
 use crate::squash_simd::{squash_x4, squash_x8};
 use crate::synapse_type::SynapseType;
 
-/// Reusable per-worker scratch: eight activation buffers, one per SIMD lane.
+/// Number of records processed per SIMD batch (one lane each).
+pub(crate) const SCORING_LANES: usize = 8;
+
+/// Reusable per-worker scratch for the batched scoring forward pass.
 ///
 /// Owning the buffers here lets the sequential path allocate once for a whole
 /// batch and the parallel path allocate once per rayon worker (via
 /// `for_each_init`), instead of once per chunk.
+///
+/// Two layouts are held so scoring can pick the cheaper gather per network
+/// (Issue #287):
+///
+/// - `inter` is the **record-interleaved** buffer used by the fast path when the
+///   network has no aggregate-squash neurons: lane `l` of neuron `n` lives at
+///   `inter[n * SCORING_LANES + l]`, so a synapse's eight records are contiguous
+///   and each gather reads one cache line instead of eight scattered buffers.
+/// - `acts` is the original eight-buffer (one-per-lane) layout, retained for the
+///   fallback path that scores networks containing aggregate squashes
+///   (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean), whose exact
+///   single-record kernels index a contiguous per-lane activation slice.
 pub struct BatchScratch {
     acts: [Vec<f32>; 8],
+    inter: Vec<f32>,
 }
 
 impl BatchScratch {
-    /// Allocate eight zeroed activation buffers sized to the network.
+    /// Allocate the zeroed activation buffers sized to the network: eight
+    /// per-lane buffers plus one interleaved buffer of `num_neurons * 8`.
     pub fn new(num_neurons: usize) -> Self {
         Self {
             acts: std::array::from_fn(|_| vec![0.0f32; num_neurons]),
+            inter: vec![0.0f32; num_neurons * SCORING_LANES],
         }
     }
 }
@@ -184,11 +203,165 @@ impl CompiledNetwork {
     ///
     /// Record `i` (0-based within `records`) writes its outputs to
     /// `out[i * num_outputs .. (i + 1) * num_outputs]`; `out` must be exactly
-    /// `records.len() * num_outputs` long. Records are grouped into 8s and
-    /// driven through [`weighted_sum_simd_8records`], then a 4-record group via
-    /// [`weighted_sum_simd_4records`], then a scalar tail — matching the
-    /// remainder handling of `mse_sum_batch_packed`.
+    /// `records.len() * num_outputs` long.
+    ///
+    /// Dispatches between two numerically-equivalent layouts (Issue #287):
+    ///
+    /// - **Interleaved fast path** ([`Self::score_batch_interleaved`]) when the
+    ///   network has no aggregate-squash neurons — the common case, including the
+    ///   all-standard-squash production topology. Records are transposed so each
+    ///   synapse gather reads one cache line.
+    /// - **Per-lane fallback** ([`Self::score_batch_per_lane`]) otherwise, which
+    ///   keeps aggregate squashes (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/
+    ///   Mean) on the exact single-record kernels.
+    ///
+    /// Both group records into 8s then a 4-record group then a scalar tail, and
+    /// both are bit-identical on the covered standard-squash neurons.
     pub(crate) fn score_batch_into(
+        &self,
+        scratch: &mut BatchScratch,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        if self.has_aggregate_squash() {
+            self.score_batch_per_lane(scratch, records, num_outputs, out);
+        } else {
+            self.score_batch_interleaved(scratch, records, num_outputs, out);
+        }
+    }
+
+    /// True when any non-constant neuron uses an aggregate squash whose exact
+    /// kernel needs a contiguous per-lane activation slice (so the interleaved
+    /// fast path does not apply). O(neurons); the scoring batch dwarfs it.
+    fn has_aggregate_squash(&self) -> bool {
+        self.neurons.iter().any(|neuron| {
+            !neuron.is_constant
+                && matches!(
+                    SquashType::from(neuron.squash_type),
+                    SquashType::Minimum
+                        | SquashType::Maximum
+                        | SquashType::If
+                        | SquashType::Hypotenuse
+                        | SquashType::HypotenuseV2
+                        | SquashType::Mean
+                )
+        })
+    }
+
+    /// Record-interleaved scoring fast path (Issue #287).
+    ///
+    /// Transposes each group of eight records into `scratch.inter`
+    /// (`inter[n * 8 + l]` = lane `l` of neuron `n`) so every synapse gather in
+    /// [`weighted_sum_interleaved_8`] reads one contiguous cache line rather than
+    /// eight scattered per-lane buffers, and each neuron's eight outputs are a
+    /// contiguous store. Full 8-record groups are bit-identical to the per-lane
+    /// 8-record path (same FMA order and vectorised squash); the trailing
+    /// `records.len() % 8` records run the exact single-record kernel
+    /// ([`neuron_activation_scalar`]) so they stay bit-for-bit identical to
+    /// `activate` — matching the per-lane fallback's scalar-tail guarantee. Only
+    /// called when [`Self::has_aggregate_squash`] is false, so the group path
+    /// needs no aggregate kernel.
+    fn score_batch_interleaved(
+        &self,
+        scratch: &mut BatchScratch,
+        records: &[Vec<f32>],
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        const L: usize = SCORING_LANES;
+        let num_inputs = self.num_inputs;
+        let num_neurons = self.num_neurons;
+        let output_start = num_neurons - num_outputs;
+        let n = records.len();
+
+        // `inter` (fast group path) and `acts[0]` (exact scalar tail) are disjoint
+        // fields, so borrow both at once.
+        let BatchScratch { acts, inter } = scratch;
+        let tail_act = &mut acts[0];
+
+        let mut base = 0usize;
+
+        // ---- full 8-record groups -------------------------------------------
+        while base + L <= n {
+            // Transpose L records into the interleaved buffer.
+            for l in 0..L {
+                let rec = &records[base + l];
+                let in_len = rec.len().min(num_inputs);
+                for i in 0..in_len {
+                    inter[i * L + l] = rec[i];
+                }
+                for i in in_len..num_inputs {
+                    inter[i * L + l] = 0.0;
+                }
+            }
+
+            // Forward pass, all L lanes at once.
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let out_base = (num_inputs + neuron_idx) * L;
+
+                if neuron.is_constant {
+                    let v = apply_limit_range(SquashType::Identity, neuron.bias);
+                    for slot in inter[out_base..out_base + L].iter_mut() {
+                        *slot = v;
+                    }
+                    continue;
+                }
+
+                let squash = SquashType::from(neuron.squash_type);
+                let start = neuron.start_synapse as usize;
+                let end = start + neuron.num_synapses as usize;
+                let sums =
+                    weighted_sum_interleaved_8(&self.synapses, inter, start, end, neuron.bias);
+
+                // Vectorised squash across all 8 lanes for the covered types
+                // (Issue #243); scalar inline fallback otherwise.
+                let squashed = squash_x8(squash, sums).unwrap_or_else(|| {
+                    let st = neuron.squash_type;
+                    sums.map(|s| inline_squash(st, squash, s))
+                });
+
+                // Resolve the output range once per neuron (Issue #245) and clamp
+                // all 8 lanes; the writes land in one contiguous cache line.
+                let (low, high) = apply_get_range(squash);
+                for l in 0..L {
+                    inter[out_base + l] = apply_limit_range_bounds(low, high, squashed[l]);
+                }
+            }
+
+            // Scatter each lane's outputs to the flat buffer.
+            for l in 0..L {
+                let dst = (base + l) * num_outputs;
+                for o in 0..num_outputs {
+                    out[dst + o] = inter[(output_start + o) * L + l];
+                }
+            }
+
+            base += L;
+        }
+
+        // ---- exact single-record tail (records.len() % 8) -------------------
+        // Bit-identical to `activate`, so a lone or partial trailing group keeps
+        // the strict single-record parity guarantee.
+        while base < n {
+            load_record(tail_act, &records[base], num_inputs);
+            for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
+                let actual_idx = num_inputs + neuron_idx;
+                tail_act[actual_idx] = neuron_activation_scalar(&self.synapses, tail_act, neuron);
+            }
+            let dst = base * num_outputs;
+            out[dst..dst + num_outputs]
+                .copy_from_slice(&tail_act[output_start..output_start + num_outputs]);
+            base += 1;
+        }
+    }
+
+    /// Per-lane fallback scoring path — the original eight-buffer layout, kept
+    /// verbatim for networks containing aggregate squashes (Issue #287). Record
+    /// `i` writes `out[i * num_outputs ..]`; records are grouped into 8s
+    /// ([`weighted_sum_simd_8records`]), then a 4-record group
+    /// ([`weighted_sum_simd_4records`]), then a scalar tail.
+    fn score_batch_per_lane(
         &self,
         scratch: &mut BatchScratch,
         records: &[Vec<f32>],

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -454,6 +454,68 @@ pub fn weighted_sum_simd_8records(
     )
 }
 
+/// Issue #287 - record-interleaved 8-lane weighted sum for the batched scoring
+/// hot path.
+///
+/// `inter` is the transposed batch activation buffer: lane `l` of source neuron
+/// `n` lives at `inter[n * 8 + l]`, so all eight records for a synapse's source
+/// are contiguous. Each gather is then two adjacent 4-wide reads from one cache
+/// line instead of eight scattered per-lane loads, cutting gather traffic on the
+/// gather-bound production topology. Numerically identical to
+/// [`weighted_sum_simd_8records`]: same per-synapse FMA order, bias seeded into
+/// every lane.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+pub fn weighted_sum_interleaved_8(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    if end <= start {
+        return [bias; 8];
+    }
+
+    let mut acc03 = f32x4_splat(bias);
+    let mut acc47 = f32x4_splat(bias);
+
+    for i in start..end {
+        let synapse = &synapses[i];
+        let base = synapse.from_index as usize * 8;
+        let weights = f32x4_splat(synapse.weight);
+
+        // The eight lanes are contiguous, so these read one cache line.
+        let acts03 = f32x4(
+            inter[base],
+            inter[base + 1],
+            inter[base + 2],
+            inter[base + 3],
+        );
+        let acts47 = f32x4(
+            inter[base + 4],
+            inter[base + 5],
+            inter[base + 6],
+            inter[base + 7],
+        );
+
+        acc03 = f32x4_relaxed_madd(weights, acts03, acc03);
+        acc47 = f32x4_relaxed_madd(weights, acts47, acc47);
+    }
+
+    [
+        f32x4_extract_lane::<0>(acc03),
+        f32x4_extract_lane::<1>(acc03),
+        f32x4_extract_lane::<2>(acc03),
+        f32x4_extract_lane::<3>(acc03),
+        f32x4_extract_lane::<0>(acc47),
+        f32x4_extract_lane::<1>(acc47),
+        f32x4_extract_lane::<2>(acc47),
+        f32x4_extract_lane::<3>(acc47),
+    ]
+}
+
 // Native (non-wasm32) multi-record helpers now live in `simd_native.rs` and use
 // AVX2/FMA on x86_64, NEON on aarch64, falling back to scalar elsewhere.
 #[cfg(not(target_arch = "wasm32"))]
@@ -466,6 +528,7 @@ mod simd_native;
 // kernels and run on the primary `activate()` forward-pass hot path.
 #[cfg(not(target_arch = "wasm32"))]
 pub use simd_native::{
-    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
-    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
+    weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
+    weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
+    weighted_sum_simd_8records,
 };

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -77,6 +77,33 @@ fn weighted_sum_simd_4records_scalar(
     (sum0, sum1, sum2, sum3)
 }
 
+/// Scalar fallback for the record-interleaved 8-lane weighted sum (Issue #287).
+///
+/// `inter` is the transposed batch activation buffer: lane `l` of neuron `n`
+/// lives at `inter[n * 8 + l]`, so all eight records for a source neuron are
+/// contiguous. This mirrors [`weighted_sum_simd_8records_scalar`] numerically —
+/// same per-synapse FMA order, bias seeded into every lane — so the covered
+/// scoring path is bit-identical whichever gather layout is used.
+#[inline]
+fn weighted_sum_interleaved_8_scalar(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    let mut acc = [bias; 8];
+    for synapse in synapses.iter().take(end).skip(start) {
+        let base = synapse.from_index as usize * 8;
+        let w = synapse.weight;
+        let chunk = &inter[base..base + 8];
+        for l in 0..8 {
+            acc[l] += chunk[l] * w;
+        }
+    }
+    acc
+}
+
 #[cfg(target_arch = "x86_64")]
 mod x86 {
     use super::SynapseData;
@@ -130,6 +157,46 @@ mod x86 {
         (
             out[0], out[1], out[2], out[3], out[4], out[5], out[6], out[7],
         )
+    }
+
+    /// Record-interleaved 8-lane weighted sum (Issue #287).
+    ///
+    /// `inter` holds the transposed batch: the eight records for source neuron
+    /// `n` are contiguous at `inter[n * 8 .. n * 8 + 8]`, so each synapse gather
+    /// is a single `_mm256_loadu_ps` from one cache line instead of eight
+    /// scattered scalar loads — the whole point of the layout change.
+    ///
+    /// # Safety
+    /// Caller must ensure AVX2 is enabled (`is_x86_feature_detected!("avx2")`).
+    /// Issue #287 - `inter.len()` must be `num_neurons * 8` and every
+    /// `synapse.from_index` in `start..end` must be `< num_neurons`, so
+    /// `from_index * 8 + 8 <= inter.len()`; `CompiledNetwork::new` validates the
+    /// synapse index range at load time. The 8-wide read is then in bounds.
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    pub unsafe fn weighted_sum_interleaved_8_avx2(
+        synapses: &[SynapseData],
+        inter: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> [f32; 8] {
+        let mut acc = _mm256_set1_ps(bias);
+        let ptr = inter.as_ptr();
+        for i in start..end {
+            let synapse = unsafe { synapses.get_unchecked(i) };
+            let base = synapse.from_index as usize * 8;
+            let w = synapse.weight;
+            // SAFETY: base + 8 <= inter.len() by the load-time index validation
+            // documented above; the unaligned 8-wide load is in bounds.
+            let acts = unsafe { _mm256_loadu_ps(ptr.add(base)) };
+            let ws = _mm256_set1_ps(w);
+            // `_mm256_fmadd_ps` needs `fma` (mirrors the 8records kernel above).
+            acc = unsafe { _mm256_fmadd_ps(ws, acts, acc) };
+        }
+        let mut out = [0.0_f32; 8];
+        unsafe { _mm256_storeu_ps(out.as_mut_ptr(), acc) };
+        out
     }
 
     /// # Safety
@@ -379,6 +446,49 @@ mod aarch64 {
         (
             o03[0], o03[1], o03[2], o03[3], o47[0], o47[1], o47[2], o47[3],
         )
+    }
+
+    /// Record-interleaved 8-lane weighted sum (Issue #287).
+    ///
+    /// `inter` holds the transposed batch: the eight records for source neuron
+    /// `n` are contiguous at `inter[n * 8 .. n * 8 + 8]`, so each synapse gather
+    /// is two adjacent `vld1q_f32` loads from one cache line instead of eight
+    /// scattered scalar loads staged through a stack array.
+    ///
+    /// # Safety
+    /// Caller must ensure NEON is available (typical on aarch64-apple-darwin /
+    /// linux-aarch64). Issue #287 - `inter.len()` must be `num_neurons * 8` and
+    /// every `synapse.from_index` in `start..end` must be `< num_neurons`, so
+    /// `from_index * 8 + 8 <= inter.len()`; `CompiledNetwork::new` validates the
+    /// synapse index range at load time, making the two 4-wide reads in bounds.
+    #[target_feature(enable = "neon")]
+    #[inline]
+    pub unsafe fn weighted_sum_interleaved_8_neon(
+        synapses: &[SynapseData],
+        inter: &[f32],
+        start: usize,
+        end: usize,
+        bias: f32,
+    ) -> [f32; 8] {
+        let mut acc03 = vdupq_n_f32(bias);
+        let mut acc47 = vdupq_n_f32(bias);
+        let ptr = inter.as_ptr();
+        for i in start..end {
+            let synapse = unsafe { synapses.get_unchecked(i) };
+            let base = synapse.from_index as usize * 8;
+            let w = synapse.weight;
+            // SAFETY: base + 8 <= inter.len() by the load-time index validation
+            // documented above; both 4-wide reads are in bounds.
+            let a03 = unsafe { vld1q_f32(ptr.add(base)) };
+            let a47 = unsafe { vld1q_f32(ptr.add(base + 4)) };
+            let vw = vdupq_n_f32(w);
+            acc03 = vfmaq_f32(acc03, vw, a03);
+            acc47 = vfmaq_f32(acc47, vw, a47);
+        }
+        let mut out = [0.0_f32; 8];
+        unsafe { vst1q_f32(out.as_mut_ptr(), acc03) };
+        unsafe { vst1q_f32(out.as_mut_ptr().add(4), acc47) };
+        out
     }
 
     /// # Safety
@@ -631,6 +741,49 @@ pub fn weighted_sum_simd_8records(
     weighted_sum_simd_8records_scalar(
         synapses, act0, act1, act2, act3, act4, act5, act6, act7, start, end, bias,
     )
+}
+
+/// Record-interleaved 8-lane weighted sum (Issue #287): AVX2+FMA on x86_64,
+/// NEON on aarch64, else scalar. `inter` is the transposed batch buffer
+/// (`inter[n * 8 + l]` = lane `l` of neuron `n`), so each synapse gather touches
+/// one cache line instead of eight scattered per-lane buffers.
+#[inline]
+pub fn weighted_sum_interleaved_8(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    if end <= start {
+        return [bias; 8];
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: the `is_x86_feature_detected!("avx2")` guard proves AVX2 is
+            // available, satisfying the `#[target_feature(enable = "avx2")]`
+            // precondition on `weighted_sum_interleaved_8_avx2`.
+            return unsafe {
+                x86::weighted_sum_interleaved_8_avx2(synapses, inter, start, end, bias)
+            };
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: the `is_aarch64_feature_detected!("neon")` guard proves NEON
+            // is available, satisfying the `#[target_feature(enable = "neon")]`
+            // precondition on `weighted_sum_interleaved_8_neon`.
+            return unsafe {
+                aarch64::weighted_sum_interleaved_8_neon(synapses, inter, start, end, bias)
+            };
+        }
+    }
+
+    weighted_sum_interleaved_8_scalar(synapses, inter, start, end, bias)
 }
 
 /// 4-record weighted sum: FMA+SSE on x86_64, NEON on aarch64, else scalar.

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -38,6 +38,115 @@ fn production_shapes_are_registered_with_expected_dimensions() {
 }
 
 #[test]
+fn production_exact_matches_committed_grq_topology() {
+    // Issue #286: the `production_exact` fixture must reproduce the committed
+    // GRQ-cluster/network.json topology to the synapse — 1,666 non-input
+    // neurons, 21,513 synapses, 2,461 inputs — so the Criterion baseline is
+    // anchored to the real production model rather than a ~13-average estimate.
+    let spec = spec("production_exact");
+    assert_eq!(spec.num_inputs, 2461, "production inputs");
+    assert_eq!(spec.num_non_inputs(), 1666, "production non-input neurons");
+    assert_eq!(spec.num_neurons, 4127, "2461 inputs + 1666 neurons");
+    assert_eq!(spec.num_outputs, 1);
+
+    let net = build_network(spec, 0x5152_5354);
+    assert_eq!(
+        net.neurons.len(),
+        1666,
+        "one NeuronData per non-input neuron"
+    );
+    assert_eq!(net.num_inputs, 2461);
+    assert_eq!(net.num_neurons, 4127);
+    assert_eq!(
+        net.synapses.len(),
+        21_513,
+        "production_exact must build exactly 21,513 synapses"
+    );
+
+    // Per-neuron `num_synapses` must sum to the flat synapse buffer length.
+    let summed: usize = net.neurons.iter().map(|n| n.num_synapses as usize).sum();
+    assert_eq!(summed, 21_513);
+}
+
+#[test]
+fn production_exact_fan_in_is_evenly_spread_and_varies() {
+    // ExactTotal spreads 21,513 synapses across 1,666 neurons as evenly as
+    // possible, so the fan-in takes exactly two values (base and base+1) with a
+    // mean near the production ~13.
+    let net = build_network(spec("production_exact"), 0x5152_5354);
+    let distinct: std::collections::BTreeSet<u16> =
+        net.neurons.iter().map(|n| n.num_synapses).collect();
+    assert!(
+        distinct.len() > 1,
+        "exact fan-in should still vary, saw only {distinct:?}"
+    );
+    assert!(
+        distinct.len() <= 2,
+        "even distribution should use at most two fan-in values, saw {distinct:?}"
+    );
+    let avg_fan_in = net.synapses.len() as f64 / net.neurons.len() as f64;
+    assert!(
+        (12.0..=14.0).contains(&avg_fan_in),
+        "average fan-in {avg_fan_in} should sit near the production ~13"
+    );
+}
+
+#[test]
+fn production_exact_build_is_deterministic() {
+    // Seeded synthesis must reproduce byte-for-byte so the baseline numbers are
+    // reproducible (Issue #286 acceptance).
+    let a = build_network(spec("production_exact"), 0x5152_5354);
+    let b = build_network(spec("production_exact"), 0x5152_5354);
+    assert_eq!(a.synapses.len(), b.synapses.len());
+    assert!(
+        a.synapses
+            .iter()
+            .zip(&b.synapses)
+            .all(|(x, y)| x.weight == y.weight && x.from_index == y.from_index),
+        "same seed must reproduce identical synapses"
+    );
+    assert!(
+        a.neurons
+            .iter()
+            .zip(&b.neurons)
+            .all(|(x, y)| x.bias == y.bias && x.num_synapses == y.num_synapses),
+        "same seed must reproduce identical neurons"
+    );
+}
+
+#[test]
+fn production_exact_backprop_data_has_exact_synapse_count() {
+    // Regression: `build_backprop_data` must honour the ExactTotal schedule too,
+    // otherwise the exact shape falls through to `draw` (which returns 0 for
+    // ExactTotal) and the backprop bench runs on a synapse-free network.
+    let spec = spec("production_exact");
+    let data = build_backprop_data(spec, 0x1357_9BDF);
+    assert_eq!(data.neurons.len(), spec.num_neurons);
+    assert_eq!(data.reverse_topo_order.len(), spec.num_non_inputs());
+    assert_eq!(
+        data.synapses.len(),
+        21_513,
+        "backprop fixture must build the same 21,513 synapses as the forward fixture"
+    );
+    let summed: usize = data.inward_counts.iter().map(|&c| c as usize).sum();
+    assert_eq!(summed, 21_513);
+    assert_eq!(summed, data.inward_indices.len());
+}
+
+#[test]
+fn production_exact_network_activates_to_finite_outputs() {
+    let spec = spec("production_exact");
+    let mut net = build_network(spec, 0x5152_5354);
+    let inputs = build_inputs(spec.num_inputs, 0xA1B2_C3D4);
+    let out = net.activate(&inputs, spec.num_outputs);
+    assert_eq!(out.len(), spec.num_outputs);
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "production_exact forward pass must produce finite outputs"
+    );
+}
+
+#[test]
 fn build_network_matches_production_neuron_and_synapse_counts() {
     let prod = spec("production");
     let net = build_network(prod, 0x5152_5354);
@@ -93,7 +202,7 @@ fn production_fixture_squash_is_homogeneous_tanh() {
     // unmeasurable on the fixture (the predictor already nails a one-arm match).
     // If a future change diversifies the fixture squash, this test fails so the
     // documented caveat is revisited rather than silently invalidated.
-    for label in ["production", "production_2x"] {
+    for label in ["production", "production_2x", "production_exact"] {
         let net = build_network(spec(label), 0x5152_5354);
         assert!(
             net.neurons

--- a/neat-core/tests/interleaved_scoring_parity.rs
+++ b/neat-core/tests/interleaved_scoring_parity.rs
@@ -1,0 +1,155 @@
+//! Parity guard for the record-interleaved scoring fast path (Issue #287).
+//!
+//! `CompiledNetwork::score_batch_into` dispatches between a record-interleaved
+//! layout (fast path, taken when the network has no aggregate-squash neurons)
+//! and the original per-lane layout (fallback, taken when it does). These are
+//! "what" tests: they build real forward networks, score batches through the
+//! public `score_records` entry point, and assert the flat output matches the
+//! scalar single-record `activate` reference — so a lane transposition, a
+//! dropped tail record, or a wrong dispatch would surface as a parity break.
+//!
+//! Record counts straddle the 8-record group boundary (1, 7, 8, 9, 16, 17) so
+//! both the vectorised group path and the exact single-record tail are covered.
+
+use neat_core::squash::SquashType;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Build a two-hidden-plus-one-output feedforward network where every non-input
+/// neuron uses `squash`. `num_inputs` inputs fully connect into each hidden
+/// neuron; both hiddens feed the output.
+fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.25 - 0.09 * (i as f32) + 0.05 * (h as f32),
+                from_index: i as u16,
+                synapse_type: 0,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.03 * (h as f32) - 0.01,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    let hidden0 = num_inputs as u16;
+    let hidden1 = num_inputs as u16 + 1;
+    synapses.push(SynapseData {
+        weight: 0.7,
+        from_index: hidden0,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.5,
+        from_index: hidden1,
+        synapse_type: 0,
+    });
+    neurons.push(NeuronData {
+        bias: 0.02,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Deterministic distinct input records so a lane mix-up cannot hide.
+fn records(num_inputs: usize, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|r| {
+            (0..num_inputs)
+                .map(|i| ((r * 7 + i * 3) as f32 * 0.017).sin() * 0.9)
+                .collect()
+        })
+        .collect()
+}
+
+/// Reference outputs from the scalar single-record `activate` path.
+fn reference(net: &CompiledNetwork, recs: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
+    let mut scratch = net.clone();
+    let mut out = Vec::with_capacity(recs.len() * num_outputs);
+    for rec in recs {
+        out.extend_from_slice(&scratch.activate(rec, num_outputs));
+    }
+    out
+}
+
+const COUNTS: [usize; 6] = [1, 7, 8, 9, 16, 17];
+/// SIMD tolerance the batched vectorised squash/weighted-sum already carries
+/// (Issue #230 / #243); the exact single-record tail is well within it.
+const TOL: f32 = 2e-3;
+
+#[test]
+fn interleaved_fast_path_matches_reference_across_boundaries() {
+    // All-Tanh network → no aggregate neurons → interleaved fast path.
+    let num_inputs = 12;
+    let net = build_network(num_inputs, SquashType::Tanh);
+    for &count in &COUNTS {
+        let recs = records(num_inputs, count);
+        let got = net.score_records(&recs, 1);
+        let want = reference(&net, &recs, 1);
+        assert_eq!(got.len(), want.len(), "count {count}: length mismatch");
+        for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+            assert!(
+                (g - w).abs() <= TOL,
+                "count {count} record {i}: interleaved {g} vs reference {w}"
+            );
+        }
+    }
+}
+
+#[test]
+fn interleaved_single_record_is_bit_identical_to_activate() {
+    // A single record runs the exact scalar tail, so it must match bit-for-bit.
+    let num_inputs = 12;
+    let net = build_network(num_inputs, SquashType::Tanh);
+    let recs = records(num_inputs, 1);
+    assert_eq!(net.score_records(&recs, 1), reference(&net, &recs, 1));
+}
+
+#[test]
+fn aggregate_fallback_path_matches_reference_across_boundaries() {
+    // A Maximum network has aggregate neurons → forces the per-lane fallback,
+    // whose exact single-record kernels are bit-identical to the reference.
+    let num_inputs = 12;
+    let net = build_network(num_inputs, SquashType::Maximum);
+    for &count in &COUNTS {
+        let recs = records(num_inputs, count);
+        let got = net.score_records(&recs, 1);
+        let want = reference(&net, &recs, 1);
+        assert_eq!(got, want, "count {count}: aggregate fallback must be exact");
+    }
+}


### PR DESCRIPTION
## Milestone: #285 Suggest neat-core performance improvements for production learn/sampler runs

This PR merges the completed milestone branch into Develop.
Closes #292

### Issues addressed
- #288: Benchmark and enable the native rayon (--features parallel) scoring lane vs wasm32, with fallback
- #287: Optimise the wasm32 single-thread per-creature scoring hot path on the production topology
- #286: Criterion baseline on the production topology (1,666 neurons / 21,513 synapses / 2,461 inputs)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.