### PR TITLE
Add least-privilege permissions to scripts-and-spelling CI job (Issue #311)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # Issue #311 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, shellcheck, bash -n, codespell); it never pushes, so it must
+    # not inherit the repository's broad default write scopes.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/docs/archive/pr-summaries/pr-summary-311.md
+++ b/docs/archive/pr-summaries/pr-summary-311.md
@@ -1,0 +1,45 @@
+## Summary
+
+Added an explicit least-privilege `permissions:` block to the `scripts-and-spelling`
+job in `.github/workflows/ci.yml`. The job previously declared no `permissions:`
+block at either workflow or job level, so it silently inherited the repository's
+broad default `GITHUB_TOKEN` scopes. This job only reads the repo (checkout,
+shellcheck, `bash -n`, codespell) and never pushes, so `contents: read` is the
+correct least-privilege grant. Closes #311.
+
+This mirrors the fix applied to the sibling `quality` job in Issue #309.
+
+```mermaid
+flowchart LR
+    A[GITHUB_TOKEN default: broad write] -->|before| B[scripts-and-spelling job]
+    C["permissions:\n  contents: read"] -->|after| B
+    B --> D[checkout / shellcheck / bash -n / codespell]
+```
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via a
+new BATS test that parses `.github/workflows/ci.yml` with `python3`/`yaml` and
+asserts the job-level (or workflow-level) `permissions:` block grants
+`contents: read` with no `write` scopes.
+
+Test run (after the fix):
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 scripts-and-spelling job declares an explicit permissions block
+ok 3 scripts-and-spelling job grants contents: read (least privilege, no write)
+```
+
+`./quality.sh` passes cleanly: `✅ All quality checks passed!`
+
+## Test Plan
+
+- Added `tests/scripts/ci_scripts_and_spelling_permissions.bats`:
+  - `ci workflow file exists`
+  - `scripts-and-spelling job declares an explicit permissions block` — fails
+    against the unfixed workflow, passes after.
+  - `scripts-and-spelling job grants contents: read (least privilege, no write)`
+    — asserts `contents: read` and that no scope is granted `write`.
+- Confirmed the test failed before the workflow change and passes after (TDD).

--- a/tests/scripts/ci_scripts_and_spelling_permissions.bats
+++ b/tests/scripts/ci_scripts_and_spelling_permissions.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# Tests for the CI `scripts-and-spelling` job least-privilege token scopes
+# (Issue #311).
+#
+# Contract under test: the `scripts-and-spelling` job in
+# .github/workflows/ci.yml must declare an explicit `permissions:` block so it
+# does not silently inherit the repository's broad default GITHUB_TOKEN scopes.
+# The job only reads the repo (checkout + shellcheck/bash -n/codespell); it
+# never pushes, so `contents: read` is the correct least-privilege grant.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "scripts-and-spelling job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["scripts-and-spelling"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "scripts-and-spelling job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "scripts-and-spelling job grants contents: read (least privilege, no write)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["scripts-and-spelling"]
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: no scope may be granted write on this read-only job.
+writes = [k for k, v in perms.items() if v == "write"]
+assert not writes, f"scripts-and-spelling job must not hold write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Added an explicit least-privilege `permissions:` block to the `scripts-and-spelling`
job in `.github/workflows/ci.yml`. The job previously declared no `permissions:`
block at either workflow or job level, so it silently inherited the repository's
broad default `GITHUB_TOKEN` scopes. This job only reads the repo (checkout,
shellcheck, `bash -n`, codespell) and never pushes, so `contents: read` is the
correct least-privilege grant. Closes #311.

This mirrors the fix applied to the sibling `quality` job in Issue #309.

```mermaid
flowchart LR
    A[GITHUB_TOKEN default: broad write] -->|before| B[scripts-and-spelling job]
    C["permissions:\n  contents: read"] -->|after| B
    B --> D[checkout / shellcheck / bash -n / codespell]
```

## Evidence

Backend/CI-config change only — no web interface to screenshot. Verified via a
new BATS test that parses `.github/workflows/ci.yml` with `python3`/`yaml` and
asserts the job-level (or workflow-level) `permissions:` block grants
`contents: read` with no `write` scopes.

Test run (after the fix):

```
1..3
ok 1 ci workflow file exists
ok 2 scripts-and-spelling job declares an explicit permissions block
ok 3 scripts-and-spelling job grants contents: read (least privilege, no write)
```

`./quality.sh` passes cleanly: `✅ All quality checks passed!`

## Test Plan

- Added `tests/scripts/ci_scripts_and_spelling_permissions.bats`:
  - `ci workflow file exists`
  - `scripts-and-spelling job declares an explicit permissions block` — fails
    against the unfixed workflow, passes after.
  - `scripts-and-spelling job grants contents: read (least privilege, no write)`
    — asserts `contents: read` and that no scope is granted `write`.
- Confirmed the test failed before the workflow change and passes after (TDD).



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrxktucz-de9723`<!-- vibe-worker-issue-311 -->