### PR TITLE
Fail the scheduled upgrade step when bump-deps.sh fails (Issue #336)

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -52,6 +52,10 @@ jobs:
           # actively-exploited advisory (Issue #124 — see SECURITY.md).
           VIBE_BUMP_QUARANTINE_HOURS: ${{ inputs.emergency_bypass == true && '0' || vars.VIBE_BUMP_QUARANTINE_HOURS || '24' }}
         run: |
+          # pipefail is mandatory: without it `| tee` masks a bump-deps.sh
+          # failure as success and the workflow opens a PR claiming gates
+          # passed that never ran clean (Issue #336).
+          set -euo pipefail
           # bump-deps.sh applies the release-age quarantine, then runs
           # cargo audit + dual native/wasm builds. A non-zero exit means the
           # bump is unsafe; the worker reverts per the contract.

--- a/docs/archive/pr-summaries/pr-summary-336.md
+++ b/docs/archive/pr-summaries/pr-summary-336.md
@@ -1,0 +1,86 @@
+# PR Summary — Issue #336
+
+## Summary
+
+`.github/workflows/upgrade-dependencies.yml` ran its "Refresh dependencies via
+`bump-deps.sh` (quarantine-aware)" step under GitHub's default `bash -e` — `-e`
+but **no `pipefail`**. Because the command pipes into `tee upgrade.log`, the
+step's exit status was `tee`'s (always 0), so a non-zero exit from
+`bump-deps.sh` (release-age quarantine violation, `cargo audit` advisory, or a
+failed native/wasm build) was swallowed. The workflow then proceeded to open a
+PR whose body asserts the bumps "have passed `cargo audit` plus dual
+native/wasm builds" — a claim that could be false, silently re-opening the
+supply-chain window Issue #76 closed.
+
+Added `set -euo pipefail` to that step so the pipeline reports the script's
+failure. `tee` still captures the log the PR body pastes. The PR-path caller in
+`ci.yml` already set `set -euo pipefail`, so only this scheduled path changed.
+
+Closes #336.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Evidence is the new
+behavioural bats suite, which executes the workflow step's real script.
+
+Failure signal before and after the fix:
+
+```mermaid
+flowchart LR
+    A["bump-deps.sh exits 7"] --> B{"pipefail set?"}
+    B -- "before: no" --> C["pipeline status = tee's 0"]
+    C --> D["step green → PR claims gates passed"]
+    B -- "after: yes" --> E["pipeline status = 7"]
+    E --> F["step fails → no misleading PR"]
+```
+
+Tests fail against the unfixed workflow and pass after the fix:
+
+```text
+# before (workflow without pipefail)
+not ok 1 a failing bump-deps.sh fails the scheduled upgrade step
+ok 2 a passing bump-deps.sh keeps the scheduled upgrade step green
+ok 3 the scheduled upgrade step still captures bump-deps.sh output to upgrade.log
+not ok 4 every piped run: block in upgrade-dependencies.yml runs under pipefail
+
+# after
+ok 1 a failing bump-deps.sh fails the scheduled upgrade step
+ok 2 a passing bump-deps.sh keeps the scheduled upgrade step green
+ok 3 the scheduled upgrade step still captures bump-deps.sh output to upgrade.log
+ok 4 every piped run: block in upgrade-dependencies.yml runs under pipefail
+```
+
+Full suite: `bats tests/scripts` — 247 passing, 0 failing.
+`./quality.sh < /dev/null` — "All quality checks passed!".
+
+## Test Plan
+
+New `tests/scripts/workflow_pipefail.bats` — "what" tests that parse the
+workflow, extract the step's actual `run:` body, and execute it under the exact
+shell GitHub would use (`bash -e` with no `shell:`, `bash --noprofile --norc
+-eo pipefail` when `shell: bash` is declared), with a stub `bump-deps.sh`:
+
+- `a failing bump-deps.sh fails the scheduled upgrade step` — regression test
+  for #336; stub exits 7, step must exit non-zero.
+- `a passing bump-deps.sh keeps the scheduled upgrade step green` — stub exits
+  0, step must stay green (guards against over-strict `-e` breakage).
+- `the scheduled upgrade step still captures bump-deps.sh output to
+  upgrade.log` — `tee` still writes the log the PR body pastes, including the
+  `--quarantine-hours 24` argument.
+- `every piped run: block in upgrade-dependencies.yml runs under pipefail` —
+  forward guard so a future piped command in this workflow cannot reintroduce
+  the swallowed exit status.
+
+No existing tests were modified or removed.
+
+## Security Self-Check
+
+- Input validation: no new external input paths.
+- Secrets: only the workflow YAML and a bats file are staged; no `.env` /
+  `.config*.json`.
+- Injection surface: the test harness heredocs are quoted (`<<'PY'`), so
+  GitHub `${{ … }}` expressions are never evaluated by the shell; the stub runs
+  in `$BATS_TEST_TMPDIR`.
+- Error handling: the change makes failures louder, not quieter — a masked
+  failure is now surfaced as a failed step.
+- Dependencies: none added.

--- a/tests/scripts/workflow_pipefail.bats
+++ b/tests/scripts/workflow_pipefail.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# Regression tests for Issue #336 — a failing `bump-deps.sh` must fail the
+# scheduled upgrade step.
+#
+# GitHub runs a `run:` block with no `shell:` override under `bash -e {0}` —
+# `-e` but *not* `pipefail`. In `cmd | tee upgrade.log` the pipeline's status is
+# `tee`'s (always 0), so a non-zero exit from `bump-deps.sh` (quarantine
+# violation, `cargo audit` advisory, failed native/wasm build) is swallowed and
+# the workflow goes on to open a PR asserting the bumps passed those gates.
+#
+# These are "what" tests: they extract the step's real script from the workflow,
+# execute it under the same shell GitHub would use with a stub `bump-deps.sh`,
+# and assert on the observed exit status — not on source text.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+  UPGRADE_WF="${WORKFLOWS_DIR}/upgrade-dependencies.yml"
+  WORK="${BATS_TEST_TMPDIR}/step"
+  mkdir -p "$WORK"
+}
+
+# Write the named step's script to $WORK/step.sh and the argv GitHub would
+# launch it with to $WORK/shell.cmd.
+extract_step() {
+  python3 - "$1" "$2" "$WORK" <<'PY'
+import os, sys, yaml
+
+workflow, needle, out = sys.argv[1:4]
+with open(workflow) as fh:
+    data = yaml.safe_load(fh)
+
+def declared_shell(step, job):
+    for scope in (step, job.get("defaults", {}).get("run", {}),
+                  (data.get("defaults") or {}).get("run", {})):
+        if scope.get("shell"):
+            return scope["shell"]
+    return None
+
+for job in (data.get("jobs") or {}).values():
+    for step in job.get("steps") or []:
+        if needle not in (step.get("name") or "") or "run" not in step:
+            continue
+        body = step["run"]
+        assert "${{" not in body, "step body interpolates a GitHub expression"
+        shell = declared_shell(step, job)
+        # GitHub: no `shell:` → `bash -e {0}`; `shell: bash` → `bash
+        # --noprofile --norc -eo pipefail {0}`.
+        argv = {
+            None: "bash -e",
+            "bash": "bash --noprofile --norc -eo pipefail",
+        }.get(shell)
+        assert argv, f"unsupported shell for this harness: {shell!r}"
+        with open(os.path.join(out, "step.sh"), "w") as fh:
+            fh.write(body)
+        with open(os.path.join(out, "shell.cmd"), "w") as fh:
+            fh.write(argv)
+        sys.exit(0)
+
+sys.exit(f"no step named like {needle!r} with a run: block in {workflow}")
+PY
+}
+
+# Run the extracted step with a stub `bump-deps.sh` that exits $1.
+run_step_with_stub() {
+  cat >"${WORK}/bump-deps.sh" <<EOF
+#!/usr/bin/env bash
+echo "stub bump-deps.sh invoked: \$*"
+exit $1
+EOF
+  chmod +x "${WORK}/bump-deps.sh"
+  read -r -a shell_argv <"${WORK}/shell.cmd"
+  (
+    cd "$WORK" || exit 1
+    VIBE_BUMP_QUARANTINE_HOURS=24 "${shell_argv[@]}" step.sh
+  )
+}
+
+@test "a failing bump-deps.sh fails the scheduled upgrade step" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  extract_step "$UPGRADE_WF" "Refresh dependencies via bump-deps.sh"
+  run run_step_with_stub 7
+  [ "$status" -ne 0 ]
+}
+
+@test "a passing bump-deps.sh keeps the scheduled upgrade step green" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  extract_step "$UPGRADE_WF" "Refresh dependencies via bump-deps.sh"
+  run run_step_with_stub 0
+  [ "$status" -eq 0 ]
+}
+
+# The PR body pastes upgrade.log, so tee must keep capturing output.
+@test "the scheduled upgrade step still captures bump-deps.sh output to upgrade.log" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  extract_step "$UPGRADE_WF" "Refresh dependencies via bump-deps.sh"
+  run run_step_with_stub 0
+  [ "$status" -eq 0 ]
+  run cat "${WORK}/upgrade.log"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stub bump-deps.sh invoked"* ]]
+  [[ "$output" == *"--quarantine-hours 24"* ]]
+}
+
+# Guard the whole workflow, not just today's step: any future piped command
+# here would inherit the same swallowed-exit-status bug.
+@test "every piped run: block in upgrade-dependencies.yml runs under pipefail" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - "$UPGRADE_WF" <<'PY'
+import re, sys, yaml
+
+workflow = sys.argv[1]
+with open(workflow) as fh:
+    data = yaml.safe_load(fh)
+
+bad = []
+for job_name, job in (data.get("jobs") or {}).items():
+    for step in job.get("steps") or []:
+        body = step.get("run")
+        if not body:
+            continue
+        code = "\n".join(
+            line for line in body.splitlines() if not line.strip().startswith("#")
+        )
+        # Ignore `||` and GitHub expressions when looking for a real pipeline.
+        scanned = re.sub(r"\|\||\$\{\{.*?\}\}", "", code)
+        if "|" not in scanned:
+            continue
+        shell = step.get("shell") or job.get("defaults", {}).get("run", {}).get("shell")
+        if shell == "bash" or re.search(r"^\s*set\s+-\S*o?\s*.*pipefail", code, re.M):
+            continue
+        bad.append(f"{job_name}: {step.get('name')!r} pipes without pipefail")
+
+if bad:
+    sys.stderr.write("Swallowed pipeline exit status:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #336

## Summary

`.github/workflows/upgrade-dependencies.yml` ran its "Refresh dependencies via
`bump-deps.sh` (quarantine-aware)" step under GitHub's default `bash -e` — `-e`
but **no `pipefail`**. Because the command pipes into `tee upgrade.log`, the
step's exit status was `tee`'s (always 0), so a non-zero exit from
`bump-deps.sh` (release-age quarantine violation, `cargo audit` advisory, or a
failed native/wasm build) was swallowed. The workflow then proceeded to open a
PR whose body asserts the bumps "have passed `cargo audit` plus dual
native/wasm builds" — a claim that could be false, silently re-opening the
supply-chain window Issue #76 closed.

Added `set -euo pipefail` to that step so the pipeline reports the script's
failure. `tee` still captures the log the PR body pastes. The PR-path caller in
`ci.yml` already set `set -euo pipefail`, so only this scheduled path changed.

Closes #336.

## Evidence

Backend/CI-only change — no web interface to screenshot. Evidence is the new
behavioural bats suite, which executes the workflow step's real script.

Failure signal before and after the fix:

```mermaid
flowchart LR
    A["bump-deps.sh exits 7"] --> B{"pipefail set?"}
    B -- "before: no" --> C["pipeline status = tee's 0"]
    C --> D["step green → PR claims gates passed"]
    B -- "after: yes" --> E["pipeline status = 7"]
    E --> F["step fails → no misleading PR"]
```

Tests fail against the unfixed workflow and pass after the fix:

```text
# before (workflow without pipefail)
not ok 1 a failing bump-deps.sh fails the scheduled upgrade step
ok 2 a passing bump-deps.sh keeps the scheduled upgrade step green
ok 3 the scheduled upgrade step still captures bump-deps.sh output to upgrade.log
not ok 4 every piped run: block in upgrade-dependencies.yml runs under pipefail

# after
ok 1 a failing bump-deps.sh fails the scheduled upgrade step
ok 2 a passing bump-deps.sh keeps the scheduled upgrade step green
ok 3 the scheduled upgrade step still captures bump-deps.sh output to upgrade.log
ok 4 every piped run: block in upgrade-dependencies.yml runs under pipefail
```

Full suite: `bats tests/scripts` — 247 passing, 0 failing.
`./quality.sh < /dev/null` — "All quality checks passed!".

## Test Plan

New `tests/scripts/workflow_pipefail.bats` — "what" tests that parse the
workflow, extract the step's actual `run:` body, and execute it under the exact
shell GitHub would use (`bash -e` with no `shell:`, `bash --noprofile --norc
-eo pipefail` when `shell: bash` is declared), with a stub `bump-deps.sh`:

- `a failing bump-deps.sh fails the scheduled upgrade step` — regression test
  for #336; stub exits 7, step must exit non-zero.
- `a passing bump-deps.sh keeps the scheduled upgrade step green` — stub exits
  0, step must stay green (guards against over-strict `-e` breakage).
- `the scheduled upgrade step still captures bump-deps.sh output to
  upgrade.log` — `tee` still writes the log the PR body pastes, including the
  `--quarantine-hours 24` argument.
- `every piped run: block in upgrade-dependencies.yml runs under pipefail` —
  forward guard so a future piped command in this workflow cannot reintroduce
  the swallowed exit status.

No existing tests were modified or removed.

## Security Self-Check

- Input validation: no new external input paths.
- Secrets: only the workflow YAML and a bats file are staged; no `.env` /
  `.config*.json`.
- Injection surface: the test harness heredocs are quoted (`<<'PY'`), so
  GitHub `${{ … }}` expressions are never evaluated by the shell; the stub runs
  in `$BATS_TEST_TMPDIR`.
- Error handling: the change makes failures louder, not quieter — a masked
  failure is now surfaced as a failed step.
- Dependencies: none added.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mry4z7v0-b036e1`<!-- vibe-worker-issue-336 -->