### PR TITLE
Stop wasm64-memory64-smoke checkout persisting credentials (Issue #332)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,14 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #332 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job only reads the repo
+        # (install Deno, run one committed smoke test); it never pushes back
+        # and fetches no private submodule, so leaving the credential on disk
+        # would only widen the blast radius of a compromised step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Install Deno
         # denoland/setup-deno@v2.0.5

--- a/docs/archive/pr-summaries/pr-summary-332.md
+++ b/docs/archive/pr-summaries/pr-summary-332.md
@@ -1,0 +1,55 @@
+# PR Summary — Issue #332
+
+## Summary
+
+The `wasm64-memory64-smoke` job in `.github/workflows/ci.yml` checked out the
+repository without `persist-credentials: false`, so `actions/checkout` wrote the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header. Every later step
+in that job — including a compromised action or injected script — could read the
+credential and act as the token. The job is read-only (checkout, install Deno,
+run one committed Memory64 smoke test): it never pushes back and fetches no
+private submodule, so the persisted credential was pure blast radius.
+
+`persist-credentials: false` is now set on that checkout step, keeping the token
+off disk. Closes #332.
+
+## Evidence
+
+This is a CI-workflow security-hardening change with no web interface, so no
+screenshot applies. Verification is by test: a new BATS suite parses `ci.yml` as
+YAML and asserts the observable CI contract — every `actions/checkout` step in
+the `wasm64-memory64-smoke` job sets `persist-credentials: false`. The test
+failed against the unfixed workflow and passes after the change.
+
+```text
+$ bats tests/scripts/ci_wasm64_memory64_smoke_checkout.bats   # before the fix
+ok 1 ci workflow defines a wasm64-memory64-smoke job
+not ok 2 ci wasm64-memory64-smoke checkout does not persist credentials on disk
+
+$ bats tests/scripts/ci_wasm64_memory64_smoke_checkout.bats   # after the fix
+ok 1 ci workflow defines a wasm64-memory64-smoke job
+ok 2 ci wasm64-memory64-smoke checkout does not persist credentials on disk
+```
+
+```mermaid
+flowchart LR
+    A["actions/checkout"] -->|"default"| B[".git/config holds GITHUB_TOKEN"]
+    B --> C["any later step can read it"]
+    A -->|"persist-credentials: false"| D["no credential on disk"]
+    D --> E["smoke test runs read-only"]
+```
+
+`./quality.sh` passes cleanly (fmt, clippy, deny, shellcheck, BATS, workspace
+tests, docs, release build).
+
+## Test Plan
+
+- Added `tests/scripts/ci_wasm64_memory64_smoke_checkout.bats`:
+  - `ci workflow defines a wasm64-memory64-smoke job` — the job still exists
+    under the expected key.
+  - `ci wasm64-memory64-smoke checkout does not persist credentials on disk` —
+    regression test that fails on the unfixed workflow; every checkout step in
+    the job must set `persist-credentials: false`.
+- Existing `tests/scripts/ci_wasm64_memory64_smoke_permissions.bats` (Issue
+  #331) continues to pass, confirming the least-privilege `permissions:` block
+  is untouched.

--- a/tests/scripts/ci_wasm64_memory64_smoke_checkout.bats
+++ b/tests/scripts/ci_wasm64_memory64_smoke_checkout.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Tests for the CI `wasm64-memory64-smoke` job checkout hardening (Issue #332).
+#
+# The contract under test IS the CI wiring: actions/checkout writes the
+# workflow GITHUB_TOKEN into .git/config by default, leaving a usable
+# credential on disk for every later step in the job. The
+# `wasm64-memory64-smoke` job only checks out the repo, installs Deno and runs
+# one committed read-only smoke test — it never pushes back and fetches no
+# private submodule — so the persisted credential is pure blast radius.
+#
+# Asserts on observable outcomes:
+#   - ci.yml parses as YAML and defines a `wasm64-memory64-smoke` job,
+#   - every actions/checkout step in that job sets persist-credentials: false.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow defines a wasm64-memory64-smoke job" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+assert "wasm64-memory64-smoke" in data["jobs"], sorted(data["jobs"])
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci wasm64-memory64-smoke checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["wasm64-memory64-smoke"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in wasm64-memory64-smoke"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #332

## Summary

The `wasm64-memory64-smoke` job in `.github/workflows/ci.yml` checked out the
repository without `persist-credentials: false`, so `actions/checkout` wrote the
workflow `GITHUB_TOKEN` into `.git/config` as an auth header. Every later step
in that job — including a compromised action or injected script — could read the
credential and act as the token. The job is read-only (checkout, install Deno,
run one committed Memory64 smoke test): it never pushes back and fetches no
private submodule, so the persisted credential was pure blast radius.

`persist-credentials: false` is now set on that checkout step, keeping the token
off disk. Closes #332.

## Evidence

This is a CI-workflow security-hardening change with no web interface, so no
screenshot applies. Verification is by test: a new BATS suite parses `ci.yml` as
YAML and asserts the observable CI contract — every `actions/checkout` step in
the `wasm64-memory64-smoke` job sets `persist-credentials: false`. The test
failed against the unfixed workflow and passes after the change.

```text
$ bats tests/scripts/ci_wasm64_memory64_smoke_checkout.bats   # before the fix
ok 1 ci workflow defines a wasm64-memory64-smoke job
not ok 2 ci wasm64-memory64-smoke checkout does not persist credentials on disk

$ bats tests/scripts/ci_wasm64_memory64_smoke_checkout.bats   # after the fix
ok 1 ci workflow defines a wasm64-memory64-smoke job
ok 2 ci wasm64-memory64-smoke checkout does not persist credentials on disk
```

```mermaid
flowchart LR
    A["actions/checkout"] -->|"default"| B[".git/config holds GITHUB_TOKEN"]
    B --> C["any later step can read it"]
    A -->|"persist-credentials: false"| D["no credential on disk"]
    D --> E["smoke test runs read-only"]
```

`./quality.sh` passes cleanly (fmt, clippy, deny, shellcheck, BATS, workspace
tests, docs, release build).

## Test Plan

- Added `tests/scripts/ci_wasm64_memory64_smoke_checkout.bats`:
  - `ci workflow defines a wasm64-memory64-smoke job` — the job still exists
    under the expected key.
  - `ci wasm64-memory64-smoke checkout does not persist credentials on disk` —
    regression test that fails on the unfixed workflow; every checkout step in
    the job must set `persist-credentials: false`.
- Existing `tests/scripts/ci_wasm64_memory64_smoke_permissions.bats` (Issue
  #331) continues to pass, confirming the least-privilege `permissions:` block
  is untouched.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxzgha3-728fe0`<!-- vibe-worker-issue-332 -->