### PR TITLE
Least-privilege GITHUB_TOKEN for CI validation job (Issue #313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # Issue #313 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, cargo metadata, manifest/README/rustdoc file checks); it never
+    # writes, so it must not inherit the repository's broad default scopes.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/docs/archive/pr-summaries/pr-summary-313.md
+++ b/docs/archive/pr-summaries/pr-summary-313.md
@@ -1,0 +1,54 @@
+# PR Summary — Issue #313
+
+## Summary
+
+The `validation` job in `.github/workflows/ci.yml` declared no `permissions:`
+block, at either job or workflow level, so it inherited the repository's broad
+default `GITHUB_TOKEN` scopes. The job is read-only — checkout, `cargo
+metadata`, and manifest/README/rustdoc file checks — so it now declares the
+least-privilege scope it actually needs:
+
+```yaml
+permissions:
+  contents: read
+```
+
+This follows the same per-job pattern already applied to `quality` (#310),
+`scripts-and-spelling` (#311), `rust-gates`, and `security` (#312).
+Closes #313.
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified by the
+new bats suite, which parses the committed workflow YAML and asserts on the
+observable CI contract:
+
+```
+$ bats tests/scripts/ci_validation_permissions.bats
+1..3
+ok 1 ci workflow file exists
+ok 2 validation job declares an explicit permissions block
+ok 3 validation job grants read-only contents and no write scopes
+```
+
+All three permission assertions failed before the workflow change and pass
+after it. Full `./quality.sh` run passes cleanly.
+
+```mermaid
+flowchart LR
+    A["PR event"] --> B["job: validation"]
+    B --> C{"permissions: block?"}
+    C -- "before: none" --> D["inherits broad default<br/>GITHUB_TOKEN scopes"]
+    C -- "after: contents: read" --> E["least-privilege token<br/>read-only, no write scopes"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/ci_validation_permissions.bats`:
+  - `ci workflow file exists`
+  - `validation job declares an explicit permissions block` — regression test
+    for #313; fails against the unfixed workflow.
+  - `validation job grants read-only contents and no write scopes` — asserts
+    `contents: read` and that no scope is granted `write`.
+- Ran `./quality.sh < /dev/null` — all checks pass (bats, shellcheck,
+  `cargo test --workspace`, clippy, docs, release build).

--- a/tests/scripts/ci_validation_permissions.bats
+++ b/tests/scripts/ci_validation_permissions.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Tests for the CI `validation` job least-privilege token scopes (Issue #313).
+#
+# Contract under test: the `validation` job in .github/workflows/ci.yml only
+# reads the repository (checkout, cargo metadata, grep/wc file checks). With no
+# `permissions:` block it inherits the repository's broad default GITHUB_TOKEN
+# scopes, so it must declare the least-privilege set it actually needs:
+# `contents: read` and no write scopes at all.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "validation job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["validation"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "validation job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "validation job grants read-only contents and no write scopes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["validation"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == [], f"validation is read-only; unexpected write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #313

## Summary

The `validation` job in `.github/workflows/ci.yml` declared no `permissions:`
block, at either job or workflow level, so it inherited the repository's broad
default `GITHUB_TOKEN` scopes. The job is read-only — checkout, `cargo
metadata`, and manifest/README/rustdoc file checks — so it now declares the
least-privilege scope it actually needs:

```yaml
permissions:
  contents: read
```

This follows the same per-job pattern already applied to `quality` (#310),
`scripts-and-spelling` (#311), `rust-gates`, and `security` (#312).
Closes #313.

## Evidence

Backend/CI-config change only — no web interface to screenshot. Verified by the
new bats suite, which parses the committed workflow YAML and asserts on the
observable CI contract:

```
$ bats tests/scripts/ci_validation_permissions.bats
1..3
ok 1 ci workflow file exists
ok 2 validation job declares an explicit permissions block
ok 3 validation job grants read-only contents and no write scopes
```

All three permission assertions failed before the workflow change and pass
after it. Full `./quality.sh` run passes cleanly.

```mermaid
flowchart LR
    A["PR event"] --> B["job: validation"]
    B --> C{"permissions: block?"}
    C -- "before: none" --> D["inherits broad default<br/>GITHUB_TOKEN scopes"]
    C -- "after: contents: read" --> E["least-privilege token<br/>read-only, no write scopes"]
```

## Test Plan

- Added `tests/scripts/ci_validation_permissions.bats`:
  - `ci workflow file exists`
  - `validation job declares an explicit permissions block` — regression test
    for #313; fails against the unfixed workflow.
  - `validation job grants read-only contents and no write scopes` — asserts
    `contents: read` and that no scope is granted `write`.
- Ran `./quality.sh < /dev/null` — all checks pass (bats, shellcheck,
  `cargo test --workspace`, clippy, docs, release build).



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxnka21-9de3ae`<!-- vibe-worker-issue-313 -->