### PR TITLE
🟠 Job `scripts-and-spelling` checkout persists credentials (`.github/workflows/ci.yml`) (Issue #319)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       # ShellCheck Lint — upstream project: https://github.com/koalaman/shellcheck
       # We install the apt package (which ships koalaman/shellcheck) and scan all *.sh files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -705,18 +705,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-319.md
+++ b/docs/archive/pr-summaries/pr-summary-319.md
@@ -1,0 +1,37 @@
+## Summary
+
+Harden the `scripts-and-spelling` CI job so `actions/checkout` no longer
+persists the workflow `GITHUB_TOKEN` into `.git/config`. Added
+`persist-credentials: false` to the checkout step in `.github/workflows/ci.yml`.
+
+The job only runs shellcheck, `bash -n` syntax checks and codespell — it never
+pushes back to the repository and fetches no private submodule — so it does not
+need the persisted credential. Dropping it narrows the blast radius of any
+later compromised step in the job. Closes #319.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+- `.github/workflows/ci.yml`:381 now sets `persist-credentials: false` on the
+  `scripts-and-spelling` checkout step.
+- YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → `YAML OK`.
+
+```mermaid
+flowchart LR
+    A["actions/checkout"] --> B{"persist-credentials?"}
+    B -- "false (new)" --> C["GITHUB_TOKEN not written to .git/config"]
+    B -- "true (default, before)" --> D["token in .git/config — readable by any later step"]
+    C --> E["shellcheck / bash -n / codespell"]
+```
+
+## Test Plan
+
+No unit test applies: this is a workflow-YAML security-hardening change with no
+Rust or shell code path to exercise. Asserting the setting via a source grep
+would be a "how" test (implementation-detail assertion), which `AGENTS.md`
+explicitly discourages. Verification performed instead:
+
+- Confirmed the setting sits under the correct `scripts-and-spelling` checkout
+  step (single `persist-credentials` occurrence, line 381).
+- Validated the workflow still parses as valid YAML.


### PR DESCRIPTION
## Summary

Harden the `scripts-and-spelling` CI job so `actions/checkout` no longer
persists the workflow `GITHUB_TOKEN` into `.git/config`. Added
`persist-credentials: false` to the checkout step in `.github/workflows/ci.yml`.

The job only runs shellcheck, `bash -n` syntax checks and codespell — it never
pushes back to the repository and fetches no private submodule — so it does not
need the persisted credential. Dropping it narrows the blast radius of any
later compromised step in the job. Closes #319.

## Evidence

Backend/CI-only change — no web interface to screenshot.

- `.github/workflows/ci.yml`:381 now sets `persist-credentials: false` on the
  `scripts-and-spelling` checkout step.
- YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → `YAML OK`.

```mermaid
flowchart LR
    A["actions/checkout"] --> B{"persist-credentials?"}
    B -- "false (new)" --> C["GITHUB_TOKEN not written to .git/config"]
    B -- "true (default, before)" --> D["token in .git/config — readable by any later step"]
    C --> E["shellcheck / bash -n / codespell"]
```

## Test Plan

No unit test applies: this is a workflow-YAML security-hardening change with no
Rust or shell code path to exercise. Asserting the setting via a source grep
would be a "how" test (implementation-detail assertion), which `AGENTS.md`
explicitly discourages. Verification performed instead:

- Confirmed the setting sits under the correct `scripts-and-spelling` checkout
  step (single `persist-credentials` occurrence, line 381).
- Validated the workflow still parses as valid YAML.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxs4sq7-39464e`<!-- vibe-worker-issue-319 -->