### PR TITLE
Add job-level timeout-minutes to every workflow job (Issue #333)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # lint-only: install actionlint + scan workflows
     steps:
       # actions/checkout@v6.0.2
       # Issue #317 — `persist-credentials: false` keeps the workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   version-increment:
     name: Auto-increment Versions
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # version bump + push
     if: github.event_name == 'pull_request'
     permissions:
       contents: write
@@ -163,6 +164,7 @@ jobs:
   version-gate:
     name: Breaking-change version gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # version comparison only
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     permissions:
@@ -208,6 +210,7 @@ jobs:
   auto-format:
     name: Auto-format Code
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # cargo fmt + push
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     permissions:
@@ -264,6 +267,7 @@ jobs:
   quality:
     name: Quality Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # cargo build + clippy + tests + docs
     if: github.event_name == 'pull_request'
     needs: [version-increment, auto-format]
     # Issue #309 — least-privilege GITHUB_TOKEN. This job only reads the repo
@@ -337,6 +341,7 @@ jobs:
   rust-gates:
     name: Lint & Compile Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # cargo fmt/clippy/check across the workspace
     # Issue #143 — explicit Rust lint + compile/syntax gates that run on every
     # push to Develop AND every pull request. Deliberately independent of the
     # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
@@ -390,6 +395,7 @@ jobs:
   typescript-gate:
     name: TypeScript validity gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # deno check over committed .ts helpers
 
     steps:
       - name: Checkout code
@@ -410,6 +416,7 @@ jobs:
   scripts-and-spelling:
     name: Scripts & spelling
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # shellcheck + bats + codespell
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     # Issue #311 — least-privilege GITHUB_TOKEN. This job only reads the repo
@@ -469,6 +476,7 @@ jobs:
   wasm64-memory64-smoke:
     name: wasm64 Memory64 smoke test
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # single deno smoke test
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
@@ -500,6 +508,7 @@ jobs:
   validation:
     name: Project Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # cargo metadata + manifest/doc checks
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     # Issue #313 — least-privilege GITHUB_TOKEN. This job only reads the repo

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # secret scan over full history
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # lint-only: markdownlint-cli2 over docs
     steps:
       # actions/checkout@v6.0.2 — Issue #97/#99: bumped off Node 20 (EOL 2026-09-16).
       # Issue #322 — `persist-credentials: false` keeps the workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Tag and release on version bump
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # tag + gh release create
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # cargo audit + dependency review
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # container pull + full SAST scan
     container:
       image: semgrep/semgrep
     steps:

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -22,6 +22,7 @@ jobs:
   upgrade:
     name: Upgrade dependencies and create PR
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # cargo upgrade + full build/test before PR
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     name: Build and publish wasm_activation bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # wasm-pack release build + bundle publish
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/docs/archive/pr-summaries/pr-summary-333.md
+++ b/docs/archive/pr-summaries/pr-summary-333.md
@@ -1,0 +1,91 @@
+# PR Summary — Issue #333
+
+## Summary
+
+None of the jobs across the repository's 9 workflow files declared a job-level
+`timeout-minutes:`, so every job inherited GitHub's default of **6 hours**. A
+wedged step — a hung `cargo` build, a stalled network fetch in `bump-deps.sh`,
+a `deno test` waiting on stdin — held a runner for the full six hours, burning
+the Actions minutes quota and blocking queued runs.
+
+Every runner job now declares an explicit budget, sized generously above its
+normal wall clock and annotated with what it covers. `Closes #333`.
+
+| Workflow | Job | `timeout-minutes` |
+| --- | --- | --- |
+| `ci.yml` | `version-increment` | 15 |
+| `ci.yml` | `version-gate` | 10 |
+| `ci.yml` | `auto-format` | 20 |
+| `ci.yml` | `quality` | 45 |
+| `ci.yml` | `rust-gates` | 45 |
+| `ci.yml` | `typescript-gate` | 10 |
+| `ci.yml` | `scripts-and-spelling` | 15 |
+| `ci.yml` | `wasm64-memory64-smoke` | 10 |
+| `ci.yml` | `validation` | 15 |
+| `security.yml` | `security` | 30 |
+| `actionlint.yml` | `actionlint` | 10 |
+| `gitleaks.yml` | `gitleaks` | 15 |
+| `markdown-lint.yml` | `markdownlint` | 10 |
+| `release.yml` | `release` | 15 |
+| `semgrep.yml` | `semgrep` | 20 |
+| `upgrade-dependencies.yml` | `upgrade` | 45 |
+| `wasm-bundle.yml` | `publish` | 45 |
+
+### Reusable-workflow caller carve-out
+
+`ci.yml`'s `security` job is a reusable-workflow **caller**
+(`uses: ./.github/workflows/security.yml`). GitHub rejects `timeout-minutes` on
+a calling job, so the budget lives on the called workflow's own `security` job
+instead — which bounds the caller just the same.
+
+```mermaid
+flowchart LR
+    A["ci.yml job: security"] -->|"uses: ./.github/workflows/security.yml"| B["security.yml job: security"]
+    A -.->|"timeout-minutes rejected by GitHub"| X["✗"]
+    B --> C["timeout-minutes: 30 — bounds both"]
+```
+
+## Evidence
+
+Backend/CI-configuration change only — there is no web interface to
+screenshot. Verified by the test suite and by `actionlint`:
+
+- `bats tests/scripts` — **231 tests, 0 failures** (4 of them new, see below).
+- `actionlint -no-color -ignore 'SC2016' .github/workflows/*.yml` — exit 0,
+  confirming no `timeout-minutes` landed anywhere GitHub would reject it.
+- `./quality.sh < /dev/null` — passed cleanly end to end (shellcheck, bats,
+  `deno check`, codespell, `cargo deny`, fmt, clippy, check, tests, docs,
+  release build).
+
+The new tests fail against the pre-fix tree and pass after the change:
+
+```text
+# before
+not ok 1 every runner job in every workflow declares a job-level timeout-minutes
+not ok 3 compile-heavy jobs budget at least 30 minutes
+
+# after
+ok 1 every runner job in every workflow declares a job-level timeout-minutes
+ok 2 every declared timeout-minutes is a positive integer no greater than 60
+ok 3 compile-heavy jobs budget at least 30 minutes
+ok 4 reusable-workflow callers carry no timeout-minutes and the callee does
+```
+
+## Test Plan
+
+Added `tests/scripts/workflow_job_timeouts.bats` — "what" tests that parse the
+workflow YAML and assert on the effective configuration, not on source text:
+
+1. `every runner job in every workflow declares a job-level timeout-minutes` —
+   regression test for the reported defect; covers all workflows, so a new
+   workflow added later without a budget fails CI.
+2. `every declared timeout-minutes is a positive integer no greater than 60` —
+   edge case: rejects `0`, negatives, booleans, strings, and runaway budgets.
+3. `compile-heavy jobs budget at least 30 minutes` — guards the other
+   direction, so a later edit cannot starve `quality`, `rust-gates`,
+   `security`, `upgrade`, or `publish` mid-build.
+4. `reusable-workflow callers carry no timeout-minutes and the callee does` —
+   error path: pins the GitHub restriction that would otherwise produce an
+   invalid workflow, and asserts the callee still carries a budget.
+
+No existing tests were modified or removed.

--- a/tests/scripts/workflow_job_timeouts.bats
+++ b/tests/scripts/workflow_job_timeouts.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# Tests for job-level `timeout-minutes` across every workflow (Issue #333).
+#
+# Rationale: a job with no `timeout-minutes` inherits GitHub's default of
+# 6 hours. A wedged step (a hung `cargo` build, a stalled network fetch in
+# `bump-deps.sh`, a `deno test` waiting on stdin) then holds a runner for six
+# hours, burning the Actions minutes quota and blocking queued runs. An
+# explicit per-job budget kills the wedge in minutes instead.
+#
+# These are "what" tests: they parse the YAML and assert on the observable
+# effective configuration (the timeout each job declares), not on source text.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "every runner job in every workflow declares a job-level timeout-minutes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+missing = []
+files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
+assert files, f"no workflow files found in {workflows_dir}"
+
+for path in files:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict):
+            continue
+        # Reusable-workflow callers cannot set timeout-minutes (GitHub rejects
+        # the key); the called workflow's own job carries the budget.
+        if "uses" in job:
+            continue
+        if "timeout-minutes" not in job:
+            missing.append(f"{os.path.basename(path)} job={job_name}")
+
+if missing:
+    sys.stderr.write("Jobs without timeout-minutes:\n  " + "\n  ".join(missing) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "every declared timeout-minutes is a positive integer no greater than 60" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+bad = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict) or "timeout-minutes" not in job:
+            continue
+        value = job["timeout-minutes"]
+        if not isinstance(value, int) or isinstance(value, bool) or not 1 <= value <= 60:
+            bad.append(f"{os.path.basename(path)} job={job_name} timeout-minutes={value!r}")
+
+if bad:
+    sys.stderr.write("Out-of-range timeout-minutes:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# The compile-heavy jobs need a bigger budget than the lint jobs: a cold
+# `cargo build --release` plus clippy, tests and docs can legitimately run for
+# half an hour. Guard both directions so a future edit cannot starve them.
+@test "compile-heavy jobs budget at least 30 minutes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+HEAVY = {
+    "ci.yml": ["quality", "rust-gates"],
+    "security.yml": ["security"],
+    "upgrade-dependencies.yml": ["upgrade"],
+    "wasm-bundle.yml": ["publish"],
+}
+
+bad = []
+for filename, job_names in HEAVY.items():
+    path = os.path.join(workflows_dir, filename)
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    jobs = data.get("jobs", {}) or {}
+    for job_name in job_names:
+        assert job_name in jobs, f"{filename}: expected job {job_name}"
+        value = jobs[job_name].get("timeout-minutes")
+        if not isinstance(value, int) or value < 30:
+            bad.append(f"{filename} job={job_name} timeout-minutes={value!r}")
+
+if bad:
+    sys.stderr.write("Compile-heavy jobs under-budgeted:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# GitHub rejects `timeout-minutes` on a job that calls a reusable workflow.
+# The budget must live on the called workflow's own job instead, so assert the
+# caller stays clean and the callee carries a timeout.
+@test "reusable-workflow callers carry no timeout-minutes and the callee does" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+callers = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if isinstance(job, dict) and "uses" in job:
+            callers.append((os.path.basename(path), job_name, job))
+
+assert callers, "expected at least one reusable-workflow caller (ci.yml security)"
+offenders = [
+    f"{f} job={j}" for f, j, job in callers if "timeout-minutes" in job
+]
+if offenders:
+    sys.stderr.write("Callers must not set timeout-minutes:\n  " + "\n  ".join(offenders) + "\n")
+    sys.exit(1)
+
+# The called workflow must budget its own job, or the caller is unbounded.
+with open(os.path.join(workflows_dir, "security.yml")) as fh:
+    called = yaml.safe_load(fh)
+assert isinstance(called["jobs"]["security"].get("timeout-minutes"), int)
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #333

## Summary

None of the jobs across the repository's 9 workflow files declared a job-level
`timeout-minutes:`, so every job inherited GitHub's default of **6 hours**. A
wedged step — a hung `cargo` build, a stalled network fetch in `bump-deps.sh`,
a `deno test` waiting on stdin — held a runner for the full six hours, burning
the Actions minutes quota and blocking queued runs.

Every runner job now declares an explicit budget, sized generously above its
normal wall clock and annotated with what it covers. `Closes #333`.

| Workflow | Job | `timeout-minutes` |
| --- | --- | --- |
| `ci.yml` | `version-increment` | 15 |
| `ci.yml` | `version-gate` | 10 |
| `ci.yml` | `auto-format` | 20 |
| `ci.yml` | `quality` | 45 |
| `ci.yml` | `rust-gates` | 45 |
| `ci.yml` | `typescript-gate` | 10 |
| `ci.yml` | `scripts-and-spelling` | 15 |
| `ci.yml` | `wasm64-memory64-smoke` | 10 |
| `ci.yml` | `validation` | 15 |
| `security.yml` | `security` | 30 |
| `actionlint.yml` | `actionlint` | 10 |
| `gitleaks.yml` | `gitleaks` | 15 |
| `markdown-lint.yml` | `markdownlint` | 10 |
| `release.yml` | `release` | 15 |
| `semgrep.yml` | `semgrep` | 20 |
| `upgrade-dependencies.yml` | `upgrade` | 45 |
| `wasm-bundle.yml` | `publish` | 45 |

### Reusable-workflow caller carve-out

`ci.yml`'s `security` job is a reusable-workflow **caller**
(`uses: ./.github/workflows/security.yml`). GitHub rejects `timeout-minutes` on
a calling job, so the budget lives on the called workflow's own `security` job
instead — which bounds the caller just the same.

```mermaid
flowchart LR
    A["ci.yml job: security"] -->|"uses: ./.github/workflows/security.yml"| B["security.yml job: security"]
    A -.->|"timeout-minutes rejected by GitHub"| X["✗"]
    B --> C["timeout-minutes: 30 — bounds both"]
```

## Evidence

Backend/CI-configuration change only — there is no web interface to
screenshot. Verified by the test suite and by `actionlint`:

- `bats tests/scripts` — **231 tests, 0 failures** (4 of them new, see below).
- `actionlint -no-color -ignore 'SC2016' .github/workflows/*.yml` — exit 0,
  confirming no `timeout-minutes` landed anywhere GitHub would reject it.
- `./quality.sh < /dev/null` — passed cleanly end to end (shellcheck, bats,
  `deno check`, codespell, `cargo deny`, fmt, clippy, check, tests, docs,
  release build).

The new tests fail against the pre-fix tree and pass after the change:

```text
# before
not ok 1 every runner job in every workflow declares a job-level timeout-minutes
not ok 3 compile-heavy jobs budget at least 30 minutes

# after
ok 1 every runner job in every workflow declares a job-level timeout-minutes
ok 2 every declared timeout-minutes is a positive integer no greater than 60
ok 3 compile-heavy jobs budget at least 30 minutes
ok 4 reusable-workflow callers carry no timeout-minutes and the callee does
```

## Test Plan

Added `tests/scripts/workflow_job_timeouts.bats` — "what" tests that parse the
workflow YAML and assert on the effective configuration, not on source text:

1. `every runner job in every workflow declares a job-level timeout-minutes` —
   regression test for the reported defect; covers all workflows, so a new
   workflow added later without a budget fails CI.
2. `every declared timeout-minutes is a positive integer no greater than 60` —
   edge case: rejects `0`, negatives, booleans, strings, and runaway budgets.
3. `compile-heavy jobs budget at least 30 minutes` — guards the other
   direction, so a later edit cannot starve `quality`, `rust-gates`,
   `security`, `upgrade`, or `publish` mid-build.
4. `reusable-workflow callers carry no timeout-minutes and the callee does` —
   error path: pins the GitHub restriction that would otherwise produce an
   invalid workflow, and asserts the callee still carries a budget.

No existing tests were modified or removed.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxx1seu-b97714`<!-- vibe-worker-issue-333 -->