### PR TITLE
Add least-privilege permissions to wasm64-memory64-smoke job (Issue #331)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,12 @@ jobs:
     name: wasm64 Memory64 smoke test
     runs-on: ubuntu-latest
     timeout-minutes: 10 # single deno smoke test
+    # Issue #331 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, install Deno, run one committed smoke test); it never writes,
+    # so it must not inherit the repository's broad default write scopes.
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2

--- a/docs/archive/pr-summaries/pr-summary-331.md
+++ b/docs/archive/pr-summaries/pr-summary-331.md
@@ -1,0 +1,58 @@
+# Least-privilege `permissions:` for the `wasm64-memory64-smoke` CI job
+
+## Summary
+
+The `wasm64-memory64-smoke` job in `.github/workflows/ci.yml` declared no
+`permissions:` block at either job or workflow level, so it inherited the
+repository's broad default `GITHUB_TOKEN` scopes (typically `contents: write`
+and more). The job only checks out the repo, installs Deno, and runs one
+committed smoke test — it never writes — so it now declares the least-privilege
+set it actually needs: `contents: read`. Closes #331.
+
+This follows the same pattern already applied to `quality`, `rust-gates`,
+`scripts-and-spelling`, `security`, and `validation` (Issues #311–#313).
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by the new
+bats contract test, which parses `ci.yml` as YAML and asserts on the resolved
+permissions of the job (job-level block, falling back to workflow-level).
+
+Test run before the fix (red):
+
+```text
+1..3
+ok 1 ci workflow file exists
+not ok 2 wasm64-memory64-smoke job declares an explicit permissions block
+not ok 3 wasm64-memory64-smoke job grants read-only contents and no write scopes
+```
+
+Test run after the fix (green):
+
+```text
+1..3
+ok 1 ci workflow file exists
+ok 2 wasm64-memory64-smoke job declares an explicit permissions block
+ok 3 wasm64-memory64-smoke job grants read-only contents and no write scopes
+```
+
+`./quality.sh` passes cleanly (`✅ All quality checks passed!`).
+
+```mermaid
+flowchart LR
+    A["wasm64-memory64-smoke job"] --> B{"permissions: block?"}
+    B -- "before: none" --> C["inherits repo default scopes<br/>(often contents: write)"]
+    B -- "after: contents: read" --> D["least-privilege token<br/>no write scopes"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/ci_wasm64_memory64_smoke_permissions.bats`:
+  - `ci workflow file exists`
+  - `wasm64-memory64-smoke job declares an explicit permissions block` — fails
+    against the unfixed workflow, passes after the fix (regression test).
+  - `wasm64-memory64-smoke job grants read-only contents and no write scopes` —
+    asserts `contents: read` and that no scope is granted `write`.
+- No existing tests were modified or removed; full `./quality.sh` gate
+  (rustfmt, clippy, cargo-deny, bats, workspace tests, docs, release build)
+  passes.

--- a/tests/scripts/ci_wasm64_memory64_smoke_permissions.bats
+++ b/tests/scripts/ci_wasm64_memory64_smoke_permissions.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for the CI `wasm64-memory64-smoke` job least-privilege token scopes
+# (Issue #331).
+#
+# Contract under test: the `wasm64-memory64-smoke` job in
+# .github/workflows/ci.yml only reads the repository (checkout, install Deno,
+# run one committed smoke test). With no `permissions:` block it inherits the
+# repository's broad default GITHUB_TOKEN scopes, so it must declare the
+# least-privilege set it actually needs: `contents: read` and no write scopes.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "wasm64-memory64-smoke job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["wasm64-memory64-smoke"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "wasm64-memory64-smoke has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "wasm64-memory64-smoke job grants read-only contents and no write scopes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["wasm64-memory64-smoke"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == [], f"wasm64-memory64-smoke is read-only; unexpected write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Least-privilege `permissions:` for the `wasm64-memory64-smoke` CI job

## Summary

The `wasm64-memory64-smoke` job in `.github/workflows/ci.yml` declared no
`permissions:` block at either job or workflow level, so it inherited the
repository's broad default `GITHUB_TOKEN` scopes (typically `contents: write`
and more). The job only checks out the repo, installs Deno, and runs one
committed smoke test — it never writes — so it now declares the least-privilege
set it actually needs: `contents: read`. Closes #331.

This follows the same pattern already applied to `quality`, `rust-gates`,
`scripts-and-spelling`, `security`, and `validation` (Issues #311–#313).

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified by the new
bats contract test, which parses `ci.yml` as YAML and asserts on the resolved
permissions of the job (job-level block, falling back to workflow-level).

Test run before the fix (red):

```text
1..3
ok 1 ci workflow file exists
not ok 2 wasm64-memory64-smoke job declares an explicit permissions block
not ok 3 wasm64-memory64-smoke job grants read-only contents and no write scopes
```

Test run after the fix (green):

```text
1..3
ok 1 ci workflow file exists
ok 2 wasm64-memory64-smoke job declares an explicit permissions block
ok 3 wasm64-memory64-smoke job grants read-only contents and no write scopes
```

`./quality.sh` passes cleanly (`✅ All quality checks passed!`).

```mermaid
flowchart LR
    A["wasm64-memory64-smoke job"] --> B{"permissions: block?"}
    B -- "before: none" --> C["inherits repo default scopes<br/>(often contents: write)"]
    B -- "after: contents: read" --> D["least-privilege token<br/>no write scopes"]
```

## Test Plan

- Added `tests/scripts/ci_wasm64_memory64_smoke_permissions.bats`:
  - `ci workflow file exists`
  - `wasm64-memory64-smoke job declares an explicit permissions block` — fails
    against the unfixed workflow, passes after the fix (regression test).
  - `wasm64-memory64-smoke job grants read-only contents and no write scopes` —
    asserts `contents: read` and that no scope is granted `write`.
- No existing tests were modified or removed; full `./quality.sh` gate
  (rustfmt, clippy, cargo-deny, bats, workspace tests, docs, release build)
  passes.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxzgha3-728fe0`<!-- vibe-worker-issue-331 -->