### PR TITLE
Add least-privilege permissions block to CI quality job (Issue #309)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment, auto-format]
+    # Issue #309 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, git pull, cargo deny/fmt/clippy/test/doc); it never pushes, so
+    # it must not inherit the repository's broad default write scopes.
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: "-D warnings"
 

--- a/docs/archive/pr-summaries/pr-summary-309.md
+++ b/docs/archive/pr-summaries/pr-summary-309.md
@@ -1,0 +1,57 @@
+# Add least-privilege `permissions:` block to CI `quality` job
+
+## Summary
+
+The `quality` job in `.github/workflows/ci.yml` declared no `permissions:`
+block at either workflow or job level, so it silently inherited the
+repository's broad default `GITHUB_TOKEN` scopes (often `contents: write` and
+more). If any step were compromised, the token could act with those broad
+scopes. The `quality` job is read-only — it checks out the repo, runs
+`git pull`, and executes `cargo deny / fmt / clippy / test / doc`; it never
+pushes. It now declares an explicit least-privilege grant:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Closes #309.
+
+## Change
+
+```mermaid
+flowchart LR
+    A[quality job] -->|before| B[inherits default token<br/>contents: write + more]
+    A -->|after| C[permissions:<br/>contents: read]
+```
+
+Scope was kept to the `quality` job named in the issue — other jobs already
+declare their own `permissions:` blocks where they need elevated scopes
+(`version-increment`, `auto-format`, `version-gate`).
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via
+new bats tests plus the existing actionlint gate, which validates the workflow
+on disk:
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 quality job declares an explicit permissions block
+ok 3 quality job grants contents: read (least privilege, no write)
+```
+
+`tests/scripts/rust_gates_workflow.bats`, `actionlint_workflow.bats`,
+`workflow_sha_pinning.bats` and `workflow_script_injection.bats` all continue to
+pass (23/23), confirming the workflow remains valid, SHA-pinned, and
+injection-safe.
+
+## Test Plan
+
+- Added `tests/scripts/ci_quality_permissions.bats`:
+  - `quality job declares an explicit permissions block` — fails against the
+    unfixed workflow (reproduces #309), passes after the fix.
+  - `quality job grants contents: read (least privilege, no write)` — asserts
+    `contents: read` and that the job holds no `write` scope.
+- Re-ran the workflow-related bats suites to confirm no regression.

--- a/tests/scripts/ci_quality_permissions.bats
+++ b/tests/scripts/ci_quality_permissions.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Tests for the CI `quality` job least-privilege token scopes (Issue #309).
+#
+# Contract under test: the `quality` job in .github/workflows/ci.yml must
+# declare an explicit `permissions:` block so it does not silently inherit the
+# repository's broad default GITHUB_TOKEN scopes. The job only reads the repo
+# (checkout + git pull + cargo checks), so `contents: read` is the correct
+# least-privilege grant.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "quality job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["quality"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "quality job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "quality job grants contents: read (least privilege, no write)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["quality"]
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: no scope may be granted write on the quality (read-only) job.
+writes = [k for k, v in perms.items() if v == "write"]
+assert not writes, f"quality job must not hold write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Add least-privilege `permissions:` block to CI `quality` job

## Summary

The `quality` job in `.github/workflows/ci.yml` declared no `permissions:`
block at either workflow or job level, so it silently inherited the
repository's broad default `GITHUB_TOKEN` scopes (often `contents: write` and
more). If any step were compromised, the token could act with those broad
scopes. The `quality` job is read-only — it checks out the repo, runs
`git pull`, and executes `cargo deny / fmt / clippy / test / doc`; it never
pushes. It now declares an explicit least-privilege grant:

```yaml
permissions:
  contents: read
```

Closes #309.

## Change

```mermaid
flowchart LR
    A[quality job] -->|before| B[inherits default token<br/>contents: write + more]
    A -->|after| C[permissions:<br/>contents: read]
```

Scope was kept to the `quality` job named in the issue — other jobs already
declare their own `permissions:` blocks where they need elevated scopes
(`version-increment`, `auto-format`, `version-gate`).

## Evidence

Backend/CI-config change only — no web interface to screenshot. Verified via
new bats tests plus the existing actionlint gate, which validates the workflow
on disk:

```
1..3
ok 1 ci workflow file exists
ok 2 quality job declares an explicit permissions block
ok 3 quality job grants contents: read (least privilege, no write)
```

`tests/scripts/rust_gates_workflow.bats`, `actionlint_workflow.bats`,
`workflow_sha_pinning.bats` and `workflow_script_injection.bats` all continue to
pass (23/23), confirming the workflow remains valid, SHA-pinned, and
injection-safe.

## Test Plan

- Added `tests/scripts/ci_quality_permissions.bats`:
  - `quality job declares an explicit permissions block` — fails against the
    unfixed workflow (reproduces #309), passes after the fix.
  - `quality job grants contents: read (least privilege, no write)` — asserts
    `contents: read` and that the job holds no `write` scope.
- Re-ran the workflow-related bats suites to confirm no regression.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxkttyz-4f3d34`<!-- vibe-worker-issue-309 -->