### PR TITLE
Enable pipefail so bump-deps.sh failure fails the scheduled upgrade step (Issue #336)

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -52,6 +52,10 @@ jobs:
           # actively-exploited advisory (Issue #124 — see SECURITY.md).
           VIBE_BUMP_QUARANTINE_HOURS: ${{ inputs.emergency_bypass == true && '0' || vars.VIBE_BUMP_QUARANTINE_HOURS || '24' }}
         run: |
+          # GitHub's default (unspecified-shell) run is `bash -e {0}` WITHOUT
+          # pipefail, so a non-zero exit from bump-deps.sh below would be masked
+          # by `tee`. Enable pipefail so the pipe reports the script's status.
+          set -euo pipefail
           # bump-deps.sh applies the release-age quarantine, then runs
           # cargo audit + dual native/wasm builds. A non-zero exit means the
           # bump is unsafe; the worker reverts per the contract.

--- a/docs/archive/pr-summaries/pr-summary-336.md
+++ b/docs/archive/pr-summaries/pr-summary-336.md
@@ -1,0 +1,64 @@
+## Summary
+
+`.github/workflows/upgrade-dependencies.yml` piped `bump-deps.sh` through
+`tee upgrade.log` in a step with no `shell:` override. GitHub runs an
+unspecified-shell `run` as `bash -e {0}` **without** `pipefail`, so the
+pipeline's exit status was `tee`'s (always 0). A non-zero exit from
+`bump-deps.sh` — the documented "the bump is unsafe" signal (release-age
+quarantine violation, `cargo audit` advisory, or a failed native/wasm build) —
+was therefore swallowed, and the workflow went on to file a PR asserting the
+bumps "have passed `cargo audit` plus dual native/wasm builds", a claim that
+could be false. This silently re-opened the fast-flagged supply-chain window the
+quarantine (Issue #76) was built to close. Only the scheduled path was affected;
+the PR-path caller in `ci.yml` already sets `set -euo pipefail`.
+
+The fix adds `set -euo pipefail` to the Refresh step's `run` body so a failed
+`bump-deps.sh` fails the step, matching the guard the `ci.yml` bump path already
+uses.
+
+Closes #336.
+
+## Evidence
+
+Backend/CI workflow change — no web interface to screenshot. Verified via a
+behavioural bats regression test that executes the step's **actual** `run` body
+(extracted from the workflow YAML) against a failing and a succeeding stubbed
+`bump-deps.sh`, reproducing GitHub's default `bash -e` (no pipefail) shell.
+
+Regression linkage — the test fails against the unfixed workflow and passes with
+the fix:
+
+```
+# unfixed (fix stashed)
+not ok 3 a failing bump-deps.sh fails the Refresh step (pipefail is enabled)
+
+# fixed
+ok 1 upgrade-dependencies.yml exists
+ok 2 the Refresh step run body is extractable and invokes bump-deps.sh via tee
+ok 3 a failing bump-deps.sh fails the Refresh step (pipefail is enabled)
+ok 4 a succeeding bump-deps.sh still passes the Refresh step
+```
+
+`./quality.sh` passes cleanly (bash syntax, shellcheck, full bats suite,
+`cargo test --workspace`, docs, release build).
+
+```mermaid
+flowchart TD
+    A["bump-deps.sh exits non-zero<br/>(unsafe bump)"] --> B{"pipefail enabled?"}
+    B -- "no (old: bash -e, tee masks status)" --> C["step exits 0"]
+    C --> D["PR filed claiming<br/>cargo audit + dual build passed"]
+    D --> E["quarantine window re-opened ❌"]
+    B -- "yes (set -euo pipefail)" --> F["step exits non-zero"]
+    F --> G["workflow fails — no false PR ✅"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/upgrade_dependencies_pipefail.bats`:
+  - `a failing bump-deps.sh fails the Refresh step (pipefail is enabled)` —
+    reproduces #336; fails without the fix, passes with it.
+  - `a succeeding bump-deps.sh still passes the Refresh step` — guards against
+    over-correction.
+  - `the Refresh step run body is extractable and invokes bump-deps.sh via tee`
+    — pins the step shape the behavioural tests rely on.
+- `./quality.sh` run to completion: all checks pass.

--- a/tests/scripts/upgrade_dependencies_pipefail.bats
+++ b/tests/scripts/upgrade_dependencies_pipefail.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Regression assertion for Issue #336 — the scheduled dependency-upgrade
+# workflow pipes bump-deps.sh through `tee upgrade.log`. GitHub's default
+# `run` shell is `bash -e {0}` WITHOUT `pipefail`, so the pipeline's exit
+# status is tee's (always 0) and a non-zero exit from bump-deps.sh — the
+# documented "the bump is unsafe" signal (release-age quarantine violation,
+# cargo audit advisory, or a failed native/wasm build) — is swallowed. The
+# workflow then files a PR asserting the bumps passed cargo audit and the
+# dual build, a claim that may be false. The step must enable pipefail so a
+# failed bump-deps.sh fails the step. These are behavioural "what" tests: they
+# execute the step's actual run body against a failing stub and assert on the
+# observed exit status.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  UPGRADE_WF="${REPO_ROOT}/.github/workflows/upgrade-dependencies.yml"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  [ -n "${WORK:-}" ] && rm -rf "$WORK"
+}
+
+# Extract and dedent the `run:` block-scalar body of the
+# "Refresh dependencies via bump-deps.sh" step from the workflow YAML.
+# Steps are indented 6 spaces (`      - name:`), keys 8 spaces, block body 10.
+extract_refresh_run_body() {
+  awk '
+    /^      - name: Refresh dependencies via bump-deps\.sh/ { instep = 1 }
+    instep && /^        run: \|/ { inrun = 1; next }
+    inrun {
+      if ($0 ~ /^[[:space:]]*$/) { print ""; next }         # keep blank lines
+      if ($0 ~ /^      - / || $0 ~ /^        [^ ]/) {        # next step / key
+        inrun = 0; instep = 0; next
+      }
+      sub(/^          /, "")                                 # dedent 10 spaces
+      print
+    }
+  ' "$UPGRADE_WF"
+}
+
+@test "upgrade-dependencies.yml exists" {
+  [ -f "$UPGRADE_WF" ]
+}
+
+@test "the Refresh step run body is extractable and invokes bump-deps.sh via tee" {
+  body="$(extract_refresh_run_body)"
+  [ -n "$body" ]
+  printf '%s\n' "$body" | grep -q 'bump-deps.sh'
+  printf '%s\n' "$body" | grep -q 'tee upgrade.log'
+}
+
+@test "a failing bump-deps.sh fails the Refresh step (pipefail is enabled)" {
+  # Stub bump-deps.sh so it fails the way an unsafe bump would.
+  cat > "$WORK/bump-deps.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "stub: unsafe bump — cargo audit advisory" >&2
+exit 1
+STUB
+  chmod +x "$WORK/bump-deps.sh"
+
+  extract_refresh_run_body > "$WORK/step.sh"
+
+  # Reproduce GitHub's default (unspecified-shell) semantics: `bash -e {0}`
+  # WITHOUT pipefail. The fix must re-enable pipefail from inside the run body.
+  # `run` captures the exit status without tripping bats' own errexit.
+  # shellcheck disable=SC2016  # $1 is a positional for the inner bash, must not expand here
+  run env VIBE_BUMP_QUARANTINE_HOURS=24 bash -c 'cd "$1" && bash -e step.sh' _ "$WORK"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "a succeeding bump-deps.sh still passes the Refresh step" {
+  cat > "$WORK/bump-deps.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "stub: bump applied, cargo audit clean, dual build ok"
+exit 0
+STUB
+  chmod +x "$WORK/bump-deps.sh"
+
+  extract_refresh_run_body > "$WORK/step.sh"
+
+  # shellcheck disable=SC2016  # $1 is a positional for the inner bash, must not expand here
+  run env VIBE_BUMP_QUARANTINE_HOURS=24 bash -c 'cd "$1" && bash -e step.sh' _ "$WORK"
+
+  [ "$status" -eq 0 ]
+  [ -f "$WORK/upgrade.log" ]
+}


### PR DESCRIPTION
## Summary

`.github/workflows/upgrade-dependencies.yml` piped `bump-deps.sh` through
`tee upgrade.log` in a step with no `shell:` override. GitHub runs an
unspecified-shell `run` as `bash -e {0}` **without** `pipefail`, so the
pipeline's exit status was `tee`'s (always 0). A non-zero exit from
`bump-deps.sh` — the documented "the bump is unsafe" signal (release-age
quarantine violation, `cargo audit` advisory, or a failed native/wasm build) —
was therefore swallowed, and the workflow went on to file a PR asserting the
bumps "have passed `cargo audit` plus dual native/wasm builds", a claim that
could be false. This silently re-opened the fast-flagged supply-chain window the
quarantine (Issue #76) was built to close. Only the scheduled path was affected;
the PR-path caller in `ci.yml` already sets `set -euo pipefail`.

The fix adds `set -euo pipefail` to the Refresh step's `run` body so a failed
`bump-deps.sh` fails the step, matching the guard the `ci.yml` bump path already
uses.

Closes #336.

## Evidence

Backend/CI workflow change — no web interface to screenshot. Verified via a
behavioural bats regression test that executes the step's **actual** `run` body
(extracted from the workflow YAML) against a failing and a succeeding stubbed
`bump-deps.sh`, reproducing GitHub's default `bash -e` (no pipefail) shell.

Regression linkage — the test fails against the unfixed workflow and passes with
the fix:

```
# unfixed (fix stashed)
not ok 3 a failing bump-deps.sh fails the Refresh step (pipefail is enabled)

# fixed
ok 1 upgrade-dependencies.yml exists
ok 2 the Refresh step run body is extractable and invokes bump-deps.sh via tee
ok 3 a failing bump-deps.sh fails the Refresh step (pipefail is enabled)
ok 4 a succeeding bump-deps.sh still passes the Refresh step
```

`./quality.sh` passes cleanly (bash syntax, shellcheck, full bats suite,
`cargo test --workspace`, docs, release build).

```mermaid
flowchart TD
    A["bump-deps.sh exits non-zero<br/>(unsafe bump)"] --> B{"pipefail enabled?"}
    B -- "no (old: bash -e, tee masks status)" --> C["step exits 0"]
    C --> D["PR filed claiming<br/>cargo audit + dual build passed"]
    D --> E["quarantine window re-opened ❌"]
    B -- "yes (set -euo pipefail)" --> F["step exits non-zero"]
    F --> G["workflow fails — no false PR ✅"]
```

## Test Plan

- Added `tests/scripts/upgrade_dependencies_pipefail.bats`:
  - `a failing bump-deps.sh fails the Refresh step (pipefail is enabled)` —
    reproduces #336; fails without the fix, passes with it.
  - `a succeeding bump-deps.sh still passes the Refresh step` — guards against
    over-correction.
  - `the Refresh step run body is extractable and invokes bump-deps.sh via tee`
    — pins the step shape the behavioural tests rely on.
- `./quality.sh` run to completion: all checks pass.



## Milestone
This PR is part of the **Clean up 23 Jul** milestone and targets the `milestone/clean-up-23-jul` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mry6b6op-5d8896`<!-- vibe-worker-issue-336 -->