### PR TITLE
wasm64 lane (c): offload training data into WASM linear memory (Issue #298)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -513,14 +513,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -543,9 +543,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,7 +634,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -720,7 +720,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,41 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 
 **`wasm_activation`** and **`pkg/`** remain in the **NEAT-AI** repo on `Develop` — not in this repository.
 
+## Training-data offload (WASM linear memory)
+
+wasm64 milestone #295, lane (c) — Issue #298. Lane (a) attributed the ~4 GB
+Learn ceiling to the **V8 JS heap** (exit-133 / "Reached heap limit"), not WASM
+linear memory. `wasm_dataset` moves the large numeric training arrays **off the
+JS heap**: neat-core owns the dataset inside its own linear memory, JS holds only
+a `u32` **handle**, and per-generation evaluation reads batches **by index** —
+the full dataset never re-crosses the JS↔WASM boundary after the initial load.
+
+- [`TrainingDataset`](neat-core/src/wasm_dataset.rs) de-interleaves the packed
+  `.bin` record stream into contiguous structure-of-arrays input/target buffers
+  once, at load time.
+- [`DatasetRegistry`](neat-core/src/wasm_dataset.rs) is the handle table:
+  `load` → handle, `free` → release. It tracks live and peak byte footprint so a
+  lifecycle leak (bytes retained past `free`) is observable — the high-water mark
+  stays flat across load → evaluate → free cycles.
+- WASM shims (`training_data_load` / `_evaluate_mse` / `_free` / `_byte_len` /
+  `_peak_bytes`) carry byte counts and record indices as `u64` (JS `BigInt`), so
+  the surface is Memory64-ready for the >4 GB jobs the milestone targets.
+
+```mermaid
+sequenceDiagram
+    participant JS as NEAT-AI Learn.ts
+    participant WASM as neat-core (linear memory)
+    JS->>WASM: training_data_load(bytes, num_inputs, num_outputs)
+    WASM-->>JS: handle (u32) — bytes now WASM-owned
+    loop each generation
+        JS->>WASM: evaluate_mse(handle, network, start, count)
+        Note over WASM: reads batch by index from<br/>owned buffers — no dataset copy
+        WASM-->>JS: mean squared error (f32)
+    end
+    JS->>WASM: training_data_free(handle)
+    Note over WASM: live_bytes → baseline,<br/>peak_bytes stays flat
+```
+
 ## Layout
 
 | Path | Role |

--- a/docs/archive/pr-summaries/pr-summary-298.md
+++ b/docs/archive/pr-summaries/pr-summary-298.md
@@ -1,0 +1,98 @@
+# wasm64 lane (c): offload training data into WASM linear memory
+
+## Summary
+
+Implements the neat-core half of milestone #295 lane (c): neat-core now **owns**
+the training dataset inside its own WASM linear memory, so the large numeric
+input/target arrays no longer sit on the V8 JS heap that lane (a) attributed the
+~4 GB Learn ceiling to (exit-133 / "Reached heap limit" = GRQ#3508). JS holds a
+small `u32` **handle**, not the bytes, and per-generation evaluation reads
+batches **by index** from the WASM-owned buffers — the full dataset never
+re-crosses the JS↔WASM boundary after the initial load. Closes #298.
+
+New module `neat-core/src/wasm_dataset.rs`:
+
+- **`TrainingDataset`** — de-interleaves the packed `.bin` record stream
+  (`inputs … outputs` per record) into contiguous structure-of-arrays
+  input/target buffers **once**, at load time. Batch reads (`input_batch`,
+  `target_batch`, `record_inputs/outputs`) are then contiguous slices, and
+  `evaluate_mse(network, start, count)` scores a batch reading straight from
+  linear memory. `byte_len()` exposes the footprint.
+- **`DatasetRegistry`** — the ownership seam agreed with NEAT-AI#3410: `load`
+  returns a handle, `free` releases the dataset. It tracks `live_bytes` and
+  `peak_bytes`, so a lifecycle leak (bytes retained past `free`) is observable —
+  the high-water mark stays flat across load → evaluate → free cycles. Freed
+  slots are reused so an equal-sized reload does not grow the peak.
+- **WASM shims** (`training_data_load` / `_evaluate_mse` / `_free` /
+  `_num_records` / `_byte_len` / `_live_bytes` / `_peak_bytes`) in
+  `wasm_exports.rs`, gated to `wasm32`. Byte counts and record indices cross as
+  `u64` (JS `BigInt`) so the surface is **Memory64-ready** for the >4 GB jobs the
+  milestone targets (lane (b) confirmed V8 grows past the 4 GiB wasm32 wall).
+
+Fail-loud throughout (Issue #3234): a ragged buffer, an out-of-range batch, an
+unknown/double-freed handle, or a network/dataset shape mismatch each surface a
+typed `DatasetError` rather than a silent wrong result.
+
+### Coordination / scope
+
+- **NEAT-AI#3410 (Learn heap / MemoryMonitor):** this PR delivers only the
+  neat-core memory + bindings seam (the handle table and by-index evaluation).
+  The `Learn.ts` wiring and the MemoryMonitor fix remain owned by NEAT-AI#3410 —
+  not duplicated here. The consuming repo bumps to a released neat-core through
+  the ordinary dependency-bump flow once this lands.
+- **Perf gate (#286 Criterion baseline):** the existing hot paths
+  (`activate` / `score_batch_into`) are unchanged, so the `hot_paths` /
+  `parallel_scoring` benches are unaffected — no throughput regression on
+  jobs that already fit. The offload adds a new load-time de-interleave, off the
+  per-generation scoring hot path.
+
+```mermaid
+sequenceDiagram
+    participant JS as NEAT-AI Learn.ts
+    participant WASM as neat-core (linear memory)
+    JS->>WASM: training_data_load(bytes, num_inputs, num_outputs)
+    WASM-->>JS: handle (u32) — bytes now WASM-owned
+    loop each generation
+        JS->>WASM: evaluate_mse(handle, network, start, count)
+        Note over WASM: reads batch by index from<br/>owned buffers — no dataset copy
+        WASM-->>JS: mean squared error (f32)
+    end
+    JS->>WASM: training_data_free(handle)
+    Note over WASM: live_bytes → baseline,<br/>peak_bytes stays flat
+```
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified by the new
+`wasm_dataset_offload` test suite plus the crate unit tests; the whole
+`./quality.sh` gate passes (fmt, clippy `-D warnings` on native **and**
+`wasm32-unknown-unknown`, tests, doc, cargo-deny, bats). `cargo check
+--target wasm32-unknown-unknown` confirms the `#[wasm_bindgen]` shims compile.
+
+Key acceptance criteria mapped to tests:
+
+- *Dataset owned in WASM, JS holds a handle* →
+  `registry_hands_out_handles_not_bytes`, `registry_free_releases_bytes_and_reuses_slot`.
+- *Evaluation reads batches by index without re-marshalling the dataset* →
+  `evaluation_reads_the_batch_by_index_from_owned_memory`,
+  `evaluation_does_not_reload_or_mutate_the_dataset` (footprint + record count
+  unchanged across 50 generations; only handle + network + bounds per call).
+- *Load → evaluate N generations → free → high-water mark stable* (leak gate) →
+  `load_evaluate_free_lifecycle_keeps_high_water_mark_stable` (8 cycles ×
+  5 generations; `live_bytes` returns to 0 after each free, `peak_bytes` flat).
+- *Fail loud* → `from_packed_bytes_rejects_unaligned_buffer`,
+  `batch_out_of_range_fails_loud`, `registry_double_free_fails_loud`,
+  `evaluation_rejects_network_dataset_shape_mismatch`,
+  `evaluation_rejects_out_of_range_batch`.
+
+## Test Plan
+
+- `neat-core/tests/wasm_dataset_offload.rs` — 6 integration "what" tests
+  (evaluation-by-index correctness, no-reload invariant, shape/range fail-loud,
+  the load/evaluate/free leak high-water-mark gate, handle-not-bytes ownership).
+- `neat-core/src/wasm_dataset.rs` unit tests — 10 tests (SoA de-interleave,
+  unaligned/zero-arity rejection, contiguous batch slices, `byte_len`,
+  `from_soa` mismatch, registry free/reuse, unknown-handle and double-free
+  fail-loud).
+- `cargo test --workspace --lib --tests --all-features` green; `cargo check
+  --target wasm32-unknown-unknown` and `cargo clippy` (native + wasm32) clean.

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod training_bin_stream;
 pub mod training_data;
 pub mod training_state;
 pub mod unsquash;
+pub mod wasm_dataset;
 
 // Issue #36 — WASM-only `#[wasm_bindgen]` shims that wrap apply_* helpers,
 // tuple returns, and the byte-packed `propagate_topological` ABI. Native
@@ -56,6 +57,7 @@ pub use training_data::{
     SeekingRecordReader, TrainingDataConfig, TrainingDataError, TrainingDataIterator,
     TrainingRecord, find_bin_files, read_dir as read_training_dir, read_file as read_training_file,
 };
+pub use wasm_dataset::{DatasetError, DatasetRegistry, TrainingDataset};
 
 // Re-export core functions
 pub use accumulate::{

--- a/neat-core/src/wasm_dataset.rs
+++ b/neat-core/src/wasm_dataset.rs
@@ -1,0 +1,592 @@
+//! Training-data offload into neat-core's own linear memory (Issue #298).
+//!
+//! wasm64 lane (c) of milestone #295. Lane (a) attributed the ~4 GB Learn
+//! ceiling to the **V8 JS heap** (exit-133 / "Reached heap limit"), not WASM
+//! linear memory. The relief is to stop retaining the large numeric training
+//! arrays on the JS heap: neat-core **owns** the dataset inside its own linear
+//! memory, JS holds only a small integer **handle**, and per-generation
+//! evaluation reads batches **by index** from the WASM-owned buffers instead of
+//! copying the full dataset across the JS↔WASM boundary on every call.
+//!
+//! # Ownership model
+//!
+//! ```text
+//!   JS                          neat-core linear memory
+//!   ──                          ───────────────────────
+//!   handle: u32   ──lookup──▶   DatasetRegistry
+//!                               └─ TrainingDataset (inputs SoA + targets SoA)
+//! ```
+//!
+//! * [`TrainingDataset`] de-interleaves the packed `.bin` record stream
+//!   (`inputs … outputs` per record) into two contiguous structure-of-arrays
+//!   buffers **once**, at load time. Batch reads are then contiguous slices.
+//! * [`DatasetRegistry`] is the handle table: `load` returns a `u32` handle,
+//!   `free` drops the dataset and releases its bytes. It tracks live and
+//!   peak footprint so a leak (memory retained past `free`) is observable —
+//!   the load → evaluate → free lifecycle high-water mark stays flat.
+//! * Evaluation ([`TrainingDataset::evaluate_mse`]) reads inputs and targets
+//!   for the requested `[start, start + count)` batch straight from the owned
+//!   buffers. The dataset bytes never re-cross the boundary after load.
+//!
+//! Fail-loud (Issue #3234): every fallible operation returns a [`DatasetError`]
+//! — a bad record length, an out-of-range batch, an unknown handle, or a
+//! network/dataset shape mismatch surfaces immediately rather than degrading
+//! into a silent wrong result.
+
+use crate::network::CompiledNetwork;
+use crate::training_data::TrainingDataConfig;
+
+/// Errors from the training-data offload path.
+#[derive(Debug, PartialEq)]
+pub enum DatasetError {
+    /// The configuration specifies zero inputs or zero outputs.
+    InvalidConfig {
+        /// Human-readable description of the invalid configuration.
+        message: String,
+    },
+    /// The packed byte buffer length is not an exact multiple of the record
+    /// size, so it cannot be split cleanly into records.
+    UnalignedBuffer {
+        /// Length of the supplied buffer in bytes.
+        buffer_len: usize,
+        /// Expected byte size of a single record.
+        record_size: usize,
+    },
+    /// A requested `[start, start + count)` batch falls outside the dataset.
+    BatchOutOfRange {
+        /// First record index requested.
+        start: usize,
+        /// Number of records requested.
+        count: usize,
+        /// Total records held by the dataset.
+        num_records: usize,
+    },
+    /// A handle did not correspond to a live dataset in the registry.
+    UnknownHandle {
+        /// The handle that was looked up.
+        handle: u32,
+    },
+    /// The network's input arity does not match the dataset's input arity.
+    ShapeMismatch {
+        /// Inputs the network expects.
+        network_inputs: usize,
+        /// Inputs each dataset record carries.
+        dataset_inputs: usize,
+    },
+}
+
+impl std::fmt::Display for DatasetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DatasetError::InvalidConfig { message } => {
+                write!(f, "Invalid dataset configuration: {message}")
+            }
+            DatasetError::UnalignedBuffer {
+                buffer_len,
+                record_size,
+            } => write!(
+                f,
+                "Buffer length {buffer_len} bytes is not a multiple of record size {record_size}"
+            ),
+            DatasetError::BatchOutOfRange {
+                start,
+                count,
+                num_records,
+            } => write!(
+                f,
+                "Batch [{start}, {start}+{count}) is out of range for {num_records} records"
+            ),
+            DatasetError::UnknownHandle { handle } => {
+                write!(f, "No live dataset for handle {handle}")
+            }
+            DatasetError::ShapeMismatch {
+                network_inputs,
+                dataset_inputs,
+            } => write!(
+                f,
+                "Network expects {network_inputs} inputs but dataset records carry {dataset_inputs}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DatasetError {}
+
+/// A training dataset owned inside neat-core's linear memory.
+///
+/// Stored structure-of-arrays: [`inputs`](Self::inputs_len) is `num_records ×
+/// num_inputs` contiguous `f32`, [`targets`](Self::targets_len) is
+/// `num_records × num_outputs`. This makes an input batch a single contiguous
+/// slice, so per-generation evaluation gathers one cache-friendly run rather
+/// than re-marshalling per-record arrays across the boundary.
+#[derive(Debug, Clone)]
+pub struct TrainingDataset {
+    config: TrainingDataConfig,
+    num_records: usize,
+    inputs: Vec<f32>,
+    targets: Vec<f32>,
+}
+
+impl TrainingDataset {
+    /// Load a dataset from the packed `.bin` byte stream produced by the
+    /// TypeScript `DataSet` module: each record is `num_inputs + num_outputs`
+    /// little-endian `f32` values, records packed contiguously.
+    ///
+    /// The buffer is de-interleaved into the structure-of-arrays layout once,
+    /// here. Fails loud if the buffer length is not a whole number of records.
+    pub fn from_packed_bytes(
+        bytes: &[u8],
+        config: TrainingDataConfig,
+    ) -> Result<Self, DatasetError> {
+        validate_config(&config)?;
+        let record_size = config.bytes_per_record();
+        if !bytes.len().is_multiple_of(record_size) {
+            return Err(DatasetError::UnalignedBuffer {
+                buffer_len: bytes.len(),
+                record_size,
+            });
+        }
+
+        let num_records = bytes.len() / record_size;
+        let num_inputs = config.num_inputs;
+        let num_outputs = config.num_outputs;
+        let mut inputs = Vec::with_capacity(num_records * num_inputs);
+        let mut targets = Vec::with_capacity(num_records * num_outputs);
+
+        for record in bytes.chunks_exact(record_size) {
+            let values = record
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]));
+            for (i, value) in values.enumerate() {
+                if i < num_inputs {
+                    inputs.push(value);
+                } else {
+                    targets.push(value);
+                }
+            }
+        }
+
+        Ok(Self {
+            config,
+            num_records,
+            inputs,
+            targets,
+        })
+    }
+
+    /// Build a dataset directly from separate input and target buffers already
+    /// in structure-of-arrays layout. Fails loud if either buffer length is
+    /// not consistent with `config` and a common record count.
+    pub fn from_soa(
+        inputs: Vec<f32>,
+        targets: Vec<f32>,
+        config: TrainingDataConfig,
+    ) -> Result<Self, DatasetError> {
+        validate_config(&config)?;
+        let by_inputs = record_count(inputs.len(), config.num_inputs)?;
+        let by_targets = record_count(targets.len(), config.num_outputs)?;
+        if by_inputs != by_targets {
+            return Err(DatasetError::InvalidConfig {
+                message: format!(
+                    "input buffer implies {by_inputs} records but target buffer implies {by_targets}"
+                ),
+            });
+        }
+        Ok(Self {
+            config,
+            num_records: by_inputs,
+            inputs,
+            targets,
+        })
+    }
+
+    /// Number of records held.
+    pub fn num_records(&self) -> usize {
+        self.num_records
+    }
+
+    /// Inputs per record.
+    pub fn num_inputs(&self) -> usize {
+        self.config.num_inputs
+    }
+
+    /// Outputs (targets) per record.
+    pub fn num_outputs(&self) -> usize {
+        self.config.num_outputs
+    }
+
+    /// Length of the owned input buffer in `f32` values.
+    pub fn inputs_len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Length of the owned target buffer in `f32` values.
+    pub fn targets_len(&self) -> usize {
+        self.targets.len()
+    }
+
+    /// Footprint of this dataset in neat-core's linear memory, in bytes.
+    ///
+    /// This is the quantity that must return to its pre-load baseline once the
+    /// dataset is freed — the anchor for the leak/high-water-mark check.
+    pub fn byte_len(&self) -> usize {
+        (self.inputs.len() + self.targets.len()) * std::mem::size_of::<f32>()
+    }
+
+    /// Contiguous input slice for the `[start, start + count)` record batch.
+    ///
+    /// Reads straight from the owned buffer — no copy crosses the boundary.
+    pub fn input_batch(&self, start: usize, count: usize) -> Result<&[f32], DatasetError> {
+        let (lo, hi) = self.batch_bounds(start, count, self.num_inputs())?;
+        Ok(&self.inputs[lo..hi])
+    }
+
+    /// Contiguous target slice for the `[start, start + count)` record batch.
+    pub fn target_batch(&self, start: usize, count: usize) -> Result<&[f32], DatasetError> {
+        let (lo, hi) = self.batch_bounds(start, count, self.num_outputs())?;
+        Ok(&self.targets[lo..hi])
+    }
+
+    /// Inputs for a single record by index.
+    pub fn record_inputs(&self, index: usize) -> Result<&[f32], DatasetError> {
+        self.input_batch(index, 1)
+    }
+
+    /// Targets for a single record by index.
+    pub fn record_outputs(&self, index: usize) -> Result<&[f32], DatasetError> {
+        self.target_batch(index, 1)
+    }
+
+    /// Evaluate a network over the `[start, start + count)` record batch and
+    /// return the mean squared error against the owned targets.
+    ///
+    /// The dataset is read **by index** from linear memory; only the network
+    /// and the batch bounds are supplied per call — the training arrays never
+    /// re-cross the boundary. Fails loud on an out-of-range batch or a
+    /// network/dataset input-arity mismatch.
+    pub fn evaluate_mse(
+        &self,
+        network: &mut CompiledNetwork,
+        start: usize,
+        count: usize,
+    ) -> Result<f32, DatasetError> {
+        if network.num_inputs != self.num_inputs() {
+            return Err(DatasetError::ShapeMismatch {
+                network_inputs: network.num_inputs,
+                dataset_inputs: self.num_inputs(),
+            });
+        }
+        // Bounds-check the whole batch up front (fail loud before any work).
+        self.batch_bounds(start, count, self.num_inputs())?;
+        self.batch_bounds(start, count, self.num_outputs())?;
+
+        if count == 0 {
+            return Ok(0.0);
+        }
+
+        let num_outputs = self.num_outputs();
+        let mut squared_error_sum = 0.0f64;
+        for offset in 0..count {
+            let index = start + offset;
+            let inputs = self.record_inputs(index)?;
+            let targets = self.record_outputs(index)?;
+            let outputs = network.activate(inputs, num_outputs);
+            for (predicted, expected) in outputs.iter().zip(targets.iter()) {
+                let diff = f64::from(*predicted) - f64::from(*expected);
+                squared_error_sum += diff * diff;
+            }
+        }
+
+        let terms = (count * num_outputs) as f64;
+        Ok((squared_error_sum / terms) as f32)
+    }
+
+    /// Translate a record batch into buffer `[lo, hi)` bounds for a per-record
+    /// stride, rejecting any batch that runs past the end.
+    fn batch_bounds(
+        &self,
+        start: usize,
+        count: usize,
+        stride: usize,
+    ) -> Result<(usize, usize), DatasetError> {
+        let end = start.checked_add(count).filter(|&e| e <= self.num_records);
+        match end {
+            Some(end) => Ok((start * stride, end * stride)),
+            None => Err(DatasetError::BatchOutOfRange {
+                start,
+                count,
+                num_records: self.num_records,
+            }),
+        }
+    }
+}
+
+/// Handle table owning every live [`TrainingDataset`] in linear memory.
+///
+/// This is the ownership seam agreed with NEAT-AI#3410: JS holds the returned
+/// `u32` handle only, never the dataset bytes. Freed slots are reused so a
+/// steady load → free cycle of equal-sized datasets keeps
+/// [`peak_bytes`](Self::peak_bytes) flat — a growing peak means a leak.
+#[derive(Debug, Default)]
+pub struct DatasetRegistry {
+    slots: Vec<Option<TrainingDataset>>,
+    live_bytes: usize,
+    peak_bytes: usize,
+}
+
+impl DatasetRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load a packed dataset and return its handle.
+    pub fn load_packed(
+        &mut self,
+        bytes: &[u8],
+        config: TrainingDataConfig,
+    ) -> Result<u32, DatasetError> {
+        let dataset = TrainingDataset::from_packed_bytes(bytes, config)?;
+        Ok(self.insert(dataset))
+    }
+
+    /// Insert an already-built dataset and return its handle, reusing a freed
+    /// slot where one is available.
+    pub fn insert(&mut self, dataset: TrainingDataset) -> u32 {
+        self.live_bytes += dataset.byte_len();
+        self.peak_bytes = self.peak_bytes.max(self.live_bytes);
+
+        let free_slot = self.slots.iter().position(Option::is_none);
+        match free_slot {
+            Some(index) => {
+                self.slots[index] = Some(dataset);
+                index as u32
+            }
+            None => {
+                self.slots.push(Some(dataset));
+                (self.slots.len() - 1) as u32
+            }
+        }
+    }
+
+    /// Borrow the dataset behind a handle, failing loud if it is not live.
+    pub fn get(&self, handle: u32) -> Result<&TrainingDataset, DatasetError> {
+        self.slots
+            .get(handle as usize)
+            .and_then(Option::as_ref)
+            .ok_or(DatasetError::UnknownHandle { handle })
+    }
+
+    /// Free the dataset behind a handle, releasing its bytes. Returns the freed
+    /// dataset's footprint in bytes. Fails loud on an unknown handle so a
+    /// double-free cannot be mistaken for success (Issue #3234).
+    pub fn free(&mut self, handle: u32) -> Result<usize, DatasetError> {
+        let slot = self
+            .slots
+            .get_mut(handle as usize)
+            .filter(|slot| slot.is_some());
+        match slot {
+            Some(slot) => {
+                let dataset = slot.take().expect("slot is Some by the filter above");
+                let freed = dataset.byte_len();
+                self.live_bytes -= freed;
+                Ok(freed)
+            }
+            None => Err(DatasetError::UnknownHandle { handle }),
+        }
+    }
+
+    /// Bytes currently held by live datasets.
+    pub fn live_bytes(&self) -> usize {
+        self.live_bytes
+    }
+
+    /// Highest [`live_bytes`](Self::live_bytes) observed over this registry's
+    /// lifetime — the linear-memory high-water mark.
+    pub fn peak_bytes(&self) -> usize {
+        self.peak_bytes
+    }
+
+    /// Number of live datasets.
+    pub fn live_count(&self) -> usize {
+        self.slots.iter().filter(|slot| slot.is_some()).count()
+    }
+}
+
+/// Reject a configuration with zero inputs or zero outputs.
+fn validate_config(config: &TrainingDataConfig) -> Result<(), DatasetError> {
+    if config.num_inputs == 0 {
+        return Err(DatasetError::InvalidConfig {
+            message: "num_inputs must be greater than zero".to_string(),
+        });
+    }
+    if config.num_outputs == 0 {
+        return Err(DatasetError::InvalidConfig {
+            message: "num_outputs must be greater than zero".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Records implied by a buffer length and a per-record stride, failing loud on
+/// a ragged buffer.
+fn record_count(buffer_len: usize, stride: usize) -> Result<usize, DatasetError> {
+    if stride == 0 || !buffer_len.is_multiple_of(stride) {
+        return Err(DatasetError::UnalignedBuffer {
+            buffer_len,
+            record_size: stride * std::mem::size_of::<f32>(),
+        });
+    }
+    Ok(buffer_len / stride)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — core dataset + registry lifecycle. Higher-level offload behaviour
+// (evaluation-by-index, leak high-water mark) lives in
+// `tests/wasm_dataset_offload.rs`.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pack interleaved records (inputs then outputs each) into `.bin` bytes.
+    fn pack(records: &[Vec<f32>]) -> Vec<u8> {
+        records
+            .iter()
+            .flat_map(|r| r.iter().flat_map(|v| v.to_le_bytes()))
+            .collect()
+    }
+
+    #[test]
+    fn from_packed_bytes_deinterleaves_into_soa() {
+        // Two records, 2 inputs + 1 output each.
+        let bytes = pack(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+
+        assert_eq!(ds.num_records(), 2);
+        assert_eq!(ds.record_inputs(0).unwrap(), &[1.0, 2.0]);
+        assert_eq!(ds.record_outputs(0).unwrap(), &[3.0]);
+        assert_eq!(ds.record_inputs(1).unwrap(), &[4.0, 5.0]);
+        assert_eq!(ds.record_outputs(1).unwrap(), &[6.0]);
+    }
+
+    #[test]
+    fn from_packed_bytes_rejects_unaligned_buffer() {
+        // 2 inputs + 1 output => 12 bytes per record; 10 bytes is ragged.
+        let err = TrainingDataset::from_packed_bytes(&[0u8; 10], TrainingDataConfig::new(2, 1))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DatasetError::UnalignedBuffer {
+                buffer_len: 10,
+                record_size: 12,
+            }
+        );
+    }
+
+    #[test]
+    fn from_packed_bytes_rejects_zero_arity_config() {
+        let err =
+            TrainingDataset::from_packed_bytes(&[], TrainingDataConfig::new(0, 1)).unwrap_err();
+        assert!(matches!(err, DatasetError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn input_batch_returns_contiguous_slice() {
+        let bytes = pack(&[
+            vec![1.0, 2.0, 10.0],
+            vec![3.0, 4.0, 20.0],
+            vec![5.0, 6.0, 30.0],
+        ]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+
+        // Batch of the middle two records.
+        assert_eq!(ds.input_batch(1, 2).unwrap(), &[3.0, 4.0, 5.0, 6.0]);
+        assert_eq!(ds.target_batch(1, 2).unwrap(), &[20.0, 30.0]);
+    }
+
+    #[test]
+    fn batch_out_of_range_fails_loud() {
+        let bytes = pack(&[vec![1.0, 2.0], vec![3.0, 4.0]]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(1, 1)).unwrap();
+        let err = ds.input_batch(1, 5).unwrap_err();
+        assert_eq!(
+            err,
+            DatasetError::BatchOutOfRange {
+                start: 1,
+                count: 5,
+                num_records: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn byte_len_counts_inputs_and_targets() {
+        let bytes = pack(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+        // 2 records * (2 inputs + 1 target) * 4 bytes.
+        assert_eq!(ds.byte_len(), 2 * 3 * 4);
+    }
+
+    #[test]
+    fn from_soa_rejects_mismatched_record_counts() {
+        // 2 input records but 1 target record.
+        let err = TrainingDataset::from_soa(
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![9.0],
+            TrainingDataConfig::new(2, 1),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DatasetError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn registry_free_releases_bytes_and_reuses_slot() {
+        let mut registry = DatasetRegistry::new();
+        let bytes = pack(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let config = TrainingDataConfig::new(2, 1);
+
+        let handle = registry.load_packed(&bytes, config.clone()).unwrap();
+        assert_eq!(registry.live_count(), 1);
+        assert_eq!(registry.live_bytes(), 2 * 3 * 4);
+
+        let freed = registry.free(handle).unwrap();
+        assert_eq!(freed, 2 * 3 * 4);
+        assert_eq!(registry.live_bytes(), 0);
+        assert_eq!(registry.live_count(), 0);
+
+        // A same-sized reload reuses the freed slot (same handle index).
+        let handle2 = registry.load_packed(&bytes, config).unwrap();
+        assert_eq!(handle2, handle);
+        assert_eq!(registry.slots.len(), 1);
+    }
+
+    #[test]
+    fn registry_get_and_free_unknown_handle_fail_loud() {
+        let mut registry = DatasetRegistry::new();
+        assert_eq!(
+            registry.get(7).unwrap_err(),
+            DatasetError::UnknownHandle { handle: 7 }
+        );
+        assert_eq!(
+            registry.free(7).unwrap_err(),
+            DatasetError::UnknownHandle { handle: 7 }
+        );
+    }
+
+    #[test]
+    fn registry_double_free_fails_loud() {
+        let mut registry = DatasetRegistry::new();
+        let bytes = pack(&[vec![1.0, 2.0]]);
+        let handle = registry
+            .load_packed(&bytes, TrainingDataConfig::new(1, 1))
+            .unwrap();
+        registry.free(handle).unwrap();
+        // Second free must not silently succeed.
+        assert_eq!(
+            registry.free(handle).unwrap_err(),
+            DatasetError::UnknownHandle { handle }
+        );
+    }
+}

--- a/neat-core/src/wasm_exports.rs
+++ b/neat-core/src/wasm_exports.rs
@@ -18,6 +18,12 @@
 
 use wasm_bindgen::prelude::*;
 
+use std::cell::RefCell;
+
+use crate::network::CompiledNetwork;
+use crate::training_data::TrainingDataConfig;
+use crate::wasm_dataset::DatasetRegistry;
+
 use crate::derivative::{apply_derivative, apply_derivative_simd_4way};
 use crate::error::{apply_calculate_error, apply_calculate_error_batch_4way};
 use crate::fused_error::apply_fused_error_distribution;
@@ -261,4 +267,121 @@ pub fn wasm_propagate_topological(data: &[u8]) -> Vec<f64> {
     };
     let output = propagate_topological_loop(&decoded.as_input());
     encode_propagate_output(&output)
+}
+
+// ---------------------------------------------------------------------------
+// Training-data offload (Issue #298) — the dataset is owned in neat-core's
+// linear memory and JS holds only a `u32` handle. Byte counts and record
+// indices are `u64` (JS `BigInt`) so the surface is Memory64-ready for the
+// >4 GB jobs the wasm64 milestone (#295) targets. The dataset bytes cross the
+// boundary once, at `training_data_load`; evaluation passes only the handle,
+// the (small) network buffer, and the batch bounds.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Process-wide handle table. wasm32/wasm64 modules are single-threaded, so
+    /// a thread-local `RefCell` is the whole synchronisation story.
+    static DATASET_REGISTRY: RefCell<DatasetRegistry> = RefCell::new(DatasetRegistry::new());
+}
+
+/// Convert a `u64` boundary value to `usize`, failing loud if it cannot fit the
+/// current address space (only possible on a wasm32 module).
+fn usize_from_u64(value: u64, what: &str) -> Result<usize, JsError> {
+    usize::try_from(value)
+        .map_err(|_| JsError::new(&format!("{what} {value} exceeds addressable range")))
+}
+
+/// JS `training_data_load(data: Uint8Array, num_inputs, num_outputs) -> handle`.
+///
+/// Loads the packed `.bin` byte stream into linear memory once and returns the
+/// handle JS retains in place of the bytes.
+#[wasm_bindgen(js_name = training_data_load)]
+pub fn wasm_training_data_load(
+    data: &[u8],
+    num_inputs: u32,
+    num_outputs: u32,
+) -> Result<u32, JsError> {
+    let config = TrainingDataConfig::new(num_inputs as usize, num_outputs as usize);
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow_mut()
+            .load_packed(data, config)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_free(handle)` — release the dataset's linear memory.
+#[wasm_bindgen(js_name = training_data_free)]
+pub fn wasm_training_data_free(handle: u32) -> Result<(), JsError> {
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow_mut()
+            .free(handle)
+            .map(|_freed| ())
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_num_records(handle) -> BigInt`.
+#[wasm_bindgen(js_name = training_data_num_records)]
+pub fn wasm_training_data_num_records(handle: u32) -> Result<u64, JsError> {
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(handle)
+            .map(|ds| ds.num_records() as u64)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_byte_len(handle) -> BigInt` — footprint in linear memory.
+#[wasm_bindgen(js_name = training_data_byte_len)]
+pub fn wasm_training_data_byte_len(handle: u32) -> Result<u64, JsError> {
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(handle)
+            .map(|ds| ds.byte_len() as u64)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_evaluate_mse(handle, network: Uint8Array, start, count) -> number`.
+///
+/// Evaluates `network` over the `[start, start + count)` record batch and
+/// returns the mean squared error. The dataset is read by index from linear
+/// memory — only the small network buffer and the batch bounds cross the
+/// boundary, never the training arrays.
+#[wasm_bindgen(js_name = training_data_evaluate_mse)]
+pub fn wasm_training_data_evaluate_mse(
+    handle: u32,
+    network: &[u8],
+    start: u64,
+    count: u64,
+) -> Result<f32, JsError> {
+    let start = usize_from_u64(start, "batch start")?;
+    let count = usize_from_u64(count, "batch count")?;
+    let mut net =
+        CompiledNetwork::new(network).map_err(|err| JsError::new(&format!("network: {err}")))?;
+    DATASET_REGISTRY.with(|registry| {
+        let registry = registry.borrow();
+        let dataset = registry
+            .get(handle)
+            .map_err(|err| JsError::new(&err.to_string()))?;
+        dataset
+            .evaluate_mse(&mut net, start, count)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_live_bytes() -> BigInt` — bytes held by live datasets.
+#[wasm_bindgen(js_name = training_data_live_bytes)]
+pub fn wasm_training_data_live_bytes() -> u64 {
+    DATASET_REGISTRY.with(|registry| registry.borrow().live_bytes() as u64)
+}
+
+/// JS `training_data_peak_bytes() -> BigInt` — linear-memory high-water mark.
+#[wasm_bindgen(js_name = training_data_peak_bytes)]
+pub fn wasm_training_data_peak_bytes() -> u64 {
+    DATASET_REGISTRY.with(|registry| registry.borrow().peak_bytes() as u64)
 }

--- a/neat-core/tests/wasm_dataset_offload.rs
+++ b/neat-core/tests/wasm_dataset_offload.rs
@@ -1,0 +1,201 @@
+//! Issue #298 — wasm64 lane (c) training-data offload suite.
+//!
+//! These "what" tests exercise the observable offload contract from milestone
+//! #295: neat-core owns the training dataset in its own linear memory, JS holds
+//! a handle, and per-generation evaluation reads batches **by index** without
+//! the dataset re-crossing the boundary. The registry's live/peak byte counters
+//! stand in for WASM linear-memory footprint so a load → evaluate → free
+//! lifecycle leak is observable natively (the wasm-bindgen shims are thin
+//! wrappers over exactly this API).
+
+use neat_core::network::CompiledNetwork;
+use neat_core::training_data::TrainingDataConfig;
+use neat_core::wasm_dataset::{DatasetError, DatasetRegistry, TrainingDataset};
+
+/// Build a compiled network with `num_inputs` inputs and a single IDENTITY
+/// output neuron that sums every input (weight 1.0) and adds `bias`.
+///
+/// Output for record `x` is therefore `sum(x) + bias`, so expected MSE against
+/// a target is easy to compute by hand in the assertions below.
+fn summing_identity_network(num_inputs: usize, bias: f64) -> CompiledNetwork {
+    let mut data = Vec::new();
+    let num_neurons = (num_inputs + 1) as u32;
+    data.extend_from_slice(&num_neurons.to_le_bytes());
+    data.extend_from_slice(&(num_inputs as u32).to_le_bytes());
+
+    // Single output neuron.
+    data.extend_from_slice(&bias.to_le_bytes()); // bias f64
+    data.push(0); // squash IDENTITY
+    data.push(0); // is_constant = false
+    data.extend_from_slice(&(num_inputs as u16).to_le_bytes()); // num_synapses
+
+    // One synapse per input, weight 1.0.
+    for from_index in 0..num_inputs as u16 {
+        data.extend_from_slice(&from_index.to_le_bytes());
+        data.push(0); // synapse_type
+        data.push(0); // padding
+        data.extend_from_slice(&1.0_f64.to_le_bytes()); // weight f64
+    }
+
+    CompiledNetwork::new(&data).expect("network should parse")
+}
+
+/// Pack interleaved records (each: inputs then outputs) into `.bin` bytes.
+fn pack(records: &[Vec<f32>]) -> Vec<u8> {
+    records
+        .iter()
+        .flat_map(|r| r.iter().flat_map(|v| v.to_le_bytes()))
+        .collect()
+}
+
+#[test]
+fn evaluation_reads_the_batch_by_index_from_owned_memory() {
+    // 3 records, 2 inputs + 1 target each. output = i0 + i1 + bias(0.0).
+    let bytes = pack(&[
+        vec![1.0, 2.0, 3.0], // predict 3.0, target 3.0 → err 0
+        vec![2.0, 2.0, 5.0], // predict 4.0, target 5.0 → err 1
+        vec![0.0, 0.0, 2.0], // predict 0.0, target 2.0 → err 4
+    ]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+    let mut net = summing_identity_network(2, 0.0);
+
+    // Evaluate only the last two records by index — MSE = (1 + 4) / 2 = 2.5.
+    let mse = ds.evaluate_mse(&mut net, 1, 2).unwrap();
+    assert!((mse - 2.5).abs() < 1e-5, "batch MSE was {mse}");
+
+    // A different batch reads a different slice of the same owned buffer.
+    let first = ds.evaluate_mse(&mut net, 0, 1).unwrap();
+    assert!(
+        first.abs() < 1e-6,
+        "first record should be exact, got {first}"
+    );
+}
+
+#[test]
+fn evaluation_does_not_reload_or_mutate_the_dataset() {
+    let bytes = pack(&[vec![1.0, 1.0], vec![2.0, 3.0], vec![4.0, 4.0]]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(1, 1)).unwrap();
+    let mut net = summing_identity_network(1, 0.0);
+
+    let footprint_before = ds.byte_len();
+    let records_before = ds.num_records();
+
+    // Many generations over the whole dataset: the result is deterministic and
+    // the owned buffer neither grows nor shrinks — the dataset is not re-passed
+    // or re-marshalled per call.
+    let first = ds.evaluate_mse(&mut net, 0, records_before).unwrap();
+    for _ in 0..50 {
+        let again = ds.evaluate_mse(&mut net, 0, records_before).unwrap();
+        assert_eq!(
+            again, first,
+            "evaluation must be deterministic across generations"
+        );
+    }
+
+    assert_eq!(ds.byte_len(), footprint_before);
+    assert_eq!(ds.num_records(), records_before);
+}
+
+#[test]
+fn evaluation_rejects_network_dataset_shape_mismatch() {
+    let bytes = pack(&[vec![1.0, 2.0, 9.0]]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+    // Network takes 3 inputs but the dataset carries 2.
+    let mut net = summing_identity_network(3, 0.0);
+
+    let err = ds.evaluate_mse(&mut net, 0, 1).unwrap_err();
+    assert_eq!(
+        err,
+        DatasetError::ShapeMismatch {
+            network_inputs: 3,
+            dataset_inputs: 2,
+        }
+    );
+}
+
+#[test]
+fn evaluation_rejects_out_of_range_batch() {
+    let bytes = pack(&[vec![1.0, 1.0], vec![2.0, 2.0]]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(1, 1)).unwrap();
+    let mut net = summing_identity_network(1, 0.0);
+
+    let err = ds.evaluate_mse(&mut net, 1, 10).unwrap_err();
+    assert_eq!(
+        err,
+        DatasetError::BatchOutOfRange {
+            start: 1,
+            count: 10,
+            num_records: 2,
+        }
+    );
+}
+
+#[test]
+fn load_evaluate_free_lifecycle_keeps_high_water_mark_stable() {
+    // The leak gate: repeatedly load a dataset, evaluate several generations,
+    // then free it. If any bytes are retained past `free`, `live_bytes` would
+    // not return to zero and `peak_bytes` would climb every cycle.
+    let mut registry = DatasetRegistry::new();
+    let config = TrainingDataConfig::new(2, 1);
+    let bytes = pack(&[
+        vec![1.0, 2.0, 3.0],
+        vec![2.0, 2.0, 4.0],
+        vec![3.0, 1.0, 4.0],
+        vec![0.5, 0.5, 1.0],
+    ]);
+    let mut net = summing_identity_network(2, 0.0);
+
+    let mut peak_after_first_cycle = None;
+    for _cycle in 0..8 {
+        let handle = registry.load_packed(&bytes, config.clone()).unwrap();
+
+        // Evaluate N "generations" reading batches by index from linear memory.
+        let ds = registry.get(handle).unwrap();
+        let num_records = ds.num_records();
+        for _generation in 0..5 {
+            let mse = ds.evaluate_mse(&mut net, 0, num_records).unwrap();
+            assert!(mse.is_finite());
+        }
+
+        // Live footprint is exactly one dataset while loaded.
+        assert_eq!(registry.live_bytes(), 4 * 3 * 4);
+
+        registry.free(handle).unwrap();
+
+        // Every byte released on free — nothing retained.
+        assert_eq!(registry.live_bytes(), 0, "dataset bytes leaked past free");
+        assert_eq!(registry.live_count(), 0);
+
+        // Peak must not grow across cycles — equal-sized reload reuses memory.
+        match peak_after_first_cycle {
+            None => peak_after_first_cycle = Some(registry.peak_bytes()),
+            Some(peak) => assert_eq!(
+                registry.peak_bytes(),
+                peak,
+                "linear-memory high-water mark grew across load/free cycles"
+            ),
+        }
+    }
+
+    assert_eq!(peak_after_first_cycle, Some(4 * 3 * 4));
+}
+
+#[test]
+fn registry_hands_out_handles_not_bytes() {
+    // JS holds only the returned u32 handle; the bytes stay owned by the
+    // registry and are reachable solely through it.
+    let mut registry = DatasetRegistry::new();
+    let config = TrainingDataConfig::new(1, 1);
+
+    let a = registry
+        .load_packed(&pack(&[vec![1.0, 1.0]]), config.clone())
+        .unwrap();
+    let b = registry
+        .load_packed(&pack(&[vec![2.0, 2.0]]), config)
+        .unwrap();
+    assert_ne!(a, b);
+    assert_eq!(registry.live_count(), 2);
+
+    assert_eq!(registry.get(a).unwrap().record_inputs(0).unwrap(), &[1.0]);
+    assert_eq!(registry.get(b).unwrap().record_inputs(0).unwrap(), &[2.0]);
+}


### PR DESCRIPTION
# wasm64 lane (c): offload training data into WASM linear memory

## Summary

Implements the neat-core half of milestone #295 lane (c): neat-core now **owns**
the training dataset inside its own WASM linear memory, so the large numeric
input/target arrays no longer sit on the V8 JS heap that lane (a) attributed the
~4 GB Learn ceiling to (exit-133 / "Reached heap limit" = GRQ#3508). JS holds a
small `u32` **handle**, not the bytes, and per-generation evaluation reads
batches **by index** from the WASM-owned buffers — the full dataset never
re-crosses the JS↔WASM boundary after the initial load. Closes #298.

New module `neat-core/src/wasm_dataset.rs`:

- **`TrainingDataset`** — de-interleaves the packed `.bin` record stream
  (`inputs … outputs` per record) into contiguous structure-of-arrays
  input/target buffers **once**, at load time. Batch reads (`input_batch`,
  `target_batch`, `record_inputs/outputs`) are then contiguous slices, and
  `evaluate_mse(network, start, count)` scores a batch reading straight from
  linear memory. `byte_len()` exposes the footprint.
- **`DatasetRegistry`** — the ownership seam agreed with NEAT-AI#3410: `load`
  returns a handle, `free` releases the dataset. It tracks `live_bytes` and
  `peak_bytes`, so a lifecycle leak (bytes retained past `free`) is observable —
  the high-water mark stays flat across load → evaluate → free cycles. Freed
  slots are reused so an equal-sized reload does not grow the peak.
- **WASM shims** (`training_data_load` / `_evaluate_mse` / `_free` /
  `_num_records` / `_byte_len` / `_live_bytes` / `_peak_bytes`) in
  `wasm_exports.rs`, gated to `wasm32`. Byte counts and record indices cross as
  `u64` (JS `BigInt`) so the surface is **Memory64-ready** for the >4 GB jobs the
  milestone targets (lane (b) confirmed V8 grows past the 4 GiB wasm32 wall).

Fail-loud throughout (Issue #3234): a ragged buffer, an out-of-range batch, an
unknown/double-freed handle, or a network/dataset shape mismatch each surface a
typed `DatasetError` rather than a silent wrong result.

### Coordination / scope

- **NEAT-AI#3410 (Learn heap / MemoryMonitor):** this PR delivers only the
  neat-core memory + bindings seam (the handle table and by-index evaluation).
  The `Learn.ts` wiring and the MemoryMonitor fix remain owned by NEAT-AI#3410 —
  not duplicated here. The consuming repo bumps to a released neat-core through
  the ordinary dependency-bump flow once this lands.
- **Perf gate (#286 Criterion baseline):** the existing hot paths
  (`activate` / `score_batch_into`) are unchanged, so the `hot_paths` /
  `parallel_scoring` benches are unaffected — no throughput regression on
  jobs that already fit. The offload adds a new load-time de-interleave, off the
  per-generation scoring hot path.

```mermaid
sequenceDiagram
    participant JS as NEAT-AI Learn.ts
    participant WASM as neat-core (linear memory)
    JS->>WASM: training_data_load(bytes, num_inputs, num_outputs)
    WASM-->>JS: handle (u32) — bytes now WASM-owned
    loop each generation
        JS->>WASM: evaluate_mse(handle, network, start, count)
        Note over WASM: reads batch by index from<br/>owned buffers — no dataset copy
        WASM-->>JS: mean squared error (f32)
    end
    JS->>WASM: training_data_free(handle)
    Note over WASM: live_bytes → baseline,<br/>peak_bytes stays flat
```

## Evidence

Backend/library change — no web interface to screenshot. Verified by the new
`wasm_dataset_offload` test suite plus the crate unit tests; the whole
`./quality.sh` gate passes (fmt, clippy `-D warnings` on native **and**
`wasm32-unknown-unknown`, tests, doc, cargo-deny, bats). `cargo check
--target wasm32-unknown-unknown` confirms the `#[wasm_bindgen]` shims compile.

Key acceptance criteria mapped to tests:

- *Dataset owned in WASM, JS holds a handle* →
  `registry_hands_out_handles_not_bytes`, `registry_free_releases_bytes_and_reuses_slot`.
- *Evaluation reads batches by index without re-marshalling the dataset* →
  `evaluation_reads_the_batch_by_index_from_owned_memory`,
  `evaluation_does_not_reload_or_mutate_the_dataset` (footprint + record count
  unchanged across 50 generations; only handle + network + bounds per call).
- *Load → evaluate N generations → free → high-water mark stable* (leak gate) →
  `load_evaluate_free_lifecycle_keeps_high_water_mark_stable` (8 cycles ×
  5 generations; `live_bytes` returns to 0 after each free, `peak_bytes` flat).
- *Fail loud* → `from_packed_bytes_rejects_unaligned_buffer`,
  `batch_out_of_range_fails_loud`, `registry_double_free_fails_loud`,
  `evaluation_rejects_network_dataset_shape_mismatch`,
  `evaluation_rejects_out_of_range_batch`.

## Test Plan

- `neat-core/tests/wasm_dataset_offload.rs` — 6 integration "what" tests
  (evaluation-by-index correctness, no-reload invariant, shape/range fail-loud,
  the load/evaluate/free leak high-water-mark gate, handle-not-bytes ownership).
- `neat-core/src/wasm_dataset.rs` unit tests — 10 tests (SoA de-interleave,
  unaligned/zero-arity rejection, contiguous batch slices, `byte_len`,
  `from_soa` mismatch, registry free/reuse, unknown-handle and double-free
  fail-loud).
- `cargo test --workspace --lib --tests --all-features` green; `cargo check
  --target wasm32-unknown-unknown` and `cargo clippy` (native + wasm32) clean.



## Milestone
This PR is part of the **#295 Adopt WASM 3.0 Memory64: wasm64 spike + training-data offload for >4 GB jobs** milestone and targets the `milestone/295-adopt-wasm-3-0-memory64-wasm64-spike-training` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrssn3rc-d4453c`<!-- vibe-worker-issue-298 -->