### PR TITLE
Add least-privilege permissions to CI security job (Issue #312)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,13 @@ jobs:
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # Issue #312 — least-privilege GITHUB_TOKEN. A reusable-workflow caller with
+    # no permissions block hands the called workflow the repository's broad
+    # default scopes. Grant only what security.yml needs: read the repo
+    # (checkout, cargo audit) plus the dependency-review PR comment summary.
+    permissions:
+      contents: read
+      pull-requests: write
     with:
       include-dependency-review: true
 

--- a/docs/archive/pr-summaries/pr-summary-312.md
+++ b/docs/archive/pr-summaries/pr-summary-312.md
@@ -1,0 +1,43 @@
+## Summary
+
+The `security` job in `.github/workflows/ci.yml` calls the reusable workflow
+`.github/workflows/security.yml` but declared no `permissions:` block, so it
+handed the called workflow the repository's broad default `GITHUB_TOKEN`
+scopes. It now declares the least-privilege set the called workflow actually
+needs — `contents: read` (checkout, `cargo audit`) plus `pull-requests: write`
+(the `dependency-review` PR comment summary). Closes #312.
+
+```mermaid
+flowchart LR
+    A["ci.yml job: security"] -->|"uses:"| B["security.yml (reusable)"]
+    A -. before: no permissions → broad repo defaults .-> C["GITHUB_TOKEN"]
+    A -->|"after: contents read + pull-requests write"| C
+```
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified via
+the new BATS suite (failing before the workflow edit, passing after) and a full
+`./quality.sh` run, which completed with `✅ All quality checks passed!`.
+
+Before the fix:
+
+```
+not ok 2 security job declares an explicit permissions block
+not ok 3 security job grants only the scopes the reusable workflow needs
+not ok 4 caller scopes cover every scope the called workflow declares
+```
+
+After the fix: all 4 tests pass.
+
+## Test Plan
+
+- Added `tests/scripts/ci_security_permissions.bats`:
+  - `security job declares an explicit permissions block` — regression test for
+    the reported finding.
+  - `security job grants only the scopes the reusable workflow needs` —
+    `contents: read`, with `pull-requests` the only write scope.
+  - `caller scopes cover every scope the called workflow declares` — the caller
+    grant is not weaker than anything `security.yml` requires, so the reusable
+    workflow keeps working.
+- Existing suites unchanged; `./quality.sh` passes.

--- a/tests/scripts/ci_security_permissions.bats
+++ b/tests/scripts/ci_security_permissions.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Tests for the CI `security` job least-privilege token scopes (Issue #312).
+#
+# Contract under test: the `security` job in .github/workflows/ci.yml calls the
+# reusable workflow .github/workflows/security.yml. A caller job with no
+# `permissions:` block hands the called workflow the repository's broad default
+# GITHUB_TOKEN scopes, so the caller must declare the least-privilege set the
+# called workflow actually needs: `contents: read` (checkout, cargo audit) plus
+# `pull-requests: write` (dependency-review PR comment summary).
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+  CALLED="${REPO_ROOT}/.github/workflows/security.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "security job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["security"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "security job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "security job grants only the scopes the reusable workflow needs" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["security"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: dependency-review's PR comment is the only write needed.
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == ["pull-requests"], f"unexpected write scopes on security job: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "caller scopes cover every scope the called workflow declares" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+caller = yaml.safe_load(open("$WORKFLOW"))["jobs"]["security"]
+called = yaml.safe_load(open("$CALLED"))["jobs"]["security"]
+caller_perms = caller.get("permissions") or {}
+called_perms = called.get("permissions") or {}
+rank = {"none": 0, "read": 1, "write": 2}
+for scope, level in called_perms.items():
+    got = caller_perms.get(scope, "none")
+    assert rank[got] >= rank[level], (
+        f"caller grants {scope}: {got}, called workflow needs {level}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

The `security` job in `.github/workflows/ci.yml` calls the reusable workflow
`.github/workflows/security.yml` but declared no `permissions:` block, so it
handed the called workflow the repository's broad default `GITHUB_TOKEN`
scopes. It now declares the least-privilege set the called workflow actually
needs — `contents: read` (checkout, `cargo audit`) plus `pull-requests: write`
(the `dependency-review` PR comment summary). Closes #312.

```mermaid
flowchart LR
    A["ci.yml job: security"] -->|"uses:"| B["security.yml (reusable)"]
    A -. before: no permissions → broad repo defaults .-> C["GITHUB_TOKEN"]
    A -->|"after: contents read + pull-requests write"| C
```

## Evidence

Backend/CI-configuration change — no web interface to screenshot. Verified via
the new BATS suite (failing before the workflow edit, passing after) and a full
`./quality.sh` run, which completed with `✅ All quality checks passed!`.

Before the fix:

```
not ok 2 security job declares an explicit permissions block
not ok 3 security job grants only the scopes the reusable workflow needs
not ok 4 caller scopes cover every scope the called workflow declares
```

After the fix: all 4 tests pass.

## Test Plan

- Added `tests/scripts/ci_security_permissions.bats`:
  - `security job declares an explicit permissions block` — regression test for
    the reported finding.
  - `security job grants only the scopes the reusable workflow needs` —
    `contents: read`, with `pull-requests` the only write scope.
  - `caller scopes cover every scope the called workflow declares` — the caller
    grant is not weaker than anything `security.yml` requires, so the reusable
    workflow keeps working.
- Existing suites unchanged; `./quality.sh` passes.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrxktucz-de9723`<!-- vibe-worker-issue-312 -->