### PR TITLE
Run Semgrep on milestone PRs (Issue #330)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,11 @@ name: Semgrep
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #330 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this scan runs on milestone sub-issue
+    # PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
 
 permissions:
   contents: read

--- a/docs/archive/pr-summaries/pr-summary-330.md
+++ b/docs/archive/pr-summaries/pr-summary-330.md
@@ -1,0 +1,60 @@
+# Semgrep workflow now gates milestone PRs (Issue #330)
+
+## Summary
+
+`.github/workflows/semgrep.yml` filtered pull requests on `branches: ["*"]`.
+GitHub branch-filter globs treat `*` as "any chars **except** `/`", so a bare
+`"*"` never matches a `milestone/<slug>` branch. Milestone sub-issue PRs target
+a shared `milestone/<name>` branch, so every one of them merged without the
+Semgrep scan running — the gap only surfaced later on the single rollup PR into
+the default branch.
+
+Added an explicit `milestone/*` pattern so the scan runs on milestone sub-issue
+PRs too. This mirrors the fixes already landed for `gitleaks.yml` (Issue #328)
+and `markdown-lint.yml` (Issue #329). Closes #330.
+
+```mermaid
+flowchart LR
+    A["sub-issue PR<br/>→ milestone/clean-up-23-jul"] -->|before: '*' does not cross '/'| B["Semgrep skipped ❌"]
+    A -->|after: 'milestone/*' matches| C["Semgrep runs ✅"]
+    C --> D["rollup PR → Develop"]
+    D --> E["Semgrep runs ✅"]
+```
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot.
+
+`tests/scripts/semgrep_workflow.bats` expands the workflow's branch patterns
+using GitHub's own globbing rules (`**` crosses `/`, `*` does not) and asserts
+`milestone/clean-up-23-jul` matches while `Develop` and `main` still do.
+
+Before the fix:
+
+```text
+not ok 2 semgrep.yml pull_request filter matches milestone branches
+```
+
+After the fix:
+
+```text
+1..3
+ok 1 semgrep.yml exists and is valid YAML
+ok 2 semgrep.yml pull_request filter matches milestone branches
+ok 3 semgrep.yml runs the semgrep scan on pull requests
+```
+
+`./quality.sh` passes cleanly (bats, shellcheck, deno check, clippy, cargo
+test, doc, release build), and `actionlint .github/workflows/semgrep.yml`
+reports no findings.
+
+## Test Plan
+
+- Added `tests/scripts/semgrep_workflow.bats`:
+  - `semgrep.yml exists and is valid YAML`
+  - `semgrep.yml pull_request filter matches milestone branches` — the
+    regression test for this issue; fails against the unfixed workflow.
+  - `semgrep.yml runs the semgrep scan on pull requests` — guards against the
+    filter being "fixed" on a workflow that no longer scans anything.
+- Picked up automatically by `quality.sh` (`bats tests/scripts`) and the CI
+  bats gate; no existing tests were modified or removed.

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Tests for the Semgrep GitHub Actions workflow.
+#
+# Issue #330 — milestone sub-issue PRs target a shared `milestone/<slug>`
+# branch. GitHub branch-filter globs treat `*` as "any chars except /", so a
+# filter of ["*"] never matches `milestone/<slug>` and this scan silently
+# skips those PRs; the gap only surfaces on the single rollup PR into the
+# default branch.
+#
+# These are "what" tests — they assert on the YAML the runner will execute,
+# not on commentary or surrounding prose.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WF="${REPO_ROOT}/.github/workflows/semgrep.yml"
+}
+
+@test "semgrep.yml exists and is valid YAML" {
+  [ -f "$WF" ]
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml; yaml.safe_load(open('$WF'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "semgrep.yml pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WF"))
+# YAML parses bare 'on:' as boolean True in some loaders; tolerate both.
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "semgrep.yml runs the semgrep scan on pull requests" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WF"))
+job = data["jobs"]["semgrep"]
+runs = [s.get("run", "") for s in job["steps"]]
+assert any("semgrep" in r for r in runs), runs
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Semgrep workflow now gates milestone PRs (Issue #330)

## Summary

`.github/workflows/semgrep.yml` filtered pull requests on `branches: ["*"]`.
GitHub branch-filter globs treat `*` as "any chars **except** `/`", so a bare
`"*"` never matches a `milestone/<slug>` branch. Milestone sub-issue PRs target
a shared `milestone/<name>` branch, so every one of them merged without the
Semgrep scan running — the gap only surfaced later on the single rollup PR into
the default branch.

Added an explicit `milestone/*` pattern so the scan runs on milestone sub-issue
PRs too. This mirrors the fixes already landed for `gitleaks.yml` (Issue #328)
and `markdown-lint.yml` (Issue #329). Closes #330.

```mermaid
flowchart LR
    A["sub-issue PR<br/>→ milestone/clean-up-23-jul"] -->|before: '*' does not cross '/'| B["Semgrep skipped ❌"]
    A -->|after: 'milestone/*' matches| C["Semgrep runs ✅"]
    C --> D["rollup PR → Develop"]
    D --> E["Semgrep runs ✅"]
```

## Evidence

Backend/CI-config change only — no web interface to screenshot.

`tests/scripts/semgrep_workflow.bats` expands the workflow's branch patterns
using GitHub's own globbing rules (`**` crosses `/`, `*` does not) and asserts
`milestone/clean-up-23-jul` matches while `Develop` and `main` still do.

Before the fix:

```text
not ok 2 semgrep.yml pull_request filter matches milestone branches
```

After the fix:

```text
1..3
ok 1 semgrep.yml exists and is valid YAML
ok 2 semgrep.yml pull_request filter matches milestone branches
ok 3 semgrep.yml runs the semgrep scan on pull requests
```

`./quality.sh` passes cleanly (bats, shellcheck, deno check, clippy, cargo
test, doc, release build), and `actionlint .github/workflows/semgrep.yml`
reports no findings.

## Test Plan

- Added `tests/scripts/semgrep_workflow.bats`:
  - `semgrep.yml exists and is valid YAML`
  - `semgrep.yml pull_request filter matches milestone branches` — the
    regression test for this issue; fails against the unfixed workflow.
  - `semgrep.yml runs the semgrep scan on pull requests` — guards against the
    filter being "fixed" on a workflow that no longer scans anything.
- Picked up automatically by `quality.sh` (`bats tests/scripts`) and the CI
  bats gate; no existing tests were modified or removed.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrxx690p-f4646d`<!-- vibe-worker-issue-330 -->