### PR TITLE
Drop push-to-Develop trigger from markdown-lint workflow (Issue #316)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,10 +1,13 @@
 name: Markdown Lint
 
+# Issue #316 — PR-only, matching actionlint.yml/gitleaks.yml/semgrep.yml. As a
+# lint gate it already runs on the PR; re-running it on push to Develop would
+# duplicate that run, burning CI minutes for no new signal.
+
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [Develop]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/archive/pr-summaries/pr-summary-316.md
+++ b/docs/archive/pr-summaries/pr-summary-316.md
@@ -1,0 +1,44 @@
+## Summary
+
+`.github/workflows/markdown-lint.yml` triggered on both `pull_request` and `push`
+to `Develop`. As a lint/check gate it already runs on the PR, so the post-merge
+push run was a duplicate — burning CI minutes and able to leave a red tick on the
+default branch for a check that already passed. Dropped the `push:` trigger,
+keeping `pull_request` and adding `workflow_dispatch` for manual re-runs. This
+matches the PR-only checkers `actionlint.yml` (Issue #314), `gitleaks.yml` and
+`semgrep.yml`. Deploy/publish workflows (`release.yml`, `wasm-bundle.yml`) and the
+main `ci.yml` build are untouched — they must keep firing on push. Closes #316.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+existing BATS suite (`bats tests/scripts/markdown_lint_workflow.bats`, 10/10
+passing, including the local `markdownlint-cli2` run over the current tree) and a
+clean `./quality.sh`.
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        P1[PR opened] --> A1[markdownlint run]
+        M1[merge → push Develop] --> A2[markdownlint run again — duplicate]
+    end
+    subgraph after["After"]
+        P2[PR opened] --> A3[markdownlint run]
+        M2[merge → push Develop] --> N2[no run]
+        D2[workflow_dispatch] --> A4[markdownlint run]
+    end
+```
+
+## Test Plan
+
+- Modified `tests/scripts/markdown_lint_workflow.bats::"markdown-lint workflow
+  gates PRs only and does not re-run on push to Develop"` (previously
+  *"...triggers on PRs and on pushes to Develop"*). **Documented business-logic
+  change:** the old assertion required `Develop` in the `push.branches` list,
+  which is exactly the behaviour this issue removes; the test now asserts
+  `pull_request` is still a trigger and that `Develop` is absent from any
+  `push.branches` filter. It failed against the unfixed workflow and passes after
+  the change. No tests were removed or commented out.
+- All 10 tests in `tests/scripts/markdown_lint_workflow.bats` pass.
+- `./quality.sh` passes cleanly (shellcheck, bats, TypeScript check, fmt, clippy,
+  deny, workspace tests, doc, release build).

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -23,7 +23,7 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "markdown-lint workflow triggers on PRs and on pushes to Develop" {
+@test "markdown-lint workflow gates PRs only and does not re-run on push to Develop" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
@@ -34,9 +34,11 @@ data = yaml.safe_load(open("$WORKFLOW"))
 triggers = data.get("on") or data.get(True)
 assert triggers is not None, data
 assert "pull_request" in triggers, triggers
-push = triggers.get("push") or {}
-branches = push.get("branches") or []
-assert "Develop" in branches, branches
+# Issue #316 — a lint/check workflow gates the PR; re-running it on push to
+# the default branch duplicates the run that already gated the merge.
+push = triggers.get("push")
+branches = (push or {}).get("branches") or []
+assert "Develop" not in branches, branches
 PY
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

`.github/workflows/markdown-lint.yml` triggered on both `pull_request` and `push`
to `Develop`. As a lint/check gate it already runs on the PR, so the post-merge
push run was a duplicate — burning CI minutes and able to leave a red tick on the
default branch for a check that already passed. Dropped the `push:` trigger,
keeping `pull_request` and adding `workflow_dispatch` for manual re-runs. This
matches the PR-only checkers `actionlint.yml` (Issue #314), `gitleaks.yml` and
`semgrep.yml`. Deploy/publish workflows (`release.yml`, `wasm-bundle.yml`) and the
main `ci.yml` build are untouched — they must keep firing on push. Closes #316.

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
existing BATS suite (`bats tests/scripts/markdown_lint_workflow.bats`, 10/10
passing, including the local `markdownlint-cli2` run over the current tree) and a
clean `./quality.sh`.

```mermaid
flowchart LR
    subgraph before["Before"]
        P1[PR opened] --> A1[markdownlint run]
        M1[merge → push Develop] --> A2[markdownlint run again — duplicate]
    end
    subgraph after["After"]
        P2[PR opened] --> A3[markdownlint run]
        M2[merge → push Develop] --> N2[no run]
        D2[workflow_dispatch] --> A4[markdownlint run]
    end
```

## Test Plan

- Modified `tests/scripts/markdown_lint_workflow.bats::"markdown-lint workflow
  gates PRs only and does not re-run on push to Develop"` (previously
  *"...triggers on PRs and on pushes to Develop"*). **Documented business-logic
  change:** the old assertion required `Develop` in the `push.branches` list,
  which is exactly the behaviour this issue removes; the test now asserts
  `pull_request` is still a trigger and that `Develop` is absent from any
  `push.branches` filter. It failed against the unfixed workflow and passes after
  the change. No tests were removed or commented out.
- All 10 tests in `tests/scripts/markdown_lint_workflow.bats` pass.
- `./quality.sh` passes cleanly (shellcheck, bats, TypeScript check, fmt, clippy,
  deny, workspace tests, doc, release build).



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxnka21-9de3ae`<!-- vibe-worker-issue-316 -->