### PR TITLE
Run markdown lint gate on milestone PRs (Issue #329)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,7 +6,11 @@ name: Markdown Lint
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #329 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this lint gate runs on milestone
+    # sub-issue PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
   workflow_dispatch:
 
 permissions:

--- a/docs/archive/pr-summaries/pr-summary-329.md
+++ b/docs/archive/pr-summaries/pr-summary-329.md
@@ -1,0 +1,60 @@
+# PR Summary — Issue #329
+
+## Summary
+
+`.github/workflows/markdown-lint.yml` gated pull requests with
+`branches: ["*"]`. GitHub branch-filter globs treat `*` as "any characters
+except `/`", so that pattern never matched a `milestone/<slug>` branch. Every
+milestone sub-issue PR merged into the shared milestone branch without the
+Markdown lint gate running — the gap only surfaced later on the single rollup PR
+into the default branch.
+
+Added an explicit `milestone/*` pattern to the filter
+(`branches: ["*", "milestone/*"]`), matching the fixes already landed for
+actionlint (#326), the CI quality workflow (#327), and gitleaks (#328).
+Milestone branch names are `milestone/<slug>` with no nested slashes, so the
+single-level glob is sufficient.
+
+Closes #329.
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified by
+the bats suite below.
+
+Branch-filter coverage before and after:
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — branches: [\"*\"]"]
+        B1["PR → Develop"] --> BG["markdown lint runs"]
+        B2["PR → milestone/clean-up-23-jul"] -.->|no pattern matches| BS["gate skipped"]
+    end
+    subgraph After["After — branches: [\"*\", \"milestone/*\"]"]
+        A1["PR → Develop"] --> AG["markdown lint runs"]
+        A2["PR → milestone/clean-up-23-jul"] --> AG
+    end
+```
+
+Full `./quality.sh` run passes (`✅ All quality checks passed!`), and the
+targeted suite is green:
+
+```text
+1..12
+ok 4 markdown-lint workflow pull_request filter matches milestone branches
+...
+```
+
+The new test fails against the unfixed workflow (confirmed before applying the
+fix) and passes after it.
+
+## Test Plan
+
+- Added `tests/scripts/markdown_lint_workflow.bats::"markdown-lint workflow
+  pull_request filter matches milestone branches"` — parses the workflow YAML,
+  reimplements GitHub's filter globbing (`*` does not cross `/`, `**` does), and
+  asserts that at least one pattern matches `milestone/clean-up-23-jul` while
+  `Develop` and `main` still match. This is the regression test for #329.
+- Re-ran the whole `tests/scripts/markdown_lint_workflow.bats` suite (12/12
+  pass) to confirm no existing behaviour regressed.
+- Ran `./quality.sh < /dev/null` — all checks pass.

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -43,6 +43,52 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #329 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["*"] never matches milestone/<slug> and this lint gate silently skips those
+# PRs. The filter must match milestone branches so the gate runs on them too.
+@test "markdown-lint workflow pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "markdown-lint workflow exposes a markdownlint job that runs markdownlint-cli2" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"


### PR DESCRIPTION
# PR Summary — Issue #329

## Summary

`.github/workflows/markdown-lint.yml` gated pull requests with
`branches: ["*"]`. GitHub branch-filter globs treat `*` as "any characters
except `/`", so that pattern never matched a `milestone/<slug>` branch. Every
milestone sub-issue PR merged into the shared milestone branch without the
Markdown lint gate running — the gap only surfaced later on the single rollup PR
into the default branch.

Added an explicit `milestone/*` pattern to the filter
(`branches: ["*", "milestone/*"]`), matching the fixes already landed for
actionlint (#326), the CI quality workflow (#327), and gitleaks (#328).
Milestone branch names are `milestone/<slug>` with no nested slashes, so the
single-level glob is sufficient.

Closes #329.

## Evidence

Backend/CI-configuration change — no web interface to screenshot. Verified by
the bats suite below.

Branch-filter coverage before and after:

```mermaid
flowchart LR
    subgraph Before["Before — branches: [\"*\"]"]
        B1["PR → Develop"] --> BG["markdown lint runs"]
        B2["PR → milestone/clean-up-23-jul"] -.->|no pattern matches| BS["gate skipped"]
    end
    subgraph After["After — branches: [\"*\", \"milestone/*\"]"]
        A1["PR → Develop"] --> AG["markdown lint runs"]
        A2["PR → milestone/clean-up-23-jul"] --> AG
    end
```

Full `./quality.sh` run passes (`✅ All quality checks passed!`), and the
targeted suite is green:

```text
1..12
ok 4 markdown-lint workflow pull_request filter matches milestone branches
...
```

The new test fails against the unfixed workflow (confirmed before applying the
fix) and passes after it.

## Test Plan

- Added `tests/scripts/markdown_lint_workflow.bats::"markdown-lint workflow
  pull_request filter matches milestone branches"` — parses the workflow YAML,
  reimplements GitHub's filter globbing (`*` does not cross `/`, `**` does), and
  asserts that at least one pattern matches `milestone/clean-up-23-jul` while
  `Develop` and `main` still match. This is the regression test for #329.
- Re-ran the whole `tests/scripts/markdown_lint_workflow.bats` suite (12/12
  pass) to confirm no existing behaviour regressed.
- Ran `./quality.sh < /dev/null` — all checks pass.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxx1seu-b97714`<!-- vibe-worker-issue-329 -->