### PR TITLE
Harden markdown-lint checkout with persist-credentials: false (Issue #322)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -17,7 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # actions/checkout@v6.0.2 — Issue #97/#99: bumped off Node 20 (EOL 2026-09-16).
+      # Issue #322 — `persist-credentials: false` keeps the workflow
+      # GITHUB_TOKEN out of .git/config. This job only lints Markdown and
+      # validates Mermaid blocks: it never pushes back and fetches no private
+      # submodule, so leaving the credential on disk would only widen the blast
+      # radius of a compromised step.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       # actions/setup-node@v6.4.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/docs/archive/pr-summaries/pr-summary-322.md
+++ b/docs/archive/pr-summaries/pr-summary-322.md
@@ -1,0 +1,41 @@
+# Job `markdownlint` checkout persists credentials — harden `markdown-lint.yml`
+
+## Summary
+
+The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job could read it and act as the token. This job only
+lints Markdown and validates Mermaid blocks — it never pushes back to the
+repository and fetches no private submodule — so the persisted credential was
+pure blast radius.
+
+Added `persist-credentials: false` to the checkout step, matching the
+established convention already applied to `actionlint.yml`, `gitleaks.yml`, and
+`ci.yml` (Issues #317–#320). Closes #322.
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|token written to .git/config| B[later step reads token]
+    C[checkout persist-credentials:false] -->|no token on disk| D[compromised step has nothing to steal]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the bats
+workflow test suite:
+
+- Added `markdown-lint workflow checkout does not persist credentials on disk`
+  to `tests/scripts/markdown_lint_workflow.bats`, which parses the workflow YAML
+  and asserts every `actions/checkout` step in the `markdownlint` job sets
+  `persist-credentials: false`.
+- Regression check: the new test **fails** against the unfixed workflow (`not ok
+  6 ... checkout does not persist credentials`) and **passes** after the fix.
+- Full `./quality.sh` run passes cleanly.
+
+## Test Plan
+
+- `tests/scripts/markdown_lint_workflow.bats` — new
+  `markdown-lint workflow checkout does not persist credentials on disk` test
+  (11/11 pass).
+- `./quality.sh < /dev/null` — all quality checks pass.

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -76,6 +76,32 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #322 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. This job only lints Markdown and validates Mermaid blocks:
+# it never pushes back to the repository and fetches no private submodule, so
+# the credential is pure blast radius.
+@test "markdown-lint workflow checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["markdownlint"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "markdown-lint workflow does not pin actions/setup-node to a deprecated Node 20 SHA" {
   # Regression test for Issue #98 — actions/setup-node@v4
   # (SHA 49933ea5288caeca8642d1e84afbd3f7d6820020) ships the Node 20


### PR DESCRIPTION
# Job `markdownlint` checkout persists credentials — harden `markdown-lint.yml`

## Summary

The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job could read it and act as the token. This job only
lints Markdown and validates Mermaid blocks — it never pushes back to the
repository and fetches no private submodule — so the persisted credential was
pure blast radius.

Added `persist-credentials: false` to the checkout step, matching the
established convention already applied to `actionlint.yml`, `gitleaks.yml`, and
`ci.yml` (Issues #317–#320). Closes #322.

```mermaid
flowchart LR
    A[checkout default] -->|token written to .git/config| B[later step reads token]
    C[checkout persist-credentials:false] -->|no token on disk| D[compromised step has nothing to steal]
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the bats
workflow test suite:

- Added `markdown-lint workflow checkout does not persist credentials on disk`
  to `tests/scripts/markdown_lint_workflow.bats`, which parses the workflow YAML
  and asserts every `actions/checkout` step in the `markdownlint` job sets
  `persist-credentials: false`.
- Regression check: the new test **fails** against the unfixed workflow (`not ok
  6 ... checkout does not persist credentials`) and **passes** after the fix.
- Full `./quality.sh` run passes cleanly.

## Test Plan

- `tests/scripts/markdown_lint_workflow.bats` — new
  `markdown-lint workflow checkout does not persist credentials on disk` test
  (11/11 pass).
- `./quality.sh < /dev/null` — all quality checks pass.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxs4sq7-39464e`<!-- vibe-worker-issue-322 -->