### PR TITLE
🟢 Duplicate clippy gate: `quality` and `rust-gates` both lint every PR (`.github/workflows/ci.yml`) (Issue #337)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,11 +352,16 @@ jobs:
     name: Lint & Compile Gates
     runs-on: ubuntu-latest
     timeout-minutes: 45 # cargo fmt/clippy/check across the workspace
-    # Issue #143 — explicit Rust lint + compile/syntax gates that run on every
-    # push to Develop AND every pull request. Deliberately independent of the
-    # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
-    # (which skip those jobs) are still gated against lint regressions and
-    # syntax errors. The full `quality` job remains the comprehensive PR gate.
+    # Issue #143 — explicit Rust lint + compile/syntax gates. Deliberately
+    # independent of the PR-only auto-bump / auto-format jobs above, so direct
+    # pushes to Develop (which skip those jobs) are still gated against lint
+    # regressions and syntax errors.
+    # Issue #337 — on pull requests the `quality` job already runs the identical
+    # clippy invocation (which compiles the workspace, subsuming `cargo check`),
+    # so running this job there compiled and linted the workspace twice per PR
+    # in separate jobs with separate caches. Scope it to the events `quality`
+    # does not cover; `quality` stays the comprehensive PR gate.
+    if: github.event_name != 'pull_request'
     # Issue #310 — least privilege: this job only checks out and compiles/lints
     # the repo, so read-only contents is all the GITHUB_TOKEN needs.
     permissions:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sequenceDiagram
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
 | `neat-core/benches/` | Opt-in Criterion harnesses: `hot_paths` (core hot paths) and `parallel_scoring` (data-parallel scoring, needs `--features parallel`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
-| `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
+| `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop`** (and `workflow_dispatch`); on pull requests the `quality` job — the full PR pipeline — runs the same clippy gate, so `rust-gates` is skipped there rather than compiling the workspace twice (Issue #337). |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build ([Vibe Coder](#glossary-vibe-coder) hook). |
 | `.github/dependabot.yml` | Advisory-triggered security-update fast lane — raises a fix PR the moment a RustSec/OSV advisory lands, independent of the weekly bump. |
 | `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`). |

--- a/docs/archive/pr-summaries/pr-summary-337.md
+++ b/docs/archive/pr-summaries/pr-summary-337.md
@@ -1,0 +1,81 @@
+## Summary
+
+`.github/workflows/ci.yml` ran the identical lint recipe twice on every pull
+request: job `quality` step "Run linter" and job `rust-gates` step "Lint gate
+(cargo clippy)" both invoked
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`, plus a
+`cargo check --workspace --all-targets --all-features` that clippy's own
+compilation already subsumes. Two jobs with separate caches compiled and linted
+the whole workspace, roughly doubling the heaviest part of the CI bill on every
+PR.
+
+`rust-gates` is now scoped to the events `quality` does not cover
+(`if: github.event_name != 'pull_request'`), which preserves its stated purpose
+from Issue #143 — gating direct pushes to `Develop`, which skip the PR-only
+jobs — while `quality` stays the comprehensive PR gate (fmt, deny, clippy,
+tests, docs). `Lint & Compile Gates` is not a required status check in
+`.github/rulesets/develop.json`, so skipping it on PRs does not block merges.
+
+Closes #337.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by the
+`bats` contract tests over the parsed workflow YAML.
+
+```mermaid
+flowchart TD
+    subgraph Before
+        P1[pull_request] --> Q1["quality: clippy -D warnings"]
+        P1 --> R1["rust-gates: cargo check + clippy -D warnings"]
+        U1[push to Develop] --> R1
+    end
+    subgraph After
+        P2[pull_request] --> Q2["quality: clippy -D warnings"]
+        U2["push to Develop / workflow_dispatch"] --> R2["rust-gates: cargo check + clippy -D warnings"]
+    end
+```
+
+Test run (`bats tests/scripts/rust_gates_workflow.bats`) — the new test fails
+against the unfixed workflow and passes after the change:
+
+```text
+1..9
+ok 1 ci workflow file exists
+ok 2 ci workflow is valid YAML
+ok 3 ci workflow triggers on PRs and on pushes to Develop
+ok 4 ci workflow runs a clippy lint gate with -D warnings
+ok 5 ci workflow runs an explicit compile/syntax gate (cargo check or build)
+ok 6 ci workflow gates lint + compile on push (not pull_request only)
+ok 7 exactly one job runs the clippy lint gate on a pull_request event
+ok 8 ci workflow pins third-party actions to commit SHAs
+ok 9 ci rust-gates checkout does not persist credentials on disk
+```
+
+Full suite: `bats tests/scripts` — 248/248 pass. `./quality.sh` passes cleanly.
+`actionlint .github/workflows/ci.yml` reports no findings.
+
+## Test Plan
+
+- **Added** `tests/scripts/rust_gates_workflow.bats::"exactly one job runs the
+  clippy lint gate on a pull_request event"` — regression test for the
+  duplicate gate. It parses `ci.yml`, keeps the jobs whose `if:` allows a
+  `pull_request` event, and asserts exactly one of them carries a
+  `cargo clippy … -D warnings` step. Fails against the unfixed workflow (two
+  jobs), passes after.
+- **Modified** (documented business-logic change)
+  `tests/scripts/rust_gates_workflow.bats::"ci workflow gates lint + compile on
+  push (not pull_request only)"` — it previously asserted the gate job's `if:`
+  text did not contain the substring `pull_request`, which cannot distinguish
+  `github.event_name == 'pull_request'` (PR only — the condition it meant to
+  reject) from `github.event_name != 'pull_request'` (everything *but* a PR —
+  which satisfies the same contract). It now evaluates the condition against a
+  `push` event via a shared `runs_on(job, event)` helper, so it still asserts
+  the same observable outcome: direct pushes to `Develop` hit the lint +
+  compile gate. No test was removed or commented out.
+- **Unchanged and still passing**: the compile/syntax-gate test (clippy's own
+  compilation covers PRs; `rust-gates` still runs `cargo check --all-targets`
+  on pushes), the SHA-pinning test, the `persist-credentials` test
+  (Issue #318), and `ci_rust_gates_permissions.bats` (Issue #310).
+- Documentation: the `ci.yml` row in `README.md` now describes which events
+  each job gates.

--- a/tests/scripts/rust_gates_workflow.bats
+++ b/tests/scripts/rust_gates_workflow.bats
@@ -15,6 +15,8 @@
 #   - a job invokes an explicit compile/syntax gate (cargo check / cargo build),
 #   - the gate job runs on push (not restricted to pull_request only), so direct
 #     pushes to Develop are gated too,
+#   - exactly one job lints on a pull_request event (Issue #337 — no duplicate
+#     clippy gate),
 #   - third-party actions in the gate job are SHA-pinned (Issue #77),
 #   - the gate job's checkout does not persist the GITHUB_TOKEN on disk
 #     (Issue #318).
@@ -22,6 +24,41 @@
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
   WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+
+  # Shared Python helpers, interpolated into the heredocs below. `runs_on`
+  # answers the observable question "would this job run for event X?" —
+  # replacing an earlier substring check on the `if:` text, which could not
+  # tell `github.event_name == 'pull_request'` (PR only) from
+  # `github.event_name != 'pull_request'` (everything but a PR).
+  read -r -d '' HELPERS <<'HELPERS_PY' || true
+import re
+
+def runs_on(job, event):
+    cond = str(job.get("if", "")).strip()
+    if not cond:
+        return True
+    expr = cond
+    if expr.startswith("${{") and expr.endswith("}}"):
+        expr = expr[3:-2].strip()
+    m = re.fullmatch(r"github\.event_name\s*(==|!=)\s*'([^']+)'", expr)
+    if not m:  # unrecognised condition — assume the job runs
+        return True
+    op, value = m.groups()
+    return event == value if op == "==" else event != value
+
+def has_lint(job):
+    return any(
+        "cargo clippy" in s.get("run", "") and "-D warnings" in s.get("run", "")
+        for s in job.get("steps", [])
+    )
+
+def has_compile(job):
+    return any(
+        ("cargo check" in s.get("run", "") or "cargo build" in s.get("run", ""))
+        and "--all-targets" in s.get("run", "")
+        for s in job.get("steps", [])
+    )
+HELPERS_PY
 }
 
 @test "ci workflow file exists" {
@@ -96,33 +133,40 @@ PY
   fi
   run python3 - <<PY
 import yaml
+$HELPERS
 data = yaml.safe_load(open("$WORKFLOW"))
 
-def has_lint(job):
-    return any(
-        "cargo clippy" in s.get("run", "") and "-D warnings" in s.get("run", "")
-        for s in job.get("steps", [])
-    )
-
-def has_compile(job):
-    return any(
-        ("cargo check" in s.get("run", "") or "cargo build" in s.get("run", ""))
-        and "--all-targets" in s.get("run", "")
-        for s in job.get("steps", [])
-    )
-
-# At least one job must carry BOTH gates and must not be restricted to
-# pull_request only, so direct pushes to Develop are gated too.
+# At least one job must carry BOTH gates and must actually run on a push
+# event, so direct pushes to Develop are gated too.
 gate_jobs = [
     job for job in data["jobs"].values()
     if has_lint(job) and has_compile(job)
 ]
 assert gate_jobs, "no single job carries both the lint and compile gates"
-runs_on_push = [
-    job for job in gate_jobs
-    if "pull_request" not in str(job.get("if", ""))
+runs_on_push = [job for job in gate_jobs if runs_on(job, "push")]
+assert runs_on_push, "lint+compile gate job does not run on push events"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Issue #337 — `quality` and `rust-gates` both ran the identical
+# `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+# on every pull request, compiling the whole workspace twice in separate jobs
+# with separate caches. Exactly one job must lint a PR; `rust-gates` keeps its
+# stated purpose by running on the events `quality` does not cover.
+@test "exactly one job runs the clippy lint gate on a pull_request event" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+$HELPERS
+data = yaml.safe_load(open("$WORKFLOW"))
+linting = [
+    name for name, job in data["jobs"].items()
+    if has_lint(job) and runs_on(job, "pull_request")
 ]
-assert runs_on_push, "lint+compile gate job is restricted to pull_request only"
+assert len(linting) == 1, f"expected exactly one PR lint job, got {linting}"
 PY
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` ran the identical lint recipe twice on every pull
request: job `quality` step "Run linter" and job `rust-gates` step "Lint gate
(cargo clippy)" both invoked
`cargo clippy --workspace --all-targets --all-features -- -D warnings`, plus a
`cargo check --workspace --all-targets --all-features` that clippy's own
compilation already subsumes. Two jobs with separate caches compiled and linted
the whole workspace, roughly doubling the heaviest part of the CI bill on every
PR.

`rust-gates` is now scoped to the events `quality` does not cover
(`if: github.event_name != 'pull_request'`), which preserves its stated purpose
from Issue #143 — gating direct pushes to `Develop`, which skip the PR-only
jobs — while `quality` stays the comprehensive PR gate (fmt, deny, clippy,
tests, docs). `Lint & Compile Gates` is not a required status check in
`.github/rulesets/develop.json`, so skipping it on PRs does not block merges.

Closes #337.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified by the
`bats` contract tests over the parsed workflow YAML.

```mermaid
flowchart TD
    subgraph Before
        P1[pull_request] --> Q1["quality: clippy -D warnings"]
        P1 --> R1["rust-gates: cargo check + clippy -D warnings"]
        U1[push to Develop] --> R1
    end
    subgraph After
        P2[pull_request] --> Q2["quality: clippy -D warnings"]
        U2["push to Develop / workflow_dispatch"] --> R2["rust-gates: cargo check + clippy -D warnings"]
    end
```

Test run (`bats tests/scripts/rust_gates_workflow.bats`) — the new test fails
against the unfixed workflow and passes after the change:

```text
1..9
ok 1 ci workflow file exists
ok 2 ci workflow is valid YAML
ok 3 ci workflow triggers on PRs and on pushes to Develop
ok 4 ci workflow runs a clippy lint gate with -D warnings
ok 5 ci workflow runs an explicit compile/syntax gate (cargo check or build)
ok 6 ci workflow gates lint + compile on push (not pull_request only)
ok 7 exactly one job runs the clippy lint gate on a pull_request event
ok 8 ci workflow pins third-party actions to commit SHAs
ok 9 ci rust-gates checkout does not persist credentials on disk
```

Full suite: `bats tests/scripts` — 248/248 pass. `./quality.sh` passes cleanly.
`actionlint .github/workflows/ci.yml` reports no findings.

## Test Plan

- **Added** `tests/scripts/rust_gates_workflow.bats::"exactly one job runs the
  clippy lint gate on a pull_request event"` — regression test for the
  duplicate gate. It parses `ci.yml`, keeps the jobs whose `if:` allows a
  `pull_request` event, and asserts exactly one of them carries a
  `cargo clippy … -D warnings` step. Fails against the unfixed workflow (two
  jobs), passes after.
- **Modified** (documented business-logic change)
  `tests/scripts/rust_gates_workflow.bats::"ci workflow gates lint + compile on
  push (not pull_request only)"` — it previously asserted the gate job's `if:`
  text did not contain the substring `pull_request`, which cannot distinguish
  `github.event_name == 'pull_request'` (PR only — the condition it meant to
  reject) from `github.event_name != 'pull_request'` (everything *but* a PR —
  which satisfies the same contract). It now evaluates the condition against a
  `push` event via a shared `runs_on(job, event)` helper, so it still asserts
  the same observable outcome: direct pushes to `Develop` hit the lint +
  compile gate. No test was removed or commented out.
- **Unchanged and still passing**: the compile/syntax-gate test (clippy's own
  compilation covers PRs; `rust-gates` still runs `cargo check --all-targets`
  on pushes), the SHA-pinning test, the `persist-credentials` test
  (Issue #318), and `ci_rust_gates_permissions.bats` (Issue #310).
- Documentation: the `ci.yml` row in `README.md` now describes which events
  each job gates.
