### PR TITLE
Disable checkout credential persistence in semgrep workflow (Issue #324)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - run: semgrep ci --config p/default
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -705,18 +705,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-324.md
+++ b/docs/archive/pr-summaries/pr-summary-324.md
@@ -1,0 +1,41 @@
+## Summary
+
+Job `semgrep` in `.github/workflows/semgrep.yml` ran `actions/checkout` without
+`persist-credentials: false`, so the workflow `GITHUB_TOKEN` was written into
+`.git/config` as an auth header. The job only checks out the repo and runs
+`semgrep ci` — it never pushes back to the repository or fetches private
+submodules — so it does not need the persisted credential. Added
+`persist-credentials: false` to the checkout step so the token is not written to
+disk, reducing the blast radius of any compromised later step. Closes #324.
+
+## Evidence
+
+Backend/CI-only change — there is no web interface to screenshot. Verification:
+
+- `actionlint .github/workflows/semgrep.yml` — no findings.
+- YAML parses cleanly (`yaml.safe_load`).
+- `./quality.sh` — all quality checks passed (workspace build, clippy, tests).
+
+```mermaid
+flowchart LR
+    A[checkout] -->|persist-credentials: false| B[.git/config has no token]
+    B --> C[semgrep ci runs]
+    C --> D[compromised step cannot read GITHUB_TOKEN from disk]
+```
+
+Diff:
+
+```yaml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+```
+
+## Test Plan
+
+- The change is a GitHub Actions workflow configuration hardening; no Rust code
+  paths are affected, so no unit tests apply.
+- Validated the workflow statically with `actionlint` (clean) and confirmed the
+  YAML parses.
+- Ran `./quality.sh` to confirm the workspace still builds, lints, and tests
+  green.


### PR DESCRIPTION
## Summary

Job `semgrep` in `.github/workflows/semgrep.yml` ran `actions/checkout` without
`persist-credentials: false`, so the workflow `GITHUB_TOKEN` was written into
`.git/config` as an auth header. The job only checks out the repo and runs
`semgrep ci` — it never pushes back to the repository or fetches private
submodules — so it does not need the persisted credential. Added
`persist-credentials: false` to the checkout step so the token is not written to
disk, reducing the blast radius of any compromised later step. Closes #324.

## Evidence

Backend/CI-only change — there is no web interface to screenshot. Verification:

- `actionlint .github/workflows/semgrep.yml` — no findings.
- YAML parses cleanly (`yaml.safe_load`).
- `./quality.sh` — all quality checks passed (workspace build, clippy, tests).

```mermaid
flowchart LR
    A[checkout] -->|persist-credentials: false| B[.git/config has no token]
    B --> C[semgrep ci runs]
    C --> D[compromised step cannot read GITHUB_TOKEN from disk]
```

Diff:

```yaml
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
        with:
          persist-credentials: false
```

## Test Plan

- The change is a GitHub Actions workflow configuration hardening; no Rust code
  paths are affected, so no unit tests apply.
- Validated the workflow statically with `actionlint` (clean) and confirmed the
  YAML parses.
- Ran `./quality.sh` to confirm the workspace still builds, lints, and tests
  green.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxul3cw-fde027`<!-- vibe-worker-issue-324 -->