### PR TITLE
Add concurrency groups to pile-up-prone workflows (Issue #334)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,6 +24,12 @@ on:
     branches: ["*", "milestone/*"]
   workflow_dispatch:
 
+# Issue #334 — one live lint run per branch. A superseded run only reports on a
+# commit that has already been replaced, so cancelling it costs no signal.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ on:
       - milestone/*
   workflow_dispatch:
 
+# Issue #334 — the heaviest gate in the repo: one run compiles the workspace
+# several times over (quality + rust-gates). Every `synchronize` push to an open
+# PR — including the bot pushes from `version-increment`/`auto-format` — queued
+# a fresh run on top of one still compiling, so a few rapid pushes stacked runs
+# several deep. Keying the group on the workflow *and* the ref keeps one live
+# run per branch and cancels the superseded ones, whose results nobody reads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,6 +17,12 @@ on:
     # sub-issue PRs too, not just the single rollup PR into the default branch.
     branches: ["*", "milestone/*"]
 
+# Issue #334 — one live secret scan per branch. The scan covers full history, so
+# a superseded run duplicates work already redone by its replacement.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,6 +13,12 @@ on:
     branches: ["*", "milestone/*"]
   workflow_dispatch:
 
+# Issue #334 — one live lint run per branch; superseded runs lint a commit that
+# no longer exists on the PR head.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,6 +8,12 @@ on:
     # PRs too, not just the single rollup PR into the default branch.
     branches: ["*", "milestone/*"]
 
+# Issue #334 — one live SAST scan per branch. Each run pulls the semgrep
+# container before scanning, so stacked runs are expensive as well as redundant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/archive/pr-summaries/pr-summary-334.md
+++ b/docs/archive/pr-summaries/pr-summary-334.md
@@ -1,0 +1,105 @@
+# PR Summary — Issue #334
+
+## Summary
+
+Added a top-level `concurrency:` group with `cancel-in-progress: true` to the
+five pile-up-prone PR/push gates — `ci.yml`, `actionlint.yml`, `gitleaks.yml`,
+`markdown-lint.yml` and `semgrep.yml`. Every `synchronize` push to an open PR
+previously queued a fresh run while the previous one was still compiling; on
+`ci.yml`, where a single run compiles the workspace several times over, a few
+rapid pushes (including the bot pushes from `version-increment`/`auto-format`)
+stacked runs several deep, burning runner minutes on results nobody reads.
+Each group is keyed on `github.workflow` **and** `github.ref`, so one live run
+is kept per workflow per branch and no workflow can cancel another's run.
+
+`release.yml` and `wasm-bundle.yml` are deliberately left uncancelled: both
+publish a per-version tag or per-commit bundle that downstream consumers pin by
+SHA, and cancelling a superseded run would silently skip an artefact. The
+reusable `security.yml` declares no group of its own — it runs inside the
+caller's context, so its own group would let one caller cancel another caller's
+in-flight scan.
+
+Closes #334.
+
+## Evidence
+
+Workflow/CI change with no web interface to screenshot. Verified by parsing the
+committed workflow YAML in a new bats suite (below) and by `actionlint`, which
+reports no new findings for the five edited files.
+
+Before — every push starts a new run and the old one keeps compiling:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Push to PR branch
+    participant GA as GitHub Actions
+    Dev->>GA: push A
+    GA->>GA: run 1 (full cargo build) …
+    Dev->>GA: push B (synchronize)
+    GA->>GA: run 2 starts — run 1 still compiling
+    Dev->>GA: push C (bot: version-increment)
+    GA->>GA: run 3 starts — runs 1 and 2 still compiling
+    Note over GA: 3 concurrent runs, only run 3's result is read
+```
+
+After — the group keeps one live run per workflow per ref:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Push to PR branch
+    participant GA as GitHub Actions
+    Dev->>GA: push A
+    GA->>GA: run 1 in group CI-refs/pull/N/merge
+    Dev->>GA: push B (synchronize)
+    GA-->>GA: cancel run 1 (superseded)
+    GA->>GA: run 2 in same group
+    Dev->>GA: push C (bot: version-increment)
+    GA-->>GA: cancel run 2 (superseded)
+    GA->>GA: run 3 in same group
+    Note over GA: 1 concurrent run; publishers keep every run
+```
+
+Local run of the new suite:
+
+```text
+$ bats tests/scripts/workflow_concurrency_groups.bats < /dev/null
+1..4
+ok 1 pile-up-prone workflows cancel superseded runs per ref
+ok 2 each gated workflow's concurrency group is distinct for the same ref
+ok 3 publishing workflows never cancel in-progress runs
+ok 4 the reusable security workflow declares no concurrency group
+```
+
+Full gate: `bats tests/scripts` → 240 passing, 0 failing; `./quality.sh` exits 0
+(fmt, clippy `-D warnings`, cargo-deny, `cargo test --workspace`, docs, release
+build).
+
+## Test Plan
+
+Added `tests/scripts/workflow_concurrency_groups.bats` — "what" tests that parse
+the workflow YAML and assert on the effective configuration, not on source text:
+
+- **`pile-up-prone workflows cancel superseded runs per ref`** — each of the
+  five gates declares a `concurrency` mapping whose group references both
+  `github.workflow` and `github.ref`, with `cancel-in-progress: true`. This is
+  the regression test: it fails against the pre-fix workflows (verified — it
+  reported "no top-level concurrency mapping" for all five) and passes after.
+- **`each gated workflow's concurrency group is distinct for the same ref`** —
+  resolves `github.workflow` to each workflow's declared `name` and asserts no
+  two workflows land in the same group, so gitleaks can never cancel CI.
+- **`publishing workflows never cancel in-progress runs`** — `release.yml` and
+  `wasm-bundle.yml` must not set `cancel-in-progress: true` at workflow or job
+  level (edge case: no group at all is also acceptable).
+- **`the reusable security workflow declares no concurrency group`** —
+  `security.yml` stays a `workflow_call` workflow with no group of its own.
+
+No existing tests were modified or removed.
+
+## Security Self-Check
+
+- No secrets, credentials or `.config*.json` files staged; the only hidden paths
+  touched are `.github/workflows/*.yml`, which the allowlist permits.
+- No new dependencies, network calls, shell interpolation or user input surface —
+  the change is five declarative YAML keys plus a test file.
+- `cancel-in-progress` is scoped away from the publishing workflows, so no
+  signed/attested artefact can be skipped by a cancellation.

--- a/tests/scripts/workflow_concurrency_groups.bats
+++ b/tests/scripts/workflow_concurrency_groups.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# Tests for top-level `concurrency:` groups on pile-up-prone workflows (Issue #334).
+#
+# Rationale: every `synchronize` push to an open PR queues a fresh run while the
+# previous one is still compiling. Without a concurrency group the superseded
+# runs keep burning runner minutes producing results nobody reads — and on
+# `ci.yml`, where a single run compiles the workspace several times over, a few
+# rapid pushes (including the bot pushes from `version-increment`/`auto-format`)
+# stack runs several deep.
+#
+# Publishing workflows are deliberately excluded from `cancel-in-progress: true`:
+# `release.yml` cuts a `v<version>` tag and `wasm-bundle.yml` publishes a
+# per-commit bundle, so cancelling a superseded run would silently skip an
+# artefact downstream consumers pin by SHA.
+#
+# These are "what" tests: they parse the YAML and assert on the observable
+# effective configuration each workflow declares, not on source text. The
+# heredocs are quoted (`<<'PY'`) and the directory arrives through the
+# environment, so GitHub `${{ … }}` expressions survive into Python untouched.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "pile-up-prone workflows cancel superseded runs per ref" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import os, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+GATES = [
+    "ci.yml",
+    "actionlint.yml",
+    "gitleaks.yml",
+    "markdown-lint.yml",
+    "semgrep.yml",
+]
+
+bad = []
+for filename in GATES:
+    path = os.path.join(workflows_dir, filename)
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    concurrency = data.get("concurrency")
+    if not isinstance(concurrency, dict):
+        bad.append(f"{filename}: no top-level concurrency mapping")
+        continue
+    group = concurrency.get("group", "")
+    if "github.workflow" not in group:
+        bad.append(f"{filename}: group must include github.workflow, got {group!r}")
+    if "github.ref" not in group:
+        bad.append(f"{filename}: group must include github.ref, got {group!r}")
+    if concurrency.get("cancel-in-progress") is not True:
+        bad.append(
+            f"{filename}: cancel-in-progress must be true, got "
+            f"{concurrency.get('cancel-in-progress')!r}"
+        )
+
+if bad:
+    sys.stderr.write("Concurrency gate failures:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Two distinct workflows must never share a queue: a group keyed only on the ref
+# would let a gitleaks run cancel the CI run for the same branch.
+@test "each gated workflow's concurrency group is distinct for the same ref" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import glob, os, re, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+groups = {}
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    concurrency = data.get("concurrency")
+    if not isinstance(concurrency, dict):
+        continue
+    # `github.workflow` resolves to the workflow's own name, so substituting the
+    # declared name models the group each workflow actually joins at run time.
+    resolved = re.sub(
+        r"\$\{\{\s*github\.workflow\s*\}\}", data["name"], concurrency["group"]
+    )
+    groups.setdefault(resolved, []).append(os.path.basename(path))
+
+collisions = {g: f for g, f in groups.items() if len(f) > 1}
+if collisions:
+    sys.stderr.write(f"Colliding concurrency groups: {collisions}\n")
+    sys.exit(1)
+assert groups, "expected at least one workflow to declare a concurrency group"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Publishing workflows produce artefacts downstream consumers pin by SHA or
+# version; a cancelled run silently skips one.
+@test "publishing workflows never cancel in-progress runs" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import os, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+PUBLISHERS = ["release.yml", "wasm-bundle.yml"]
+
+bad = []
+for filename in PUBLISHERS:
+    path = os.path.join(workflows_dir, filename)
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    concurrency = data.get("concurrency")
+    if concurrency is not None:
+        if not isinstance(concurrency, dict):
+            bad.append(f"{filename}: concurrency must be a mapping, got {concurrency!r}")
+        elif concurrency.get("cancel-in-progress") is True:
+            bad.append(f"{filename}: cancel-in-progress must not be true")
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        job_concurrency = job.get("concurrency") if isinstance(job, dict) else None
+        if isinstance(job_concurrency, dict) and job_concurrency.get("cancel-in-progress") is True:
+            bad.append(f"{filename} job={job_name}: cancel-in-progress must not be true")
+
+if bad:
+    sys.stderr.write("Publishing workflow failures:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# A reusable workflow runs inside the caller's context; giving it its own group
+# would let one caller cancel another caller's in-flight security scan.
+@test "the reusable security workflow declares no concurrency group" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import os, sys, yaml
+
+with open(os.path.join(os.environ["WORKFLOWS_DIR"], "security.yml")) as fh:
+    data = yaml.safe_load(fh)
+
+# PyYAML resolves the bare `on:` key to the boolean True.
+triggers = data.get("on", data.get(True))
+assert "workflow_call" in triggers, "security.yml must stay reusable"
+if "concurrency" in data:
+    sys.stderr.write("security.yml must not declare its own concurrency group\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #334

## Summary

Added a top-level `concurrency:` group with `cancel-in-progress: true` to the
five pile-up-prone PR/push gates — `ci.yml`, `actionlint.yml`, `gitleaks.yml`,
`markdown-lint.yml` and `semgrep.yml`. Every `synchronize` push to an open PR
previously queued a fresh run while the previous one was still compiling; on
`ci.yml`, where a single run compiles the workspace several times over, a few
rapid pushes (including the bot pushes from `version-increment`/`auto-format`)
stacked runs several deep, burning runner minutes on results nobody reads.
Each group is keyed on `github.workflow` **and** `github.ref`, so one live run
is kept per workflow per branch and no workflow can cancel another's run.

`release.yml` and `wasm-bundle.yml` are deliberately left uncancelled: both
publish a per-version tag or per-commit bundle that downstream consumers pin by
SHA, and cancelling a superseded run would silently skip an artefact. The
reusable `security.yml` declares no group of its own — it runs inside the
caller's context, so its own group would let one caller cancel another caller's
in-flight scan.

Closes #334.

## Evidence

Workflow/CI change with no web interface to screenshot. Verified by parsing the
committed workflow YAML in a new bats suite (below) and by `actionlint`, which
reports no new findings for the five edited files.

Before — every push starts a new run and the old one keeps compiling:

```mermaid
sequenceDiagram
    participant Dev as Push to PR branch
    participant GA as GitHub Actions
    Dev->>GA: push A
    GA->>GA: run 1 (full cargo build) …
    Dev->>GA: push B (synchronize)
    GA->>GA: run 2 starts — run 1 still compiling
    Dev->>GA: push C (bot: version-increment)
    GA->>GA: run 3 starts — runs 1 and 2 still compiling
    Note over GA: 3 concurrent runs, only run 3's result is read
```

After — the group keeps one live run per workflow per ref:

```mermaid
sequenceDiagram
    participant Dev as Push to PR branch
    participant GA as GitHub Actions
    Dev->>GA: push A
    GA->>GA: run 1 in group CI-refs/pull/N/merge
    Dev->>GA: push B (synchronize)
    GA-->>GA: cancel run 1 (superseded)
    GA->>GA: run 2 in same group
    Dev->>GA: push C (bot: version-increment)
    GA-->>GA: cancel run 2 (superseded)
    GA->>GA: run 3 in same group
    Note over GA: 1 concurrent run, publishers keep every run
```

Local run of the new suite:

```text
$ bats tests/scripts/workflow_concurrency_groups.bats < /dev/null
1..4
ok 1 pile-up-prone workflows cancel superseded runs per ref
ok 2 each gated workflow's concurrency group is distinct for the same ref
ok 3 publishing workflows never cancel in-progress runs
ok 4 the reusable security workflow declares no concurrency group
```

Full gate: `bats tests/scripts` → 240 passing, 0 failing; `./quality.sh` exits 0
(fmt, clippy `-D warnings`, cargo-deny, `cargo test --workspace`, docs, release
build).

## Test Plan

Added `tests/scripts/workflow_concurrency_groups.bats` — "what" tests that parse
the workflow YAML and assert on the effective configuration, not on source text:

- **`pile-up-prone workflows cancel superseded runs per ref`** — each of the
  five gates declares a `concurrency` mapping whose group references both
  `github.workflow` and `github.ref`, with `cancel-in-progress: true`. This is
  the regression test: it fails against the pre-fix workflows (verified — it
  reported "no top-level concurrency mapping" for all five) and passes after.
- **`each gated workflow's concurrency group is distinct for the same ref`** —
  resolves `github.workflow` to each workflow's declared `name` and asserts no
  two workflows land in the same group, so gitleaks can never cancel CI.
- **`publishing workflows never cancel in-progress runs`** — `release.yml` and
  `wasm-bundle.yml` must not set `cancel-in-progress: true` at workflow or job
  level (edge case: no group at all is also acceptable).
- **`the reusable security workflow declares no concurrency group`** —
  `security.yml` stays a `workflow_call` workflow with no group of its own.

No existing tests were modified or removed.

## Security Self-Check

- No secrets, credentials or `.config*.json` files staged; the only hidden paths
  touched are `.github/workflows/*.yml`, which the allowlist permits.
- No new dependencies, network calls, shell interpolation or user input surface —
  the change is five declarative YAML keys plus a test file.
- `cancel-in-progress` is scoped away from the publishing workflows, so no
  signed/attested artefact can be skipped by a cancellation.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mry1ozro-e4e12a`<!-- vibe-worker-issue-334 -->