### PR TITLE
wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host verification (Issue #299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ the full dataset never re-crosses the JS↔WASM boundary after the initial load.
   `_peak_bytes`) carry byte counts and record indices as `u64` (JS `BigInt`), so
   the surface is Memory64-ready for the >4 GB jobs the milestone targets.
 
+Lane (d) — Issue #299 — verifies the GRQ-side adoption end-to-end: GRQ's
+`worker/learn.sh` injects a **RAM-aware** `--v8-flags=--max-old-space-size`
+(sized by `memory_calc.sh`, floored safely below the 8 GB tier) and fails **loud**
+on a V8 heap abort (exit 133). The neat-core acceptance model
+[`tests/perf/learn_flags_wiring.ts`](tests/perf/learn_flags_wiring.ts) re-derives
+that selection lock-step with GRQ and pins the budget-fit / safe-fall-back
+invariants; see
+[`docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`](docs/research/wasm64-lane-d-grq-learn-wiring-verification.md).
+
 ```mermaid
 sequenceDiagram
     participant JS as NEAT-AI Learn.ts

--- a/docs/archive/pr-summaries/pr-summary-299.md
+++ b/docs/archive/pr-summaries/pr-summary-299.md
@@ -1,0 +1,85 @@
+# wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host verification
+
+## Summary
+
+Milestone #295 lane (d): verify — end-to-end, from neat-core — that GRQ's learn
+invocation adopts the chosen headroom mitigation correctly, and record the 8 GB
+host outcome for GRQ#3508. **Closes #299.**
+
+Lane (a) (#296) attributed the GRQ#3508 learn OOME to the **V8 old-space heap**
+(exit 133 / "Reached heap limit"), liftable by
+`--v8-flags=--max-old-space-size=<N>`. This lane confirms GRQ's
+`worker/learn.sh` selects that flag **RAM-aware** and fails **loud** on a heap
+abort, and pins those invariants with a neat-core acceptance model that is
+**lock-step** with GRQ's production selector.
+
+Verified against `stSoftwareAU/GRQ` `Develop` (no change was required there — the
+wiring already ships):
+
+1. **RAM-aware heap flag** — `worker/learn.sh` injects
+   `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}`, sized by
+   `worker/shared/memory_calc.sh` (`get_max_heap_size`): `clamp((available −
+   1536) × 65%, floor(total) .. 24576)` MB.
+2. **Constrained-host guard (#3342)** — the 8 GB-tier floor steps *down* on a
+   low-available host (≤45% of available, never below 1536 MB), so it can never
+   over-commit a constrained 8 GB host (the GRQ-26 crash class).
+3. **Silent-failure guard (GRQ#2391 / #3234)** — learn.sh's
+   `grq_fail_loud_exit_trap` EXIT trap emits a `[learn] FAIL:` marker on a
+   native exit-133 abort, so node.sh cannot downgrade it to success.
+
+The neat-core acceptance model `tests/perf/learn_flags_wiring.ts` re-derives the
+selection and was **cross-checked against GRQ's real `memory_calc.sh`** — the MB
+values match exactly (4 GB → 1664, 8 GB → 4326, constrained-8 GB → 1739, 16 GB →
+9651, 64 GB → 24576, 2 GB → 1536).
+
+### 8 GB-host status (honest)
+
+- **GRQ#3508 is closed `COMPLETED`** — the GRQ-side containment is shipped; the
+  fleet owns the live 8 GB job re-run. Recorded, not simulated: a live fleet-host
+  run needs the full GRQ cluster environment and is fleet/human-owned.
+- The **residual heap growth** (why an 8 GB host cannot simply be handed a bigger
+  heap) is fixed by lane (c)'s `wasm_dataset` offload, whose `Learn.ts` adoption
+  is upstream in **NEAT-AI#3410** and reaches GRQ via the ordinary
+  released-dependency bump (#1613/#2944) once released — not via a raw
+  commit/pre-release.
+
+## Evidence
+
+Backend/CLI verification — no web interface to screenshot. Evidence is the
+lock-step cross-check and the passing tests.
+
+```mermaid
+flowchart TD
+    A["worker/learn.sh"] --> B["memory_calc.sh get_max_heap_size → MAX_HEAP_SIZE"]
+    B --> C["deno run --v8-flags=--max-old-space-size=$MAX_HEAP_SIZE src/Learn.ts"]
+    C -->|"exit 133 heap abort"| D["grq_fail_loud_exit_trap → [learn] FAIL: marker"]
+    C -->|"clean"| E["check-in + cluster promote"]
+```
+
+| Host (total / available) | model | real `memory_calc.sh` | heap + 1536 ≤ total |
+| --- | --- | --- | --- |
+| 4 GB / 4096 | 1664 | 1664 | ✓ |
+| 8 GB / 8192 | 4326 | 4326 | ✓ |
+| 8 GB / 3865 (constrained) | 1739 | 1739 | ✓ |
+| 16 GB / 16384 | 9651 | 9651 | ✓ |
+| 64 GB / 65536 | 24576 | 24576 | ✓ |
+
+Full finding:
+[`docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`](../../research/wasm64-lane-d-grq-learn-wiring-verification.md).
+
+## Test Plan
+
+- Added `tests/perf/learn_flags_wiring.ts` (acceptance model) +
+  `tests/perf/learn_flags_wiring_test.ts` — **13 "what" tests**, all passing
+  (`deno test tests/perf/learn_flags_wiring_test.ts`). They assert:
+  - RAM-aware selection for 2/4/8/16/64 GB (incl. the constrained-8 GB #3342
+    step-down) — lock-step with GRQ `test/worker/MemoryCalcHeapSize.ts`.
+  - Budget-fit: heap + FFI/OS headroom ≤ total RAM on every supported tier.
+  - Monotonic in RAM; safe fall-back below the 8 GB tier (4 GB keeps the 1536 MB
+    floor, not the 8 GB tier's 3072 MB).
+  - The composed `--v8-flags=--max-old-space-size` token.
+  - The silent-failure `[learn] FAIL:` marker on a marker-less exit-133.
+- No Rust touched — `cargo check --workspace --all-targets --all-features` is
+  green; shellcheck, codespell, markdownlint, `deno fmt/lint/check` all pass.
+- The production selector's authoritative CI gate remains GRQ's own
+  `MemoryCalcHeapSize.ts` / `MemoryCalcHostFloor.ts`.

--- a/docs/research/wasm64-lane-d-grq-learn-wiring-verification.md
+++ b/docs/research/wasm64-lane-d-grq-learn-wiring-verification.md
@@ -1,0 +1,119 @@
+# wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host verification
+
+Milestone [#295](https://github.com/stSoftwareAU/NEAT-AI-core/issues/295),
+lane (d) — Issue
+[#299](https://github.com/stSoftwareAU/NEAT-AI-core/issues/299). Motivating OOME:
+[GRQ#3508](https://github.com/stSoftwareAU/GRQ/issues/3508) (learn-stage exit-133
+on the 8 GB GRQ-21 host).
+
+## Purpose
+
+Lanes (a)/(b)/(c) established **what** to ship; lane (d) verifies the GRQ-side
+**wiring** end-to-end and records the outcome:
+
+- **Lane (a) (#296):** the ~4 GB learn ceiling is the **V8 old-space heap**
+  (exit 133 / "Reached heap limit"), liftable by
+  `--v8-flags=--max-old-space-size=<N>` — *not* the wasm32 4 GiB linear-memory
+  wall.
+- **Lane (b) (#297):** a wasm64 build is feasible only on the raw
+  nightly + `-Z build-std` path (wasm-bindgen silently strips exports), so
+  wasm64 is **not adopted yet**.
+- **Lane (c) (#298):** `wasm_dataset` moves the large training arrays **off the
+  JS heap** into neat-core's own linear memory (the residual-growth fix), with
+  the `Learn.ts` adoption owned upstream by
+  [NEAT-AI#3410](https://github.com/stSoftwareAU/NEAT-AI/issues/3410).
+
+Lane (d) confirms GRQ's learn invocation selects the heap flag **RAM-aware** and
+fails **loud** on a heap abort, and records the 8 GB-host verification status.
+
+## End-to-end wiring (as shipped in GRQ)
+
+```mermaid
+flowchart TD
+    A["worker/learn.sh"] --> B["source worker/shared/memory_calc.sh"]
+    B --> C["get_max_heap_size → MAX_HEAP_SIZE (RAM-aware)"]
+    C --> D["deno run --v8-flags=--max-old-space-size=$MAX_HEAP_SIZE src/Learn.ts"]
+    D -->|"clean exit"| E["check-in + cluster promote"]
+    D -->|"exit 133 (V8 heap abort)"| F["grq_fail_loud_exit_trap"]
+    F --> G["[learn] FAIL: marker → GRQ-logs (never silent, GRQ#2391/#3234)"]
+```
+
+The three wiring facts, each already present in `stSoftwareAU/GRQ` on `Develop`:
+
+1. **RAM-aware heap flag.** `worker/learn.sh` sources
+   `worker/shared/memory_calc.sh`, which exports `MAX_HEAP_SIZE` from
+   `get_max_heap_size`, and injects
+   `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}` into the
+   `deno run … src/Learn.ts` argv (the `BEGIN_LEARN_DENO_ARGV_2950` block).
+   Sizing is `clamp((available − 1536) × 65%, floor(total) .. 24576)` MB.
+2. **Constrained-host guard (#3342).** The 8 GB-tier floor steps **down** on a
+   host whose *available* RAM is low (capped at 45% of available, never below
+   1536 MB), so a fixed 3072 MB floor can never over-commit a constrained 8 GB
+   host — the GRQ-26 crash class.
+3. **Silent-failure guard (GRQ#2391 / Issue #3234).** learn.sh sets
+   `GRQ_FAIL_LOUD_TASK=learn` and `trap grq_fail_loud_exit_trap EXIT`
+   (`worker/shared/stage_fail_marker.sh`), so a native V8 heap abort (exit 133,
+   which cannot print its own marker) still emits a `[learn] FAIL:` line and is
+   never downgraded to success by node.sh.
+
+## Verified: RAM-aware selection (lock-step with GRQ)
+
+The neat-core acceptance model
+[`tests/perf/learn_flags_wiring.ts`](../../tests/perf/learn_flags_wiring.ts)
+re-derives the GRQ selection and is asserted by
+[`tests/perf/learn_flags_wiring_test.ts`](../../tests/perf/learn_flags_wiring_test.ts)
+(13 "what" tests). The model's numbers were cross-checked against GRQ's **real**
+`worker/shared/memory_calc.sh` (Deno 2.9.0 host):
+
+| Host (total / available) | `--max-old-space-size` (model) | `memory_calc.sh` (production) | Heap + 1536 headroom ≤ total? |
+| --- | --- | --- | --- |
+| 4 GB / 4096 MB | **1664** | 1664 | 3200 ≤ 4096 ✓ |
+| 8 GB / 8192 MB | **4326** | 4326 | 5862 ≤ 8192 ✓ |
+| 8 GB / 3865 MB (constrained) | **1739** | 1739 | 3275 ≤ 8192 ✓ |
+| 16 GB / 16384 MB | **9651** | 9651 | 11187 ≤ 16384 ✓ |
+| 64 GB / 65536 MB | **24576** (capped) | 24576 | 26112 ≤ 65536 ✓ |
+| 2 GB / 2048 MB | **1536** (floor) | 1536 | — (below the 4 GB support tier) |
+
+Invariants the tests pin — the acceptance criterion *"flags are RAM-aware (no
+regression / new OOME on smaller hosts)"*:
+
+- **Budget-fit:** on every supported tier (4/8/16/32/64 GB) the selected heap
+  plus the FFI/OS headroom fits within the host's **total** RAM.
+- **Monotonic:** heap never decreases as RAM grows — a smaller host is never
+  sized above a larger one.
+- **Safe fall-back below 8 GB:** a 4 GB host keeps the 1536 MB global floor and
+  does **not** inherit the 8 GB tier's 3072 MB floor.
+- **Silent-failure guard:** a marker-less exit-133 yields a `[learn] FAIL:`
+  marker; a clean or already-marked exit stays silent.
+
+The authoritative CI gate for the production selector remains GRQ's own
+`test/worker/MemoryCalcHeapSize.ts` / `MemoryCalcHostFloor.ts`; this model is the
+neat-core-side lock-step check so a GRQ formula drift is visible from the
+milestone repo too.
+
+## 8 GB-host end-to-end status
+
+- **GRQ#3508 is closed `COMPLETED`.** The GRQ-side containment (RAM-aware heap +
+  the #3342 constrained-8 GB step-down + the fail-loud marker) is shipped on
+  `Develop`; the fleet owns the live GRQ#3508 job re-run on an 8 GB host.
+- **Residual heap growth** (why an 8 GB host cannot simply be given a larger
+  heap — 4326 MB is already ~all an 8 GB host can back) is addressed by lane
+  (c)'s `wasm_dataset` offload, whose `Learn.ts` adoption + `MemoryMonitor` fix
+  are **upstream** in NEAT-AI#3410. That fix reaches GRQ through the ordinary
+  released-dependency bump (Issue #1613) once NEAT-AI#3410 lands and is
+  released — it is **not** pulled in via a raw commit/pre-release (Issue #2944).
+- **Not fabricated here:** a live 8 GB fleet-host run of the GRQ#3508 job class
+  requires the full GRQ cluster environment and is fleet/human-owned; it is
+  recorded as the remaining confirmation rather than simulated.
+
+## Reproduce
+
+```bash
+# neat-core acceptance model (this repo)
+deno test tests/perf/learn_flags_wiring_test.ts
+
+# cross-check against GRQ's real selector (in a GRQ checkout)
+bash -c 'source worker/shared/memory_calc.sh
+  get_total_memory_gb(){ echo 8; }; get_available_memory_mb(){ echo 8192; }
+  get_max_heap_size'   # → 4326
+```

--- a/tests/perf/learn_flags_wiring.ts
+++ b/tests/perf/learn_flags_wiring.ts
@@ -1,0 +1,124 @@
+// learn_flags_wiring.ts — wasm64 lane (d) GRQ learn-invocation wiring model
+// (Issue #299).
+//
+// Lane (a) (#296) attributed the GRQ#3508 learn OOME to the **V8 old-space heap**
+// (exit 133 / "Reached heap limit"), liftable by
+// `--v8-flags=--max-old-space-size=<N>`. Lane (d) is the GRQ-side wiring plus
+// end-to-end verification: GRQ's learn invocation must select that flag
+// **RAM-aware**, so a bigger heap on a roomy host never pushes a smaller host
+// past its limit, and a V8 old-space abort is never silently reported as
+// success.
+//
+// The PRODUCTION selection lives in GRQ (stSoftwareAU/GRQ):
+//   * `worker/shared/memory_calc.sh` — `get_max_heap_size` / `get_heap_floor_mb`
+//     size the heap from currently-available RAM after a fixed FFI/OS headroom.
+//   * `worker/learn.sh` — injects `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}`
+//     into the `deno run src/Learn.ts` argv (the BEGIN_LEARN_DENO_ARGV_2950 block).
+//   * `worker/shared/stage_fail_marker.sh` — the EXIT-trap emits a
+//     `[learn] FAIL:` marker on any non-zero exit (incl. 133), so node.sh cannot
+//     downgrade a marker-less OOM abort to success (GRQ#2391 / Issue #3234).
+// It is CI-guarded in GRQ by `test/worker/MemoryCalcHeapSize.ts` and
+// `test/worker/MemoryCalcHostFloor.ts`.
+//
+// This module is the **neat-core-side acceptance model** of that selection: a
+// pure re-derivation used to verify the milestone's headroom invariants from
+// this repo end-to-end (the "neat-core adoption verified end-to-end" tracked by
+// #299). It must stay in **lock-step** with `memory_calc.sh`; the constants
+// below mirror it exactly. A divergence between this model's numbers and GRQ's
+// is itself the regression signal. See
+// `docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`.
+
+/** Fixed headroom (MB) reserved for Rust FFI + OS caches before apportioning to
+ * V8 — `MEMORY_FFI_OS_HEADROOM_MB` in memory_calc.sh (#1768). */
+export const FFI_OS_HEADROOM_MB = 1536;
+/** Share of the post-headroom budget granted to V8 (`get_max_heap_size` default). */
+export const HEAP_PERCENTAGE = 65;
+/** Heap ceiling (MB): large hosts keep RAM for OS/non-heap (`GRQ_MAX_HEAP_CAP_MB`). */
+export const HEAP_CAP_MB = 24576;
+/** Global heap floor (MB) for hosts smaller than the 8 GB tier. */
+export const GLOBAL_HEAP_FLOOR_MB = 1536;
+/** 8 GB sloth-class working-set floor (MB), ample-available case (#2084/#3342). */
+export const EIGHT_GB_HEAP_FLOOR_MB = 3072;
+/** >=16 GB working-set floor (MB), ample-available case (#2243/#3294). */
+export const SIXTEEN_GB_HEAP_FLOOR_MB = 4096;
+/** Minority share of *available* RAM the step-down floor may claim (`get_heap_floor_avail_pct`). */
+export const HEAP_FLOOR_AVAIL_PCT = 45;
+/** V8 fatal heap-limit abort code (SIGTRAP, 128 + 5) — GRQ#3508's signature. */
+export const OOM_EXIT_CODE = 133;
+
+/** A host's memory picture, in MB. */
+export interface HostMemory {
+  /** Total physical RAM in MB. */
+  totalMb: number;
+  /** Currently-available RAM in MB; defaults to `totalMb` (an idle host). */
+  availableMb?: number;
+}
+
+/**
+ * Mirror of `memory_calc.sh get_heap_floor_mb`. Hosts below 8 GB keep the global
+ * 1536 MB floor. The 8 GB tier uses a 3072 MB working-set floor that steps
+ * **down** on a constrained host (available-aware, #3342, always on for the
+ * learn/teams victim): capped at a minority share (45%) of *available* RAM but
+ * never below the 1536 MB global floor. >=16 GB hosts use a 4096 MB floor (the
+ * available-aware step-down there is opt-in via `GRQ_HEAP_AVAILABLE_AWARE_FLOOR`
+ * and off for the learn path, so the fixed floor is the learn-path value).
+ */
+export function heapFloorMb(host: HostMemory): number {
+  const totalGb = Math.floor(host.totalMb / 1024);
+  const availableMb = host.availableMb ?? host.totalMb;
+  if (totalGb >= 16) return SIXTEEN_GB_HEAP_FLOOR_MB;
+  if (totalGb === 8) {
+    let floor = EIGHT_GB_HEAP_FLOOR_MB;
+    const availCap = Math.floor((availableMb * HEAP_FLOOR_AVAIL_PCT) / 100);
+    if (availCap < floor) floor = availCap;
+    if (floor < GLOBAL_HEAP_FLOOR_MB) floor = GLOBAL_HEAP_FLOOR_MB;
+    return floor;
+  }
+  return GLOBAL_HEAP_FLOOR_MB;
+}
+
+/**
+ * Mirror of `memory_calc.sh get_max_heap_size`: the `--max-old-space-size` value
+ * (MB) GRQ's learn invocation selects for a host.
+ *
+ *   heap = clamp((available - FFI_OS_HEADROOM) * 65%, floor(total) .. 24576)
+ */
+export function selectMaxOldSpaceSizeMb(host: HostMemory): number {
+  const availableMb = host.availableMb ?? host.totalMb;
+  const budget = Math.max(availableMb - FFI_OS_HEADROOM_MB, 0);
+  let heap = Math.floor((budget * HEAP_PERCENTAGE) / 100);
+  if (heap > HEAP_CAP_MB) heap = HEAP_CAP_MB;
+  const floor = heapFloorMb(host);
+  if (heap < floor) heap = floor;
+  return heap;
+}
+
+/** The exact `--v8-flags` token `worker/learn.sh` injects for the learn stage. */
+export function learnV8HeapFlag(host: HostMemory): string {
+  return `--v8-flags=--max-old-space-size=${selectMaxOldSpaceSizeMb(host)}`;
+}
+
+/**
+ * RAM-aware guard: the selected heap plus the FFI/OS headroom must fit within
+ * the host's **total** RAM, so a bigger heap on a roomy host never pushes a
+ * smaller host past its limit (acceptance: "no regression / new OOME on smaller
+ * hosts"). Returns true iff the invocation stays within the host's budget.
+ */
+export function heapFitsHostBudget(host: HostMemory): boolean {
+  return selectMaxOldSpaceSizeMb(host) + FFI_OS_HEADROOM_MB <= host.totalMb;
+}
+
+/**
+ * Silent-failure guard (GRQ#2391 / Issue #3234). A V8 old-space OOM is a native
+ * abort (exit 133): the crashed child cannot print its own marker, and node.sh
+ * downgrades a marker-less non-zero exit to success. `learn.sh`'s EXIT trap must
+ * therefore emit a `[learn] FAIL:` marker. Returns the marker line for a
+ * marker-less non-zero exit, or `null` for a clean exit or one already marked.
+ */
+export function learnFailMarkerForExit(
+  exitCode: number,
+  alreadyMarked = false,
+): string | null {
+  if (exitCode === 0 || alreadyMarked) return null;
+  return `[learn] FAIL: learn exited ${exitCode}`;
+}

--- a/tests/perf/learn_flags_wiring_test.ts
+++ b/tests/perf/learn_flags_wiring_test.ts
@@ -1,0 +1,127 @@
+// learn_flags_wiring_test.ts — "what" tests for the wasm64 lane (d) GRQ
+// learn-invocation wiring model (Issue #299).
+//
+// These pin the RAM-aware `--v8-flags=--max-old-space-size` selection GRQ's
+// `worker/learn.sh` injects, verified from neat-core. The expected MB values are
+// the SAME numbers GRQ's own CI asserts in `test/worker/MemoryCalcHeapSize.ts`
+// (e.g. 8 GB → 4326, 16 GB → 9651, 4 GB → 1664): if GRQ's sizing formula drifts,
+// these lock-step values catch it here too.
+//
+// Run: deno test tests/perf/learn_flags_wiring_test.ts
+
+import { assert, assertEquals, assertGreater } from "jsr:@std/assert@^1";
+import {
+  EIGHT_GB_HEAP_FLOOR_MB,
+  FFI_OS_HEADROOM_MB,
+  GLOBAL_HEAP_FLOOR_MB,
+  heapFitsHostBudget,
+  heapFloorMb,
+  type HostMemory,
+  learnFailMarkerForExit,
+  learnV8HeapFlag,
+  OOM_EXIT_CODE,
+  selectMaxOldSpaceSizeMb,
+  SIXTEEN_GB_HEAP_FLOOR_MB,
+} from "./learn_flags_wiring.ts";
+
+const GB = 1024;
+const host = (totalGb: number, availableMb?: number): HostMemory => ({
+  totalMb: totalGb * GB,
+  availableMb,
+});
+
+// --- RAM-aware heap selection, lock-step with GRQ MemoryCalcHeapSize.ts --------
+
+Deno.test("selectMaxOldSpaceSizeMb: 4 GB host gets 1664 MB (above the 1536 floor)", () => {
+  // (4096 - 1536) * 65 / 100 = 1664
+  assertEquals(selectMaxOldSpaceSizeMb(host(4)), 1664);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 8 GB host gets 4326 MB (the GRQ#3508 tier)", () => {
+  // (8192 - 1536) * 65 / 100 = 4326
+  assertEquals(selectMaxOldSpaceSizeMb(host(8)), 4326);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 16 GB host gets 9651 MB", () => {
+  // (16384 - 1536) * 65 / 100 = 9651
+  assertEquals(selectMaxOldSpaceSizeMb(host(16)), 9651);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 64 GB host is capped at 24576 MB", () => {
+  // (65536 - 1536) * 65 / 100 = 41600 → capped at the 24 GB ceiling
+  assertEquals(selectMaxOldSpaceSizeMb(host(64)), 24576);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 2 GB host is floored at 1536 MB", () => {
+  // (2048 - 1536) * 65 / 100 = 332 → floored at the global 1536 MB floor
+  assertEquals(selectMaxOldSpaceSizeMb(host(2)), GLOBAL_HEAP_FLOOR_MB);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: constrained 8 GB host sizes off AVAILABLE, not total (#3342)", () => {
+  // GRQ-26: 8 GB total but only 3865 MB available. Heap = (3865 - 1536) * 65 /
+  // 100 = 1513; the available-aware floor steps down to min(3072, 3865 * 45 /
+  // 100 = 1739) = 1739, so the selection is 1739 — far below the fixed-3072
+  // over-commit that fatal-OOM'd GRQ-26, and below the 4326 a roomy 8 GB gets.
+  assertEquals(selectMaxOldSpaceSizeMb(host(8, 3865)), 1739);
+  assertGreater(
+    selectMaxOldSpaceSizeMb(host(8)),
+    selectMaxOldSpaceSizeMb(host(8, 3865)),
+  );
+});
+
+// --- Falls back safely below the 8 GB tier ------------------------------------
+
+Deno.test("heapFloorMb: below-8 GB hosts keep the 1536 MB global floor, not the 8 GB tier floor", () => {
+  assertEquals(heapFloorMb(host(4)), GLOBAL_HEAP_FLOOR_MB);
+  assertEquals(heapFloorMb(host(8)), EIGHT_GB_HEAP_FLOOR_MB);
+  assertEquals(heapFloorMb(host(16)), SIXTEEN_GB_HEAP_FLOOR_MB);
+  // A 4 GB host must not inherit the 8 GB tier's higher floor.
+  assertGreater(heapFloorMb(host(8)), heapFloorMb(host(4)));
+});
+
+// --- RAM-aware budget guard: no new OOME on smaller hosts ---------------------
+
+Deno.test("heapFitsHostBudget: 4 / 8 / 16 GB hosts all stay within their total RAM", () => {
+  for (const gb of [4, 8, 16, 32, 64]) {
+    assert(
+      heapFitsHostBudget(host(gb)),
+      `heap + FFI/OS headroom must fit in ${gb} GB total RAM`,
+    );
+  }
+});
+
+Deno.test("heapFitsHostBudget: heap + headroom never exceeds total on the 8 GB tier", () => {
+  const h = host(8);
+  assert(selectMaxOldSpaceSizeMb(h) + FFI_OS_HEADROOM_MB <= h.totalMb);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: heap grows monotonically with host RAM (no smaller host over-sized)", () => {
+  const h4 = selectMaxOldSpaceSizeMb(host(4));
+  const h8 = selectMaxOldSpaceSizeMb(host(8));
+  const h16 = selectMaxOldSpaceSizeMb(host(16));
+  assertGreater(h8, h4, "8 GB must not be sized below 4 GB");
+  assertGreater(h16, h8, "16 GB must not be sized below 8 GB");
+});
+
+// --- The exact flag token learn.sh injects ------------------------------------
+
+Deno.test("learnV8HeapFlag: composes the --v8-flags=--max-old-space-size token", () => {
+  assertEquals(
+    learnV8HeapFlag(host(8)),
+    "--v8-flags=--max-old-space-size=4326",
+  );
+});
+
+// --- Silent-failure guard (GRQ#2391 / #3234) ----------------------------------
+
+Deno.test("learnFailMarkerForExit: a marker-less exit-133 abort gets a [learn] FAIL: marker", () => {
+  assertEquals(
+    learnFailMarkerForExit(OOM_EXIT_CODE),
+    "[learn] FAIL: learn exited 133",
+  );
+});
+
+Deno.test("learnFailMarkerForExit: a clean exit and an already-marked exit stay silent", () => {
+  assertEquals(learnFailMarkerForExit(0), null);
+  assertEquals(learnFailMarkerForExit(OOM_EXIT_CODE, true), null);
+});


### PR DESCRIPTION
# wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host verification

## Summary

Milestone #295 lane (d): verify — end-to-end, from neat-core — that GRQ's learn
invocation adopts the chosen headroom mitigation correctly, and record the 8 GB
host outcome for GRQ#3508. **Closes #299.**

Lane (a) (#296) attributed the GRQ#3508 learn OOME to the **V8 old-space heap**
(exit 133 / "Reached heap limit"), liftable by
`--v8-flags=--max-old-space-size=<N>`. This lane confirms GRQ's
`worker/learn.sh` selects that flag **RAM-aware** and fails **loud** on a heap
abort, and pins those invariants with a neat-core acceptance model that is
**lock-step** with GRQ's production selector.

Verified against `stSoftwareAU/GRQ` `Develop` (no change was required there — the
wiring already ships):

1. **RAM-aware heap flag** — `worker/learn.sh` injects
   `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}`, sized by
   `worker/shared/memory_calc.sh` (`get_max_heap_size`): `clamp((available −
   1536) × 65%, floor(total) .. 24576)` MB.
2. **Constrained-host guard (#3342)** — the 8 GB-tier floor steps *down* on a
   low-available host (≤45% of available, never below 1536 MB), so it can never
   over-commit a constrained 8 GB host (the GRQ-26 crash class).
3. **Silent-failure guard (GRQ#2391 / #3234)** — learn.sh's
   `grq_fail_loud_exit_trap` EXIT trap emits a `[learn] FAIL:` marker on a
   native exit-133 abort, so node.sh cannot downgrade it to success.

The neat-core acceptance model `tests/perf/learn_flags_wiring.ts` re-derives the
selection and was **cross-checked against GRQ's real `memory_calc.sh`** — the MB
values match exactly (4 GB → 1664, 8 GB → 4326, constrained-8 GB → 1739, 16 GB →
9651, 64 GB → 24576, 2 GB → 1536).

### 8 GB-host status (honest)

- **GRQ#3508 is closed `COMPLETED`** — the GRQ-side containment is shipped; the
  fleet owns the live 8 GB job re-run. Recorded, not simulated: a live fleet-host
  run needs the full GRQ cluster environment and is fleet/human-owned.
- The **residual heap growth** (why an 8 GB host cannot simply be handed a bigger
  heap) is fixed by lane (c)'s `wasm_dataset` offload, whose `Learn.ts` adoption
  is upstream in **NEAT-AI#3410** and reaches GRQ via the ordinary
  released-dependency bump (#1613/#2944) once released — not via a raw
  commit/pre-release.

## Evidence

Backend/CLI verification — no web interface to screenshot. Evidence is the
lock-step cross-check and the passing tests.

```mermaid
flowchart TD
    A["worker/learn.sh"] --> B["memory_calc.sh get_max_heap_size → MAX_HEAP_SIZE"]
    B --> C["deno run --v8-flags=--max-old-space-size=$MAX_HEAP_SIZE src/Learn.ts"]
    C -->|"exit 133 heap abort"| D["grq_fail_loud_exit_trap → [learn] FAIL: marker"]
    C -->|"clean"| E["check-in + cluster promote"]
