### PR TITLE
Add least-privilege permissions block to rust-gates CI job (Issue #310)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,10 @@ jobs:
     # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
     # (which skip those jobs) are still gated against lint regressions and
     # syntax errors. The full `quality` job remains the comprehensive PR gate.
+    # Issue #310 — least privilege: this job only checks out and compiles/lints
+    # the repo, so read-only contents is all the GITHUB_TOKEN needs.
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: "-D warnings"
 

--- a/docs/archive/pr-summaries/pr-summary-310.md
+++ b/docs/archive/pr-summaries/pr-summary-310.md
@@ -1,0 +1,38 @@
+## Summary
+
+The `rust-gates` job in `.github/workflows/ci.yml` declared no `permissions:` block at
+either job or workflow level, so it inherited the repository's broad default
+`GITHUB_TOKEN` scopes. The job only checks out the repo and runs `cargo check` /
+`cargo clippy`, so it now declares the least-privilege grant `contents: read`.
+Closes #310.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by a new bats
+suite that parses the committed workflow YAML and asserts the observable CI
+contract (job holds an explicit `permissions:` block, `contents: read`, and no
+write scopes). The suite failed before the workflow edit and passes after:
+
+```text
+1..3
+ok 1 ci workflow file exists
+ok 2 rust-gates job declares an explicit permissions block
+ok 3 rust-gates job grants contents: read (least privilege, no write)
+```
+
+`./quality.sh` passes cleanly.
+
+```mermaid
+flowchart LR
+    A[CI run] --> B["job: rust-gates"]
+    B --> C["permissions: contents: read"]
+    C --> D["cargo check / cargo clippy"]
+    C -. "no write scopes" .-> E[repo contents protected]
+```
+
+## Test Plan
+
+- Added `tests/scripts/ci_rust_gates_permissions.bats` (3 tests) — mirrors the
+  Issue #309 `quality`-job suite; regression test that fails against the
+  unfixed workflow and passes after the fix.
+- Existing `bats tests/scripts` and full `./quality.sh` gate re-run green.

--- a/tests/scripts/ci_rust_gates_permissions.bats
+++ b/tests/scripts/ci_rust_gates_permissions.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Tests for the CI `rust-gates` job least-privilege token scopes (Issue #310).
+#
+# Contract under test: the `rust-gates` job in .github/workflows/ci.yml must
+# declare an explicit `permissions:` block so it does not silently inherit the
+# repository's broad default GITHUB_TOKEN scopes. The job only reads the repo
+# (checkout + cargo check/clippy), so `contents: read` is the correct
+# least-privilege grant.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "rust-gates job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["rust-gates"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "rust-gates job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "rust-gates job grants contents: read (least privilege, no write)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["rust-gates"]
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: no scope may be granted write on the rust-gates (read-only) job.
+writes = [k for k, v in perms.items() if v == "write"]
+assert not writes, f"rust-gates job must not hold write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

The `rust-gates` job in `.github/workflows/ci.yml` declared no `permissions:` block at
either job or workflow level, so it inherited the repository's broad default
`GITHUB_TOKEN` scopes. The job only checks out the repo and runs `cargo check` /
`cargo clippy`, so it now declares the least-privilege grant `contents: read`.
Closes #310.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified by a new bats
suite that parses the committed workflow YAML and asserts the observable CI
contract (job holds an explicit `permissions:` block, `contents: read`, and no
write scopes). The suite failed before the workflow edit and passes after:

```text
1..3
ok 1 ci workflow file exists
ok 2 rust-gates job declares an explicit permissions block
ok 3 rust-gates job grants contents: read (least privilege, no write)
```

`./quality.sh` passes cleanly.

```mermaid
flowchart LR
    A[CI run] --> B["job: rust-gates"]
    B --> C["permissions: contents: read"]
    C --> D["cargo check / cargo clippy"]
    C -. "no write scopes" .-> E[repo contents protected]
```

## Test Plan

- Added `tests/scripts/ci_rust_gates_permissions.bats` (3 tests) — mirrors the
  Issue #309 `quality`-job suite; regression test that fails against the
  unfixed workflow and passes after the fix.
- Existing `bats tests/scripts` and full `./quality.sh` gate re-run green.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxkttyz-4f3d34`<!-- vibe-worker-issue-310 -->