### PR TITLE
Milestone: #295 Adopt WASM 3.0 Memory64: wasm64 spike + training-data offload for >4 GB jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,28 @@ jobs:
           skip: "./target,./.git"
           ignore_words_list: renderD,mape
 
+  # Issue #297 — wasm64 lane (b) Memory64 runtime guard. The committed smoke
+  # test instantiates a minimal `(memory i64 ...)` module, grows linear memory
+  # past the wasm32 4 GiB ceiling, and round-trips a BigInt (64-bit) pointer
+  # across the JS↔WASM boundary. A Deno/V8 upgrade that drops or breaks Wasm 3.0
+  # Memory64 support fails HERE, in CI, rather than being rediscovered mid-port.
+  wasm64-memory64-smoke:
+    name: wasm64 Memory64 smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Deno
+        # denoland/setup-deno@v2.0.5
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+        with:
+          deno-version: "2.9.3"
+
+      - name: Run Memory64 smoke test
+        run: deno test tests/wasm64_memory64_smoke_test.ts < /dev/null
+
   security:
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -101,18 +101,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -220,21 +220,21 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -387,18 +387,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -498,22 +498,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.1",
 ]
 
 [[package]]
@@ -546,6 +546,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -623,7 +634,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -709,11 +720,11 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -513,14 +513,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -543,9 +543,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,7 +634,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -720,7 +720,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.16"
+version = "0.2.17"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,41 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 
 **`wasm_activation`** and **`pkg/`** remain in the **NEAT-AI** repo on `Develop` — not in this repository.
 
+## Training-data offload (WASM linear memory)
+
+wasm64 milestone #295, lane (c) — Issue #298. Lane (a) attributed the ~4 GB
+Learn ceiling to the **V8 JS heap** (exit-133 / "Reached heap limit"), not WASM
+linear memory. `wasm_dataset` moves the large numeric training arrays **off the
+JS heap**: neat-core owns the dataset inside its own linear memory, JS holds only
+a `u32` **handle**, and per-generation evaluation reads batches **by index** —
+the full dataset never re-crosses the JS↔WASM boundary after the initial load.
+
+- [`TrainingDataset`](neat-core/src/wasm_dataset.rs) de-interleaves the packed
+  `.bin` record stream into contiguous structure-of-arrays input/target buffers
+  once, at load time.
+- [`DatasetRegistry`](neat-core/src/wasm_dataset.rs) is the handle table:
+  `load` → handle, `free` → release. It tracks live and peak byte footprint so a
+  lifecycle leak (bytes retained past `free`) is observable — the high-water mark
+  stays flat across load → evaluate → free cycles.
+- WASM shims (`training_data_load` / `_evaluate_mse` / `_free` / `_byte_len` /
+  `_peak_bytes`) carry byte counts and record indices as `u64` (JS `BigInt`), so
+  the surface is Memory64-ready for the >4 GB jobs the milestone targets.
+
+```mermaid
+sequenceDiagram
+    participant JS as NEAT-AI Learn.ts
+    participant WASM as neat-core (linear memory)
+    JS->>WASM: training_data_load(bytes, num_inputs, num_outputs)
+    WASM-->>JS: handle (u32) — bytes now WASM-owned
+    loop each generation
+        JS->>WASM: evaluate_mse(handle, network, start, count)
+        Note over WASM: reads batch by index from<br/>owned buffers — no dataset copy
+        WASM-->>JS: mean squared error (f32)
+    end
+    JS->>WASM: training_data_free(handle)
+    Note over WASM: live_bytes → baseline,<br/>peak_bytes stays flat
+```
+
 ## Layout
 
 | Path | Role |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ the full dataset never re-crosses the JS↔WASM boundary after the initial load.
   `_peak_bytes`) carry byte counts and record indices as `u64` (JS `BigInt`), so
   the surface is Memory64-ready for the >4 GB jobs the milestone targets.
 
