### PR TITLE
Disable credential persistence in actionlint checkout (Issue #317)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,7 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # actions/checkout@v6.0.2
+      # Issue #317 — `persist-credentials: false` keeps the workflow
+      # GITHUB_TOKEN out of .git/config. This job only lints workflow files:
+      # it never pushes back and fetches no private submodule, so leaving the
+      # credential on disk would only widen the blast radius of a compromised
+      # step.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       # Install actionlint CLI from a version-pinned release tarball with
       # SHA-256 verification. Bump ACTIONLINT_VERSION + ACTIONLINT_SHA256

--- a/docs/archive/pr-summaries/pr-summary-317.md
+++ b/docs/archive/pr-summaries/pr-summary-317.md
@@ -1,0 +1,45 @@
+## Summary
+
+The `actionlint` job checked out the repo with `actions/checkout` defaults, which writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. Every later step in the job — including a compromised dependency or injected script — could read it and act as the token. The job only lints workflow files: it never pushes back and fetches no private submodule, so the persisted credential was pure blast radius.
+
+Added `persist-credentials: false` to the checkout step in `.github/workflows/actionlint.yml`. Closes #317.
+
+## Evidence
+
+CI/workflow change — no web interface to screenshot. Verified via the repo's bats workflow tests and `./quality.sh`.
+
+Failing before the fix, passing after:
+
+```
+not ok 7 actionlint workflow checkout does not persist credentials on disk   # before
+ok 7 actionlint workflow checkout does not persist credentials on disk       # after
+```
+
+Full suite after the fix:
+
+```
+1..8
+ok 1 actionlint workflow file exists
+ok 2 actionlint workflow is valid YAML
+ok 3 actionlint workflow gates PRs only and does not re-run on push to Develop
+ok 4 actionlint workflow exposes a job that runs the actionlint binary
+ok 5 actionlint workflow pins third-party actions to commit SHAs
+ok 6 actionlint workflow pins both version and SHA-256 for the CLI install
+ok 7 actionlint workflow checkout does not persist credentials on disk
+ok 8 actionlint passes against the current workflows on disk
+```
+
+`./quality.sh < /dev/null` → `✅ All quality checks passed!`
+
+```mermaid
+flowchart LR
+    A[actions/checkout] -->|default| B[".git/config holds GITHUB_TOKEN"]
+    B --> C[any later step can read it]
+    A -->|persist-credentials: false| D["no token on disk"]
+    D --> E[compromised step gains nothing]
+```
+
+## Test Plan
+
+- Added `tests/scripts/actionlint_workflow.bats::actionlint workflow checkout does not persist credentials on disk` — parses the workflow YAML and asserts every `actions/checkout` step in the `actionlint` job sets `with.persist-credentials: false`. Reproduces #317 (fails against the unfixed workflow, passes after).
+- Existing tests in the same file unchanged and still passing.

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -8,6 +8,7 @@
 #   - third-party actions are SHA-pinned (consistent with Issue #77),
 #   - the install step pins both version and SHA-256 (supply-chain hygiene
 #     mirroring gitleaks.yml from Issue #99 and wasm-pack from Issue #78),
+#   - the checkout step does not persist the GITHUB_TOKEN on disk (Issue #317),
 #   - if `actionlint` is installed locally, it passes against the current
 #     workflows on disk (behavioural sanity check).
 
@@ -120,6 +121,32 @@ assert re.match(r"^[0-9a-f]{64}$", str(sha256)), sha256
 # The run script must invoke sha256sum -c to verify the downloaded asset.
 run_script = step.get("run", "")
 assert "sha256sum" in run_script and "-c" in run_script, run_script
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Issue #317 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. This job only lints workflow files: it never pushes back to
+# the repository and fetches no private submodule, so the credential is pure
+# blast radius.
+@test "actionlint workflow checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["actionlint"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
 PY
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

The `actionlint` job checked out the repo with `actions/checkout` defaults, which writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. Every later step in the job — including a compromised dependency or injected script — could read it and act as the token. The job only lints workflow files: it never pushes back and fetches no private submodule, so the persisted credential was pure blast radius.

Added `persist-credentials: false` to the checkout step in `.github/workflows/actionlint.yml`. Closes #317.

## Evidence

CI/workflow change — no web interface to screenshot. Verified via the repo's bats workflow tests and `./quality.sh`.

Failing before the fix, passing after:

```
not ok 7 actionlint workflow checkout does not persist credentials on disk   # before
ok 7 actionlint workflow checkout does not persist credentials on disk       # after
```

Full suite after the fix:

```
1..8
ok 1 actionlint workflow file exists
ok 2 actionlint workflow is valid YAML
ok 3 actionlint workflow gates PRs only and does not re-run on push to Develop
ok 4 actionlint workflow exposes a job that runs the actionlint binary
ok 5 actionlint workflow pins third-party actions to commit SHAs
ok 6 actionlint workflow pins both version and SHA-256 for the CLI install
ok 7 actionlint workflow checkout does not persist credentials on disk
ok 8 actionlint passes against the current workflows on disk
```

`./quality.sh < /dev/null` → `✅ All quality checks passed!`

```mermaid
flowchart LR
    A[actions/checkout] -->|default| B[".git/config holds GITHUB_TOKEN"]
    B --> C[any later step can read it]
    A -->|persist-credentials: false| D["no token on disk"]
    D --> E[compromised step gains nothing]
```

## Test Plan

- Added `tests/scripts/actionlint_workflow.bats::actionlint workflow checkout does not persist credentials on disk` — parses the workflow YAML and asserts every `actions/checkout` step in the `actionlint` job sets `with.persist-credentials: false`. Reproduces #317 (fails against the unfixed workflow, passes after).
- Existing tests in the same file unchanged and still passing.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxpuv9z-aa0093`<!-- vibe-worker-issue-317 -->