### PR TITLE
wasm64 lane (b): Memory64 build-lane feasibility spike (Issue #297)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,28 @@ jobs:
           skip: "./target,./.git"
           ignore_words_list: renderD,mape
 
+  # Issue #297 — wasm64 lane (b) Memory64 runtime guard. The committed smoke
+  # test instantiates a minimal `(memory i64 ...)` module, grows linear memory
+  # past the wasm32 4 GiB ceiling, and round-trips a BigInt (64-bit) pointer
+  # across the JS↔WASM boundary. A Deno/V8 upgrade that drops or breaks Wasm 3.0
+  # Memory64 support fails HERE, in CI, rather than being rediscovered mid-port.
+  wasm64-memory64-smoke:
+    name: wasm64 Memory64 smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Deno
+        # denoland/setup-deno@v2.0.5
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+        with:
+          deno-version: "2.9.3"
+
+      - name: Run Memory64 smoke test
+        run: deno test tests/wasm64_memory64_smoke_test.ts < /dev/null
+
   security:
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'

--- a/docs/archive/pr-summaries/pr-summary-297.md
+++ b/docs/archive/pr-summaries/pr-summary-297.md
@@ -1,0 +1,93 @@
+# wasm64 lane (b): build-lane feasibility spike (Rust Tier 3 + Deno/V8 Memory64)
+
+## Summary
+
+Time-boxed feasibility spike for milestone #295 (lane b). Establishes — with
+exact toolchain versions, flags, and reproduction steps — **whether a working
+wasm64 (Memory64) neat-core artefact is buildable and loadable in Deno 2.9.3
+today**. Delivers a committed, runnable Memory64 smoke test wired into CI, plus a
+written go/no-go finding backed by captured evidence. `Closes #297`.
+
+**Finding — qualified GO:**
+
+- **Runtime — GO.** Deno 2.9.3 / V8 14.9.207.2 instantiates a minimal
+  `(memory i64 …)` module and grows linear memory past the wasm32 4 GiB ceiling,
+  up to the V8 implementation limit of **262144 pages = 16 GiB**. `Memory.grow()`
+  on an i64 memory requires and returns a `BigInt` (the observable 64-bit index
+  signature). Growth reserves address space lazily, so the probe touches only a
+  few pages (~34 MiB RSS) — cheap enough to run in default CI.
+- **Build (raw) — GO, nightly only.** A trivial neat-core-style kernel builds for
+  `wasm64-unknown-unknown` with `nightly-2026-07-19` + `rust-src` +
+  `-Z build-std=std,panic_abort`, producing a genuine Memory64 module. **Stable
+  is a no-go** (Tier 3, no prebuilt `std`; `rustup target add` refuses).
+- **Bindings (raw) — GO.** The kernel is callable across the JS↔WASM boundary
+  with 64-bit pointers passed as `BigInt`.
+- **Build (production) — NO-GO.** `wasm-bindgen` / `wasm-pack` (the path this
+  repo ships via `scripts/build-wasm-bundle.sh`) **silently strip** the exported
+  bindings from a Memory64 module: the CLI exits 0 but the generated glue and
+  `_bg.wasm` contain no `accumulate` / `__wbindgen_malloc`. The same crate emits
+  working glue on wasm32. This is the hard blocker for any wasm-pack-based port.
+- **Perf — no measurable regression.** A raw accumulate kernel over a 4 MiB
+  (4 GiB-fitting) buffer runs within **±2 %** (measurement noise) wasm64 vs
+  wasm32. A full #286 Criterion comparison is blocked by the wasm-bindgen no-go
+  and is recorded as such rather than hidden.
+
+**Recommendation (feeds #295 planning):** consistent with lane (a), do **not**
+adopt wasm64 yet (today's ceiling is the V8 heap, liftable with
+`--max-old-space-size`). If/when wasm64 is needed, the viable path is raw
+`extern "C"` exports + hand-rolled `BigInt` bindings on nightly + `-Z build-std`
+— **not** `wasm-pack`, until the toolchain ships working wasm64 post-processing.
+
+Full write-up:
+[`docs/research/wasm64-lane-b-build-lane-feasibility.md`](../../research/wasm64-lane-b-build-lane-feasibility.md).
+
+## Evidence
+
+Backend/runtime spike — no web interface to screenshot. Evidence is the captured
+runtime signatures (in the finding doc), the committed smoke test, and the new
+CI job that guards it.
+
+```mermaid
+flowchart TD
+    A["Need >4 GiB in neat-core WASM?"] --> B{"Lane (a): which pool binds?"}
+    B -- "V8 heap (today)" --> C["Raise --max-old-space-size — wasm64 NOT needed yet"]
+    B -- "WASM linear memory" --> D["wasm64 (Memory64) required"]
+    D --> E{"Binding path?"}
+    E -- "raw extern C + BigInt" --> F["GO: nightly + -Z build-std, callable today"]
+    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO: CLI silently strips exports"]
+    G --> H["Blocker: await wasm-bindgen wasm64 support, or use raw path"]
+```
+
+Captured on Deno 2.9.3 / V8 14.9.207.2, rustc nightly `1.99.0 (9f36de775)`,
+wasm-pack 0.13.1, wasm-bindgen 0.2.108:
+
+| Axis | Result |
+| --- | --- |
+| Memory64 grow ceiling | 262144 pages = **16 GiB** (V8 impl limit) |
+| `Memory.grow()` on i64 memory | requires + returns **`BigInt`**; `Number` throws `TypeError` |
+| wasm64 raw build | **OK** (nightly + `-Z build-std`), module memory flag `0x04` = i64 |
+| wasm-bindgen wasm32 vs wasm64 | wasm32 glue exports `accumulate`; **wasm64 strips it (exit 0)** |
+| wasm64 vs wasm32 accumulate | within **±2 %** — no measurable regression |
+
+## Test Plan
+
+- Added `tests/wasm64_memory64_smoke_test.ts` (+ helpers
+  `tests/wasm64_memory64_smoke.ts`) — 6 "what" tests that call real code and
+  assert on observable outcomes:
+  - a hand-assembled `(memory i64 …)` module validates and its memory section
+    sets the i64 index flag (`0x04`);
+  - `buildMemory64Module` rejects a max that cannot exceed the 4 GiB wall;
+  - the module instantiates and grows linear memory **past 4 GiB**
+    (`byteLength > 4 GiB`);
+  - `grow()` requires and returns a `BigInt`; a `Number` delta throws;
+  - a `BigInt` offset **above 4 GiB** round-trips through the module's exported
+    `store`/`load` functions (two independent addresses, no 32-bit wrap-around);
+  - `unsignedLeb128` encodes multi-byte page counts.
+  - Run: `deno test tests/wasm64_memory64_smoke_test.ts` → 6 passed, ~9 ms,
+    ~34 MiB RSS. Full `deno test tests/` → 19 passed (with lane a).
+- Added a `wasm64-memory64-smoke` CI job (`.github/workflows/ci.yml`, Deno 2.9.3,
+  `denoland/setup-deno` SHA-pinned) so a Deno/V8 upgrade dropping Memory64 fails
+  in CI — the issue's earliest failure-detection point.
+- No Rust changed. Confirmed unaffected: `cargo check` / `cargo clippy -D
+  warnings` / `cargo test` all green; `actionlint` and the workflow-guard bats
+  suite pass on the updated `ci.yml`; markdownlint + codespell clean on new docs.

--- a/docs/research/wasm64-lane-b-build-lane-feasibility.md
+++ b/docs/research/wasm64-lane-b-build-lane-feasibility.md
@@ -1,0 +1,199 @@
+# wasm64 lane (b): build-lane feasibility spike (Rust Tier 3 + Deno/V8 Memory64)
+
+Feasibility spike for milestone #295 (Issue #297). Follows lane (a)
+([`wasm64-lane-a-4gb-ceiling-attribution.md`](wasm64-lane-a-4gb-ceiling-attribution.md)),
+which found the ~4 GB learn-job ceiling currently binds on the **V8 JS heap**,
+not WASM linear memory — so lanes (b)/(c) are **not needed yet, but not closed**.
+This lane answers the gating engineering question for lane (b): *if* a wasm64
+(Memory64) build becomes necessary, **can it actually be built and loaded in
+Deno 2.9.3 today?** Method-first per the performance workflow (#177/#1428):
+measure, don't guess.
+
+## Go / no-go finding
+
+**Qualified GO.** A working wasm64 (Memory64) neat-core artefact **is** buildable
+and loadable in Deno 2.9.3 today — but **only** via the raw `extern "C"` +
+hand-rolled `BigInt` bindings path on a Rust **nightly** toolchain with
+`-Z build-std`. The production binding path this repo actually ships
+(`wasm-bindgen` / `wasm-pack`, see
+[`scripts/build-wasm-bundle.sh`](../../scripts/build-wasm-bundle.sh)) is a
+**NO-GO** today: the `wasm-bindgen` CLI silently strips the exported bindings
+from a Memory64 module.
+
+| Spike axis | Verdict | Evidence (this host) |
+| --- | --- | --- |
+| **Runtime** — Deno 2.9.3 / V8 14.9 instantiates Memory64 & grows past 4 GiB | **GO** | grows to the V8 impl limit of **262144 pages = 16 GiB**; committed smoke test |
+| **Build (raw)** — `cargo build --target wasm64-unknown-unknown -Z build-std` | **GO (nightly only)** | produces a genuine `(memory i64 …)` module exporting `accumulate` |
+| **Bindings (raw)** — 64-bit (`BigInt`) pointers across JS↔WASM | **GO** | `accumulate(BigInt ptr, BigInt len)` returns the correct sum |
+| **Build (production)** — `wasm-bindgen` / `wasm-pack` on wasm64 | **NO-GO** | CLI exits 0 but strips `accumulate` + `__wbindgen_malloc` from the output |
+| **Perf** — wasm64 vs wasm32 on a 4 GiB-fitting job | **no measurable regression** | scalar accumulate within **±2 %** (measurement noise) |
+
+## Exact toolchain versions (reproduction baseline)
+
+| Tool | Version |
+| --- | --- |
+| Deno | `2.9.3 (stable, release, aarch64-apple-darwin)` |
+| V8 | `14.9.207.2-rusty` |
+| rustc (build) | `1.99.0-nightly (9f36de775 2026-07-19)` + `rust-src` |
+| rustc (stable) | `1.97.1 (8bab26f4f 2026-07-14)` |
+| wasm-pack | `0.13.1` |
+| wasm-bindgen CLI | `0.2.108` |
+| wasm-bindgen crate | `0.2.126` (repo default; skew noted below) |
+
+## 1. Runtime support — GO (committed as a smoke test)
+
+Deno 2.9.3's V8 **does** support Wasm 3.0 Memory64. A minimal hand-assembled
+`(memory i64 …)` module validates, instantiates, and grows linear memory well
+past the wasm32 4 GiB wall:
+
+- `WebAssembly.validate` accepts the i64 memory-type flag (`0x04`).
+- `WebAssembly.Memory.grow()` on an i64 memory **requires and returns a
+  `BigInt`** — a `Number` delta throws `TypeError: Cannot convert … to a
+  BigInt`. This is the observable signature of the 64-bit index type.
+- Growth succeeds up to the **V8 implementation limit of 262144 pages = 16 GiB**
+  (a declared maximum above that fails at compile with
+  `maximum memory size (… pages) is larger than implementation limit (262144
+  pages)`).
+- Pages are reserved lazily: growing past 4 GiB reserves address space without
+  committing physical RAM — the smoke test touches only a handful of pages, so
+  peak RSS stays ~34 MiB. This is what makes it safe to run in default CI.
+
+This is captured as the committed
+[`tests/wasm64_memory64_smoke_test.ts`](../../tests/wasm64_memory64_smoke_test.ts)
+(+ helpers in
+[`tests/wasm64_memory64_smoke.ts`](../../tests/wasm64_memory64_smoke.ts)). It
+instantiates the minimal module, grows past 4 GiB, and round-trips a `BigInt`
+offset above 4 GiB through the module's exported `store`/`load` functions. It is
+wired into a new `wasm64-memory64-smoke` CI job (`.github/workflows/ci.yml`) so a
+Deno/V8 upgrade that drops or breaks Memory64 fails **in CI**, not mid-port.
+
+## 2. Build toolchain — GO on nightly, breakages documented
+
+`wasm64-unknown-unknown` is a **Rust Tier 3** target: `rustc` knows it
+(`rustc --print target-list` lists it) but there are **no prebuilt `std`
+artefacts**.
+
+- **Stable is a NO-GO.** `rustup target add wasm64-unknown-unknown` refuses
+  (`has no prebuilt artifacts available for target 'wasm64-unknown-unknown'`),
+  and a stable build fails with `error[E0463]: can't find crate for std … build
+  the standard library from source with -Zbuild-std`.
+- **Nightly + `build-std` is a GO.** With `nightly-2026-07-19` and the
+  `rust-src` component, a trivial neat-core-style kernel builds cleanly:
+
+  ```text
+  cargo +nightly build --target wasm64-unknown-unknown --release \
+    -Z build-std=std,panic_abort
+  ```
+
+  The output `.wasm` is a genuine Memory64 module — its memory section carries
+  flags `0x04` (i64 index) and it exports `accumulate` + `memory`.
+
+### `Cargo.toml` gap: the wasm cfg is keyed to `wasm32`
+
+`neat-core/Cargo.toml` gates its wasm deps on `cfg(target_arch = "wasm32")`:
+
+```toml
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.126"
+```
+
+For a `wasm64-unknown-unknown` build `target_arch` is `"wasm64"`, so this table
+would **not** apply — a real port must widen the cfg to
+`cfg(target_family = "wasm")` (and re-audit the `rayon`
+`cfg(not(target_arch = "wasm32"))` exclusion, which would wrongly pull `rayon`
+into a wasm64 build). No change is made in this spike; it is recorded for the
+planning stage.
+
+## 3. Bindings — GO for raw `extern "C"`, NO-GO for wasm-bindgen
+
+**Raw path works.** Instantiated from Deno, the raw kernel is callable across the
+boundary with 64-bit pointers passed as `BigInt`:
+
+```text
+accumulate(BigInt(1024), 4n) = 7.25   // 4 f32 written at byte offset 1024
+```
+
+**wasm-bindgen / wasm-pack silently drop exports on wasm64.** The crate
+*compiles* for wasm64, but the CLI post-processing step is broken. With the CLI
+and crate versions aligned to `0.2.108`, the **same crate** yields:
+
+| Target | `accumulate` in generated glue? | `accumulate` in `_bg.wasm` exports? |
+| --- | --- | --- |
+| `wasm32-unknown-unknown` | **yes** (`export function accumulate(xs)`) | yes (+ `__wbindgen_malloc`) |
+| `wasm64-unknown-unknown` | **no** — glue has only `initSync`/`init` | **no** — `accumulate` + `__wbindgen_malloc` stripped |
+
+Critically, `wasm-bindgen … --target web` **exits 0** while producing a package
+with no working bindings — a **silent failure** (cf. the repo's "never fail
+silently" principle). Any future wasm64 adoption via `wasm-pack` must treat this
+as a hard blocker and pin/verify a `wasm-bindgen` release that documents wasm64
+support, or fall back to the raw `extern "C"` + `BigInt` binding path.
+
+> The observed CLI/crate skew (installed CLI `0.2.108` vs repo default crate
+> `0.2.126`) is a separate, ordinary version-match issue and is **not** the
+> wasm64 breakage — the table above was produced with both pinned to `0.2.108`.
+
+## 4. Performance — no measurable regression on 4 GiB-fitting jobs
+
+Per the parent decision, headroom is prioritised over throughput, but a
+regression on jobs that fit 4 GB must be **recorded, not hidden**. A full #286
+Criterion comparison of the real neat-core wasm bundle is **blocked** by the
+wasm-bindgen no-go above (the production bundle cannot be built for wasm64). As a
+proportionate substitute, the identical raw `extern "C"` accumulate kernel was
+built for both targets and timed in Deno over a 4 MiB (1 M × f32) buffer that
+fits comfortably under 4 GiB:
+
+| Target | µs / call (500 iters × 1 M f32) |
+| --- | --- |
+| wasm32 | ~515–525 µs |
+| wasm64 | ~515–525 µs |
+
+Across repeated runs the wasm64/wasm32 ratio stays within **±2 %** — within
+measurement noise, i.e. **no measurable regression** for a scalar accumulate on
+4 GiB-fitting work. (This is a micro-benchmark, not the #286 Criterion baseline;
+a full comparison must wait until the production bundle is buildable for wasm64.)
+
+## Recommendation (feeds #295 planning)
+
+```mermaid
+flowchart TD
+    A["Need >4 GiB in neat-core WASM?"] --> B{"Lane (a): which pool binds?"}
+    B -- "V8 heap (today)" --> C["Raise --max-old-space-size — wasm64 NOT needed yet"]
+    B -- "WASM linear memory" --> D["wasm64 (Memory64) required"]
+    D --> E{"Binding path?"}
+    E -- "raw extern C + BigInt" --> F["GO: nightly + -Z build-std, callable today"]
+    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO: CLI silently strips exports on wasm64"]
+    G --> H["Blocker: wait for wasm-bindgen wasm64 support, or use raw path"]
+```
+
+- **Do not adopt wasm64 yet** — consistent with lane (a): the current production
+  ceiling is the V8 heap, liftable with `--max-old-space-size`. wasm64 becomes
+  necessary only if the real Learn.ts job attributes its peak to WASM linear
+  memory (lane (d), #299).
+- **When/if wasm64 is adopted**, the viable path today is **raw `extern "C"`
+  exports with hand-rolled `BigInt` bindings** on nightly + `-Z build-std`, not
+  `wasm-pack`. A wasm-bindgen-based port is blocked until the toolchain ships
+  working wasm64 post-processing.
+- **The runtime side is proven and guarded.** The committed smoke test locks in
+  the Memory64 runtime capability so a future regression is caught in CI.
+
+## Reproducing
+
+```text
+# Runtime (Memory64) smoke test — runs in default CI, ~34 MiB RSS:
+deno test tests/wasm64_memory64_smoke_test.ts
+
+# Build the raw kernel for wasm64 (nightly + rust-src required):
+rustup toolchain install nightly --profile minimal --component rust-src
+cargo +nightly build --target wasm64-unknown-unknown --release \
+  -Z build-std=std,panic_abort
+#   -> target/wasm64-unknown-unknown/release/<crate>.wasm  (memory flags 0x04 = i64)
+
+# Confirm the production binding path is a no-go (wasm-bindgen strips exports):
+wasm-bindgen <wasm64 .wasm> --target web --out-dir pkg64   # exits 0, no accumulate binding
+```
+
+The wasm64 build requires a network-fetched nightly toolchain + `rust-src`, so
+it is **not** wired into default CI as a build step (unlike the runtime smoke
+test); it is documented here for reproduction and for the lane (d) / planning
+decision. If wasm64 is adopted, the exact `cargo … -Z build-std` invocation above
+becomes the CI build step per this issue's Failure Detection.

--- a/tests/wasm64_memory64_smoke.ts
+++ b/tests/wasm64_memory64_smoke.ts
@@ -1,0 +1,182 @@
+// Memory64 (Wasm 3.0) runtime probe for wasm64 lane (b) — Issue #297.
+//
+// Self-contained: hand-assembles a minimal `(memory i64 ...)` module that
+// exports `store(i64 addr, i32 val)` / `load(i64 addr) -> i32`, so the smoke
+// test needs NO checked-in `.wasm` binary and NO nightly build step. It probes
+// the *runtime* half of the spike: does this Deno/V8 instantiate a Memory64
+// module, grow linear memory past the wasm32 4 GiB ceiling, and round-trip a
+// 64-bit (`BigInt`) pointer across the JS↔WASM boundary?
+//
+// Every value below is a plain byte constant — the module is small enough to
+// audit by hand against the WebAssembly binary format.
+
+/** Bytes in one WASM page (64 KiB). */
+export const WASM_PAGE_BYTES = 64 * 1024;
+
+/** wasm32 linear memory is capped at 65536 pages = exactly 4 GiB. */
+export const WASM32_MAX_PAGES = 65536;
+
+/** The hard wasm32 address-space ceiling in bytes (4 GiB). */
+export const WASM32_MAX_BYTES = WASM32_MAX_PAGES * WASM_PAGE_BYTES;
+
+/**
+ * Memory-type flag bit that marks a 64-bit (i64) index type. A wasm32 memory
+ * has this bit clear; a Memory64 memory has it set. (Bit 0 = has-maximum.)
+ */
+export const MEMORY64_INDEX_FLAG = 0x04;
+
+/** Unsigned LEB128 encoding of a non-negative integer. */
+export function unsignedLeb128(value: number): number[] {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`unsignedLeb128 expects a non-negative integer, got ${value}`);
+  }
+  const out: number[] = [];
+  let n = value;
+  do {
+    let byte = n & 0x7f;
+    n = Math.floor(n / 128);
+    if (n !== 0) byte |= 0x80;
+    out.push(byte);
+  } while (n !== 0);
+  return out;
+}
+
+function section(id: number, body: number[]): number[] {
+  return [id, ...unsignedLeb128(body.length), ...body];
+}
+
+function nameBytes(s: string): number[] {
+  return [s.length, ...[...s].map((c) => c.charCodeAt(0))];
+}
+
+/**
+ * Assemble a minimal Memory64 module with a store/load boundary.
+ *
+ * @param maxPages declared maximum pages for the memory. Must exceed
+ *   {@link WASM32_MAX_PAGES} so the module can grow past 4 GiB.
+ */
+export function buildMemory64Module(maxPages: number): Uint8Array<ArrayBuffer> {
+  if (maxPages <= WASM32_MAX_PAGES) {
+    throw new RangeError(
+      `maxPages (${maxPages}) must exceed the wasm32 ceiling (${WASM32_MAX_PAGES}) to prove >4 GiB growth`,
+    );
+  }
+  // Type section: (i64,i32)->()  and  (i64)->(i32)
+  const types = section(0x01, [
+    0x02,
+    0x60, 0x02, 0x7e, 0x7f, 0x00, // store: (i64 addr, i32 val) -> ()
+    0x60, 0x01, 0x7e, 0x01, 0x7f, // load:  (i64 addr) -> i32
+  ]);
+  // Function section: func0 uses type0 (store), func1 uses type1 (load)
+  const funcs = section(0x03, [0x02, 0x00, 0x01]);
+  // Memory section: one memory, flags 0x05 = has-maximum(0x01) | is64(0x04),
+  // minimum 1 page, maximum maxPages.
+  const mem = section(0x05, [
+    0x01,
+    MEMORY64_INDEX_FLAG | 0x01,
+    ...unsignedLeb128(1),
+    ...unsignedLeb128(maxPages),
+  ]);
+  // Export section: memory, store, load
+  const exportSec = section(0x07, [
+    0x03,
+    ...nameBytes("mem"), 0x02, 0x00,
+    ...nameBytes("store"), 0x00, 0x00,
+    ...nameBytes("load"), 0x00, 0x01,
+  ]);
+  // Code section. i32.store/i32.load take the address from the stack as i64
+  // when the memory is 64-bit; memarg is (align=2, offset=0).
+  const storeBody = [0x00, 0x20, 0x00, 0x20, 0x01, 0x36, 0x02, 0x00, 0x0b];
+  const loadBody = [0x00, 0x20, 0x00, 0x28, 0x02, 0x00, 0x0b];
+  const code = section(0x0a, [
+    0x02,
+    ...unsignedLeb128(storeBody.length), ...storeBody,
+    ...unsignedLeb128(loadBody.length), ...loadBody,
+  ]);
+  const parts = [
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+    ...types,
+    ...funcs,
+    ...mem,
+    ...exportSec,
+    ...code,
+  ];
+  // Back the module with a concrete ArrayBuffer (not ArrayBufferLike) so it
+  // satisfies the `BufferSource` parameter of WebAssembly.{validate,Module}.
+  const out = new Uint8Array(new ArrayBuffer(parts.length));
+  out.set(parts);
+  return out;
+}
+
+/** Parsed limits of the first memory declared in a module. */
+export interface MemoryLimits {
+  count: number;
+  flags: number;
+  /** True when the memory declares a 64-bit (i64) index type. */
+  isMemory64: boolean;
+}
+
+/**
+ * Parse the memory section (id 0x05) of a module and report its flags. Used to
+ * assert — without instantiating — that the module we built really carries the
+ * i64 index type.
+ */
+export function parseMemoryLimits(bytes: Uint8Array<ArrayBuffer>): MemoryLimits {
+  let p = 8; // skip magic + version
+  const readLeb = (): number => {
+    let result = 0, shift = 0, byte: number;
+    do {
+      byte = bytes[p++];
+      result |= (byte & 0x7f) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    return result >>> 0;
+  };
+  while (p < bytes.length) {
+    const id = bytes[p++];
+    const len = readLeb();
+    const start = p;
+    if (id === 0x05) {
+      const count = readLeb();
+      const flags = bytes[p];
+      return { count, flags, isMemory64: (flags & MEMORY64_INDEX_FLAG) !== 0 };
+    }
+    p = start + len;
+  }
+  throw new Error("no memory section (0x05) found in module");
+}
+
+/** Handles bound to an instantiated Memory64 store/load module. */
+export interface Memory64Instance {
+  memory: WebAssembly.Memory;
+  store: (addr: bigint, value: number) => void;
+  load: (addr: bigint) => number;
+}
+
+/** Instantiate a Memory64 store/load module built by {@link buildMemory64Module}. */
+export function instantiateMemory64(bytes: Uint8Array<ArrayBuffer>): Memory64Instance {
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+  return {
+    memory: inst.exports.mem as WebAssembly.Memory,
+    store: inst.exports.store as (addr: bigint, value: number) => void,
+    load: inst.exports.load as (addr: bigint) => number,
+  };
+}
+
+/**
+ * Grow an i64 memory to `targetPages`. Growth on a Memory64 uses a `BigInt`
+ * delta (the 64-bit index type) and returns the previous page count as a
+ * `BigInt`. Returns the resulting `byteLength`.
+ *
+ * Pages are reserved lazily by V8, so growing past 4 GiB reserves address space
+ * without committing physical RAM — only pages actually written are committed.
+ */
+export function growToPages(memory: WebAssembly.Memory, targetPages: number): number {
+  const currentPages = memory.buffer.byteLength / WASM_PAGE_BYTES;
+  const delta = targetPages - currentPages;
+  if (delta > 0) {
+    // BigInt delta is mandatory for a 64-bit memory — a Number throws.
+    memory.grow(BigInt(delta) as unknown as number);
+  }
+  return memory.buffer.byteLength;
+}

--- a/tests/wasm64_memory64_smoke_test.ts
+++ b/tests/wasm64_memory64_smoke_test.ts
@@ -1,0 +1,91 @@
+// Committed Memory64 smoke test for wasm64 lane (b) — Issue #297.
+//
+// This is the *earliest failure-detection point* for the wasm64 spike: if a
+// Deno/V8 upgrade drops or breaks Wasm 3.0 Memory64 support, this test fails in
+// the repo's `deno test` CI job rather than being rediscovered mid-port later.
+//
+// "What" tests (AGENTS.md): they instantiate a real minimal `(memory i64 ...)`
+// module and assert on observable outcomes — the module validates, linear
+// memory grows past the wasm32 4 GiB ceiling, growth uses the 64-bit `BigInt`
+// index type, and a `BigInt` offset above 4 GiB round-trips across the JS↔WASM
+// boundary through the exported `store`/`load` functions.
+//
+// Run: deno test tests/wasm64_memory64_smoke_test.ts
+
+import { assert, assertEquals, assertThrows } from "jsr:@std/assert@1";
+import {
+  buildMemory64Module,
+  instantiateMemory64,
+  MEMORY64_INDEX_FLAG,
+  parseMemoryLimits,
+  unsignedLeb128,
+  WASM32_MAX_BYTES,
+  WASM32_MAX_PAGES,
+  WASM_PAGE_BYTES,
+} from "./wasm64_memory64_smoke.ts";
+
+// ~4.004 GiB: just enough headroom to prove growth strictly past the 4 GiB wall
+// while keeping reserved address space (and touched pages) minimal.
+const MAX_PAGES = WASM32_MAX_PAGES + 128;
+const FOUR_GIB = BigInt(WASM32_MAX_BYTES);
+
+Deno.test("unsignedLeb128 encodes multi-byte page counts correctly", () => {
+  assertEquals(unsignedLeb128(0), [0x00]);
+  assertEquals(unsignedLeb128(1), [0x01]);
+  // 65664 = 0x100 80 ... verify it decodes back to itself via the parser path.
+  assertEquals(unsignedLeb128(624485), [0xe5, 0x8e, 0x26]);
+  assertThrows(() => unsignedLeb128(-1), RangeError);
+});
+
+Deno.test("minimal (memory i64 ...) module validates and marks the i64 index type", () => {
+  const bytes = buildMemory64Module(MAX_PAGES);
+  assert(WebAssembly.validate(bytes), "Memory64 module must validate in this V8");
+  const limits = parseMemoryLimits(bytes);
+  assertEquals(limits.count, 1);
+  assert(
+    (limits.flags & MEMORY64_INDEX_FLAG) !== 0,
+    `memory flags 0x${limits.flags.toString(16)} must set the i64 index bit`,
+  );
+  assert(limits.isMemory64);
+});
+
+Deno.test("buildMemory64Module rejects a max that cannot exceed the 4 GiB wall", () => {
+  assertThrows(() => buildMemory64Module(WASM32_MAX_PAGES), RangeError);
+});
+
+Deno.test("instantiates and grows linear memory past the wasm32 4 GiB ceiling", () => {
+  const { memory } = instantiateMemory64(buildMemory64Module(MAX_PAGES));
+  assertEquals(memory.buffer.byteLength, WASM_PAGE_BYTES); // starts at 1 page
+  memory.grow(BigInt(MAX_PAGES - 1) as unknown as number);
+  assert(
+    memory.buffer.byteLength > WASM32_MAX_BYTES,
+    `byteLength ${memory.buffer.byteLength} must exceed the wasm32 4 GiB ceiling ${WASM32_MAX_BYTES}`,
+  );
+});
+
+Deno.test("grow on an i64 memory requires and returns a BigInt (64-bit index)", () => {
+  const { memory } = instantiateMemory64(buildMemory64Module(MAX_PAGES));
+  const prev = memory.grow(1n as unknown as number);
+  assertEquals(typeof prev, "bigint");
+  assertEquals(prev as unknown as bigint, 1n); // previous page count, as a BigInt
+  // A plain Number delta is rejected: the index type is genuinely 64-bit.
+  assertThrows(() => memory.grow(1 as unknown as number), TypeError);
+});
+
+Deno.test("round-trips a BigInt offset above 4 GiB across the JS↔WASM boundary", () => {
+  const { memory, store, load } = instantiateMemory64(buildMemory64Module(MAX_PAGES));
+  memory.grow(BigInt(MAX_PAGES - 1) as unknown as number);
+
+  // Address strictly above the wasm32 4 GiB ceiling — unreachable on wasm32.
+  const addr = FOUR_GIB + 2048n;
+  const value = 0x1234abcd | 0;
+  store(addr, value);
+  assertEquals(load(addr) >>> 0, 0x1234abcd);
+
+  // A second address, also above 4 GiB, is independent (no aliasing wrap-around
+  // to a 32-bit offset).
+  const addr2 = FOUR_GIB + BigInt(WASM_PAGE_BYTES) + 16n;
+  store(addr2, 0x0badf00d | 0);
+  assertEquals(load(addr2) >>> 0, 0x0badf00d);
+  assertEquals(load(addr) >>> 0, 0x1234abcd); // first write untouched
+});


### PR DESCRIPTION
# wasm64 lane (b): build-lane feasibility spike (Rust Tier 3 + Deno/V8 Memory64)

## Summary

Time-boxed feasibility spike for milestone #295 (lane b). Establishes — with
exact toolchain versions, flags, and reproduction steps — **whether a working
wasm64 (Memory64) neat-core artefact is buildable and loadable in Deno 2.9.3
today**. Delivers a committed, runnable Memory64 smoke test wired into CI, plus a
written go/no-go finding backed by captured evidence. `Closes #297`.

**Finding — qualified GO:**

- **Runtime — GO.** Deno 2.9.3 / V8 14.9.207.2 instantiates a minimal
  `(memory i64 …)` module and grows linear memory past the wasm32 4 GiB ceiling,
  up to the V8 implementation limit of **262144 pages = 16 GiB**. `Memory.grow()`
  on an i64 memory requires and returns a `BigInt` (the observable 64-bit index
  signature). Growth reserves address space lazily, so the probe touches only a
  few pages (~34 MiB RSS) — cheap enough to run in default CI.
- **Build (raw) — GO, nightly only.** A trivial neat-core-style kernel builds for
  `wasm64-unknown-unknown` with `nightly-2026-07-19` + `rust-src` +
  `-Z build-std=std,panic_abort`, producing a genuine Memory64 module. **Stable
  is a no-go** (Tier 3, no prebuilt `std`; `rustup target add` refuses).
- **Bindings (raw) — GO.** The kernel is callable across the JS↔WASM boundary
  with 64-bit pointers passed as `BigInt`.
- **Build (production) — NO-GO.** `wasm-bindgen` / `wasm-pack` (the path this
  repo ships via `scripts/build-wasm-bundle.sh`) **silently strip** the exported
  bindings from a Memory64 module: the CLI exits 0 but the generated glue and
  `_bg.wasm` contain no `accumulate` / `__wbindgen_malloc`. The same crate emits
  working glue on wasm32. This is the hard blocker for any wasm-pack-based port.
- **Perf — no measurable regression.** A raw accumulate kernel over a 4 MiB
  (4 GiB-fitting) buffer runs within **±2 %** (measurement noise) wasm64 vs
  wasm32. A full #286 Criterion comparison is blocked by the wasm-bindgen no-go
  and is recorded as such rather than hidden.

**Recommendation (feeds #295 planning):** consistent with lane (a), do **not**
adopt wasm64 yet (today's ceiling is the V8 heap, liftable with
`--max-old-space-size`). If/when wasm64 is needed, the viable path is raw
`extern "C"` exports + hand-rolled `BigInt` bindings on nightly + `-Z build-std`
— **not** `wasm-pack`, until the toolchain ships working wasm64 post-processing.

Full write-up:
[`docs/research/wasm64-lane-b-build-lane-feasibility.md`](../../research/wasm64-lane-b-build-lane-feasibility.md).

## Evidence

Backend/runtime spike — no web interface to screenshot. Evidence is the captured
runtime signatures (in the finding doc), the committed smoke test, and the new
CI job that guards it.

```mermaid
flowchart TD
    A["Need >4 GiB in neat-core WASM?"] --> B{"Lane (a): which pool binds?"}
    B -- "V8 heap (today)" --> C["Raise --max-old-space-size — wasm64 NOT needed yet"]
    B -- "WASM linear memory" --> D["wasm64 (Memory64) required"]
    D --> E{"Binding path?"}
    E -- "raw extern C + BigInt" --> F["GO: nightly + -Z build-std, callable today"]
    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO: CLI silently strips exports"]
    G --> H["Blocker: await wasm-bindgen wasm64 support, or use raw path"]
```

Captured on Deno 2.9.3 / V8 14.9.207.2, rustc nightly `1.99.0 (9f36de775)`,
wasm-pack 0.13.1, wasm-bindgen 0.2.108:

| Axis | Result |
| --- | --- |
| Memory64 grow ceiling | 262144 pages = **16 GiB** (V8 impl limit) |
| `Memory.grow()` on i64 memory | requires + returns **`BigInt`**; `Number` throws `TypeError` |
| wasm64 raw build | **OK** (nightly + `-Z build-std`), module memory flag `0x04` = i64 |
| wasm-bindgen wasm32 vs wasm64 | wasm32 glue exports `accumulate`; **wasm64 strips it (exit 0)** |
| wasm64 vs wasm32 accumulate | within **±2 %** — no measurable regression |

## Test Plan

- Added `tests/wasm64_memory64_smoke_test.ts` (+ helpers
  `tests/wasm64_memory64_smoke.ts`) — 6 "what" tests that call real code and
  assert on observable outcomes:
  - a hand-assembled `(memory i64 …)` module validates and its memory section
    sets the i64 index flag (`0x04`);
  - `buildMemory64Module` rejects a max that cannot exceed the 4 GiB wall;
  - the module instantiates and grows linear memory **past 4 GiB**
    (`byteLength > 4 GiB`);
  - `grow()` requires and returns a `BigInt`; a `Number` delta throws;
  - a `BigInt` offset **above 4 GiB** round-trips through the module's exported
    `store`/`load` functions (two independent addresses, no 32-bit wrap-around);
  - `unsignedLeb128` encodes multi-byte page counts.
  - Run: `deno test tests/wasm64_memory64_smoke_test.ts` → 6 passed, ~9 ms,
    ~34 MiB RSS. Full `deno test tests/` → 19 passed (with lane a).
- Added a `wasm64-memory64-smoke` CI job (`.github/workflows/ci.yml`, Deno 2.9.3,
  `denoland/setup-deno` SHA-pinned) so a Deno/V8 upgrade dropping Memory64 fails
  in CI — the issue's earliest failure-detection point.
- No Rust changed. Confirmed unaffected: `cargo check` / `cargo clippy -D
  warnings` / `cargo test` all green; `actionlint` and the workflow-guard bats
  suite pass on the updated `ci.yml`; markdownlint + codespell clean on new docs.



## Milestone
This PR is part of the **#295 Adopt WASM 3.0 Memory64: wasm64 spike + training-data offload for >4 GB jobs** milestone and targets the `milestone/295-adopt-wasm-3-0-memory64-wasm64-spike-training` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrspexod-9c2f63`<!-- vibe-worker-issue-297 -->