+Lane (d) — Issue #299 — verifies the GRQ-side adoption end-to-end: GRQ's
+`worker/learn.sh` injects a **RAM-aware** `--v8-flags=--max-old-space-size`
+(sized by `memory_calc.sh`, floored safely below the 8 GB tier) and fails **loud**
+on a V8 heap abort (exit 133). The neat-core acceptance model
+[`tests/perf/learn_flags_wiring.ts`](tests/perf/learn_flags_wiring.ts) re-derives
+that selection lock-step with GRQ and pins the budget-fit / safe-fall-back
+invariants; see
+[`docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`](docs/research/wasm64-lane-d-grq-learn-wiring-verification.md).
+
 ```mermaid
 sequenceDiagram
     participant JS as NEAT-AI Learn.ts

--- a/docs/archive/pr-summaries/pr-summary-296.md
+++ b/docs/archive/pr-summaries/pr-summary-296.md
@@ -1,0 +1,80 @@
+# wasm64 lane (a): diagnose whether the ~4 GB ceiling is the V8 heap or WASM linear memory
+
+## Summary
+
+Gating diagnostic for milestone #295. Establishes **where the ~4 GB learn-job
+ceiling actually binds** — the V8 JS heap (old-space) or WASM linear memory —
+before committing to a wasm64 build (lane b, #297) or a data-offload
+architecture (lane c, #298). Delivers a runnable, dual-probe reproducer plus a
+written finding backed by captured crash signatures and peak-memory numbers.
+`Closes #296`.
+
+**Finding (evidence-based):** the currently observed production ceiling is the
+**V8 JS heap**. GRQ#3508's captured signature is exit 133 / `Reached heap limit`
+— the V8 old-space abort, reproduced here byte-for-byte — **not** a
+`WebAssembly.Memory` RangeError or out-of-bounds trap. Raising
+`--v8-flags=--max-old-space-size` demonstrably lets a previously-OOMing
+old-space job complete. On this evidence lanes (b)/(c) are **not needed yet**,
+but are **not closed**: they proceed if the dual-probe on the real Learn.ts job
+attributes the peak to WASM linear memory, or if raising old-space merely walks
+the job toward the hard **wasm32 4 GiB wall** (65536 pages × 64 KiB, verified
+RAM-independent). The production re-run (acceptance step 3) needs an 8 GB GRQ
+host and is owned by lane (d) (#299); the finding hands it off explicitly rather
+than shipping an unverified "heap cap suffices" conclusion.
+
+Full write-up:
+[`docs/research/wasm64-lane-a-4gb-ceiling-attribution.md`](../../research/wasm64-lane-a-4gb-ceiling-attribution.md).
+
+### Captured evidence (Deno 2.9.0 / V8 14.9, 24 GB host)
+
+| Ceiling | Signature captured | `--max-old-space-size` lifts it? |
+| --- | --- | --- |
+| V8 old-space | `Fatal JavaScript out of memory: Reached heap limit`, **exit 133** (= GRQ#3508) | **Yes** — 2000 MiB job OOMs at cap 256, completes at cap 3072 |
+| WASM linear memory (wasm32) | `RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded` at **3.938 GiB → 4 GiB hard cap** | **No** — architectural, RAM-independent |
+
+### Silent-failure guard (GRQ#2391)
+
+A V8 old-space OOM is a **native abort** — the crashing child cannot print its
+own `[learn] FAIL:` marker, and node.sh downgrades marker-less non-zero exits to
+success. The harness's `markerForExit()` / `guard` mode subprocess the learn
+child and synthesise the marker on exit 133, the launcher-side rule lane (d)
+must adopt.
+
+## Evidence
+
+Backend/CLI diagnostic — no web interface to screenshot. Evidence is the
+captured signatures above (reproduced in the finding doc) and the passing tests
+below.
+
+```mermaid
+flowchart TD
+    A[Learn OOME] --> B{Crash signature?}
+    B -- "exit 133 / Reached heap limit" --> C[V8 old-space]
+    B -- "WebAssembly.Memory RangeError / OOB" --> D[WASM linear memory 4 GiB wall]
+    C --> E{Dual-probe peak on real job = heapUsed?}
+    E -- yes --> F["Raise --max-old-space-size — lanes (b)/(c) NOT needed yet"]
+    E -- "no, peak = wasm/external" --> G["Old-space flag will not help"]
+    D --> G
+    G --> H["Pursue lane (b) wasm64 and/or (c) data-offload"]
+```
+
+## Test Plan
+
+- Added `tests/perf/learn_oome_repro.ts` — runnable diagnostic (modes
+  `heap` / `wasm` / `guard` / `probe`), gated behind `LEARN_OOME_REPRO=1` so it
+  never runs in default CI (8 GB+ host only). Captures **both** probes
+  (`Deno.memoryUsage()` and `WebAssembly.Memory.buffer.byteLength`) and emits
+  `[learn] FAIL:` markers.
+- Added `tests/perf/learn_oome_repro_test.ts` — 13 "what" tests on the real
+  classifier / probe / attribution / marker functions:
+  - `classifyCrashSignature` maps exit-133 text → `v8-heap` and the
+    `WebAssembly.Memory` RangeError → `wasm-linear-memory`.
+  - `attributePeak` picks the dominant pool from a dual-probe snapshot.
+  - `snapshotProbes` reports both probes together (never one silently).
+  - `growWasmToCeiling` hits the hard 4 GiB cap when asked for more.
+  - `markerForExit` synthesises the `[learn] FAIL:` marker for a marker-less
+    exit 133 and stays silent on clean/already-flagged exits.
+  - Run: `deno test --allow-env tests/perf/learn_oome_repro_test.ts` → 13 passed.
+- No Rust touched — the cargo quality gates (`build`/`clippy`/`test`/`doc`) are
+  unaffected; repo-wide `codespell` and `markdownlint-cli2` pass clean on the
+  new files.

--- a/docs/archive/pr-summaries/pr-summary-297.md
+++ b/docs/archive/pr-summaries/pr-summary-297.md
@@ -1,0 +1,93 @@
+# wasm64 lane (b): build-lane feasibility spike (Rust Tier 3 + Deno/V8 Memory64)
+
+## Summary
+
+Time-boxed feasibility spike for milestone #295 (lane b). Establishes — with
+exact toolchain versions, flags, and reproduction steps — **whether a working
+wasm64 (Memory64) neat-core artefact is buildable and loadable in Deno 2.9.3
+today**. Delivers a committed, runnable Memory64 smoke test wired into CI, plus a
+written go/no-go finding backed by captured evidence. `Closes #297`.
+
+**Finding — qualified GO:**
+
+- **Runtime — GO.** Deno 2.9.3 / V8 14.9.207.2 instantiates a minimal
+  `(memory i64 …)` module and grows linear memory past the wasm32 4 GiB ceiling,
+  up to the V8 implementation limit of **262144 pages = 16 GiB**. `Memory.grow()`
+  on an i64 memory requires and returns a `BigInt` (the observable 64-bit index
+  signature). Growth reserves address space lazily, so the probe touches only a
+  few pages (~34 MiB RSS) — cheap enough to run in default CI.
+- **Build (raw) — GO, nightly only.** A trivial neat-core-style kernel builds for
+  `wasm64-unknown-unknown` with `nightly-2026-07-19` + `rust-src` +
+  `-Z build-std=std,panic_abort`, producing a genuine Memory64 module. **Stable
+  is a no-go** (Tier 3, no prebuilt `std`; `rustup target add` refuses).
+- **Bindings (raw) — GO.** The kernel is callable across the JS↔WASM boundary
+  with 64-bit pointers passed as `BigInt`.
+- **Build (production) — NO-GO.** `wasm-bindgen` / `wasm-pack` (the path this
+  repo ships via `scripts/build-wasm-bundle.sh`) **silently strip** the exported
+  bindings from a Memory64 module: the CLI exits 0 but the generated glue and
+  `_bg.wasm` contain no `accumulate` / `__wbindgen_malloc`. The same crate emits
+  working glue on wasm32. This is the hard blocker for any wasm-pack-based port.
+- **Perf — no measurable regression.** A raw accumulate kernel over a 4 MiB
+  (4 GiB-fitting) buffer runs within **±2 %** (measurement noise) wasm64 vs
+  wasm32. A full #286 Criterion comparison is blocked by the wasm-bindgen no-go
+  and is recorded as such rather than hidden.
+
+**Recommendation (feeds #295 planning):** consistent with lane (a), do **not**
+adopt wasm64 yet (today's ceiling is the V8 heap, liftable with
+`--max-old-space-size`). If/when wasm64 is needed, the viable path is raw
+`extern "C"` exports + hand-rolled `BigInt` bindings on nightly + `-Z build-std`
+— **not** `wasm-pack`, until the toolchain ships working wasm64 post-processing.
+
+Full write-up:
+[`docs/research/wasm64-lane-b-build-lane-feasibility.md`](../../research/wasm64-lane-b-build-lane-feasibility.md).
+
+## Evidence
+
+Backend/runtime spike — no web interface to screenshot. Evidence is the captured
+runtime signatures (in the finding doc), the committed smoke test, and the new
+CI job that guards it.
+
+```mermaid
+flowchart TD
+    A["Need >4 GiB in neat-core WASM?"] --> B{"Lane (a): which pool binds?"}
+    B -- "V8 heap (today)" --> C["Raise --max-old-space-size — wasm64 NOT needed yet"]
+    B -- "WASM linear memory" --> D["wasm64 (Memory64) required"]
+    D --> E{"Binding path?"}
+    E -- "raw extern C + BigInt" --> F["GO: nightly + -Z build-std, callable today"]
+    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO: CLI silently strips exports"]
+    G --> H["Blocker: await wasm-bindgen wasm64 support, or use raw path"]
+```
+
+Captured on Deno 2.9.3 / V8 14.9.207.2, rustc nightly `1.99.0 (9f36de775)`,
+wasm-pack 0.13.1, wasm-bindgen 0.2.108:
+
+| Axis | Result |
+| --- | --- |
+| Memory64 grow ceiling | 262144 pages = **16 GiB** (V8 impl limit) |
+| `Memory.grow()` on i64 memory | requires + returns **`BigInt`**; `Number` throws `TypeError` |
+| wasm64 raw build | **OK** (nightly + `-Z build-std`), module memory flag `0x04` = i64 |
+| wasm-bindgen wasm32 vs wasm64 | wasm32 glue exports `accumulate`; **wasm64 strips it (exit 0)** |
+| wasm64 vs wasm32 accumulate | within **±2 %** — no measurable regression |
+
+## Test Plan
+
+- Added `tests/wasm64_memory64_smoke_test.ts` (+ helpers
+  `tests/wasm64_memory64_smoke.ts`) — 6 "what" tests that call real code and
+  assert on observable outcomes:
+  - a hand-assembled `(memory i64 …)` module validates and its memory section
+    sets the i64 index flag (`0x04`);
+  - `buildMemory64Module` rejects a max that cannot exceed the 4 GiB wall;
+  - the module instantiates and grows linear memory **past 4 GiB**
+    (`byteLength > 4 GiB`);
+  - `grow()` requires and returns a `BigInt`; a `Number` delta throws;
+  - a `BigInt` offset **above 4 GiB** round-trips through the module's exported
+    `store`/`load` functions (two independent addresses, no 32-bit wrap-around);
+  - `unsignedLeb128` encodes multi-byte page counts.
+  - Run: `deno test tests/wasm64_memory64_smoke_test.ts` → 6 passed, ~9 ms,
+    ~34 MiB RSS. Full `deno test tests/` → 19 passed (with lane a).
+- Added a `wasm64-memory64-smoke` CI job (`.github/workflows/ci.yml`, Deno 2.9.3,
+  `denoland/setup-deno` SHA-pinned) so a Deno/V8 upgrade dropping Memory64 fails
+  in CI — the issue's earliest failure-detection point.
+- No Rust changed. Confirmed unaffected: `cargo check` / `cargo clippy -D
+  warnings` / `cargo test` all green; `actionlint` and the workflow-guard bats
+  suite pass on the updated `ci.yml`; markdownlint + codespell clean on new docs.

--- a/docs/archive/pr-summaries/pr-summary-298.md
+++ b/docs/archive/pr-summaries/pr-summary-298.md
@@ -1,0 +1,98 @@
+# wasm64 lane (c): offload training data into WASM linear memory
+
+## Summary
+
+Implements the neat-core half of milestone #295 lane (c): neat-core now **owns**
+the training dataset inside its own WASM linear memory, so the large numeric
+input/target arrays no longer sit on the V8 JS heap that lane (a) attributed the
+~4 GB Learn ceiling to (exit-133 / "Reached heap limit" = GRQ#3508). JS holds a
+small `u32` **handle**, not the bytes, and per-generation evaluation reads
+batches **by index** from the WASM-owned buffers — the full dataset never
+re-crosses the JS↔WASM boundary after the initial load. Closes #298.
+
+New module `neat-core/src/wasm_dataset.rs`:
+
+- **`TrainingDataset`** — de-interleaves the packed `.bin` record stream
+  (`inputs … outputs` per record) into contiguous structure-of-arrays
+  input/target buffers **once**, at load time. Batch reads (`input_batch`,
+  `target_batch`, `record_inputs/outputs`) are then contiguous slices, and
+  `evaluate_mse(network, start, count)` scores a batch reading straight from
+  linear memory. `byte_len()` exposes the footprint.
+- **`DatasetRegistry`** — the ownership seam agreed with NEAT-AI#3410: `load`
+  returns a handle, `free` releases the dataset. It tracks `live_bytes` and
+  `peak_bytes`, so a lifecycle leak (bytes retained past `free`) is observable —
+  the high-water mark stays flat across load → evaluate → free cycles. Freed
+  slots are reused so an equal-sized reload does not grow the peak.
+- **WASM shims** (`training_data_load` / `_evaluate_mse` / `_free` /
+  `_num_records` / `_byte_len` / `_live_bytes` / `_peak_bytes`) in
+  `wasm_exports.rs`, gated to `wasm32`. Byte counts and record indices cross as
+  `u64` (JS `BigInt`) so the surface is **Memory64-ready** for the >4 GB jobs the
+  milestone targets (lane (b) confirmed V8 grows past the 4 GiB wasm32 wall).
+
+Fail-loud throughout (Issue #3234): a ragged buffer, an out-of-range batch, an
+unknown/double-freed handle, or a network/dataset shape mismatch each surface a
+typed `DatasetError` rather than a silent wrong result.
+
+### Coordination / scope
+
+- **NEAT-AI#3410 (Learn heap / MemoryMonitor):** this PR delivers only the
+  neat-core memory + bindings seam (the handle table and by-index evaluation).
+  The `Learn.ts` wiring and the MemoryMonitor fix remain owned by NEAT-AI#3410 —
+  not duplicated here. The consuming repo bumps to a released neat-core through
+  the ordinary dependency-bump flow once this lands.
+- **Perf gate (#286 Criterion baseline):** the existing hot paths
+  (`activate` / `score_batch_into`) are unchanged, so the `hot_paths` /
+  `parallel_scoring` benches are unaffected — no throughput regression on
+  jobs that already fit. The offload adds a new load-time de-interleave, off the
+  per-generation scoring hot path.
+
+```mermaid
+sequenceDiagram
+    participant JS as NEAT-AI Learn.ts
+    participant WASM as neat-core (linear memory)
+    JS->>WASM: training_data_load(bytes, num_inputs, num_outputs)
+    WASM-->>JS: handle (u32) — bytes now WASM-owned
+    loop each generation
+        JS->>WASM: evaluate_mse(handle, network, start, count)
+        Note over WASM: reads batch by index from<br/>owned buffers — no dataset copy
+        WASM-->>JS: mean squared error (f32)
+    end
+    JS->>WASM: training_data_free(handle)
+    Note over WASM: live_bytes → baseline,<br/>peak_bytes stays flat
+```
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified by the new
+`wasm_dataset_offload` test suite plus the crate unit tests; the whole
+`./quality.sh` gate passes (fmt, clippy `-D warnings` on native **and**
+`wasm32-unknown-unknown`, tests, doc, cargo-deny, bats). `cargo check
+--target wasm32-unknown-unknown` confirms the `#[wasm_bindgen]` shims compile.
+
+Key acceptance criteria mapped to tests:
+
+- *Dataset owned in WASM, JS holds a handle* →
+  `registry_hands_out_handles_not_bytes`, `registry_free_releases_bytes_and_reuses_slot`.
+- *Evaluation reads batches by index without re-marshalling the dataset* →
+  `evaluation_reads_the_batch_by_index_from_owned_memory`,
+  `evaluation_does_not_reload_or_mutate_the_dataset` (footprint + record count
+  unchanged across 50 generations; only handle + network + bounds per call).
+- *Load → evaluate N generations → free → high-water mark stable* (leak gate) →
+  `load_evaluate_free_lifecycle_keeps_high_water_mark_stable` (8 cycles ×
+  5 generations; `live_bytes` returns to 0 after each free, `peak_bytes` flat).
+- *Fail loud* → `from_packed_bytes_rejects_unaligned_buffer`,
+  `batch_out_of_range_fails_loud`, `registry_double_free_fails_loud`,
+  `evaluation_rejects_network_dataset_shape_mismatch`,
+  `evaluation_rejects_out_of_range_batch`.
+
+## Test Plan
+
+- `neat-core/tests/wasm_dataset_offload.rs` — 6 integration "what" tests
+  (evaluation-by-index correctness, no-reload invariant, shape/range fail-loud,
+  the load/evaluate/free leak high-water-mark gate, handle-not-bytes ownership).
+- `neat-core/src/wasm_dataset.rs` unit tests — 10 tests (SoA de-interleave,
+  unaligned/zero-arity rejection, contiguous batch slices, `byte_len`,
+  `from_soa` mismatch, registry free/reuse, unknown-handle and double-free
+  fail-loud).
+- `cargo test --workspace --lib --tests --all-features` green; `cargo check
+  --target wasm32-unknown-unknown` and `cargo clippy` (native + wasm32) clean.

--- a/docs/archive/pr-summaries/pr-summary-299.md
+++ b/docs/archive/pr-summaries/pr-summary-299.md
@@ -1,0 +1,85 @@
+# wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host verification
+
+## Summary
+
+Milestone #295 lane (d): verify — end-to-end, from neat-core — that GRQ's learn
+invocation adopts the chosen headroom mitigation correctly, and record the 8 GB
+host outcome for GRQ#3508. **Closes #299.**
+
+Lane (a) (#296) attributed the GRQ#3508 learn OOME to the **V8 old-space heap**
+(exit 133 / "Reached heap limit"), liftable by
+`--v8-flags=--max-old-space-size=<N>`. This lane confirms GRQ's
+`worker/learn.sh` selects that flag **RAM-aware** and fails **loud** on a heap
+abort, and pins those invariants with a neat-core acceptance model that is
+**lock-step** with GRQ's production selector.
+
+Verified against `stSoftwareAU/GRQ` `Develop` (no change was required there — the
+wiring already ships):
+
+1. **RAM-aware heap flag** — `worker/learn.sh` injects
+   `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}`, sized by
+   `worker/shared/memory_calc.sh` (`get_max_heap_size`): `clamp((available −
+   1536) × 65%, floor(total) .. 24576)` MB.
+2. **Constrained-host guard (#3342)** — the 8 GB-tier floor steps *down* on a
+   low-available host (≤45% of available, never below 1536 MB), so it can never
+   over-commit a constrained 8 GB host (the GRQ-26 crash class).
+3. **Silent-failure guard (GRQ#2391 / #3234)** — learn.sh's
+   `grq_fail_loud_exit_trap` EXIT trap emits a `[learn] FAIL:` marker on a
+   native exit-133 abort, so node.sh cannot downgrade it to success.
+
+The neat-core acceptance model `tests/perf/learn_flags_wiring.ts` re-derives the
+selection and was **cross-checked against GRQ's real `memory_calc.sh`** — the MB
+values match exactly (4 GB → 1664, 8 GB → 4326, constrained-8 GB → 1739, 16 GB →
+9651, 64 GB → 24576, 2 GB → 1536).
+
+### 8 GB-host status (honest)
+
+- **GRQ#3508 is closed `COMPLETED`** — the GRQ-side containment is shipped; the
+  fleet owns the live 8 GB job re-run. Recorded, not simulated: a live fleet-host
+  run needs the full GRQ cluster environment and is fleet/human-owned.
+- The **residual heap growth** (why an 8 GB host cannot simply be handed a bigger
+  heap) is fixed by lane (c)'s `wasm_dataset` offload, whose `Learn.ts` adoption
+  is upstream in **NEAT-AI#3410** and reaches GRQ via the ordinary
+  released-dependency bump (#1613/#2944) once released — not via a raw
+  commit/pre-release.
+
+## Evidence
+
+Backend/CLI verification — no web interface to screenshot. Evidence is the
+lock-step cross-check and the passing tests.
+
+```mermaid
+flowchart TD
+    A["worker/learn.sh"] --> B["memory_calc.sh get_max_heap_size → MAX_HEAP_SIZE"]
+    B --> C["deno run --v8-flags=--max-old-space-size=$MAX_HEAP_SIZE src/Learn.ts"]
+    C -->|"exit 133 heap abort"| D["grq_fail_loud_exit_trap → [learn] FAIL: marker"]
+    C -->|"clean"| E["check-in + cluster promote"]
+```
+
+| Host (total / available) | model | real `memory_calc.sh` | heap + 1536 ≤ total |
+| --- | --- | --- | --- |
+| 4 GB / 4096 | 1664 | 1664 | ✓ |
+| 8 GB / 8192 | 4326 | 4326 | ✓ |
+| 8 GB / 3865 (constrained) | 1739 | 1739 | ✓ |
+| 16 GB / 16384 | 9651 | 9651 | ✓ |
+| 64 GB / 65536 | 24576 | 24576 | ✓ |
+
+Full finding:
+[`docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`](../../research/wasm64-lane-d-grq-learn-wiring-verification.md).
+
+## Test Plan
+
+- Added `tests/perf/learn_flags_wiring.ts` (acceptance model) +
+  `tests/perf/learn_flags_wiring_test.ts` — **13 "what" tests**, all passing
+  (`deno test tests/perf/learn_flags_wiring_test.ts`). They assert:
+  - RAM-aware selection for 2/4/8/16/64 GB (incl. the constrained-8 GB #3342
+    step-down) — lock-step with GRQ `test/worker/MemoryCalcHeapSize.ts`.
+  - Budget-fit: heap + FFI/OS headroom ≤ total RAM on every supported tier.
+  - Monotonic in RAM; safe fall-back below the 8 GB tier (4 GB keeps the 1536 MB
+    floor, not the 8 GB tier's 3072 MB).
+  - The composed `--v8-flags=--max-old-space-size` token.
+  - The silent-failure `[learn] FAIL:` marker on a marker-less exit-133.
+- No Rust touched — `cargo check --workspace --all-targets --all-features` is
+  green; shellcheck, codespell, markdownlint, `deno fmt/lint/check` all pass.
+- The production selector's authoritative CI gate remains GRQ's own
+  `MemoryCalcHeapSize.ts` / `MemoryCalcHostFloor.ts`.

--- a/docs/research/wasm64-lane-a-4gb-ceiling-attribution.md
+++ b/docs/research/wasm64-lane-a-4gb-ceiling-attribution.md
@@ -1,0 +1,175 @@
+# wasm64 lane (a): where the ~4 GB ceiling binds — V8 heap vs WASM linear memory
+
+Gating diagnostic for milestone #295 (Issue #296). This lane decides whether the
+wasm64 build lane (b, #297) and the data-offload lane (c, #298) are needed at
+all. Method-first per the performance workflow (#177/#1428): measure, don't
+guess.
+
+## Question
+
+Production learn jobs were scaled down to fit a ~4 GB ceiling even though the
+GRQ hosts have far more RAM (GRQ#3508: `Learn.ts` exit 133 OOME at ~4.2 GB).
+Before committing to a wasm64 build or a data-offload architecture we must prove
+**which pool binds**: the V8 JS heap (old-space) or WASM linear memory.
+
+## The two ceilings are distinguishable by signature
+
+A Deno learn process spends memory across three distinct pools, each with its
+own ceiling and its own crash signature:
+
+| Pool | What lives there | Ceiling | Crash signature | Lifted by `--max-old-space-size`? |
+| --- | --- | --- | --- | --- |
+| V8 old-space (JS heap) | plain JS objects, arrays of boxed numbers, object graphs | `--max-old-space-size` (default ~2–4 GB) | `Fatal JavaScript out of memory: Reached heap limit`, **exit 133** | **Yes** |
+| External buffers | `ArrayBuffer` / `TypedArray` backing stores | host RAM / RSS | allocation error or OS OOM kill | No |
+| WASM linear memory | data owned by the `wasm_activation` module | **hard 4 GiB on wasm32** (65536 pages × 64 KiB) | `RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded` / `RuntimeError: memory access out of bounds` | **No** |
+
+The exit-133 `Reached heap limit` abort and the `WebAssembly.Memory` RangeError
+are unambiguous in the log text — that is what makes the attribution decidable.
+
+## Evidence (captured locally, Deno 2.9.0 / V8 14.9, 24 GB host)
+
+Reproduced with the committed harness
+[`tests/perf/learn_oome_repro.ts`](../../tests/perf/learn_oome_repro.ts) and its
+tests. Both probes — `Deno.memoryUsage()` **and**
+`WebAssembly.Memory.buffer.byteLength` — are captured together, because
+NEAT-AI#3410 shows a single-probe MemoryMonitor misreads the limit.
+
+### V8 old-space (JS heap) — matches GRQ#3508
+
+`heap` mode grows retained plain-JS objects until the process aborts:
+
+```text
+$ LEARN_OOME_REPRO=1 deno run --allow-env \
+    --v8-flags=--max-old-space-size=256 tests/perf/learn_oome_repro.ts heap 2000
+
+<--- Last few GCs --->
+[..] Mark-Compact 255.9 (260.5) -> 255.9 (260.5) MB [..] last resort; GC in old space requested
+#
+# Fatal JavaScript out of memory: Reached heap limit
+#
+exit=133
+```
+
+This is the **exact GRQ#3508 signature**: exit 133, `Reached heap limit`. It is
+a V8 old-space abort.
+
+Raising the cap lets the *identical* job complete:
+
+```text
+$ LEARN_OOME_REPRO=1 deno run --allow-env \
+    --v8-flags=--max-old-space-size=3072 tests/perf/learn_oome_repro.ts heap 2000
+[learn] PEAK(heap): rss=2138MiB heapUsed=2050MiB heapTotal=2084MiB external=1MiB wasm=0MiB -> attributed=v8-heap
+[learn] OK: heap job reached 2000 MiB old-space
+exit=0
+```
+
+**Answer to the `--max-old-space-size` question: yes** — a 2000 MiB old-space
+job that aborts (exit 133) at `--max-old-space-size=256` completes cleanly at
+`--max-old-space-size=3072`, at negligible wall-clock cost (sub-second here; the
+flag changes the GC limit, not the work done).
+
+### WASM linear memory (wasm32) — a hard 4 GiB wall
+
+`wasm` mode grows a `WebAssembly.Memory` towards a >4 GiB target:
+
+```text
+$ LEARN_OOME_REPRO=1 deno run --allow-env tests/perf/learn_oome_repro.ts wasm 6
+[learn] PEAK(wasm): rss=40MiB heapUsed=2MiB heapTotal=4MiB external=1MiB wasm=4032MiB -> attributed=wasm-linear-memory
+[learn] FAIL: wasm-linear-memory | peakPages=64513 peakBytes=4227923968 (3.938 GiB) | RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded
+```
+
+Constructing a Memory larger than 4 GiB fails at the boundary:
+
+```text
+RangeError: WebAssembly.Memory(): Property 'initial': value 65537 is above the upper bound 65536
+```
+
+This ceiling is **architectural and RAM-independent**: 65536 pages × 64 KiB =
+exactly 4 GiB is the entire wasm32 address space. Adding host RAM or raising
+`--max-old-space-size` cannot move it. The production `wasm_activation` bundle is
+built `wasm-pack build neat-core --target web`
+([`scripts/build-wasm-bundle.sh`](../../scripts/build-wasm-bundle.sh)) — a
+**wasm32** module with no `memory64` feature — so any data the module holds is
+subject to this 4 GiB wall.
+
+## Silent-failure risk found: exit 133 is a native abort with no marker
+
+A V8 old-space OOM is a **native process abort**, not a catchable JS exception —
+the crashing child cannot print its own `[learn] FAIL:` marker. GRQ node.sh
+downgrades a marker-less non-zero exit to success (GRQ#2391), so an exit-133
+learn crash would be **silently reported green**. The harness closes this at the
+launcher: `markerForExit()` / the `guard` mode subprocess the learn child and
+synthesise the marker on exit 133:
+
+```text
+$ LEARN_OOME_REPRO=1 deno run --allow-env --allow-run \
+    tests/perf/learn_oome_repro.ts guard 2000 256
+[learn] FAIL: v8-heap | child exited 133 (Reached heap limit) with no marker
+```
+
+Lane (d) (GRQ wiring, #299) must adopt this launcher-side rule: **treat exit 133
+as a hard failure regardless of marker**.
+
+## Attribution and recommendation
+
+```mermaid
+flowchart TD
+    A[Learn OOME] --> B{Crash signature?}
+    B -- "exit 133 / Reached heap limit" --> C[V8 old-space]
+    B -- "WebAssembly.Memory RangeError / OOB" --> D[WASM linear memory 4 GiB wall]
+    C --> E{Dual-probe peak on real job = heapUsed?}
+    E -- yes --> F["Raise --max-old-space-size — lanes (b)/(c) NOT needed yet"]
+    E -- "no, peak = wasm/external" --> G["Old-space flag will not help"]
+    D --> G
+    G --> H["Pursue lane (b) wasm64 and/or (c) data-offload"]
+```
+
+- **The currently observed production ceiling is the V8 JS heap.** GRQ#3508's
+  captured signature is exit 133 / `Reached heap limit` — the V8 old-space
+  abort, reproduced here byte-for-byte. It is **not** a `WebAssembly.Memory`
+  RangeError or an out-of-bounds trap, so WASM linear memory is not what is
+  binding today.
+- **The cheap fix is the correct first move.** Raising
+  `--v8-flags=--max-old-space-size=<N>` demonstrably lets a previously-OOMing
+  old-space job complete, and the GRQ hosts have the RAM for it.
+- **Do not pursue lanes (b)/(c) yet, but do not close them.** On current
+  evidence the wasm64 build (b) and data-offload (c) are not required to clear
+  GRQ#3508. They become necessary if, and only if, either:
+  1. the dual-probe on the **real** Learn.ts job attributes the peak to WASM
+     linear memory or external buffers (not `heapUsed`); or
+  2. raising old-space merely walks the job toward the wasm32 4 GiB wall as the
+     training set grows — at which point only a wasm64 (Memory64) build lifts it.
+
+### What remains — owned by lane (d) (#299)
+
+Acceptance step 3 (re-run the *actual* failing production job on an 8 GB GRQ
+host under the raised flag) requires the GRQ learn invocation and an 8 GB host,
+which lane (d) (#299) owns end-to-end. Lane (d) should run the real job with the
+dual probe from this harness and confirm the peak is `heapUsed`-dominated before
+the "heap cap suffices" conclusion is locked in and #295 is closed. If that
+production dual-probe instead attributes the peak to WASM linear memory, this
+finding's conclusion is wrong and lanes (b)/(c) proceed — that is the failure
+signal to watch (per this issue's Failure Detection).
+
+## Reproducing
+
+```text
+# V8 heap ceiling (exit 133) and the raised-cap completion:
+LEARN_OOME_REPRO=1 deno run --allow-env \
+  --v8-flags=--max-old-space-size=256  tests/perf/learn_oome_repro.ts heap 2000
+LEARN_OOME_REPRO=1 deno run --allow-env \
+  --v8-flags=--max-old-space-size=3072 tests/perf/learn_oome_repro.ts heap 2000
+
+# WASM linear-memory 4 GiB wall:
+LEARN_OOME_REPRO=1 deno run --allow-env tests/perf/learn_oome_repro.ts wasm 6
+
+# Launcher marker synthesis for the native exit-133 abort:
+LEARN_OOME_REPRO=1 deno run --allow-env --allow-run \
+  tests/perf/learn_oome_repro.ts guard 2000 256
+
+# Unit tests for the classifier / probe / attribution functions:
+deno test --allow-env tests/perf/learn_oome_repro_test.ts
+```
+
+The harness is gated behind `LEARN_OOME_REPRO=1` so it never runs in default CI —
+only on an 8 GB+ host.

--- a/docs/research/wasm64-lane-b-build-lane-feasibility.md
+++ b/docs/research/wasm64-lane-b-build-lane-feasibility.md
@@ -1,0 +1,199 @@
+# wasm64 lane (b): build-lane feasibility spike (Rust Tier 3 + Deno/V8 Memory64)
+
+Feasibility spike for milestone #295 (Issue #297). Follows lane (a)
+([`wasm64-lane-a-4gb-ceiling-attribution.md`](wasm64-lane-a-4gb-ceiling-attribution.md)),
+which found the ~4 GB learn-job ceiling currently binds on the **V8 JS heap**,
+not WASM linear memory — so lanes (b)/(c) are **not needed yet, but not closed**.
+This lane answers the gating engineering question for lane (b): *if* a wasm64
+(Memory64) build becomes necessary, **can it actually be built and loaded in
+Deno 2.9.3 today?** Method-first per the performance workflow (#177/#1428):
+measure, don't guess.
+
+## Go / no-go finding
+
+**Qualified GO.** A working wasm64 (Memory64) neat-core artefact **is** buildable
+and loadable in Deno 2.9.3 today — but **only** via the raw `extern "C"` +
+hand-rolled `BigInt` bindings path on a Rust **nightly** toolchain with
+`-Z build-std`. The production binding path this repo actually ships
+(`wasm-bindgen` / `wasm-pack`, see
+[`scripts/build-wasm-bundle.sh`](../../scripts/build-wasm-bundle.sh)) is a
+**NO-GO** today: the `wasm-bindgen` CLI silently strips the exported bindings
+from a Memory64 module.
+
+| Spike axis | Verdict | Evidence (this host) |
+| --- | --- | --- |
+| **Runtime** — Deno 2.9.3 / V8 14.9 instantiates Memory64 & grows past 4 GiB | **GO** | grows to the V8 impl limit of **262144 pages = 16 GiB**; committed smoke test |
+| **Build (raw)** — `cargo build --target wasm64-unknown-unknown -Z build-std` | **GO (nightly only)** | produces a genuine `(memory i64 …)` module exporting `accumulate` |
+| **Bindings (raw)** — 64-bit (`BigInt`) pointers across JS↔WASM | **GO** | `accumulate(BigInt ptr, BigInt len)` returns the correct sum |
+| **Build (production)** — `wasm-bindgen` / `wasm-pack` on wasm64 | **NO-GO** | CLI exits 0 but strips `accumulate` + `__wbindgen_malloc` from the output |
+| **Perf** — wasm64 vs wasm32 on a 4 GiB-fitting job | **no measurable regression** | scalar accumulate within **±2 %** (measurement noise) |
+
+## Exact toolchain versions (reproduction baseline)
+
+| Tool | Version |
+| --- | --- |
+| Deno | `2.9.3 (stable, release, aarch64-apple-darwin)` |
+| V8 | `14.9.207.2-rusty` |
+| rustc (build) | `1.99.0-nightly (9f36de775 2026-07-19)` + `rust-src` |
+| rustc (stable) | `1.97.1 (8bab26f4f 2026-07-14)` |
+| wasm-pack | `0.13.1` |
+| wasm-bindgen CLI | `0.2.108` |
+| wasm-bindgen crate | `0.2.126` (repo default; skew noted below) |
+
+## 1. Runtime support — GO (committed as a smoke test)
+
+Deno 2.9.3's V8 **does** support Wasm 3.0 Memory64. A minimal hand-assembled
+`(memory i64 …)` module validates, instantiates, and grows linear memory well
+past the wasm32 4 GiB wall:
+
+- `WebAssembly.validate` accepts the i64 memory-type flag (`0x04`).
+- `WebAssembly.Memory.grow()` on an i64 memory **requires and returns a
+  `BigInt`** — a `Number` delta throws `TypeError: Cannot convert … to a
+  BigInt`. This is the observable signature of the 64-bit index type.
+- Growth succeeds up to the **V8 implementation limit of 262144 pages = 16 GiB**
+  (a declared maximum above that fails at compile with
+  `maximum memory size (… pages) is larger than implementation limit (262144
+  pages)`).
+- Pages are reserved lazily: growing past 4 GiB reserves address space without
+  committing physical RAM — the smoke test touches only a handful of pages, so
+  peak RSS stays ~34 MiB. This is what makes it safe to run in default CI.
+
+This is captured as the committed
+[`tests/wasm64_memory64_smoke_test.ts`](../../tests/wasm64_memory64_smoke_test.ts)
+(+ helpers in
+[`tests/wasm64_memory64_smoke.ts`](../../tests/wasm64_memory64_smoke.ts)). It
+instantiates the minimal module, grows past 4 GiB, and round-trips a `BigInt`
+offset above 4 GiB through the module's exported `store`/`load` functions. It is
+wired into a new `wasm64-memory64-smoke` CI job (`.github/workflows/ci.yml`) so a
+Deno/V8 upgrade that drops or breaks Memory64 fails **in CI**, not mid-port.
+
+## 2. Build toolchain — GO on nightly, breakages documented
+
+`wasm64-unknown-unknown` is a **Rust Tier 3** target: `rustc` knows it
+(`rustc --print target-list` lists it) but there are **no prebuilt `std`
+artefacts**.
+
+- **Stable is a NO-GO.** `rustup target add wasm64-unknown-unknown` refuses
+  (`has no prebuilt artifacts available for target 'wasm64-unknown-unknown'`),
+  and a stable build fails with `error[E0463]: can't find crate for std … build
+  the standard library from source with -Zbuild-std`.
+- **Nightly + `build-std` is a GO.** With `nightly-2026-07-19` and the
+  `rust-src` component, a trivial neat-core-style kernel builds cleanly:
+
+  ```text
+  cargo +nightly build --target wasm64-unknown-unknown --release \
+    -Z build-std=std,panic_abort
+  ```
+
+  The output `.wasm` is a genuine Memory64 module — its memory section carries
+  flags `0x04` (i64 index) and it exports `accumulate` + `memory`.
+
+### `Cargo.toml` gap: the wasm cfg is keyed to `wasm32`
+
+`neat-core/Cargo.toml` gates its wasm deps on `cfg(target_arch = "wasm32")`:
+
+```toml
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.126"
+```
+
+For a `wasm64-unknown-unknown` build `target_arch` is `"wasm64"`, so this table
+would **not** apply — a real port must widen the cfg to
+`cfg(target_family = "wasm")` (and re-audit the `rayon`
+`cfg(not(target_arch = "wasm32"))` exclusion, which would wrongly pull `rayon`
+into a wasm64 build). No change is made in this spike; it is recorded for the
+planning stage.
+
+## 3. Bindings — GO for raw `extern "C"`, NO-GO for wasm-bindgen
+
+**Raw path works.** Instantiated from Deno, the raw kernel is callable across the
+boundary with 64-bit pointers passed as `BigInt`:
+
+```text
+accumulate(BigInt(1024), 4n) = 7.25   // 4 f32 written at byte offset 1024
+```
+
+**wasm-bindgen / wasm-pack silently drop exports on wasm64.** The crate
+*compiles* for wasm64, but the CLI post-processing step is broken. With the CLI
+and crate versions aligned to `0.2.108`, the **same crate** yields:
+
+| Target | `accumulate` in generated glue? | `accumulate` in `_bg.wasm` exports? |
+| --- | --- | --- |
+| `wasm32-unknown-unknown` | **yes** (`export function accumulate(xs)`) | yes (+ `__wbindgen_malloc`) |
+| `wasm64-unknown-unknown` | **no** — glue has only `initSync`/`init` | **no** — `accumulate` + `__wbindgen_malloc` stripped |
+
+Critically, `wasm-bindgen … --target web` **exits 0** while producing a package
+with no working bindings — a **silent failure** (cf. the repo's "never fail
+silently" principle). Any future wasm64 adoption via `wasm-pack` must treat this
+as a hard blocker and pin/verify a `wasm-bindgen` release that documents wasm64
+support, or fall back to the raw `extern "C"` + `BigInt` binding path.
+
+> The observed CLI/crate skew (installed CLI `0.2.108` vs repo default crate
+> `0.2.126`) is a separate, ordinary version-match issue and is **not** the
+> wasm64 breakage — the table above was produced with both pinned to `0.2.108`.
+
+## 4. Performance — no measurable regression on 4 GiB-fitting jobs
+
+Per the parent decision, headroom is prioritised over throughput, but a
+regression on jobs that fit 4 GB must be **recorded, not hidden**. A full #286
+Criterion comparison of the real neat-core wasm bundle is **blocked** by the
+wasm-bindgen no-go above (the production bundle cannot be built for wasm64). As a
+proportionate substitute, the identical raw `extern "C"` accumulate kernel was
+built for both targets and timed in Deno over a 4 MiB (1 M × f32) buffer that
+fits comfortably under 4 GiB:
+
+| Target | µs / call (500 iters × 1 M f32) |
+| --- | --- |
+| wasm32 | ~515–525 µs |
+| wasm64 | ~515–525 µs |
+
+Across repeated runs the wasm64/wasm32 ratio stays within **±2 %** — within
+measurement noise, i.e. **no measurable regression** for a scalar accumulate on
+4 GiB-fitting work. (This is a micro-benchmark, not the #286 Criterion baseline;
+a full comparison must wait until the production bundle is buildable for wasm64.)
+
+## Recommendation (feeds #295 planning)
+
+```mermaid
+flowchart TD
+    A["Need >4 GiB in neat-core WASM?"] --> B{"Lane (a): which pool binds?"}
+    B -- "V8 heap (today)" --> C["Raise --max-old-space-size — wasm64 NOT needed yet"]
+    B -- "WASM linear memory" --> D["wasm64 (Memory64) required"]
+    D --> E{"Binding path?"}
+    E -- "raw extern C + BigInt" --> F["GO: nightly + -Z build-std, callable today"]
+    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO: CLI silently strips exports on wasm64"]
+    G --> H["Blocker: wait for wasm-bindgen wasm64 support, or use raw path"]
+```
+
+- **Do not adopt wasm64 yet** — consistent with lane (a): the current production
+  ceiling is the V8 heap, liftable with `--max-old-space-size`. wasm64 becomes
+  necessary only if the real Learn.ts job attributes its peak to WASM linear
+  memory (lane (d), #299).
+- **When/if wasm64 is adopted**, the viable path today is **raw `extern "C"`
+  exports with hand-rolled `BigInt` bindings** on nightly + `-Z build-std`, not
+  `wasm-pack`. A wasm-bindgen-based port is blocked until the toolchain ships
+  working wasm64 post-processing.
+- **The runtime side is proven and guarded.** The committed smoke test locks in
+  the Memory64 runtime capability so a future regression is caught in CI.
+
+## Reproducing
+
+```text
+# Runtime (Memory64) smoke test — runs in default CI, ~34 MiB RSS:
+deno test tests/wasm64_memory64_smoke_test.ts
+
+# Build the raw kernel for wasm64 (nightly + rust-src required):
+rustup toolchain install nightly --profile minimal --component rust-src
+cargo +nightly build --target wasm64-unknown-unknown --release \
+  -Z build-std=std,panic_abort
+#   -> target/wasm64-unknown-unknown/release/<crate>.wasm  (memory flags 0x04 = i64)
+
+# Confirm the production binding path is a no-go (wasm-bindgen strips exports):
+wasm-bindgen <wasm64 .wasm> --target web --out-dir pkg64   # exits 0, no accumulate binding
+```
+
+The wasm64 build requires a network-fetched nightly toolchain + `rust-src`, so
+it is **not** wired into default CI as a build step (unlike the runtime smoke
+test); it is documented here for reproduction and for the lane (d) / planning
+decision. If wasm64 is adopted, the exact `cargo … -Z build-std` invocation above
+becomes the CI build step per this issue's Failure Detection.

--- a/docs/research/wasm64-lane-d-grq-learn-wiring-verification.md
+++ b/docs/research/wasm64-lane-d-grq-learn-wiring-verification.md
@@ -1,0 +1,119 @@
+# wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host verification
+
+Milestone [#295](https://github.com/stSoftwareAU/NEAT-AI-core/issues/295),
+lane (d) — Issue
+[#299](https://github.com/stSoftwareAU/NEAT-AI-core/issues/299). Motivating OOME:
+[GRQ#3508](https://github.com/stSoftwareAU/GRQ/issues/3508) (learn-stage exit-133
+on the 8 GB GRQ-21 host).
+
+## Purpose
+
+Lanes (a)/(b)/(c) established **what** to ship; lane (d) verifies the GRQ-side
+**wiring** end-to-end and records the outcome:
+
+- **Lane (a) (#296):** the ~4 GB learn ceiling is the **V8 old-space heap**
+  (exit 133 / "Reached heap limit"), liftable by
+  `--v8-flags=--max-old-space-size=<N>` — *not* the wasm32 4 GiB linear-memory
+  wall.
+- **Lane (b) (#297):** a wasm64 build is feasible only on the raw
+  nightly + `-Z build-std` path (wasm-bindgen silently strips exports), so
+  wasm64 is **not adopted yet**.
+- **Lane (c) (#298):** `wasm_dataset` moves the large training arrays **off the
+  JS heap** into neat-core's own linear memory (the residual-growth fix), with
+  the `Learn.ts` adoption owned upstream by
+  [NEAT-AI#3410](https://github.com/stSoftwareAU/NEAT-AI/issues/3410).
+
+Lane (d) confirms GRQ's learn invocation selects the heap flag **RAM-aware** and
+fails **loud** on a heap abort, and records the 8 GB-host verification status.
+
+## End-to-end wiring (as shipped in GRQ)
+
+```mermaid
+flowchart TD
+    A["worker/learn.sh"] --> B["source worker/shared/memory_calc.sh"]
+    B --> C["get_max_heap_size → MAX_HEAP_SIZE (RAM-aware)"]
+    C --> D["deno run --v8-flags=--max-old-space-size=$MAX_HEAP_SIZE src/Learn.ts"]
+    D -->|"clean exit"| E["check-in + cluster promote"]
+    D -->|"exit 133 (V8 heap abort)"| F["grq_fail_loud_exit_trap"]
+    F --> G["[learn] FAIL: marker → GRQ-logs (never silent, GRQ#2391/#3234)"]
+```
+
+The three wiring facts, each already present in `stSoftwareAU/GRQ` on `Develop`:
+
+1. **RAM-aware heap flag.** `worker/learn.sh` sources
+   `worker/shared/memory_calc.sh`, which exports `MAX_HEAP_SIZE` from
+   `get_max_heap_size`, and injects
+   `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}` into the
+   `deno run … src/Learn.ts` argv (the `BEGIN_LEARN_DENO_ARGV_2950` block).
+   Sizing is `clamp((available − 1536) × 65%, floor(total) .. 24576)` MB.
+2. **Constrained-host guard (#3342).** The 8 GB-tier floor steps **down** on a
+   host whose *available* RAM is low (capped at 45% of available, never below
+   1536 MB), so a fixed 3072 MB floor can never over-commit a constrained 8 GB
+   host — the GRQ-26 crash class.
+3. **Silent-failure guard (GRQ#2391 / Issue #3234).** learn.sh sets
+   `GRQ_FAIL_LOUD_TASK=learn` and `trap grq_fail_loud_exit_trap EXIT`
+   (`worker/shared/stage_fail_marker.sh`), so a native V8 heap abort (exit 133,
+   which cannot print its own marker) still emits a `[learn] FAIL:` line and is
+   never downgraded to success by node.sh.
+
+## Verified: RAM-aware selection (lock-step with GRQ)
+
+The neat-core acceptance model
+[`tests/perf/learn_flags_wiring.ts`](../../tests/perf/learn_flags_wiring.ts)
+re-derives the GRQ selection and is asserted by
+[`tests/perf/learn_flags_wiring_test.ts`](../../tests/perf/learn_flags_wiring_test.ts)
+(13 "what" tests). The model's numbers were cross-checked against GRQ's **real**
+`worker/shared/memory_calc.sh` (Deno 2.9.0 host):
+
+| Host (total / available) | `--max-old-space-size` (model) | `memory_calc.sh` (production) | Heap + 1536 headroom ≤ total? |
+| --- | --- | --- | --- |
+| 4 GB / 4096 MB | **1664** | 1664 | 3200 ≤ 4096 ✓ |
+| 8 GB / 8192 MB | **4326** | 4326 | 5862 ≤ 8192 ✓ |
+| 8 GB / 3865 MB (constrained) | **1739** | 1739 | 3275 ≤ 8192 ✓ |
+| 16 GB / 16384 MB | **9651** | 9651 | 11187 ≤ 16384 ✓ |
+| 64 GB / 65536 MB | **24576** (capped) | 24576 | 26112 ≤ 65536 ✓ |
+| 2 GB / 2048 MB | **1536** (floor) | 1536 | — (below the 4 GB support tier) |
+
+Invariants the tests pin — the acceptance criterion *"flags are RAM-aware (no
+regression / new OOME on smaller hosts)"*:
+
+- **Budget-fit:** on every supported tier (4/8/16/32/64 GB) the selected heap
+  plus the FFI/OS headroom fits within the host's **total** RAM.
+- **Monotonic:** heap never decreases as RAM grows — a smaller host is never
+  sized above a larger one.
+- **Safe fall-back below 8 GB:** a 4 GB host keeps the 1536 MB global floor and
+  does **not** inherit the 8 GB tier's 3072 MB floor.
+- **Silent-failure guard:** a marker-less exit-133 yields a `[learn] FAIL:`
+  marker; a clean or already-marked exit stays silent.
+
+The authoritative CI gate for the production selector remains GRQ's own
+`test/worker/MemoryCalcHeapSize.ts` / `MemoryCalcHostFloor.ts`; this model is the
+neat-core-side lock-step check so a GRQ formula drift is visible from the
+milestone repo too.
+
+## 8 GB-host end-to-end status
+
+- **GRQ#3508 is closed `COMPLETED`.** The GRQ-side containment (RAM-aware heap +
+  the #3342 constrained-8 GB step-down + the fail-loud marker) is shipped on
+  `Develop`; the fleet owns the live GRQ#3508 job re-run on an 8 GB host.
+- **Residual heap growth** (why an 8 GB host cannot simply be given a larger
+  heap — 4326 MB is already ~all an 8 GB host can back) is addressed by lane
+  (c)'s `wasm_dataset` offload, whose `Learn.ts` adoption + `MemoryMonitor` fix
+  are **upstream** in NEAT-AI#3410. That fix reaches GRQ through the ordinary
+  released-dependency bump (Issue #1613) once NEAT-AI#3410 lands and is
+  released — it is **not** pulled in via a raw commit/pre-release (Issue #2944).
+- **Not fabricated here:** a live 8 GB fleet-host run of the GRQ#3508 job class
+  requires the full GRQ cluster environment and is fleet/human-owned; it is
+  recorded as the remaining confirmation rather than simulated.
+
+## Reproduce
+
+```bash
+# neat-core acceptance model (this repo)
+deno test tests/perf/learn_flags_wiring_test.ts
+
+# cross-check against GRQ's real selector (in a GRQ checkout)
+bash -c 'source worker/shared/memory_calc.sh
+  get_total_memory_gb(){ echo 8; }; get_available_memory_mb(){ echo 8192; }
+  get_max_heap_size'   # → 4326
+```

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod training_bin_stream;
 pub mod training_data;
 pub mod training_state;
 pub mod unsquash;
+pub mod wasm_dataset;
 
 // Issue #36 — WASM-only `#[wasm_bindgen]` shims that wrap apply_* helpers,
 // tuple returns, and the byte-packed `propagate_topological` ABI. Native
@@ -56,6 +57,7 @@ pub use training_data::{
     SeekingRecordReader, TrainingDataConfig, TrainingDataError, TrainingDataIterator,
     TrainingRecord, find_bin_files, read_dir as read_training_dir, read_file as read_training_file,
 };
+pub use wasm_dataset::{DatasetError, DatasetRegistry, TrainingDataset};
 
 // Re-export core functions
 pub use accumulate::{

--- a/neat-core/src/wasm_dataset.rs
+++ b/neat-core/src/wasm_dataset.rs
@@ -1,0 +1,592 @@
+//! Training-data offload into neat-core's own linear memory (Issue #298).
+//!
+//! wasm64 lane (c) of milestone #295. Lane (a) attributed the ~4 GB Learn
+//! ceiling to the **V8 JS heap** (exit-133 / "Reached heap limit"), not WASM
+//! linear memory. The relief is to stop retaining the large numeric training
+//! arrays on the JS heap: neat-core **owns** the dataset inside its own linear
+//! memory, JS holds only a small integer **handle**, and per-generation
+//! evaluation reads batches **by index** from the WASM-owned buffers instead of
+//! copying the full dataset across the JS↔WASM boundary on every call.
+//!
+//! # Ownership model
+//!
+//! ```text
+//!   JS                          neat-core linear memory
+//!   ──                          ───────────────────────
+//!   handle: u32   ──lookup──▶   DatasetRegistry
+//!                               └─ TrainingDataset (inputs SoA + targets SoA)
+//! ```
+//!
+//! * [`TrainingDataset`] de-interleaves the packed `.bin` record stream
+//!   (`inputs … outputs` per record) into two contiguous structure-of-arrays
+//!   buffers **once**, at load time. Batch reads are then contiguous slices.
+//! * [`DatasetRegistry`] is the handle table: `load` returns a `u32` handle,
+//!   `free` drops the dataset and releases its bytes. It tracks live and
+//!   peak footprint so a leak (memory retained past `free`) is observable —
+//!   the load → evaluate → free lifecycle high-water mark stays flat.
+//! * Evaluation ([`TrainingDataset::evaluate_mse`]) reads inputs and targets
+//!   for the requested `[start, start + count)` batch straight from the owned
+//!   buffers. The dataset bytes never re-cross the boundary after load.
+//!
+//! Fail-loud (Issue #3234): every fallible operation returns a [`DatasetError`]
+//! — a bad record length, an out-of-range batch, an unknown handle, or a
+//! network/dataset shape mismatch surfaces immediately rather than degrading
+//! into a silent wrong result.
+
+use crate::network::CompiledNetwork;
+use crate::training_data::TrainingDataConfig;
+
+/// Errors from the training-data offload path.
+#[derive(Debug, PartialEq)]
+pub enum DatasetError {
+    /// The configuration specifies zero inputs or zero outputs.
+    InvalidConfig {
+        /// Human-readable description of the invalid configuration.
+        message: String,
+    },
+    /// The packed byte buffer length is not an exact multiple of the record
+    /// size, so it cannot be split cleanly into records.
+    UnalignedBuffer {
+        /// Length of the supplied buffer in bytes.
+        buffer_len: usize,
+        /// Expected byte size of a single record.
+        record_size: usize,
+    },
+    /// A requested `[start, start + count)` batch falls outside the dataset.
+    BatchOutOfRange {
+        /// First record index requested.
+        start: usize,
+        /// Number of records requested.
+        count: usize,
+        /// Total records held by the dataset.
+        num_records: usize,
+    },
+    /// A handle did not correspond to a live dataset in the registry.
+    UnknownHandle {
+        /// The handle that was looked up.
+        handle: u32,
+    },
+    /// The network's input arity does not match the dataset's input arity.
+    ShapeMismatch {
+        /// Inputs the network expects.
+        network_inputs: usize,
+        /// Inputs each dataset record carries.
+        dataset_inputs: usize,
+    },
+}
+
+impl std::fmt::Display for DatasetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DatasetError::InvalidConfig { message } => {
+                write!(f, "Invalid dataset configuration: {message}")
+            }
+            DatasetError::UnalignedBuffer {
+                buffer_len,
+                record_size,
+            } => write!(
+                f,
+                "Buffer length {buffer_len} bytes is not a multiple of record size {record_size}"
+            ),
+            DatasetError::BatchOutOfRange {
+                start,
+                count,
+                num_records,
+            } => write!(
+                f,
+                "Batch [{start}, {start}+{count}) is out of range for {num_records} records"
+            ),
+            DatasetError::UnknownHandle { handle } => {
+                write!(f, "No live dataset for handle {handle}")
+            }
+            DatasetError::ShapeMismatch {
+                network_inputs,
+                dataset_inputs,
+            } => write!(
+                f,
+                "Network expects {network_inputs} inputs but dataset records carry {dataset_inputs}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DatasetError {}
+
+/// A training dataset owned inside neat-core's linear memory.
+///
+/// Stored structure-of-arrays: [`inputs`](Self::inputs_len) is `num_records ×
+/// num_inputs` contiguous `f32`, [`targets`](Self::targets_len) is
+/// `num_records × num_outputs`. This makes an input batch a single contiguous
+/// slice, so per-generation evaluation gathers one cache-friendly run rather
+/// than re-marshalling per-record arrays across the boundary.
+#[derive(Debug, Clone)]
+pub struct TrainingDataset {
+    config: TrainingDataConfig,
+    num_records: usize,
+    inputs: Vec<f32>,
+    targets: Vec<f32>,
+}
+
+impl TrainingDataset {
+    /// Load a dataset from the packed `.bin` byte stream produced by the
+    /// TypeScript `DataSet` module: each record is `num_inputs + num_outputs`
+    /// little-endian `f32` values, records packed contiguously.
+    ///
+    /// The buffer is de-interleaved into the structure-of-arrays layout once,
+    /// here. Fails loud if the buffer length is not a whole number of records.
+    pub fn from_packed_bytes(
+        bytes: &[u8],
+        config: TrainingDataConfig,
+    ) -> Result<Self, DatasetError> {
+        validate_config(&config)?;
+        let record_size = config.bytes_per_record();
+        if !bytes.len().is_multiple_of(record_size) {
+            return Err(DatasetError::UnalignedBuffer {
+                buffer_len: bytes.len(),
+                record_size,
+            });
+        }
+
+        let num_records = bytes.len() / record_size;
+        let num_inputs = config.num_inputs;
+        let num_outputs = config.num_outputs;
+        let mut inputs = Vec::with_capacity(num_records * num_inputs);
+        let mut targets = Vec::with_capacity(num_records * num_outputs);
+
+        for record in bytes.chunks_exact(record_size) {
+            let values = record
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]));
+            for (i, value) in values.enumerate() {
+                if i < num_inputs {
+                    inputs.push(value);
+                } else {
+                    targets.push(value);
+                }
+            }
+        }
+
+        Ok(Self {
+            config,
+            num_records,
+            inputs,
+            targets,
+        })
+    }
+
+    /// Build a dataset directly from separate input and target buffers already
+    /// in structure-of-arrays layout. Fails loud if either buffer length is
+    /// not consistent with `config` and a common record count.
+    pub fn from_soa(
+        inputs: Vec<f32>,
+        targets: Vec<f32>,
+        config: TrainingDataConfig,
+    ) -> Result<Self, DatasetError> {
+        validate_config(&config)?;
+        let by_inputs = record_count(inputs.len(), config.num_inputs)?;
+        let by_targets = record_count(targets.len(), config.num_outputs)?;
+        if by_inputs != by_targets {
+            return Err(DatasetError::InvalidConfig {
+                message: format!(
+                    "input buffer implies {by_inputs} records but target buffer implies {by_targets}"
+                ),
+            });
+        }
+        Ok(Self {
+            config,
+            num_records: by_inputs,
+            inputs,
+            targets,
+        })
+    }
+
+    /// Number of records held.
+    pub fn num_records(&self) -> usize {
+        self.num_records
+    }
+
+    /// Inputs per record.
+    pub fn num_inputs(&self) -> usize {
+        self.config.num_inputs
+    }
+
+    /// Outputs (targets) per record.
+    pub fn num_outputs(&self) -> usize {
+        self.config.num_outputs
+    }
+
+    /// Length of the owned input buffer in `f32` values.
+    pub fn inputs_len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Length of the owned target buffer in `f32` values.
+    pub fn targets_len(&self) -> usize {
+        self.targets.len()
+    }
+
+    /// Footprint of this dataset in neat-core's linear memory, in bytes.
+    ///
+    /// This is the quantity that must return to its pre-load baseline once the
+    /// dataset is freed — the anchor for the leak/high-water-mark check.
+    pub fn byte_len(&self) -> usize {
+        (self.inputs.len() + self.targets.len()) * std::mem::size_of::<f32>()
+    }
+
+    /// Contiguous input slice for the `[start, start + count)` record batch.
+    ///
+    /// Reads straight from the owned buffer — no copy crosses the boundary.
+    pub fn input_batch(&self, start: usize, count: usize) -> Result<&[f32], DatasetError> {
+        let (lo, hi) = self.batch_bounds(start, count, self.num_inputs())?;
+        Ok(&self.inputs[lo..hi])
+    }
+
+    /// Contiguous target slice for the `[start, start + count)` record batch.
+    pub fn target_batch(&self, start: usize, count: usize) -> Result<&[f32], DatasetError> {
+        let (lo, hi) = self.batch_bounds(start, count, self.num_outputs())?;
+        Ok(&self.targets[lo..hi])
+    }
+
+    /// Inputs for a single record by index.
+    pub fn record_inputs(&self, index: usize) -> Result<&[f32], DatasetError> {
+        self.input_batch(index, 1)
+    }
+
+    /// Targets for a single record by index.
+    pub fn record_outputs(&self, index: usize) -> Result<&[f32], DatasetError> {
+        self.target_batch(index, 1)
+    }
+
+    /// Evaluate a network over the `[start, start + count)` record batch and
+    /// return the mean squared error against the owned targets.
+    ///
+    /// The dataset is read **by index** from linear memory; only the network
+    /// and the batch bounds are supplied per call — the training arrays never
+    /// re-cross the boundary. Fails loud on an out-of-range batch or a
+    /// network/dataset input-arity mismatch.
+    pub fn evaluate_mse(
+        &self,
+        network: &mut CompiledNetwork,
+        start: usize,
+        count: usize,
+    ) -> Result<f32, DatasetError> {
+        if network.num_inputs != self.num_inputs() {
+            return Err(DatasetError::ShapeMismatch {
+                network_inputs: network.num_inputs,
+                dataset_inputs: self.num_inputs(),
+            });
+        }
+        // Bounds-check the whole batch up front (fail loud before any work).
+        self.batch_bounds(start, count, self.num_inputs())?;
+        self.batch_bounds(start, count, self.num_outputs())?;
+
+        if count == 0 {
+            return Ok(0.0);
+        }
+
+        let num_outputs = self.num_outputs();
+        let mut squared_error_sum = 0.0f64;
+        for offset in 0..count {
+            let index = start + offset;
+            let inputs = self.record_inputs(index)?;
+            let targets = self.record_outputs(index)?;
+            let outputs = network.activate(inputs, num_outputs);
+            for (predicted, expected) in outputs.iter().zip(targets.iter()) {
+                let diff = f64::from(*predicted) - f64::from(*expected);
+                squared_error_sum += diff * diff;
+            }
+        }
+
+        let terms = (count * num_outputs) as f64;
+        Ok((squared_error_sum / terms) as f32)
+    }
+
+    /// Translate a record batch into buffer `[lo, hi)` bounds for a per-record
+    /// stride, rejecting any batch that runs past the end.
+    fn batch_bounds(
+        &self,
+        start: usize,
+        count: usize,
+        stride: usize,
+    ) -> Result<(usize, usize), DatasetError> {
+        let end = start.checked_add(count).filter(|&e| e <= self.num_records);
+        match end {
+            Some(end) => Ok((start * stride, end * stride)),
+            None => Err(DatasetError::BatchOutOfRange {
+                start,
+                count,
+                num_records: self.num_records,
+            }),
+        }
+    }
+}
+
+/// Handle table owning every live [`TrainingDataset`] in linear memory.
+///
+/// This is the ownership seam agreed with NEAT-AI#3410: JS holds the returned
+/// `u32` handle only, never the dataset bytes. Freed slots are reused so a
+/// steady load → free cycle of equal-sized datasets keeps
+/// [`peak_bytes`](Self::peak_bytes) flat — a growing peak means a leak.
+#[derive(Debug, Default)]
+pub struct DatasetRegistry {
+    slots: Vec<Option<TrainingDataset>>,
+    live_bytes: usize,
+    peak_bytes: usize,
+}
+
+impl DatasetRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load a packed dataset and return its handle.
+    pub fn load_packed(
+        &mut self,
+        bytes: &[u8],
+        config: TrainingDataConfig,
+    ) -> Result<u32, DatasetError> {
+        let dataset = TrainingDataset::from_packed_bytes(bytes, config)?;
+        Ok(self.insert(dataset))
+    }
+
+    /// Insert an already-built dataset and return its handle, reusing a freed
+    /// slot where one is available.
+    pub fn insert(&mut self, dataset: TrainingDataset) -> u32 {
+        self.live_bytes += dataset.byte_len();
+        self.peak_bytes = self.peak_bytes.max(self.live_bytes);
+
+        let free_slot = self.slots.iter().position(Option::is_none);
+        match free_slot {
+            Some(index) => {
+                self.slots[index] = Some(dataset);
+                index as u32
+            }
+            None => {
+                self.slots.push(Some(dataset));
+                (self.slots.len() - 1) as u32
+            }
+        }
+    }
+
+    /// Borrow the dataset behind a handle, failing loud if it is not live.
+    pub fn get(&self, handle: u32) -> Result<&TrainingDataset, DatasetError> {
+        self.slots
+            .get(handle as usize)
+            .and_then(Option::as_ref)
+            .ok_or(DatasetError::UnknownHandle { handle })
+    }
+
+    /// Free the dataset behind a handle, releasing its bytes. Returns the freed
+    /// dataset's footprint in bytes. Fails loud on an unknown handle so a
+    /// double-free cannot be mistaken for success (Issue #3234).
+    pub fn free(&mut self, handle: u32) -> Result<usize, DatasetError> {
+        let slot = self
+            .slots
+            .get_mut(handle as usize)
+            .filter(|slot| slot.is_some());
+        match slot {
+            Some(slot) => {
+                let dataset = slot.take().expect("slot is Some by the filter above");
+                let freed = dataset.byte_len();
+                self.live_bytes -= freed;
+                Ok(freed)
+            }
+            None => Err(DatasetError::UnknownHandle { handle }),
+        }
+    }
+
+    /// Bytes currently held by live datasets.
+    pub fn live_bytes(&self) -> usize {
+        self.live_bytes
+    }
+
+    /// Highest [`live_bytes`](Self::live_bytes) observed over this registry's
+    /// lifetime — the linear-memory high-water mark.
+    pub fn peak_bytes(&self) -> usize {
+        self.peak_bytes
+    }
+
+    /// Number of live datasets.
+    pub fn live_count(&self) -> usize {
+        self.slots.iter().filter(|slot| slot.is_some()).count()
+    }
+}
+
+/// Reject a configuration with zero inputs or zero outputs.
+fn validate_config(config: &TrainingDataConfig) -> Result<(), DatasetError> {
+    if config.num_inputs == 0 {
+        return Err(DatasetError::InvalidConfig {
+            message: "num_inputs must be greater than zero".to_string(),
+        });
+    }
+    if config.num_outputs == 0 {
+        return Err(DatasetError::InvalidConfig {
+            message: "num_outputs must be greater than zero".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Records implied by a buffer length and a per-record stride, failing loud on
+/// a ragged buffer.
+fn record_count(buffer_len: usize, stride: usize) -> Result<usize, DatasetError> {
+    if stride == 0 || !buffer_len.is_multiple_of(stride) {
+        return Err(DatasetError::UnalignedBuffer {
+            buffer_len,
+            record_size: stride * std::mem::size_of::<f32>(),
+        });
+    }
+    Ok(buffer_len / stride)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — core dataset + registry lifecycle. Higher-level offload behaviour
+// (evaluation-by-index, leak high-water mark) lives in
+// `tests/wasm_dataset_offload.rs`.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pack interleaved records (inputs then outputs each) into `.bin` bytes.
+    fn pack(records: &[Vec<f32>]) -> Vec<u8> {
+        records
+            .iter()
+            .flat_map(|r| r.iter().flat_map(|v| v.to_le_bytes()))
+            .collect()
+    }
+
+    #[test]
+    fn from_packed_bytes_deinterleaves_into_soa() {
+        // Two records, 2 inputs + 1 output each.
+        let bytes = pack(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+
+        assert_eq!(ds.num_records(), 2);
+        assert_eq!(ds.record_inputs(0).unwrap(), &[1.0, 2.0]);
+        assert_eq!(ds.record_outputs(0).unwrap(), &[3.0]);
+        assert_eq!(ds.record_inputs(1).unwrap(), &[4.0, 5.0]);
+        assert_eq!(ds.record_outputs(1).unwrap(), &[6.0]);
+    }
+
+    #[test]
+    fn from_packed_bytes_rejects_unaligned_buffer() {
+        // 2 inputs + 1 output => 12 bytes per record; 10 bytes is ragged.
+        let err = TrainingDataset::from_packed_bytes(&[0u8; 10], TrainingDataConfig::new(2, 1))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DatasetError::UnalignedBuffer {
+                buffer_len: 10,
+                record_size: 12,
+            }
+        );
+    }
+
+    #[test]
+    fn from_packed_bytes_rejects_zero_arity_config() {
+        let err =
+            TrainingDataset::from_packed_bytes(&[], TrainingDataConfig::new(0, 1)).unwrap_err();
+        assert!(matches!(err, DatasetError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn input_batch_returns_contiguous_slice() {
+        let bytes = pack(&[
+            vec![1.0, 2.0, 10.0],
+            vec![3.0, 4.0, 20.0],
+            vec![5.0, 6.0, 30.0],
+        ]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+
+        // Batch of the middle two records.
+        assert_eq!(ds.input_batch(1, 2).unwrap(), &[3.0, 4.0, 5.0, 6.0]);
+        assert_eq!(ds.target_batch(1, 2).unwrap(), &[20.0, 30.0]);
+    }
+
+    #[test]
+    fn batch_out_of_range_fails_loud() {
+        let bytes = pack(&[vec![1.0, 2.0], vec![3.0, 4.0]]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(1, 1)).unwrap();
+        let err = ds.input_batch(1, 5).unwrap_err();
+        assert_eq!(
+            err,
+            DatasetError::BatchOutOfRange {
+                start: 1,
+                count: 5,
+                num_records: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn byte_len_counts_inputs_and_targets() {
+        let bytes = pack(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+        // 2 records * (2 inputs + 1 target) * 4 bytes.
+        assert_eq!(ds.byte_len(), 2 * 3 * 4);
+    }
+
+    #[test]
+    fn from_soa_rejects_mismatched_record_counts() {
+        // 2 input records but 1 target record.
+        let err = TrainingDataset::from_soa(
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![9.0],
+            TrainingDataConfig::new(2, 1),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DatasetError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn registry_free_releases_bytes_and_reuses_slot() {
+        let mut registry = DatasetRegistry::new();
+        let bytes = pack(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let config = TrainingDataConfig::new(2, 1);
+
+        let handle = registry.load_packed(&bytes, config.clone()).unwrap();
+        assert_eq!(registry.live_count(), 1);
+        assert_eq!(registry.live_bytes(), 2 * 3 * 4);
+
+        let freed = registry.free(handle).unwrap();
+        assert_eq!(freed, 2 * 3 * 4);
+        assert_eq!(registry.live_bytes(), 0);
+        assert_eq!(registry.live_count(), 0);
+
+        // A same-sized reload reuses the freed slot (same handle index).
+        let handle2 = registry.load_packed(&bytes, config).unwrap();
+        assert_eq!(handle2, handle);
+        assert_eq!(registry.slots.len(), 1);
+    }
+
+    #[test]
+    fn registry_get_and_free_unknown_handle_fail_loud() {
+        let mut registry = DatasetRegistry::new();
+        assert_eq!(
+            registry.get(7).unwrap_err(),
+            DatasetError::UnknownHandle { handle: 7 }
+        );
+        assert_eq!(
+            registry.free(7).unwrap_err(),
+            DatasetError::UnknownHandle { handle: 7 }
+        );
+    }
+
+    #[test]
+    fn registry_double_free_fails_loud() {
+        let mut registry = DatasetRegistry::new();
+        let bytes = pack(&[vec![1.0, 2.0]]);
+        let handle = registry
+            .load_packed(&bytes, TrainingDataConfig::new(1, 1))
+            .unwrap();
+        registry.free(handle).unwrap();
+        // Second free must not silently succeed.
+        assert_eq!(
+            registry.free(handle).unwrap_err(),
+            DatasetError::UnknownHandle { handle }
+        );
+    }
+}

--- a/neat-core/src/wasm_exports.rs
+++ b/neat-core/src/wasm_exports.rs
@@ -18,6 +18,12 @@
 
 use wasm_bindgen::prelude::*;
 
+use std::cell::RefCell;
+
+use crate::network::CompiledNetwork;
+use crate::training_data::TrainingDataConfig;
+use crate::wasm_dataset::DatasetRegistry;
+
 use crate::derivative::{apply_derivative, apply_derivative_simd_4way};
 use crate::error::{apply_calculate_error, apply_calculate_error_batch_4way};
 use crate::fused_error::apply_fused_error_distribution;
@@ -261,4 +267,121 @@ pub fn wasm_propagate_topological(data: &[u8]) -> Vec<f64> {
     };
     let output = propagate_topological_loop(&decoded.as_input());
     encode_propagate_output(&output)
+}
+
+// ---------------------------------------------------------------------------
+// Training-data offload (Issue #298) — the dataset is owned in neat-core's
+// linear memory and JS holds only a `u32` handle. Byte counts and record
+// indices are `u64` (JS `BigInt`) so the surface is Memory64-ready for the
+// >4 GB jobs the wasm64 milestone (#295) targets. The dataset bytes cross the
+// boundary once, at `training_data_load`; evaluation passes only the handle,
+// the (small) network buffer, and the batch bounds.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Process-wide handle table. wasm32/wasm64 modules are single-threaded, so
+    /// a thread-local `RefCell` is the whole synchronisation story.
+    static DATASET_REGISTRY: RefCell<DatasetRegistry> = RefCell::new(DatasetRegistry::new());
+}
+
+/// Convert a `u64` boundary value to `usize`, failing loud if it cannot fit the
+/// current address space (only possible on a wasm32 module).
+fn usize_from_u64(value: u64, what: &str) -> Result<usize, JsError> {
+    usize::try_from(value)
+        .map_err(|_| JsError::new(&format!("{what} {value} exceeds addressable range")))
+}
+
+/// JS `training_data_load(data: Uint8Array, num_inputs, num_outputs) -> handle`.
+///
+/// Loads the packed `.bin` byte stream into linear memory once and returns the
+/// handle JS retains in place of the bytes.
+#[wasm_bindgen(js_name = training_data_load)]
+pub fn wasm_training_data_load(
+    data: &[u8],
+    num_inputs: u32,
+    num_outputs: u32,
+) -> Result<u32, JsError> {
+    let config = TrainingDataConfig::new(num_inputs as usize, num_outputs as usize);
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow_mut()
+            .load_packed(data, config)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_free(handle)` — release the dataset's linear memory.
+#[wasm_bindgen(js_name = training_data_free)]
+pub fn wasm_training_data_free(handle: u32) -> Result<(), JsError> {
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow_mut()
+            .free(handle)
+            .map(|_freed| ())
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_num_records(handle) -> BigInt`.
+#[wasm_bindgen(js_name = training_data_num_records)]
+pub fn wasm_training_data_num_records(handle: u32) -> Result<u64, JsError> {
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(handle)
+            .map(|ds| ds.num_records() as u64)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_byte_len(handle) -> BigInt` — footprint in linear memory.
+#[wasm_bindgen(js_name = training_data_byte_len)]
+pub fn wasm_training_data_byte_len(handle: u32) -> Result<u64, JsError> {
+    DATASET_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(handle)
+            .map(|ds| ds.byte_len() as u64)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_evaluate_mse(handle, network: Uint8Array, start, count) -> number`.
+///
+/// Evaluates `network` over the `[start, start + count)` record batch and
+/// returns the mean squared error. The dataset is read by index from linear
+/// memory — only the small network buffer and the batch bounds cross the
+/// boundary, never the training arrays.
+#[wasm_bindgen(js_name = training_data_evaluate_mse)]
+pub fn wasm_training_data_evaluate_mse(
+    handle: u32,
+    network: &[u8],
+    start: u64,
+    count: u64,
+) -> Result<f32, JsError> {
+    let start = usize_from_u64(start, "batch start")?;
+    let count = usize_from_u64(count, "batch count")?;
+    let mut net =
+        CompiledNetwork::new(network).map_err(|err| JsError::new(&format!("network: {err}")))?;
+    DATASET_REGISTRY.with(|registry| {
+        let registry = registry.borrow();
+        let dataset = registry
+            .get(handle)
+            .map_err(|err| JsError::new(&err.to_string()))?;
+        dataset
+            .evaluate_mse(&mut net, start, count)
+            .map_err(|err| JsError::new(&err.to_string()))
+    })
+}
+
+/// JS `training_data_live_bytes() -> BigInt` — bytes held by live datasets.
+#[wasm_bindgen(js_name = training_data_live_bytes)]
+pub fn wasm_training_data_live_bytes() -> u64 {
+    DATASET_REGISTRY.with(|registry| registry.borrow().live_bytes() as u64)
+}
+
+/// JS `training_data_peak_bytes() -> BigInt` — linear-memory high-water mark.
+#[wasm_bindgen(js_name = training_data_peak_bytes)]
+pub fn wasm_training_data_peak_bytes() -> u64 {
+    DATASET_REGISTRY.with(|registry| registry.borrow().peak_bytes() as u64)
 }

--- a/neat-core/tests/wasm_dataset_offload.rs
+++ b/neat-core/tests/wasm_dataset_offload.rs
@@ -1,0 +1,201 @@
+//! Issue #298 — wasm64 lane (c) training-data offload suite.
+//!
+//! These "what" tests exercise the observable offload contract from milestone
+//! #295: neat-core owns the training dataset in its own linear memory, JS holds
+//! a handle, and per-generation evaluation reads batches **by index** without
+//! the dataset re-crossing the boundary. The registry's live/peak byte counters
+//! stand in for WASM linear-memory footprint so a load → evaluate → free
+//! lifecycle leak is observable natively (the wasm-bindgen shims are thin
+//! wrappers over exactly this API).
+
+use neat_core::network::CompiledNetwork;
+use neat_core::training_data::TrainingDataConfig;
+use neat_core::wasm_dataset::{DatasetError, DatasetRegistry, TrainingDataset};
+
+/// Build a compiled network with `num_inputs` inputs and a single IDENTITY
+/// output neuron that sums every input (weight 1.0) and adds `bias`.
+///
+/// Output for record `x` is therefore `sum(x) + bias`, so expected MSE against
+/// a target is easy to compute by hand in the assertions below.
+fn summing_identity_network(num_inputs: usize, bias: f64) -> CompiledNetwork {
+    let mut data = Vec::new();
+    let num_neurons = (num_inputs + 1) as u32;
+    data.extend_from_slice(&num_neurons.to_le_bytes());
+    data.extend_from_slice(&(num_inputs as u32).to_le_bytes());
+
+    // Single output neuron.
+    data.extend_from_slice(&bias.to_le_bytes()); // bias f64
+    data.push(0); // squash IDENTITY
+    data.push(0); // is_constant = false
+    data.extend_from_slice(&(num_inputs as u16).to_le_bytes()); // num_synapses
+
+    // One synapse per input, weight 1.0.
+    for from_index in 0..num_inputs as u16 {
+        data.extend_from_slice(&from_index.to_le_bytes());
+        data.push(0); // synapse_type
+        data.push(0); // padding
+        data.extend_from_slice(&1.0_f64.to_le_bytes()); // weight f64
+    }
+
+    CompiledNetwork::new(&data).expect("network should parse")
+}
+
+/// Pack interleaved records (each: inputs then outputs) into `.bin` bytes.
+fn pack(records: &[Vec<f32>]) -> Vec<u8> {
+    records
+        .iter()
+        .flat_map(|r| r.iter().flat_map(|v| v.to_le_bytes()))
+        .collect()
+}
+
+#[test]
+fn evaluation_reads_the_batch_by_index_from_owned_memory() {
+    // 3 records, 2 inputs + 1 target each. output = i0 + i1 + bias(0.0).
+    let bytes = pack(&[
+        vec![1.0, 2.0, 3.0], // predict 3.0, target 3.0 → err 0
+        vec![2.0, 2.0, 5.0], // predict 4.0, target 5.0 → err 1
+        vec![0.0, 0.0, 2.0], // predict 0.0, target 2.0 → err 4
+    ]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+    let mut net = summing_identity_network(2, 0.0);
+
+    // Evaluate only the last two records by index — MSE = (1 + 4) / 2 = 2.5.
+    let mse = ds.evaluate_mse(&mut net, 1, 2).unwrap();
+    assert!((mse - 2.5).abs() < 1e-5, "batch MSE was {mse}");
+
+    // A different batch reads a different slice of the same owned buffer.
+    let first = ds.evaluate_mse(&mut net, 0, 1).unwrap();
+    assert!(
+        first.abs() < 1e-6,
+        "first record should be exact, got {first}"
+    );
+}
+
+#[test]
+fn evaluation_does_not_reload_or_mutate_the_dataset() {
+    let bytes = pack(&[vec![1.0, 1.0], vec![2.0, 3.0], vec![4.0, 4.0]]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(1, 1)).unwrap();
+    let mut net = summing_identity_network(1, 0.0);
+
+    let footprint_before = ds.byte_len();
+    let records_before = ds.num_records();
+
+    // Many generations over the whole dataset: the result is deterministic and
+    // the owned buffer neither grows nor shrinks — the dataset is not re-passed
+    // or re-marshalled per call.
+    let first = ds.evaluate_mse(&mut net, 0, records_before).unwrap();
+    for _ in 0..50 {
+        let again = ds.evaluate_mse(&mut net, 0, records_before).unwrap();
+        assert_eq!(
+            again, first,
+            "evaluation must be deterministic across generations"
+        );
+    }
+
+    assert_eq!(ds.byte_len(), footprint_before);
+    assert_eq!(ds.num_records(), records_before);
+}
+
+#[test]
+fn evaluation_rejects_network_dataset_shape_mismatch() {
+    let bytes = pack(&[vec![1.0, 2.0, 9.0]]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(2, 1)).unwrap();
+    // Network takes 3 inputs but the dataset carries 2.
+    let mut net = summing_identity_network(3, 0.0);
+
+    let err = ds.evaluate_mse(&mut net, 0, 1).unwrap_err();
+    assert_eq!(
+        err,
+        DatasetError::ShapeMismatch {
+            network_inputs: 3,
+            dataset_inputs: 2,
+        }
+    );
+}
+
+#[test]
+fn evaluation_rejects_out_of_range_batch() {
+    let bytes = pack(&[vec![1.0, 1.0], vec![2.0, 2.0]]);
+    let ds = TrainingDataset::from_packed_bytes(&bytes, TrainingDataConfig::new(1, 1)).unwrap();
+    let mut net = summing_identity_network(1, 0.0);
+
+    let err = ds.evaluate_mse(&mut net, 1, 10).unwrap_err();
+    assert_eq!(
+        err,
+        DatasetError::BatchOutOfRange {
+            start: 1,
+            count: 10,
+            num_records: 2,
+        }
+    );
+}
+
+#[test]
+fn load_evaluate_free_lifecycle_keeps_high_water_mark_stable() {
+    // The leak gate: repeatedly load a dataset, evaluate several generations,
+    // then free it. If any bytes are retained past `free`, `live_bytes` would
+    // not return to zero and `peak_bytes` would climb every cycle.
+    let mut registry = DatasetRegistry::new();
+    let config = TrainingDataConfig::new(2, 1);
+    let bytes = pack(&[
+        vec![1.0, 2.0, 3.0],
+        vec![2.0, 2.0, 4.0],
+        vec![3.0, 1.0, 4.0],
+        vec![0.5, 0.5, 1.0],
+    ]);
+    let mut net = summing_identity_network(2, 0.0);
+
+    let mut peak_after_first_cycle = None;
+    for _cycle in 0..8 {
+        let handle = registry.load_packed(&bytes, config.clone()).unwrap();
+
+        // Evaluate N "generations" reading batches by index from linear memory.
+        let ds = registry.get(handle).unwrap();
+        let num_records = ds.num_records();
+        for _generation in 0..5 {
+            let mse = ds.evaluate_mse(&mut net, 0, num_records).unwrap();
+            assert!(mse.is_finite());
+        }
+
+        // Live footprint is exactly one dataset while loaded.
+        assert_eq!(registry.live_bytes(), 4 * 3 * 4);
+
+        registry.free(handle).unwrap();
+
+        // Every byte released on free — nothing retained.
+        assert_eq!(registry.live_bytes(), 0, "dataset bytes leaked past free");
+        assert_eq!(registry.live_count(), 0);
+
+        // Peak must not grow across cycles — equal-sized reload reuses memory.
+        match peak_after_first_cycle {
+            None => peak_after_first_cycle = Some(registry.peak_bytes()),
+            Some(peak) => assert_eq!(
+                registry.peak_bytes(),
+                peak,
+                "linear-memory high-water mark grew across load/free cycles"
+            ),
+        }
+    }
+
+    assert_eq!(peak_after_first_cycle, Some(4 * 3 * 4));
+}
+
+#[test]
+fn registry_hands_out_handles_not_bytes() {
+    // JS holds only the returned u32 handle; the bytes stay owned by the
+    // registry and are reachable solely through it.
+    let mut registry = DatasetRegistry::new();
+    let config = TrainingDataConfig::new(1, 1);
+
+    let a = registry
+        .load_packed(&pack(&[vec![1.0, 1.0]]), config.clone())
+        .unwrap();
+    let b = registry
+        .load_packed(&pack(&[vec![2.0, 2.0]]), config)
+        .unwrap();
+    assert_ne!(a, b);
+    assert_eq!(registry.live_count(), 2);
+
+    assert_eq!(registry.get(a).unwrap().record_inputs(0).unwrap(), &[1.0]);
+    assert_eq!(registry.get(b).unwrap().record_inputs(0).unwrap(), &[2.0]);
+}

--- a/tests/perf/learn_flags_wiring.ts
+++ b/tests/perf/learn_flags_wiring.ts
@@ -1,0 +1,124 @@
+// learn_flags_wiring.ts — wasm64 lane (d) GRQ learn-invocation wiring model
+// (Issue #299).
+//
+// Lane (a) (#296) attributed the GRQ#3508 learn OOME to the **V8 old-space heap**
+// (exit 133 / "Reached heap limit"), liftable by
+// `--v8-flags=--max-old-space-size=<N>`. Lane (d) is the GRQ-side wiring plus
+// end-to-end verification: GRQ's learn invocation must select that flag
+// **RAM-aware**, so a bigger heap on a roomy host never pushes a smaller host
+// past its limit, and a V8 old-space abort is never silently reported as
+// success.
+//
+// The PRODUCTION selection lives in GRQ (stSoftwareAU/GRQ):
+//   * `worker/shared/memory_calc.sh` — `get_max_heap_size` / `get_heap_floor_mb`
+//     size the heap from currently-available RAM after a fixed FFI/OS headroom.
+//   * `worker/learn.sh` — injects `--v8-flags=--max-old-space-size=${MAX_HEAP_SIZE}`
+//     into the `deno run src/Learn.ts` argv (the BEGIN_LEARN_DENO_ARGV_2950 block).
+//   * `worker/shared/stage_fail_marker.sh` — the EXIT-trap emits a
+//     `[learn] FAIL:` marker on any non-zero exit (incl. 133), so node.sh cannot
+//     downgrade a marker-less OOM abort to success (GRQ#2391 / Issue #3234).
+// It is CI-guarded in GRQ by `test/worker/MemoryCalcHeapSize.ts` and
+// `test/worker/MemoryCalcHostFloor.ts`.
+//
+// This module is the **neat-core-side acceptance model** of that selection: a
+// pure re-derivation used to verify the milestone's headroom invariants from
+// this repo end-to-end (the "neat-core adoption verified end-to-end" tracked by
+// #299). It must stay in **lock-step** with `memory_calc.sh`; the constants
+// below mirror it exactly. A divergence between this model's numbers and GRQ's
+// is itself the regression signal. See
+// `docs/research/wasm64-lane-d-grq-learn-wiring-verification.md`.
+
+/** Fixed headroom (MB) reserved for Rust FFI + OS caches before apportioning to
+ * V8 — `MEMORY_FFI_OS_HEADROOM_MB` in memory_calc.sh (#1768). */
+export const FFI_OS_HEADROOM_MB = 1536;
+/** Share of the post-headroom budget granted to V8 (`get_max_heap_size` default). */
+export const HEAP_PERCENTAGE = 65;
+/** Heap ceiling (MB): large hosts keep RAM for OS/non-heap (`GRQ_MAX_HEAP_CAP_MB`). */
+export const HEAP_CAP_MB = 24576;
+/** Global heap floor (MB) for hosts smaller than the 8 GB tier. */
+export const GLOBAL_HEAP_FLOOR_MB = 1536;
+/** 8 GB sloth-class working-set floor (MB), ample-available case (#2084/#3342). */
+export const EIGHT_GB_HEAP_FLOOR_MB = 3072;
+/** >=16 GB working-set floor (MB), ample-available case (#2243/#3294). */
+export const SIXTEEN_GB_HEAP_FLOOR_MB = 4096;
+/** Minority share of *available* RAM the step-down floor may claim (`get_heap_floor_avail_pct`). */
+export const HEAP_FLOOR_AVAIL_PCT = 45;
+/** V8 fatal heap-limit abort code (SIGTRAP, 128 + 5) — GRQ#3508's signature. */
+export const OOM_EXIT_CODE = 133;
+
+/** A host's memory picture, in MB. */
+export interface HostMemory {
+  /** Total physical RAM in MB. */
+  totalMb: number;
+  /** Currently-available RAM in MB; defaults to `totalMb` (an idle host). */
+  availableMb?: number;
+}
+
+/**
+ * Mirror of `memory_calc.sh get_heap_floor_mb`. Hosts below 8 GB keep the global
+ * 1536 MB floor. The 8 GB tier uses a 3072 MB working-set floor that steps
+ * **down** on a constrained host (available-aware, #3342, always on for the
+ * learn/teams victim): capped at a minority share (45%) of *available* RAM but
+ * never below the 1536 MB global floor. >=16 GB hosts use a 4096 MB floor (the
+ * available-aware step-down there is opt-in via `GRQ_HEAP_AVAILABLE_AWARE_FLOOR`
+ * and off for the learn path, so the fixed floor is the learn-path value).
+ */
+export function heapFloorMb(host: HostMemory): number {
+  const totalGb = Math.floor(host.totalMb / 1024);
+  const availableMb = host.availableMb ?? host.totalMb;
+  if (totalGb >= 16) return SIXTEEN_GB_HEAP_FLOOR_MB;
+  if (totalGb === 8) {
+    let floor = EIGHT_GB_HEAP_FLOOR_MB;
+    const availCap = Math.floor((availableMb * HEAP_FLOOR_AVAIL_PCT) / 100);
+    if (availCap < floor) floor = availCap;
+    if (floor < GLOBAL_HEAP_FLOOR_MB) floor = GLOBAL_HEAP_FLOOR_MB;
+    return floor;
+  }
+  return GLOBAL_HEAP_FLOOR_MB;
+}
+
+/**
+ * Mirror of `memory_calc.sh get_max_heap_size`: the `--max-old-space-size` value
+ * (MB) GRQ's learn invocation selects for a host.
+ *
+ *   heap = clamp((available - FFI_OS_HEADROOM) * 65%, floor(total) .. 24576)
+ */
+export function selectMaxOldSpaceSizeMb(host: HostMemory): number {
+  const availableMb = host.availableMb ?? host.totalMb;
+  const budget = Math.max(availableMb - FFI_OS_HEADROOM_MB, 0);
+  let heap = Math.floor((budget * HEAP_PERCENTAGE) / 100);
+  if (heap > HEAP_CAP_MB) heap = HEAP_CAP_MB;
+  const floor = heapFloorMb(host);
+  if (heap < floor) heap = floor;
+  return heap;
+}
+
+/** The exact `--v8-flags` token `worker/learn.sh` injects for the learn stage. */
+export function learnV8HeapFlag(host: HostMemory): string {
+  return `--v8-flags=--max-old-space-size=${selectMaxOldSpaceSizeMb(host)}`;
+}
+
+/**
+ * RAM-aware guard: the selected heap plus the FFI/OS headroom must fit within
+ * the host's **total** RAM, so a bigger heap on a roomy host never pushes a
+ * smaller host past its limit (acceptance: "no regression / new OOME on smaller
+ * hosts"). Returns true iff the invocation stays within the host's budget.
+ */
+export function heapFitsHostBudget(host: HostMemory): boolean {
+  return selectMaxOldSpaceSizeMb(host) + FFI_OS_HEADROOM_MB <= host.totalMb;
+}
+
+/**
+ * Silent-failure guard (GRQ#2391 / Issue #3234). A V8 old-space OOM is a native
+ * abort (exit 133): the crashed child cannot print its own marker, and node.sh
+ * downgrades a marker-less non-zero exit to success. `learn.sh`'s EXIT trap must
+ * therefore emit a `[learn] FAIL:` marker. Returns the marker line for a
+ * marker-less non-zero exit, or `null` for a clean exit or one already marked.
+ */
+export function learnFailMarkerForExit(
+  exitCode: number,
+  alreadyMarked = false,
+): string | null {
+  if (exitCode === 0 || alreadyMarked) return null;
+  return `[learn] FAIL: learn exited ${exitCode}`;
+}

--- a/tests/perf/learn_flags_wiring_test.ts
+++ b/tests/perf/learn_flags_wiring_test.ts
@@ -1,0 +1,127 @@
+// learn_flags_wiring_test.ts — "what" tests for the wasm64 lane (d) GRQ
+// learn-invocation wiring model (Issue #299).
+//
+// These pin the RAM-aware `--v8-flags=--max-old-space-size` selection GRQ's
+// `worker/learn.sh` injects, verified from neat-core. The expected MB values are
+// the SAME numbers GRQ's own CI asserts in `test/worker/MemoryCalcHeapSize.ts`
+// (e.g. 8 GB → 4326, 16 GB → 9651, 4 GB → 1664): if GRQ's sizing formula drifts,
+// these lock-step values catch it here too.
+//
+// Run: deno test tests/perf/learn_flags_wiring_test.ts
+
+import { assert, assertEquals, assertGreater } from "jsr:@std/assert@^1";
+import {
+  EIGHT_GB_HEAP_FLOOR_MB,
+  FFI_OS_HEADROOM_MB,
+  GLOBAL_HEAP_FLOOR_MB,
+  heapFitsHostBudget,
+  heapFloorMb,
+  type HostMemory,
+  learnFailMarkerForExit,
+  learnV8HeapFlag,
+  OOM_EXIT_CODE,
+  selectMaxOldSpaceSizeMb,
+  SIXTEEN_GB_HEAP_FLOOR_MB,
+} from "./learn_flags_wiring.ts";
+
+const GB = 1024;
+const host = (totalGb: number, availableMb?: number): HostMemory => ({
+  totalMb: totalGb * GB,
+  availableMb,
+});
+
+// --- RAM-aware heap selection, lock-step with GRQ MemoryCalcHeapSize.ts --------
+
+Deno.test("selectMaxOldSpaceSizeMb: 4 GB host gets 1664 MB (above the 1536 floor)", () => {
+  // (4096 - 1536) * 65 / 100 = 1664
+  assertEquals(selectMaxOldSpaceSizeMb(host(4)), 1664);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 8 GB host gets 4326 MB (the GRQ#3508 tier)", () => {
+  // (8192 - 1536) * 65 / 100 = 4326
+  assertEquals(selectMaxOldSpaceSizeMb(host(8)), 4326);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 16 GB host gets 9651 MB", () => {
+  // (16384 - 1536) * 65 / 100 = 9651
+  assertEquals(selectMaxOldSpaceSizeMb(host(16)), 9651);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 64 GB host is capped at 24576 MB", () => {
+  // (65536 - 1536) * 65 / 100 = 41600 → capped at the 24 GB ceiling
+  assertEquals(selectMaxOldSpaceSizeMb(host(64)), 24576);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: 2 GB host is floored at 1536 MB", () => {
+  // (2048 - 1536) * 65 / 100 = 332 → floored at the global 1536 MB floor
+  assertEquals(selectMaxOldSpaceSizeMb(host(2)), GLOBAL_HEAP_FLOOR_MB);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: constrained 8 GB host sizes off AVAILABLE, not total (#3342)", () => {
+  // GRQ-26: 8 GB total but only 3865 MB available. Heap = (3865 - 1536) * 65 /
+  // 100 = 1513; the available-aware floor steps down to min(3072, 3865 * 45 /
+  // 100 = 1739) = 1739, so the selection is 1739 — far below the fixed-3072
+  // over-commit that fatal-OOM'd GRQ-26, and below the 4326 a roomy 8 GB gets.
+  assertEquals(selectMaxOldSpaceSizeMb(host(8, 3865)), 1739);
+  assertGreater(
+    selectMaxOldSpaceSizeMb(host(8)),
+    selectMaxOldSpaceSizeMb(host(8, 3865)),
+  );
+});
+
+// --- Falls back safely below the 8 GB tier ------------------------------------
+
+Deno.test("heapFloorMb: below-8 GB hosts keep the 1536 MB global floor, not the 8 GB tier floor", () => {
+  assertEquals(heapFloorMb(host(4)), GLOBAL_HEAP_FLOOR_MB);
+  assertEquals(heapFloorMb(host(8)), EIGHT_GB_HEAP_FLOOR_MB);
+  assertEquals(heapFloorMb(host(16)), SIXTEEN_GB_HEAP_FLOOR_MB);
+  // A 4 GB host must not inherit the 8 GB tier's higher floor.
+  assertGreater(heapFloorMb(host(8)), heapFloorMb(host(4)));
+});
+
+// --- RAM-aware budget guard: no new OOME on smaller hosts ---------------------
+
+Deno.test("heapFitsHostBudget: 4 / 8 / 16 GB hosts all stay within their total RAM", () => {
+  for (const gb of [4, 8, 16, 32, 64]) {
+    assert(
+      heapFitsHostBudget(host(gb)),
+      `heap + FFI/OS headroom must fit in ${gb} GB total RAM`,
+    );
+  }
+});
+
+Deno.test("heapFitsHostBudget: heap + headroom never exceeds total on the 8 GB tier", () => {
+  const h = host(8);
+  assert(selectMaxOldSpaceSizeMb(h) + FFI_OS_HEADROOM_MB <= h.totalMb);
+});
+
+Deno.test("selectMaxOldSpaceSizeMb: heap grows monotonically with host RAM (no smaller host over-sized)", () => {
+  const h4 = selectMaxOldSpaceSizeMb(host(4));
+  const h8 = selectMaxOldSpaceSizeMb(host(8));
+  const h16 = selectMaxOldSpaceSizeMb(host(16));
+  assertGreater(h8, h4, "8 GB must not be sized below 4 GB");
+  assertGreater(h16, h8, "16 GB must not be sized below 8 GB");
+});
+
+// --- The exact flag token learn.sh injects ------------------------------------
+
+Deno.test("learnV8HeapFlag: composes the --v8-flags=--max-old-space-size token", () => {
+  assertEquals(
+    learnV8HeapFlag(host(8)),
+    "--v8-flags=--max-old-space-size=4326",
+  );
+});
+
+// --- Silent-failure guard (GRQ#2391 / #3234) ----------------------------------
+
+Deno.test("learnFailMarkerForExit: a marker-less exit-133 abort gets a [learn] FAIL: marker", () => {
+  assertEquals(
+    learnFailMarkerForExit(OOM_EXIT_CODE),
+    "[learn] FAIL: learn exited 133",
+  );
+});
+
+Deno.test("learnFailMarkerForExit: a clean exit and an already-marked exit stay silent", () => {
+  assertEquals(learnFailMarkerForExit(0), null);
+  assertEquals(learnFailMarkerForExit(OOM_EXIT_CODE, true), null);
+});

--- a/tests/perf/learn_oome_repro.ts
+++ b/tests/perf/learn_oome_repro.ts
@@ -1,0 +1,312 @@
+// learn_oome_repro.ts — wasm64 lane (a) gating diagnostic (Issue #296).
+//
+// Reproduces the two *distinct* out-of-memory ceilings a Deno learn job can hit
+// and attributes a peak to the pool that actually binds:
+//
+//   1. V8 old-space (the JS heap)     — abort signature "Reached heap limit",
+//      process exit 133. Raising `--v8-flags=--max-old-space-size=<N>` lifts it.
+//   2. WASM linear memory on wasm32    — RangeError from `WebAssembly.Memory`
+//      construction / `.grow()` at the hard 4 GiB (65536-page) address-space
+//      cap. `--max-old-space-size` cannot lift this; only a wasm64 (Memory64)
+//      build can.
+//
+// The harness is DATA-set free on purpose: both ceilings are architectural, so
+// it drives them synthetically and captures the same crash signatures a real
+// `Learn.ts` job emits. It is gated behind `LEARN_OOME_REPRO=1` so it never runs
+// in default CI — only on an 8 GB+ host (see the finding in
+// docs/research/wasm64-lane-a-4gb-ceiling-attribution.md).
+//
+// Run examples (Deno >= 2.9.3):
+//   LEARN_OOME_REPRO=1 deno run --allow-env tests/perf/learn_oome_repro.ts wasm
+//   LEARN_OOME_REPRO=1 deno run --allow-env \
+//     --v8-flags=--max-old-space-size=256 tests/perf/learn_oome_repro.ts heap 2000
+//
+// On the crash path the harness prints a `[learn] FAIL:` marker so GRQ node.sh
+// does not downgrade a marker-less non-zero exit to success (GRQ#2391).
+
+/** Hard wasm32 linear-memory ceiling: 65536 pages x 64 KiB = exactly 4 GiB. */
+export const WASM32_MAX_PAGES = 65536;
+/** wasm32 linear-memory ceiling in bytes (4 GiB). */
+export const WASM32_MAX_BYTES = WASM32_MAX_PAGES * 64 * 1024;
+
+/** Which memory pool a crash signature or peak snapshot is attributed to. */
+export type Pool =
+  | "v8-heap"
+  | "wasm-linear-memory"
+  | "external-buffers"
+  | "unknown";
+
+/**
+ * Classify a raw crash / abort string as a V8 JS-heap ceiling or a WASM
+ * linear-memory ceiling. The two are unambiguous in the log text, which is the
+ * whole point of lane (a): exit 133 + "Reached heap limit" is V8 old-space;
+ * a `WebAssembly.Memory` RangeError / out-of-bounds trap is WASM memory.
+ */
+export function classifyCrashSignature(text: string): Pool {
+  const t = text.toLowerCase();
+  // WASM linear-memory signatures (checked first: they can also mention "memory").
+  if (
+    t.includes("webassembly.memory") ||
+    t.includes("maximum memory size exceeded") ||
+    t.includes("memory access out of bounds") ||
+    t.includes("out of bounds memory access")
+  ) {
+    return "wasm-linear-memory";
+  }
+  // V8 JS-heap (old-space) abort signatures.
+  if (
+    t.includes("reached heap limit") ||
+    t.includes("javascript heap out of memory") ||
+    t.includes("allocation failed - javascript heap") ||
+    (t.includes("fatal") && t.includes("heap"))
+  ) {
+    return "v8-heap";
+  }
+  return "unknown";
+}
+
+/** Dual-probe memory snapshot: BOTH probes required by the acceptance criteria. */
+export interface ProbeSnapshot {
+  /** Resident set size of the whole process (Deno.memoryUsage().rss). */
+  rssBytes: number;
+  /** V8 old-space live bytes (Deno.memoryUsage().heapUsed). */
+  heapUsedBytes: number;
+  /** V8 old-space reserved bytes (Deno.memoryUsage().heapTotal). */
+  heapTotalBytes: number;
+  /** Off-heap ArrayBuffer/TypedArray bytes tracked by V8 (external). */
+  externalBytes: number;
+  /** WASM linear-memory bytes (memory.buffer.byteLength), 0 if no module. */
+  wasmBytes: number;
+}
+
+/**
+ * Capture both probes at once. NEAT-AI#3410 shows MemoryMonitor misreads the
+ * limit from a single probe, so the finding must cite `Deno.memoryUsage()` AND
+ * `WebAssembly.Memory.buffer.byteLength` together.
+ */
+export function snapshotProbes(mem?: WebAssembly.Memory | null): ProbeSnapshot {
+  const u = Deno.memoryUsage();
+  return {
+    rssBytes: u.rss,
+    heapUsedBytes: u.heapUsed,
+    heapTotalBytes: u.heapTotal,
+    externalBytes: u.external,
+    wasmBytes: mem ? mem.buffer.byteLength : 0,
+  };
+}
+
+/**
+ * Attribute a peak snapshot to the pool that dominates it. This is the core
+ * decision lane (a) exists to make: a peak dominated by WASM linear memory sat
+ * at ~4 GiB cannot be helped by `--max-old-space-size`; one dominated by V8
+ * old-space can.
+ */
+export function attributePeak(p: ProbeSnapshot): Pool {
+  const wasm = p.wasmBytes;
+  const heap = p.heapUsedBytes;
+  const external = p.externalBytes;
+  const max = Math.max(wasm, heap, external);
+  if (max === 0) return "unknown";
+  if (max === wasm) return "wasm-linear-memory";
+  if (max === heap) return "v8-heap";
+  return "external-buffers";
+}
+
+/**
+ * Grow a wasm32 `WebAssembly.Memory` towards `targetPages`, returning the peak
+ * reached and any grow-failure signature. Demonstrates the hard 4 GiB cap:
+ * asking for more than 65536 pages fails with a RangeError regardless of host
+ * RAM.
+ */
+export function growWasmToCeiling(
+  targetPages: number,
+): {
+  mem: WebAssembly.Memory;
+  peakPages: number;
+  peakBytes: number;
+  signature: string;
+} {
+  // Cap the declared maximum at the wasm32 ceiling so the grow (not the
+  // constructor) is what fails when target > ceiling — mirroring a real module
+  // whose static `maximum` is the wasm32 limit.
+  const maximum = Math.min(targetPages, WASM32_MAX_PAGES);
+  const mem = new WebAssembly.Memory({ initial: 1, maximum });
+  let pages = 1;
+  let signature = "";
+  const step = 1024; // 64 MiB per grow
+  try {
+    while (pages < targetPages) {
+      const grow = Math.min(step, targetPages - pages);
+      mem.grow(grow);
+      pages += grow;
+    }
+  } catch (e) {
+    signature = `${(e as Error).name}: ${(e as Error).message}`;
+  }
+  return { mem, peakPages: pages, peakBytes: mem.buffer.byteLength, signature };
+}
+
+/**
+ * A V8 old-space OOM is a *native* abort (exit 133) — it cannot be caught
+ * in-process, so the crashing child can never print its own `[learn] FAIL:`
+ * marker. `markerForExit` is the launcher-side rule that closes that gap: given
+ * a child's exit code and captured output, it returns the marker line the
+ * launcher must emit so a marker-less exit 133 is not downgraded to success by
+ * GRQ node.sh (GRQ#2391). Returns null when the child already emitted a marker
+ * or exited cleanly.
+ */
+export function markerForExit(
+  code: number,
+  childOutput: string,
+): string | null {
+  if (childOutput.includes("[learn] FAIL:")) return null; // child already flagged
+  if (code === 0) return null;
+  if (
+    code === 133 || childOutput.toLowerCase().includes("reached heap limit")
+  ) {
+    return "[learn] FAIL: v8-heap | child exited 133 (Reached heap limit) with no marker";
+  }
+  return `[learn] FAIL: unknown | child exited ${code} with no marker`;
+}
+
+function fmtMiB(bytes: number): string {
+  return `${(bytes / 1024 ** 2).toFixed(0)}MiB`;
+}
+
+function reportPeak(label: string, p: ProbeSnapshot): void {
+  console.log(
+    `[learn] PEAK(${label}): rss=${fmtMiB(p.rssBytes)} ` +
+      `heapUsed=${fmtMiB(p.heapUsedBytes)} heapTotal=${
+        fmtMiB(p.heapTotalBytes)
+      } ` +
+      `external=${fmtMiB(p.externalBytes)} wasm=${fmtMiB(p.wasmBytes)} ` +
+      `-> attributed=${attributePeak(p)}`,
+  );
+}
+
+/** Fill V8 old-space with retained plain-JS objects until `targetMiB` is live. */
+function runHeapMode(targetMiB: number): number {
+  const retained: number[][] = [];
+  let iter = 0;
+  try {
+    while (true) {
+      const chunk = new Array<number>(128 * 1024); // ~1 MiB of boxed doubles
+      for (let i = 0; i < chunk.length; i++) chunk[i] = i * 1.0001;
+      retained.push(chunk);
+      iter++;
+      if ((iter & 63) === 0) {
+        const snap = snapshotProbes(null);
+        if (snap.heapUsedBytes / 1024 ** 2 >= targetMiB) {
+          reportPeak("heap", snap);
+          console.log(
+            `[learn] OK: heap job reached ${targetMiB} MiB old-space`,
+          );
+          return 0;
+        }
+      }
+    }
+  } catch (e) {
+    // A soft OOM surfaced as a catchable error (rare — V8 usually hard-aborts).
+    console.error(
+      `[learn] FAIL: ${classifyCrashSignature(String(e))} | ${
+        (e as Error).message
+      }`,
+    );
+    return 1;
+  }
+}
+
+/** Grow wasm32 linear memory towards `targetGiB` and report the ceiling hit. */
+function runWasmMode(targetGiB: number): number {
+  const targetPages = Math.ceil((targetGiB * 1024 ** 3) / (64 * 1024));
+  const { mem, peakPages, peakBytes, signature } = growWasmToCeiling(
+    targetPages,
+  );
+  reportPeak("wasm", snapshotProbes(mem));
+  if (signature) {
+    console.error(
+      `[learn] FAIL: ${classifyCrashSignature(signature)} | ` +
+        `peakPages=${peakPages} peakBytes=${peakBytes} (${
+          (peakBytes / 1024 ** 3).toFixed(3)
+        } GiB) | ${signature}`,
+    );
+    return 1;
+  }
+  console.log(
+    `[learn] OK: wasm reached ${peakPages} pages (${
+      (peakBytes / 1024 ** 3).toFixed(3)
+    } GiB)`,
+  );
+  return 0;
+}
+
+/**
+ * Launcher demonstrator: run the `heap` child under a chosen old-space cap and
+ * synthesise the `[learn] FAIL:` marker if it aborts with exit 133 but printed
+ * no marker of its own. This is the pattern GRQ node.sh / the learn wrapper
+ * (lane (d), #299) must adopt so a V8 heap OOM is never seen as success.
+ */
+async function runGuardMode(
+  targetMiB: number,
+  maxOldSpaceMiB: number,
+): Promise<number> {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--quiet",
+      "--allow-env",
+      `--v8-flags=--max-old-space-size=${maxOldSpaceMiB}`,
+      new URL(import.meta.url).pathname,
+      "heap",
+      String(targetMiB),
+    ],
+    env: { LEARN_OOME_REPRO: "1" },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const out = await cmd.output();
+  const text = new TextDecoder().decode(out.stdout) +
+    new TextDecoder().decode(out.stderr);
+  const marker = markerForExit(out.code, text);
+  if (marker) {
+    console.error(marker);
+    return 1;
+  }
+  console.log(`[learn] OK: guarded heap child exited ${out.code}`);
+  return out.code;
+}
+
+async function main(): Promise<number> {
+  if (Deno.env.get("LEARN_OOME_REPRO") !== "1") {
+    console.error(
+      "[learn] SKIP: set LEARN_OOME_REPRO=1 to run (8 GB+ host only; not for default CI).",
+    );
+    return 0;
+  }
+  const mode = Deno.args[0] ?? "wasm";
+  const arg = Number(Deno.args[1] ?? "");
+  const arg2 = Number(Deno.args[2] ?? "");
+  switch (mode) {
+    case "heap":
+      return runHeapMode(Number.isFinite(arg) && arg > 0 ? arg : 4096);
+    case "wasm":
+      return runWasmMode(Number.isFinite(arg) && arg > 0 ? arg : 6);
+    case "guard":
+      return await runGuardMode(
+        Number.isFinite(arg) && arg > 0 ? arg : 2000,
+        Number.isFinite(arg2) && arg2 > 0 ? arg2 : 256,
+      );
+    case "probe":
+      reportPeak("probe", snapshotProbes(null));
+      return 0;
+    default:
+      console.error(
+        `[learn] FAIL: unknown mode '${mode}' (use heap|wasm|guard|probe)`,
+      );
+      return 2;
+  }
+}
+
+if (import.meta.main) {
+  Deno.exit(await main());
+}

--- a/tests/perf/learn_oome_repro_test.ts
+++ b/tests/perf/learn_oome_repro_test.ts
@@ -1,0 +1,149 @@
+// Tests for the wasm64 lane (a) OOME reproducer (Issue #296).
+// "What" tests: they call the real classifier / probe / attribution functions
+// and assert on observable outcomes — not on how those functions are wired.
+//
+// Run: deno test --allow-env tests/perf/learn_oome_repro_test.ts
+
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  attributePeak,
+  classifyCrashSignature,
+  growWasmToCeiling,
+  markerForExit,
+  type ProbeSnapshot,
+  snapshotProbes,
+  WASM32_MAX_BYTES,
+  WASM32_MAX_PAGES,
+} from "./learn_oome_repro.ts";
+
+Deno.test("classifyCrashSignature maps the exit-133 V8 abort to v8-heap", () => {
+  assertEquals(
+    classifyCrashSignature(
+      "Fatal JavaScript out of memory: Reached heap limit",
+    ),
+    "v8-heap",
+  );
+  assertEquals(
+    classifyCrashSignature("FATAL ERROR: ... JavaScript heap out of memory"),
+    "v8-heap",
+  );
+});
+
+Deno.test("classifyCrashSignature maps the wasm grow failure to wasm-linear-memory", () => {
+  assertEquals(
+    classifyCrashSignature(
+      "RangeError: WebAssembly.Memory.grow(): Maximum memory size exceeded",
+    ),
+    "wasm-linear-memory",
+  );
+  assertEquals(
+    classifyCrashSignature("RuntimeError: memory access out of bounds"),
+    "wasm-linear-memory",
+  );
+});
+
+Deno.test("classifyCrashSignature returns unknown for unrelated errors", () => {
+  assertEquals(
+    classifyCrashSignature("TypeError: x is not a function"),
+    "unknown",
+  );
+});
+
+Deno.test("attributePeak picks the dominant pool", () => {
+  const wasmBound: ProbeSnapshot = {
+    rssBytes: 4_300_000_000,
+    heapUsedBytes: 120_000_000,
+    heapTotalBytes: 160_000_000,
+    externalBytes: 5_000_000,
+    wasmBytes: WASM32_MAX_BYTES,
+  };
+  assertEquals(attributePeak(wasmBound), "wasm-linear-memory");
+
+  const heapBound: ProbeSnapshot = {
+    rssBytes: 4_300_000_000,
+    heapUsedBytes: 4_100_000_000,
+    heapTotalBytes: 4_200_000_000,
+    externalBytes: 5_000_000,
+    wasmBytes: 0,
+  };
+  assertEquals(attributePeak(heapBound), "v8-heap");
+
+  const externalBound: ProbeSnapshot = {
+    rssBytes: 4_300_000_000,
+    heapUsedBytes: 50_000_000,
+    heapTotalBytes: 80_000_000,
+    externalBytes: 4_000_000_000,
+    wasmBytes: 0,
+  };
+  assertEquals(attributePeak(externalBound), "external-buffers");
+});
+
+Deno.test("attributePeak returns unknown when every pool is empty", () => {
+  const empty: ProbeSnapshot = {
+    rssBytes: 0,
+    heapUsedBytes: 0,
+    heapTotalBytes: 0,
+    externalBytes: 0,
+    wasmBytes: 0,
+  };
+  assertEquals(attributePeak(empty), "unknown");
+});
+
+Deno.test("snapshotProbes reports both probes together", () => {
+  const mem = new WebAssembly.Memory({ initial: 2, maximum: 4 });
+  const snap = snapshotProbes(mem);
+  // WASM probe reflects the live buffer (2 pages x 64 KiB).
+  assertEquals(snap.wasmBytes, 2 * 64 * 1024);
+  // V8 probe is present and positive on any running process.
+  assertEquals(snap.rssBytes > 0, true);
+  assertEquals(snap.heapTotalBytes > 0, true);
+  // With no module the WASM probe is zero — never silently omitted.
+  assertEquals(snapshotProbes(null).wasmBytes, 0);
+});
+
+Deno.test("wasm32 constant is exactly 4 GiB", () => {
+  assertEquals(WASM32_MAX_PAGES, 65536);
+  assertEquals(WASM32_MAX_BYTES, 4 * 1024 ** 3);
+});
+
+Deno.test("growWasmToCeiling hits the hard 4 GiB cap when asked for more", () => {
+  // Ask for 4 GiB + 1 page. wasm32 cannot represent it: the grow must fail with
+  // a RangeError classified as a WASM linear-memory ceiling.
+  const r = growWasmToCeiling(WASM32_MAX_PAGES + 1);
+  assertEquals(r.signature.includes("RangeError"), true);
+  assertEquals(classifyCrashSignature(r.signature), "wasm-linear-memory");
+  assertEquals(r.peakBytes <= WASM32_MAX_BYTES, true);
+});
+
+Deno.test("markerForExit synthesises a FAIL marker for a marker-less exit 133", () => {
+  // The GRQ#2391 gap: V8 aborts natively, so the child prints no marker.
+  assertEquals(
+    markerForExit(133, "some gc log\n#\n# Fatal JavaScript out of memory\n"),
+    "[learn] FAIL: v8-heap | child exited 133 (Reached heap limit) with no marker",
+  );
+});
+
+Deno.test("markerForExit stays silent when the child already flagged failure", () => {
+  assertEquals(
+    markerForExit(1, "[learn] FAIL: wasm-linear-memory | ..."),
+    null,
+  );
+});
+
+Deno.test("markerForExit stays silent on a clean exit", () => {
+  assertEquals(markerForExit(0, "[learn] OK: done"), null);
+});
+
+Deno.test("markerForExit flags any other marker-less non-zero exit", () => {
+  assertEquals(
+    markerForExit(2, "boom"),
+    "[learn] FAIL: unknown | child exited 2 with no marker",
+  );
+});
+
+Deno.test("growWasmToCeiling reaches a small target cleanly", () => {
+  const r = growWasmToCeiling(8); // 512 KiB
+  assertEquals(r.signature, "");
+  assertEquals(r.peakPages, 8);
+  assertEquals(r.peakBytes, 8 * 64 * 1024);
+});

--- a/tests/wasm64_memory64_smoke.ts
+++ b/tests/wasm64_memory64_smoke.ts
@@ -1,0 +1,182 @@
+// Memory64 (Wasm 3.0) runtime probe for wasm64 lane (b) — Issue #297.
+//
+// Self-contained: hand-assembles a minimal `(memory i64 ...)` module that
+// exports `store(i64 addr, i32 val)` / `load(i64 addr) -> i32`, so the smoke
+// test needs NO checked-in `.wasm` binary and NO nightly build step. It probes
+// the *runtime* half of the spike: does this Deno/V8 instantiate a Memory64
+// module, grow linear memory past the wasm32 4 GiB ceiling, and round-trip a
+// 64-bit (`BigInt`) pointer across the JS↔WASM boundary?
+//
+// Every value below is a plain byte constant — the module is small enough to
+// audit by hand against the WebAssembly binary format.
+
+/** Bytes in one WASM page (64 KiB). */
+export const WASM_PAGE_BYTES = 64 * 1024;
+
+/** wasm32 linear memory is capped at 65536 pages = exactly 4 GiB. */
+export const WASM32_MAX_PAGES = 65536;
+
+/** The hard wasm32 address-space ceiling in bytes (4 GiB). */
+export const WASM32_MAX_BYTES = WASM32_MAX_PAGES * WASM_PAGE_BYTES;
+
+/**
+ * Memory-type flag bit that marks a 64-bit (i64) index type. A wasm32 memory
+ * has this bit clear; a Memory64 memory has it set. (Bit 0 = has-maximum.)
+ */
+export const MEMORY64_INDEX_FLAG = 0x04;
+
+/** Unsigned LEB128 encoding of a non-negative integer. */
+export function unsignedLeb128(value: number): number[] {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`unsignedLeb128 expects a non-negative integer, got ${value}`);
+  }
+  const out: number[] = [];
+  let n = value;
+  do {
+    let byte = n & 0x7f;
+    n = Math.floor(n / 128);
+    if (n !== 0) byte |= 0x80;
+    out.push(byte);
+  } while (n !== 0);
+  return out;
+}
+
+function section(id: number, body: number[]): number[] {
+  return [id, ...unsignedLeb128(body.length), ...body];
+}
+
+function nameBytes(s: string): number[] {
+  return [s.length, ...[...s].map((c) => c.charCodeAt(0))];
+}
+
+/**
+ * Assemble a minimal Memory64 module with a store/load boundary.
+ *
+ * @param maxPages declared maximum pages for the memory. Must exceed
+ *   {@link WASM32_MAX_PAGES} so the module can grow past 4 GiB.
+ */
+export function buildMemory64Module(maxPages: number): Uint8Array<ArrayBuffer> {
+  if (maxPages <= WASM32_MAX_PAGES) {
+    throw new RangeError(
+      `maxPages (${maxPages}) must exceed the wasm32 ceiling (${WASM32_MAX_PAGES}) to prove >4 GiB growth`,
+    );
+  }
+  // Type section: (i64,i32)->()  and  (i64)->(i32)
+  const types = section(0x01, [
+    0x02,
+    0x60, 0x02, 0x7e, 0x7f, 0x00, // store: (i64 addr, i32 val) -> ()
+    0x60, 0x01, 0x7e, 0x01, 0x7f, // load:  (i64 addr) -> i32
+  ]);
+  // Function section: func0 uses type0 (store), func1 uses type1 (load)
+  const funcs = section(0x03, [0x02, 0x00, 0x01]);
+  // Memory section: one memory, flags 0x05 = has-maximum(0x01) | is64(0x04),
+  // minimum 1 page, maximum maxPages.
+  const mem = section(0x05, [
+    0x01,
+    MEMORY64_INDEX_FLAG | 0x01,
+    ...unsignedLeb128(1),
+    ...unsignedLeb128(maxPages),
+  ]);
+  // Export section: memory, store, load
+  const exportSec = section(0x07, [
+    0x03,
+    ...nameBytes("mem"), 0x02, 0x00,
+    ...nameBytes("store"), 0x00, 0x00,
+    ...nameBytes("load"), 0x00, 0x01,
+  ]);
+  // Code section. i32.store/i32.load take the address from the stack as i64
+  // when the memory is 64-bit; memarg is (align=2, offset=0).
+  const storeBody = [0x00, 0x20, 0x00, 0x20, 0x01, 0x36, 0x02, 0x00, 0x0b];
+  const loadBody = [0x00, 0x20, 0x00, 0x28, 0x02, 0x00, 0x0b];
+  const code = section(0x0a, [
+    0x02,
+    ...unsignedLeb128(storeBody.length), ...storeBody,
+    ...unsignedLeb128(loadBody.length), ...loadBody,
+  ]);
+  const parts = [
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+    ...types,
+    ...funcs,
+    ...mem,
+    ...exportSec,
+    ...code,
+  ];
+  // Back the module with a concrete ArrayBuffer (not ArrayBufferLike) so it
+  // satisfies the `BufferSource` parameter of WebAssembly.{validate,Module}.
+  const out = new Uint8Array(new ArrayBuffer(parts.length));
+  out.set(parts);
+  return out;
+}
+
+/** Parsed limits of the first memory declared in a module. */
+export interface MemoryLimits {
+  count: number;
+  flags: number;
+  /** True when the memory declares a 64-bit (i64) index type. */
+  isMemory64: boolean;
+}
+
+/**
+ * Parse the memory section (id 0x05) of a module and report its flags. Used to
+ * assert — without instantiating — that the module we built really carries the
+ * i64 index type.
+ */
+export function parseMemoryLimits(bytes: Uint8Array<ArrayBuffer>): MemoryLimits {
+  let p = 8; // skip magic + version
+  const readLeb = (): number => {
+    let result = 0, shift = 0, byte: number;
+    do {
+      byte = bytes[p++];
+      result |= (byte & 0x7f) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    return result >>> 0;
+  };
+  while (p < bytes.length) {
+    const id = bytes[p++];
+    const len = readLeb();
+    const start = p;
+    if (id === 0x05) {
+      const count = readLeb();
+      const flags = bytes[p];
+      return { count, flags, isMemory64: (flags & MEMORY64_INDEX_FLAG) !== 0 };
+    }
+    p = start + len;
+  }
+  throw new Error("no memory section (0x05) found in module");
+}
+
+/** Handles bound to an instantiated Memory64 store/load module. */
+export interface Memory64Instance {
+  memory: WebAssembly.Memory;
+  store: (addr: bigint, value: number) => void;
+  load: (addr: bigint) => number;
+}
+
+/** Instantiate a Memory64 store/load module built by {@link buildMemory64Module}. */
+export function instantiateMemory64(bytes: Uint8Array<ArrayBuffer>): Memory64Instance {
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+  return {
+    memory: inst.exports.mem as WebAssembly.Memory,
+    store: inst.exports.store as (addr: bigint, value: number) => void,
+    load: inst.exports.load as (addr: bigint) => number,
+  };
+}
+
+/**
+ * Grow an i64 memory to `targetPages`. Growth on a Memory64 uses a `BigInt`
+ * delta (the 64-bit index type) and returns the previous page count as a
+ * `BigInt`. Returns the resulting `byteLength`.
+ *
+ * Pages are reserved lazily by V8, so growing past 4 GiB reserves address space
+ * without committing physical RAM — only pages actually written are committed.
+ */
+export function growToPages(memory: WebAssembly.Memory, targetPages: number): number {
+  const currentPages = memory.buffer.byteLength / WASM_PAGE_BYTES;
+  const delta = targetPages - currentPages;
+  if (delta > 0) {
+    // BigInt delta is mandatory for a 64-bit memory — a Number throws.
+    memory.grow(BigInt(delta) as unknown as number);
+  }
+  return memory.buffer.byteLength;
+}

--- a/tests/wasm64_memory64_smoke_test.ts
+++ b/tests/wasm64_memory64_smoke_test.ts
@@ -1,0 +1,91 @@
+// Committed Memory64 smoke test for wasm64 lane (b) — Issue #297.
+//
+// This is the *earliest failure-detection point* for the wasm64 spike: if a
+// Deno/V8 upgrade drops or breaks Wasm 3.0 Memory64 support, this test fails in
+// the repo's `deno test` CI job rather than being rediscovered mid-port later.
+//
+// "What" tests (AGENTS.md): they instantiate a real minimal `(memory i64 ...)`
+// module and assert on observable outcomes — the module validates, linear
+// memory grows past the wasm32 4 GiB ceiling, growth uses the 64-bit `BigInt`
+// index type, and a `BigInt` offset above 4 GiB round-trips across the JS↔WASM
+// boundary through the exported `store`/`load` functions.
+//
+// Run: deno test tests/wasm64_memory64_smoke_test.ts
+
+import { assert, assertEquals, assertThrows } from "jsr:@std/assert@1";
+import {
+  buildMemory64Module,
+  instantiateMemory64,
+  MEMORY64_INDEX_FLAG,
+  parseMemoryLimits,
+  unsignedLeb128,
+  WASM32_MAX_BYTES,
+  WASM32_MAX_PAGES,
+  WASM_PAGE_BYTES,
+} from "./wasm64_memory64_smoke.ts";
+
+// ~4.004 GiB: just enough headroom to prove growth strictly past the 4 GiB wall
+// while keeping reserved address space (and touched pages) minimal.
+const MAX_PAGES = WASM32_MAX_PAGES + 128;
+const FOUR_GIB = BigInt(WASM32_MAX_BYTES);
+
+Deno.test("unsignedLeb128 encodes multi-byte page counts correctly", () => {
+  assertEquals(unsignedLeb128(0), [0x00]);
+  assertEquals(unsignedLeb128(1), [0x01]);
+  // 65664 = 0x100 80 ... verify it decodes back to itself via the parser path.
+  assertEquals(unsignedLeb128(624485), [0xe5, 0x8e, 0x26]);
+  assertThrows(() => unsignedLeb128(-1), RangeError);
+});
+
+Deno.test("minimal (memory i64 ...) module validates and marks the i64 index type", () => {
+  const bytes = buildMemory64Module(MAX_PAGES);
+  assert(WebAssembly.validate(bytes), "Memory64 module must validate in this V8");
+  const limits = parseMemoryLimits(bytes);
+  assertEquals(limits.count, 1);
+  assert(
+    (limits.flags & MEMORY64_INDEX_FLAG) !== 0,
+    `memory flags 0x${limits.flags.toString(16)} must set the i64 index bit`,
+  );
+  assert(limits.isMemory64);
+});
+
+Deno.test("buildMemory64Module rejects a max that cannot exceed the 4 GiB wall", () => {
+  assertThrows(() => buildMemory64Module(WASM32_MAX_PAGES), RangeError);
+});
+
+Deno.test("instantiates and grows linear memory past the wasm32 4 GiB ceiling", () => {
+  const { memory } = instantiateMemory64(buildMemory64Module(MAX_PAGES));
+  assertEquals(memory.buffer.byteLength, WASM_PAGE_BYTES); // starts at 1 page
+  memory.grow(BigInt(MAX_PAGES - 1) as unknown as number);
+  assert(
+    memory.buffer.byteLength > WASM32_MAX_BYTES,
+    `byteLength ${memory.buffer.byteLength} must exceed the wasm32 4 GiB ceiling ${WASM32_MAX_BYTES}`,
+  );
+});
+
+Deno.test("grow on an i64 memory requires and returns a BigInt (64-bit index)", () => {
+  const { memory } = instantiateMemory64(buildMemory64Module(MAX_PAGES));
+  const prev = memory.grow(1n as unknown as number);
+  assertEquals(typeof prev, "bigint");
+  assertEquals(prev as unknown as bigint, 1n); // previous page count, as a BigInt
+  // A plain Number delta is rejected: the index type is genuinely 64-bit.
+  assertThrows(() => memory.grow(1 as unknown as number), TypeError);
+});
+
+Deno.test("round-trips a BigInt offset above 4 GiB across the JS↔WASM boundary", () => {
+  const { memory, store, load } = instantiateMemory64(buildMemory64Module(MAX_PAGES));
+  memory.grow(BigInt(MAX_PAGES - 1) as unknown as number);
+
+  // Address strictly above the wasm32 4 GiB ceiling — unreachable on wasm32.
+  const addr = FOUR_GIB + 2048n;
+  const value = 0x1234abcd | 0;
+  store(addr, value);
+  assertEquals(load(addr) >>> 0, 0x1234abcd);
+
+  // A second address, also above 4 GiB, is independent (no aliasing wrap-around
+  // to a 32-bit offset).
+  const addr2 = FOUR_GIB + BigInt(WASM_PAGE_BYTES) + 16n;
+  store(addr2, 0x0badf00d | 0);
+  assertEquals(load(addr2) >>> 0, 0x0badf00d);
+  assertEquals(load(addr) >>> 0, 0x1234abcd); // first write untouched
+});


### PR DESCRIPTION
## Milestone: #295 Adopt WASM 3.0 Memory64: wasm64 spike + training-data offload for >4 GB jobs

This PR merges the completed milestone branch into Develop.
Closes #304

### Issues addressed
- #299: wasm64 lane (d): GRQ learn-invocation wiring + 8 GB-host end-to-end verification (GRQ#3508)
- #298: wasm64 lane (c): offload training data into WASM linear memory (Learn architecture change)
- #297: wasm64 lane (b): wasm64 build-lane feasibility spike (Rust Tier 3 + Deno/V8 Memory64)
- #296: wasm64 lane (a): diagnose whether the ~4 GB ceiling is the V8 heap or WASM linear memory

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.