### PR TITLE
Add milestone/* to CI quality workflow PR branch filter (Issue #327)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - Develop
+      # Issue #327 — milestone sub-issue PRs target a shared milestone/<slug>
+      # branch; `*` never crosses `/`, so this single-level glob gates them too.
+      - milestone/*
   workflow_dispatch:
 
 env:

--- a/docs/archive/pr-summaries/pr-summary-327.md
+++ b/docs/archive/pr-summaries/pr-summary-327.md
@@ -1,0 +1,59 @@
+## Summary
+
+The CI quality workflow (`.github/workflows/ci.yml`) gated PRs with a
+`pull_request.branches` filter of `[Develop]` only. GitHub branch-filter globs
+treat `*` as "any character except `/`", so milestone sub-issue PRs targeting a
+shared `milestone/<slug>` branch never matched the filter — the fmt/clippy/deny/
+test/doc gate silently skipped them, and they merged into the milestone branch
+unchecked until the single rollup PR into `Develop` finally exercised the gate.
+
+Added `milestone/*` to the filter so the quality gate runs on milestone PRs too,
+while still gating PRs into `Develop`. Milestone branch names are
+`milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
+glob is sufficient. Closes #327.
+
+This mirrors the same fix already applied to `actionlint.yml` (Issue #326).
+
+```mermaid
+flowchart LR
+    A["sub-issue PR<br/>→ milestone/clean-up-23-jul"] --> B{"pull_request.branches<br/>matches?"}
+    B -- "before: [Develop] only" --> C["gate SKIPPED<br/>merges unchecked"]
+    B -- "after: adds milestone/*" --> D["CI quality gate runs<br/>fmt/clippy/deny/test/doc"]
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via a new
+bats test that models GitHub's branch-glob semantics (`*` does not cross `/`)
+and asserts the filter matches `milestone/clean-up-23-jul` while still matching
+`Develop`.
+
+Before the fix (test 3 fails):
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 ci workflow is valid YAML
+not ok 3 ci workflow pull_request filter matches milestone branches
+```
+
+After the fix:
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 ci workflow is valid YAML
+ok 3 ci workflow pull_request filter matches milestone branches
+```
+
+`./quality.sh` passes cleanly (bash syntax, shellcheck, bats, TypeScript gate,
+fmt/clippy/deny, workspace tests, doc, release build).
+
+## Test Plan
+
+- Added `tests/scripts/ci_workflow.bats`:
+  - `ci workflow file exists` — the workflow YAML is present.
+  - `ci workflow is valid YAML` — it parses.
+  - `ci workflow pull_request filter matches milestone branches` — regression
+    test reproducing #327: fails against the unfixed `[Develop]` filter, passes
+    once `milestone/*` is added; also asserts `Develop` still matches.

--- a/tests/scripts/ci_workflow.bats
+++ b/tests/scripts/ci_workflow.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# Tests for the CI quality workflow branch filters (Issue #327).
+#
+# Asserts on observable outcomes:
+#   - the workflow YAML file exists and parses,
+#   - its pull_request branch filter matches milestone/<slug> feature branches
+#     as well as the existing default branch, so the quality gate runs on
+#     milestone sub-issue PRs (Issue #327).
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "ci workflow is valid YAML" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW'))"
+  [ "$status" -eq 0 ]
+}
+
+# Issue #327 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["Develop"] never matches milestone/<slug> and the quality gate silently skips
+# those PRs. The filter must match milestone branches so the gate runs on them
+# too, while still matching the existing default branch.
+@test "ci workflow pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+# YAML parses bare 'on:' as boolean True in some loaders; tolerate both.
+triggers = data.get("on") or data.get(True)
+assert triggers is not None, data
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branch must still match.
+assert any(matches(p, "Develop") for p in patterns), (
+    f"no branch pattern matches 'Develop': {patterns}"
+)
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

The CI quality workflow (`.github/workflows/ci.yml`) gated PRs with a
`pull_request.branches` filter of `[Develop]` only. GitHub branch-filter globs
treat `*` as "any character except `/`", so milestone sub-issue PRs targeting a
shared `milestone/<slug>` branch never matched the filter — the fmt/clippy/deny/
test/doc gate silently skipped them, and they merged into the milestone branch
unchecked until the single rollup PR into `Develop` finally exercised the gate.

Added `milestone/*` to the filter so the quality gate runs on milestone PRs too,
while still gating PRs into `Develop`. Milestone branch names are
`milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
glob is sufficient. Closes #327.

This mirrors the same fix already applied to `actionlint.yml` (Issue #326).

```mermaid
flowchart LR
    A["sub-issue PR<br/>→ milestone/clean-up-23-jul"] --> B{"pull_request.branches<br/>matches?"}
    B -- "before: [Develop] only" --> C["gate SKIPPED<br/>merges unchecked"]
    B -- "after: adds milestone/*" --> D["CI quality gate runs<br/>fmt/clippy/deny/test/doc"]
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via a new
bats test that models GitHub's branch-glob semantics (`*` does not cross `/`)
and asserts the filter matches `milestone/clean-up-23-jul` while still matching
`Develop`.

Before the fix (test 3 fails):

```
1..3
ok 1 ci workflow file exists
ok 2 ci workflow is valid YAML
not ok 3 ci workflow pull_request filter matches milestone branches
```

After the fix:

```
1..3
ok 1 ci workflow file exists
ok 2 ci workflow is valid YAML
ok 3 ci workflow pull_request filter matches milestone branches
```

`./quality.sh` passes cleanly (bash syntax, shellcheck, bats, TypeScript gate,
fmt/clippy/deny, workspace tests, doc, release build).

## Test Plan

- Added `tests/scripts/ci_workflow.bats`:
  - `ci workflow file exists` — the workflow YAML is present.
  - `ci workflow is valid YAML` — it parses.
  - `ci workflow pull_request filter matches milestone branches` — regression
    test reproducing #327: fails against the unfixed `[Develop]` filter, passes
    once `milestone/*` is added; also asserts `Develop` still matches.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxul3cw-fde027`<!-- vibe-worker-issue-327 -->