### PR TITLE
Add least-privilege permissions default to ci.yml (Issue #309)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default GITHUB_TOKEN scope for every job (Issue #309).
+# Read-only jobs (quality, rust-gates, scripts-and-spelling, wasm64-memory64-smoke,
+# validation) inherit this; jobs that must push (version-increment, version-gate,
+# auto-format) override it with their own broader job-level permissions block.
+permissions:
+  contents: read
+
 jobs:
   version-increment:
     name: Auto-increment Versions

--- a/docs/archive/pr-summaries/pr-summary-309.md
+++ b/docs/archive/pr-summaries/pr-summary-309.md
@@ -1,0 +1,54 @@
+# PR Summary — Issue #309
+
+## Summary
+
+The `quality` job in `.github/workflows/ci.yml` (and its read-only siblings)
+inherited the repository's broad default `GITHUB_TOKEN` scopes because `ci.yml`
+declared no workflow-level `permissions:` block — every other workflow in the
+repo already sets a top-level default, making `ci.yml` the outlier.
+
+Added a least-privilege top-level `permissions: contents: read` default to
+`ci.yml`. Read-only jobs (`quality`, `rust-gates`, `scripts-and-spelling`,
+`wasm64-memory64-smoke`, `validation`) now inherit this narrow scope; the jobs
+that must push to PR branches (`version-increment`, `version-gate`,
+`auto-format`) keep their broader job-level `permissions` overrides, so their
+behaviour is unchanged.
+
+This closes the least-privilege gap for the `quality` job with a single
+workflow-level change, consistent with the pattern used by every other workflow
+in this repository. Closes #309.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+Effective token scope per job after the change:
+
+```mermaid
+flowchart TD
+    W["ci.yml top-level<br/>permissions: contents: read"]
+    W --> Q["quality → contents: read (inherited)"]
+    W --> R["rust-gates → contents: read (inherited)"]
+    W --> S["scripts-and-spelling → contents: read (inherited)"]
+    W --> M["wasm64-memory64-smoke → contents: read (inherited)"]
+    W --> V["validation → contents: read (inherited)"]
+    W -. overridden .-> VI["version-increment → contents+PRs: write"]
+    W -. overridden .-> VG["version-gate → contents+PRs: write"]
+    W -. overridden .-> AF["auto-format → contents+PRs: write"]
+```
+
+Verification (`bats tests/scripts/`): all 190 tests pass, including the two new
+assertions. `actionlint .github/workflows/ci.yml` is clean and the YAML parses.
+
+## Test Plan
+
+Added `tests/scripts/workflow_least_privilege_permissions.bats` (TDD — both
+tests failed before the fix, pass after):
+
+- `every job in every workflow has an explicit permissions block` — parses each
+  workflow's YAML and asserts every job has effective permissions (workflow-level
+  default or job-level override). This is the regression guard: before the fix
+  the `quality` job failed it.
+- `ci.yml quality job runs under contents: read (no write scopes)` — resolves
+  the `quality` job's effective permissions and asserts `contents: read` with no
+  `write` scopes granted.

