### PR TITLE
Stop wasm-bundle publish checkout persisting GITHUB_TOKEN (Issue #325)

### DIFF
--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -21,7 +21,14 @@ jobs:
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2
+        # Issue #325 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job builds the bundle and
+        # publishes the per-commit Release via `gh` using GH_TOKEN from the
+        # environment; it never pushes back through the git remote, so the
+        # persisted token would be pure blast radius for any later step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain (with wasm32 target)
         # dtolnay/rust-toolchain@stable

--- a/docs/archive/pr-summaries/pr-summary-325.md
+++ b/docs/archive/pr-summaries/pr-summary-325.md
@@ -1,0 +1,52 @@
+## Summary
+
+Hardened the `publish` job's checkout in `.github/workflows/wasm-bundle.yml` by
+adding `persist-credentials: false`. By default `actions/checkout` writes the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
+step in the job — including a compromised dependency — can read it and act as
+the token.
+
+The `publish` job never pushes back through the git remote: it builds the
+`wasm_activation` bundle and publishes the per-commit Release exclusively via the
+`gh` CLI using `GH_TOKEN` from the environment (`Publish per-commit Release` and
+`Verify published bundle` steps). It also fetches no private submodules. The
+persisted checkout credential is therefore unused and only widens the blast
+radius of a compromised step, so disabling it is safe.
+
+This mirrors the same hardening already applied across the repo's other
+workflows (Issues #317–#324: `actionlint.yml`, `ci.yml`, `gitleaks.yml`,
+`markdown-lint.yml`, `release.yml`, `semgrep.yml`).
+
+Closes #325.
+
+## Evidence
+
+Backend/CI configuration change — no web interface to screenshot.
+
+Validation performed:
+
+- The workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"` → `YAML OK`).
+- Manual data-flow review confirms the `publish` job uses `GH_TOKEN` (env) for
+  every GitHub operation and performs no `git push`/private-submodule fetch that
+  would need the persisted credential.
+
+```mermaid
+flowchart LR
+    A[checkout\npersist-credentials: false] --> B[build wasm bundle]
+    B --> C[gh release create\nGH_TOKEN env]
+    C --> D[gh release download\nverify — GH_TOKEN env]
+    style A fill:#d4f7d4
+```
+
+The token is no longer written to `.git/config`; the release/verify steps rely
+on `GH_TOKEN` from the environment, which is unaffected.
+
+## Test Plan
+
+No unit tests apply — this is a declarative GitHub Actions workflow security
+setting with no callable function to exercise (consistent with the merged
+sibling PRs #352–#354 for Issues #322–#324). Verified by:
+
+- YAML schema/parse validation of `.github/workflows/wasm-bundle.yml`.
+- Review confirming the checkout credential is genuinely unused by the job,
+  ruling out the false-positive case called out in the issue.


### PR DESCRIPTION
## Summary

Hardened the `publish` job's checkout in `.github/workflows/wasm-bundle.yml` by
adding `persist-credentials: false`. By default `actions/checkout` writes the
workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
step in the job — including a compromised dependency — can read it and act as
the token.

The `publish` job never pushes back through the git remote: it builds the
`wasm_activation` bundle and publishes the per-commit Release exclusively via the
`gh` CLI using `GH_TOKEN` from the environment (`Publish per-commit Release` and
`Verify published bundle` steps). It also fetches no private submodules. The
persisted checkout credential is therefore unused and only widens the blast
radius of a compromised step, so disabling it is safe.

This mirrors the same hardening already applied across the repo's other
workflows (Issues #317–#324: `actionlint.yml`, `ci.yml`, `gitleaks.yml`,
`markdown-lint.yml`, `release.yml`, `semgrep.yml`).

Closes #325.

## Evidence

Backend/CI configuration change — no web interface to screenshot.

Validation performed:

- The workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"` → `YAML OK`).
- Manual data-flow review confirms the `publish` job uses `GH_TOKEN` (env) for
  every GitHub operation and performs no `git push`/private-submodule fetch that
  would need the persisted credential.

```mermaid
flowchart LR
    A[checkout\npersist-credentials: false] --> B[build wasm bundle]
    B --> C[gh release create\nGH_TOKEN env]
    C --> D[gh release download\nverify — GH_TOKEN env]
    style A fill:#d4f7d4
```

The token is no longer written to `.git/config`; the release/verify steps rely
on `GH_TOKEN` from the environment, which is unaffected.

## Test Plan

No unit tests apply — this is a declarative GitHub Actions workflow security
setting with no callable function to exercise (consistent with the merged
sibling PRs #352–#354 for Issues #322–#324). Verified by:

- YAML schema/parse validation of `.github/workflows/wasm-bundle.yml`.
- Review confirming the checkout credential is genuinely unused by the job,
  ruling out the false-positive case called out in the issue.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxul3cw-fde027`<!-- vibe-worker-issue-325 -->