### PR TITLE
Stop release checkout persisting GITHUB_TOKEN (Issue #323)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,15 @@ jobs:
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2
+        # Issue #323 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job cuts the tag and publishes
+        # the release via `gh` using GH_TOKEN from the environment, and its git
+        # operations (`git ls-remote origin`) target a public repo that needs
+        # no credential, so the persisted token would be pure blast radius.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Decide whether this version needs a release
         id: gate

--- a/docs/archive/pr-summaries/pr-summary-323.md
+++ b/docs/archive/pr-summaries/pr-summary-323.md
@@ -1,0 +1,29 @@
+## Summary
+
+The `release` job's `actions/checkout` step ran without `persist-credentials: false`, so `actions/checkout` wrote the workflow `GITHUB_TOKEN` into `.git/config` as an auth header — leaving a usable credential on disk for every later step in the job. This job cuts the semver tag and publishes the GitHub release via `gh` using `GH_TOKEN` from the environment, and its only git-over-network operation (`git ls-remote origin`) targets this **public** repository, which needs no credential. The persisted token was therefore pure blast radius.
+
+Added `persist-credentials: false` to the release job's checkout step, matching the pattern already applied across this repo's other workflows (Issues #317, #318, #320, #322). Closes #323.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the `release_sbom.bats` "what" test suite (parses `release.yml` and asserts observable workflow behaviour) and the full `./quality.sh` gate.
+
+```mermaid
+flowchart LR
+    A[actions/checkout] -->|before| B["writes GITHUB_TOKEN\ninto .git/config"]
+    B --> C["any later step can read\nand act as the token"]
+    A -->|after: persist-credentials false| D["no token on disk"]
+    D --> E["gh uses GH_TOKEN from env;\ngit ls-remote hits public repo"]
+```
+
+Test run:
+
+```
+ok 6 release workflow checkout does not persist credentials on disk
+```
+
+## Test Plan
+
+- Added `tests/scripts/release_sbom.bats::"release workflow checkout does not persist credentials on disk"` — parses `release.yml` and asserts every `actions/checkout@` step in the `release` job sets `persist-credentials: false`. Fails against the unfixed workflow, passes after the fix.
+- Ran `bats tests/scripts/release_sbom.bats` — 7/7 pass.
+- Ran `./quality.sh` — all quality checks pass.

--- a/tests/scripts/release_sbom.bats
+++ b/tests/scripts/release_sbom.bats
@@ -86,6 +86,33 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #323 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. The release job cuts the tag and publishes the release via
+# `gh` with GH_TOKEN from the environment, and its git operations
+# (`git ls-remote origin`) target a public repository that needs no credential,
+# so the persisted token is pure blast radius.
+@test "release workflow checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["release"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "SBOM is generated before the Release is published" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"


### PR DESCRIPTION
## Summary

The `release` job's `actions/checkout` step ran without `persist-credentials: false`, so `actions/checkout` wrote the workflow `GITHUB_TOKEN` into `.git/config` as an auth header — leaving a usable credential on disk for every later step in the job. This job cuts the semver tag and publishes the GitHub release via `gh` using `GH_TOKEN` from the environment, and its only git-over-network operation (`git ls-remote origin`) targets this **public** repository, which needs no credential. The persisted token was therefore pure blast radius.

Added `persist-credentials: false` to the release job's checkout step, matching the pattern already applied across this repo's other workflows (Issues #317, #318, #320, #322). Closes #323.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the `release_sbom.bats` "what" test suite (parses `release.yml` and asserts observable workflow behaviour) and the full `./quality.sh` gate.

```mermaid
flowchart LR
    A[actions/checkout] -->|before| B["writes GITHUB_TOKEN\ninto .git/config"]
    B --> C["any later step can read\nand act as the token"]
    A -->|after: persist-credentials false| D["no token on disk"]
    D --> E["gh uses GH_TOKEN from env;\ngit ls-remote hits public repo"]
```

Test run:

```
ok 6 release workflow checkout does not persist credentials on disk
```

## Test Plan

- Added `tests/scripts/release_sbom.bats::"release workflow checkout does not persist credentials on disk"` — parses `release.yml` and asserts every `actions/checkout@` step in the `release` job sets `persist-credentials: false`. Fails against the unfixed workflow, passes after the fix.
- Ran `bats tests/scripts/release_sbom.bats` — 7/7 pass.
- Ran `./quality.sh` — all quality checks pass.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxs4sq7-39464e`<!-- vibe-worker-issue-323 -->