--- a/tests/scripts/workflow_least_privilege_permissions.bats
+++ b/tests/scripts/workflow_least_privilege_permissions.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Tests that every job in every workflow runs under an explicit least-privilege
+# `permissions:` block (Issue #309).
+#
+# Rationale: a job with no `permissions:` at either the workflow or the job
+# level inherits the repository's default GITHUB_TOKEN scopes, which are often
+# broad (contents: write and more). If any step is compromised the token can
+# act with those scopes. Declaring an explicit block — a top-level default that
+# every job inherits, or a per-job override — closes that gap. Every other
+# workflow in this repo already sets a top-level `permissions:` block; the
+# regression this guards is the `quality` job (and its siblings) in ci.yml
+# inheriting the broad default because ci.yml had no workflow-level default.
+#
+# These are "what" tests: they parse the YAML and assert on the observable
+# outcome (each job has effective permissions), not on source-text heuristics.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "every job in every workflow has an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+
+failures = []
+files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
+assert files, f"no workflow files found in {workflows_dir}"
+
+for path in files:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    top_level = "permissions" in (data or {})
+    jobs = (data or {}).get("jobs", {}) or {}
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        job_level = "permissions" in job
+        if not (top_level or job_level):
+            failures.append(f"{os.path.basename(path)} job={job_name}")
+
+if failures:
+    sys.stderr.write(
+        "Jobs without an explicit permissions block:\n  "
+        + "\n  ".join(failures) + "\n"
+    )
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci.yml quality job runs under contents: read (no write scopes)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import sys, yaml
+
+with open("$WORKFLOWS_DIR/ci.yml") as fh:
+    data = yaml.safe_load(fh)
+
+# Effective permissions for the quality job: its own block, else the
+# workflow-level default.
+quality = data["jobs"]["quality"]
+perms = quality.get("permissions", data.get("permissions"))
+assert perms is not None, "quality job has no effective permissions block"
+assert isinstance(perms, dict), f"expected a scoped permissions mapping, got {perms!r}"
+
+# Least privilege: no write scope granted to the quality job.
+write_scopes = [scope for scope, level in perms.items() if level == "write"]
+assert not write_scopes, f"quality job granted write scopes: {write_scopes}"
+assert perms.get("contents") == "read", f"expected contents: read, got {perms.get('contents')!r}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #309

## Summary

The `quality` job in `.github/workflows/ci.yml` (and its read-only siblings)
inherited the repository's broad default `GITHUB_TOKEN` scopes because `ci.yml`
declared no workflow-level `permissions:` block — every other workflow in the
repo already sets a top-level default, making `ci.yml` the outlier.

Added a least-privilege top-level `permissions: contents: read` default to
`ci.yml`. Read-only jobs (`quality`, `rust-gates`, `scripts-and-spelling`,
`wasm64-memory64-smoke`, `validation`) now inherit this narrow scope; the jobs
that must push to PR branches (`version-increment`, `version-gate`,
`auto-format`) keep their broader job-level `permissions` overrides, so their
behaviour is unchanged.

This closes the least-privilege gap for the `quality` job with a single
workflow-level change, consistent with the pattern used by every other workflow
in this repository. Closes #309.

## Evidence

Backend/CI-only change — no web interface to screenshot.

Effective token scope per job after the change:

```mermaid
flowchart TD
    W["ci.yml top-level<br/>permissions: contents: read"]
    W --> Q["quality → contents: read (inherited)"]
    W --> R["rust-gates → contents: read (inherited)"]
    W --> S["scripts-and-spelling → contents: read (inherited)"]
    W --> M["wasm64-memory64-smoke → contents: read (inherited)"]
    W --> V["validation → contents: read (inherited)"]
    W -. overridden .-> VI["version-increment → contents+PRs: write"]
    W -. overridden .-> VG["version-gate → contents+PRs: write"]
    W -. overridden .-> AF["auto-format → contents+PRs: write"]
```

Verification (`bats tests/scripts/`): all 190 tests pass, including the two new
assertions. `actionlint .github/workflows/ci.yml` is clean and the YAML parses.

## Test Plan

Added `tests/scripts/workflow_least_privilege_permissions.bats` (TDD — both
tests failed before the fix, pass after):

- `every job in every workflow has an explicit permissions block` — parses each
  workflow's YAML and asserts every job has effective permissions (workflow-level
  default or job-level override). This is the regression guard: before the fix
  the `quality` job failed it.
- `ci.yml quality job runs under contents: read (no write scopes)` — resolves
  the `quality` job's effective permissions and asserts `contents: read` with no
  `write` scopes granted.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrxi5knb-33aeb1`<!-- vibe-worker-issue-309 -->