### PR TITLE
Run gitleaks secret scan on milestone PRs (Issue #328)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,7 +11,11 @@ name: Gitleaks
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #328 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this secret scan runs on milestone
+    # sub-issue PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
 
 permissions:
   contents: read

--- a/docs/archive/pr-summaries/pr-summary-328.md
+++ b/docs/archive/pr-summaries/pr-summary-328.md
@@ -1,0 +1,66 @@
+# Run the gitleaks secret scan on milestone PRs (Issue #328)
+
+## Summary
+
+`.github/workflows/gitleaks.yml` triggered on `pull_request` with
+`branches: ["*"]`. GitHub branch-filter globbing treats `*` as "any character
+except `/`", so the filter never matched a `milestone/<slug>` branch. Milestone
+sub-issue PRs target a shared `milestone/<slug>` branch, so the secret scan was
+silently skipped on every one of them — the leak would only be caught later by
+the single rollup PR into the default branch.
+
+Added an explicit `milestone/*` pattern to the filter
+(`branches: ["*", "milestone/*"]`), mirroring the fix already landed for
+`actionlint.yml` (Issue #326) and `ci.yml` (Issue #327). Milestone branch names
+carry no nested slashes, so the single-level glob is sufficient.
+
+Closes #328.
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified by
+the bats suite plus a local `actionlint` run over the edited workflow (clean).
+
+Trigger coverage before and after:
+
+```mermaid
+flowchart LR
+    A["PR → Develop / main"] --> G["gitleaks scan runs"]
+    B["PR → milestone/&lt;slug&gt;"] -.->|before: `*` never crosses `/`| S["scan skipped ❌"]
+    B ==>|after: `milestone/*` added| G
+```
+
+Test run after the fix:
+
+```text
+1..7
+ok 1 gitleaks.yml does not use the Node-based gitleaks-action
+ok 2 gitleaks.yml installs gitleaks from a version-pinned release URL
+ok 3 gitleaks.yml verifies the gitleaks tarball with sha256sum -c
+ok 4 gitleaks.yml declares a 64-hex GITLEAKS_SHA256 env var
+ok 5 gitleaks.yml declares a semver GITLEAKS_VERSION env var
+ok 6 gitleaks.yml pull_request filter matches milestone branches
+ok 7 gitleaks.yml invokes the gitleaks CLI
+```
+
+Before the workflow edit, test 6 failed (`not ok 6`) — a genuine
+red-then-green regression test.
+
+`./quality.sh < /dev/null` passes cleanly (exit 0).
+
+## Test Plan
+
+- Added `tests/scripts/gitleaks_pinned_install.bats::"gitleaks.yml
+  pull_request filter matches milestone branches"` — parses the workflow YAML,
+  re-implements GitHub's filter glob semantics (`*` does not cross `/`, `**`
+  does), and asserts the `pull_request.branches` patterns match
+  `milestone/clean-up-23-jul` while still matching `Develop` and `main`.
+- Existing gitleaks workflow tests unchanged and still passing; no tests were
+  removed or disabled.
+
+## Security Self-Check
+
+- No secrets or hidden files staged — only `.github/workflows/gitleaks.yml`
+  (allowlisted workflow YAML), a bats test, and this summary.
+- Change strictly widens a CI gate's coverage; no permissions, tokens, or
+  script behaviour altered.

--- a/tests/scripts/gitleaks_pinned_install.bats
+++ b/tests/scripts/gitleaks_pinned_install.bats
@@ -62,6 +62,52 @@ strip_comments() {
   [ "$status" -eq 0 ]
 }
 
+# Issue #328 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["*"] never matches milestone/<slug> and the secret scan silently skips those
+# PRs. The filter must match milestone branches so the gate runs on them too.
+@test "gitleaks.yml pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WF"))
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "gitleaks.yml invokes the gitleaks CLI" {
   [ -f "$WF" ]
   # Either `./gitleaks detect …` (binary extracted to CWD) or


### PR DESCRIPTION
# Run the gitleaks secret scan on milestone PRs (Issue #328)

## Summary

`.github/workflows/gitleaks.yml` triggered on `pull_request` with
`branches: ["*"]`. GitHub branch-filter globbing treats `*` as "any character
except `/`", so the filter never matched a `milestone/<slug>` branch. Milestone
sub-issue PRs target a shared `milestone/<slug>` branch, so the secret scan was
silently skipped on every one of them — the leak would only be caught later by
the single rollup PR into the default branch.

Added an explicit `milestone/*` pattern to the filter
(`branches: ["*", "milestone/*"]`), mirroring the fix already landed for
`actionlint.yml` (Issue #326) and `ci.yml` (Issue #327). Milestone branch names
carry no nested slashes, so the single-level glob is sufficient.

Closes #328.

## Evidence

Backend/CI-configuration change — no web interface to screenshot. Verified by
the bats suite plus a local `actionlint` run over the edited workflow (clean).

Trigger coverage before and after:

```mermaid
flowchart LR
    A["PR → Develop / main"] --> G["gitleaks scan runs"]
    B["PR → milestone/&lt;slug&gt;"] -.->|before: `*` never crosses `/`| S["scan skipped ❌"]
    B ==>|after: `milestone/*` added| G
```

Test run after the fix:

```text
1..7
ok 1 gitleaks.yml does not use the Node-based gitleaks-action
ok 2 gitleaks.yml installs gitleaks from a version-pinned release URL
ok 3 gitleaks.yml verifies the gitleaks tarball with sha256sum -c
ok 4 gitleaks.yml declares a 64-hex GITLEAKS_SHA256 env var
ok 5 gitleaks.yml declares a semver GITLEAKS_VERSION env var
ok 6 gitleaks.yml pull_request filter matches milestone branches
ok 7 gitleaks.yml invokes the gitleaks CLI
```

Before the workflow edit, test 6 failed (`not ok 6`) — a genuine
red-then-green regression test.

`./quality.sh < /dev/null` passes cleanly (exit 0).

## Test Plan

- Added `tests/scripts/gitleaks_pinned_install.bats::"gitleaks.yml
  pull_request filter matches milestone branches"` — parses the workflow YAML,
  re-implements GitHub's filter glob semantics (`*` does not cross `/`, `**`
  does), and asserts the `pull_request.branches` patterns match
  `milestone/clean-up-23-jul` while still matching `Develop` and `main`.
- Existing gitleaks workflow tests unchanged and still passing; no tests were
  removed or disabled.

## Security Self-Check

- No secrets or hidden files staged — only `.github/workflows/gitleaks.yml`
  (allowlisted workflow YAML), a bats test, and this summary.
- Change strictly widens a CI gate's coverage; no permissions, tokens, or
  script behaviour altered.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxx1seu-b97714`<!-- vibe-worker-issue-328 -->