```

| Host (total / available) | model | real `memory_calc.sh` | heap + 1536 ≤ total |
| --- | --- | --- | --- |
| 4 GB / 4096 | 1664 | 1664 | ✓ |
| 8 GB / 8192 | 4326 | 4326 | ✓ |
| 8 GB / 3865 (constrained) | 1739 | 1739 | ✓ |
| 16 GB / 16384 | 9651 | 9651 | ✓ |
| 64 GB / 65536 | 24576 | 24576 | ✓ |

Full finding:
[`docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`](../../research/wasm64-lane-d-grq-learn-wiring-verification.md).

## Test Plan

- Added `tests/perf/learn_flags_wiring.ts` (acceptance model) +
  `tests/perf/learn_flags_wiring_test.ts` — **13 "what" tests**, all passing
  (`deno test tests/perf/learn_flags_wiring_test.ts`). They assert:
  - RAM-aware selection for 2/4/8/16/64 GB (incl. the constrained-8 GB #3342
    step-down) — lock-step with GRQ `test/worker/MemoryCalcHeapSize.ts`.
  - Budget-fit: heap + FFI/OS headroom ≤ total RAM on every supported tier.
  - Monotonic in RAM; safe fall-back below the 8 GB tier (4 GB keeps the 1536 MB
    floor, not the 8 GB tier's 3072 MB).
  - The composed `--v8-flags=--max-old-space-size` token.
  - The silent-failure `[learn] FAIL:` marker on a marker-less exit-133.
- No Rust touched — `cargo check --workspace --all-targets --all-features` is
  green; shellcheck, codespell, markdownlint, `deno fmt/lint/check` all pass.
- The production selector's authoritative CI gate remains GRQ's own
  `MemoryCalcHeapSize.ts` / `MemoryCalcHostFloor.ts`.



## Milestone
This PR is part of the **#295 Adopt WASM 3.0 Memory64: wasm64 spike + training-data offload for >4 GB jobs** milestone and targets the `milestone/295-adopt-wasm-3-0-memory64-wasm64-spike-training` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrssn3rc-d4453c`<!-- vibe-worker-issue-299 -->