### PR TITLE
Stop the validation job checkout persisting credentials (Issue #320)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,10 +507,16 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #320 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job only reads the repo
+        # (manifest, README and rustdoc checks); it never pushes back and
+        # fetches no private submodule, so the persisted credential would only
+        # widen the blast radius of a compromised later step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         # dtolnay/rust-toolchain@stable

--- a/docs/archive/pr-summaries/pr-summary-320.md
+++ b/docs/archive/pr-summaries/pr-summary-320.md
@@ -1,0 +1,50 @@
+## Summary
+
+The CI `validation` job checked out the repository without
+`persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Every later step in that
+job — including a compromised dependency or an injected script — could read it
+and act as the token.
+
+The job is read-only (manifest, README and rustdoc checks): it never pushes back
+and fetches no private submodule, so the persisted credential was pure blast
+radius. Added `persist-credentials: false` to the job's checkout step, mirroring
+the hardening already applied to `rust-gates` (Issue #318) and `actionlint`
+(Issue #317).
+
+Closes #320.
+
+## Evidence
+
+Backend/CI-configuration change — there is no web interface to screenshot.
+Verified by a new bats gate that parses `.github/workflows/ci.yml` and asserts
+the observable contract:
+
+```
+$ bats tests/scripts/validation_workflow.bats   # before the fix
+ok 1 ci workflow defines a validation job
+not ok 2 ci validation checkout does not persist credentials on disk
+
+$ bats tests/scripts                            # after the fix
+216 passing, 0 failing
+
+$ ./quality.sh < /dev/null
+✅ All quality checks passed!
+```
+
+```mermaid
+flowchart LR
+    A["actions/checkout"] -->|"default"| B["GITHUB_TOKEN written to .git/config"]
+    B --> C["any later step can read the token"]
+    A -->|"persist-credentials: false"| D["no credential on disk"]
+    D --> E["read-only validation steps run unchanged"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/validation_workflow.bats`:
+  - `ci workflow defines a validation job` — guards the job name the second
+    test targets, so a rename fails loudly rather than silently passing.
+  - `ci validation checkout does not persist credentials on disk` — regression
+    test that fails against the unfixed workflow and passes after the fix.
+- Re-ran the full `bats tests/scripts` suite (216 tests) and `./quality.sh`.

--- a/tests/scripts/validation_workflow.bats
+++ b/tests/scripts/validation_workflow.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Tests for the CI `validation` job checkout hardening (Issue #320).
+#
+# The contract under test IS the CI wiring: actions/checkout writes the
+# workflow GITHUB_TOKEN into .git/config by default, leaving a usable
+# credential on disk for every later step in the job. The `validation` job only
+# checks out the repo and runs read-only manifest/README/rustdoc checks — it
+# never pushes back and fetches no private submodule — so the persisted
+# credential is pure blast radius.
+#
+# Asserts on observable outcomes:
+#   - ci.yml parses as YAML and defines a `validation` job,
+#   - every actions/checkout step in that job sets persist-credentials: false.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow defines a validation job" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+assert "validation" in data["jobs"], sorted(data["jobs"])
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci validation checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["validation"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in validation"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

The CI `validation` job checked out the repository without
`persist-credentials: false`, so `actions/checkout` wrote the workflow
`GITHUB_TOKEN` into `.git/config` as an auth header. Every later step in that
job — including a compromised dependency or an injected script — could read it
and act as the token.

The job is read-only (manifest, README and rustdoc checks): it never pushes back
and fetches no private submodule, so the persisted credential was pure blast
radius. Added `persist-credentials: false` to the job's checkout step, mirroring
the hardening already applied to `rust-gates` (Issue #318) and `actionlint`
(Issue #317).

Closes #320.

## Evidence

Backend/CI-configuration change — there is no web interface to screenshot.
Verified by a new bats gate that parses `.github/workflows/ci.yml` and asserts
the observable contract:

```
$ bats tests/scripts/validation_workflow.bats   # before the fix
ok 1 ci workflow defines a validation job
not ok 2 ci validation checkout does not persist credentials on disk

$ bats tests/scripts                            # after the fix
216 passing, 0 failing

$ ./quality.sh < /dev/null
✅ All quality checks passed!
```

```mermaid
flowchart LR
    A["actions/checkout"] -->|"default"| B["GITHUB_TOKEN written to .git/config"]
    B --> C["any later step can read the token"]
    A -->|"persist-credentials: false"| D["no credential on disk"]
    D --> E["read-only validation steps run unchanged"]
```

## Test Plan

- Added `tests/scripts/validation_workflow.bats`:
  - `ci workflow defines a validation job` — guards the job name the second
    test targets, so a rename fails loudly rather than silently passing.
  - `ci validation checkout does not persist credentials on disk` — regression
    test that fails against the unfixed workflow and passes after the fix.
- Re-ran the full `bats tests/scripts` suite (216 tests) and `./quality.sh`.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxpuv9z-aa0093`<!-- vibe-worker-issue-320 -->