### PR TITLE
Don't persist checkout credentials in rust-gates job (Issue #318)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,15 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #318 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job only compiles and lints;
+        # it never pushes back and fetches no private submodule, so the
+        # persisted credential would only widen the blast radius of a
+        # compromised later step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         # dtolnay/rust-toolchain@stable

--- a/docs/archive/pr-summaries/pr-summary-318.md
+++ b/docs/archive/pr-summaries/pr-summary-318.md
@@ -1,0 +1,40 @@
+## Summary
+
+The `rust-gates` job in `.github/workflows/ci.yml` checked out the repository
+without `persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
+including a compromised dependency or injected script — could read it and act as
+the token. The job only checks out, compiles (`cargo check`) and lints
+(`cargo clippy`): it never pushes back to the repository and fetches no private
+submodule, so the persisted credential was pure blast radius.
+
+Added `persist-credentials: false` to that checkout step, matching the existing
+treatment of the `actionlint` workflow (Issue #317). Closes #318.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+```mermaid
+flowchart LR
+    A[rust-gates job starts] --> B["actions/checkout"]
+    B -->|before| C["GITHUB_TOKEN written to .git/config"]
+    C --> D["readable by every later step"]
+    B -->|after: persist-credentials false| E["no credential on disk"]
+    E --> F["cargo check / cargo clippy"]
+```
+
+Verified with the repository's own gates:
+
+- `bats tests/scripts/rust_gates_workflow.bats` — 8/8 pass (the new test fails
+  against the unfixed workflow and passes after the change).
+- `./quality.sh < /dev/null` — passes cleanly.
+
+## Test Plan
+
+- Added `tests/scripts/rust_gates_workflow.bats::"ci rust-gates checkout does
+  not persist credentials on disk"` — parses `ci.yml`, locates every
+  `actions/checkout` step in the `rust-gates` job and asserts
+  `with.persist-credentials is False`. This is a regression test: it failed
+  before the workflow change and passes after it.
+- All pre-existing tests in that file remain unchanged and still pass.

--- a/tests/scripts/rust_gates_workflow.bats
+++ b/tests/scripts/rust_gates_workflow.bats
@@ -15,7 +15,9 @@
 #   - a job invokes an explicit compile/syntax gate (cargo check / cargo build),
 #   - the gate job runs on push (not restricted to pull_request only), so direct
 #     pushes to Develop are gated too,
-#   - third-party actions in the gate job are SHA-pinned (Issue #77).
+#   - third-party actions in the gate job are SHA-pinned (Issue #77),
+#   - the gate job's checkout does not persist the GITHUB_TOKEN on disk
+#     (Issue #318).
 
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
@@ -139,6 +141,32 @@ for job in data["jobs"].values():
         if uses is None:
             continue
         assert sha_re.match(uses), f"action not SHA-pinned: {uses}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Issue #318 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. The rust-gates job only checks out, compiles and lints: it
+# never pushes back to the repository and fetches no private submodule, so the
+# persisted credential is pure blast radius.
+@test "ci rust-gates checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["rust-gates"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in rust-gates"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
 PY
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

The `rust-gates` job in `.github/workflows/ci.yml` checked out the repository
without `persist-credentials: false`, so `actions/checkout` wrote the workflow
`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
including a compromised dependency or injected script — could read it and act as
the token. The job only checks out, compiles (`cargo check`) and lints
(`cargo clippy`): it never pushes back to the repository and fetches no private
submodule, so the persisted credential was pure blast radius.

Added `persist-credentials: false` to that checkout step, matching the existing
treatment of the `actionlint` workflow (Issue #317). Closes #318.

## Evidence

Backend/CI-only change — no web interface to screenshot.

```mermaid
flowchart LR
    A[rust-gates job starts] --> B["actions/checkout"]
    B -->|before| C["GITHUB_TOKEN written to .git/config"]
    C --> D["readable by every later step"]
    B -->|after: persist-credentials false| E["no credential on disk"]
    E --> F["cargo check / cargo clippy"]
```

Verified with the repository's own gates:

- `bats tests/scripts/rust_gates_workflow.bats` — 8/8 pass (the new test fails
  against the unfixed workflow and passes after the change).
- `./quality.sh < /dev/null` — passes cleanly.

## Test Plan

- Added `tests/scripts/rust_gates_workflow.bats::"ci rust-gates checkout does
  not persist credentials on disk"` — parses `ci.yml`, locates every
  `actions/checkout` step in the `rust-gates` job and asserts
  `with.persist-credentials is False`. This is a regression test: it failed
  before the workflow change and passes after it.
- All pre-existing tests in that file remain unchanged and still pass.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxpuv9z-aa0093`<!-- vibe-worker-issue-318 -->