### PR TITLE
Run actionlint gate on milestone PRs (Issue #326)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,11 @@ name: Actionlint
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #326 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this lint gate runs on milestone
+    # sub-issue PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
   workflow_dispatch:
 
 permissions:

--- a/docs/archive/pr-summaries/pr-summary-326.md
+++ b/docs/archive/pr-summaries/pr-summary-326.md
@@ -1,0 +1,48 @@
+## Summary
+
+The `actionlint.yml` CI quality workflow gated pull requests with a
+`pull_request.branches` filter of `["*"]`. GitHub branch-filter globbing treats
+`*` as "any characters except `/`", so the pattern never matched
+`milestone/<slug>` feature branches. Milestone sub-issue PRs — which target a
+shared `milestone/<name>` branch under the planning delivery workflow — merged
+without the actionlint gate ever running; the gap was only caught later by the
+single rollup PR into the default branch.
+
+Added an explicit `milestone/*` pattern to the filter so the lint gate runs on
+milestone PRs too, while the existing `*` keeps matching `Develop`, `main`, and
+other single-segment branches. Milestone branch names are `milestone/<slug>`
+with no nested slashes, so the single-level `milestone/*` glob is sufficient.
+
+Closes #326.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+behavioural bats test below, which reimplements GitHub's filter globbing (`**`
+crosses `/`, `*` does not) and asserts the configured patterns match a real
+milestone branch name while still matching the default branches.
+
+```mermaid
+flowchart LR
+    A["milestone/clean-up-23-jul PR"] --> B{"branches filter"}
+    B -- "before: [\"*\"] — * stops at /" --> C["gate SKIPPED ✗"]
+    B -- "after: [\"*\", \"milestone/*\"]" --> D["actionlint runs ✓"]
+```
+
+Test run:
+
+```
+ok 4 actionlint workflow pull_request filter matches milestone branches
+ok 9 actionlint passes against the current workflows on disk
+```
+
+## Test Plan
+
+- Added `actionlint workflow pull_request filter matches milestone branches` to
+  `tests/scripts/actionlint_workflow.bats`. It parses the workflow's
+  `pull_request.branches` filter and, using GitHub's glob semantics, asserts a
+  milestone branch (`milestone/clean-up-23-jul`) matches a pattern and that
+  `Develop`/`main` still match. This test fails against the old `["*"]` filter
+  and passes after the fix.
+- Full `tests/scripts/actionlint_workflow.bats` suite: 9 passing.
+- `./quality.sh` passes cleanly (Rust workspace tests, docs, release build).

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -50,6 +50,52 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #326 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["*"] never matches milestone/<slug> and the gate silently skips those PRs.
+# The filter must match milestone branches so the lint gate runs on them too.
+@test "actionlint workflow pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "actionlint workflow exposes a job that runs the actionlint binary" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"


### PR DESCRIPTION
## Summary

The `actionlint.yml` CI quality workflow gated pull requests with a
`pull_request.branches` filter of `["*"]`. GitHub branch-filter globbing treats
`*` as "any characters except `/`", so the pattern never matched
`milestone/<slug>` feature branches. Milestone sub-issue PRs — which target a
shared `milestone/<name>` branch under the planning delivery workflow — merged
without the actionlint gate ever running; the gap was only caught later by the
single rollup PR into the default branch.

Added an explicit `milestone/*` pattern to the filter so the lint gate runs on
milestone PRs too, while the existing `*` keeps matching `Develop`, `main`, and
other single-segment branches. Milestone branch names are `milestone/<slug>`
with no nested slashes, so the single-level `milestone/*` glob is sufficient.

Closes #326.

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
behavioural bats test below, which reimplements GitHub's filter globbing (`**`
crosses `/`, `*` does not) and asserts the configured patterns match a real
milestone branch name while still matching the default branches.

```mermaid
flowchart LR
    A["milestone/clean-up-23-jul PR"] --> B{"branches filter"}
    B -- "before: [\"*\"] — * stops at /" --> C["gate SKIPPED ✗"]
    B -- "after: [\"*\", \"milestone/*\"]" --> D["actionlint runs ✓"]
```

Test run:

```
ok 4 actionlint workflow pull_request filter matches milestone branches
ok 9 actionlint passes against the current workflows on disk
```

## Test Plan

- Added `actionlint workflow pull_request filter matches milestone branches` to
  `tests/scripts/actionlint_workflow.bats`. It parses the workflow's
  `pull_request.branches` filter and, using GitHub's glob semantics, asserts a
  milestone branch (`milestone/clean-up-23-jul`) matches a pattern and that
  `Develop`/`main` still match. This test fails against the old `["*"]` filter
  and passes after the fix.
- Full `tests/scripts/actionlint_workflow.bats` suite: 9 passing.
- `./quality.sh` passes cleanly (Rust workspace tests, docs, release build).



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxul3cw-fde027`<!-- vibe-worker-issue-326 -->