### PR TITLE
Milestone: Clean up 23 Jul

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,6 +24,12 @@ on:
     branches: ["*", "milestone/*"]
   workflow_dispatch:
 
+# Issue #334 — one live lint run per branch. A superseded run only reports on a
+# commit that has already been replaced, so cancelling it costs no signal.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,7 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # actions/checkout@v6.0.2
+      # Issue #317 — `persist-credentials: false` keeps the workflow
+      # GITHUB_TOKEN out of .git/config. This job only lints workflow files:
+      # it never pushes back and fetches no private submodule, so leaving the
+      # credential on disk would only widen the blast radius of a compromised
+      # step.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       # Install actionlint CLI from a version-pinned release tarball with
       # SHA-256 verification. Bump ACTIONLINT_VERSION + ACTIONLINT_SHA256

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # lint-only: install actionlint + scan workflows
     steps:
       # actions/checkout@v6.0.2
       # Issue #317 — `persist-credentials: false` keeps the workflow

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,11 @@ name: Actionlint
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #326 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this lint gate runs on milestone
+    # sub-issue PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,8 +2,12 @@ name: Actionlint
 
 # Issue #96 — CI lint gate for GitHub Actions workflows.
 #
-# Runs the upstream actionlint binary (rhysd/actionlint) on every push to
-# Develop and every pull request so workflow regressions fail the build.
+# Runs the upstream actionlint binary (rhysd/actionlint) on every pull request
+# so workflow regressions fail the build before merge.
+#
+# Issue #314 — PR-only, matching gitleaks.yml/semgrep.yml. As a check gate it
+# already runs on the PR; re-running it on push to Develop would duplicate that
+# run, burning CI minutes for no new signal.
 #
 # Install pattern mirrors gitleaks.yml (Issue #99) and the wasm-pack pinned
 # install (Issue #78): download a version-pinned release tarball and verify
@@ -12,10 +16,9 @@ name: Actionlint
 # to commit SHAs (Issue #77).
 
 on:
-  push:
-    branches: [Develop]
   pull_request:
     branches: ["*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # Issue #313 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, cargo metadata, manifest/README/rustdoc file checks); it never
+    # writes, so it must not inherit the repository's broad default scopes.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       # ShellCheck Lint — upstream project: https://github.com/koalaman/shellcheck
       # We install the apt package (which ships koalaman/shellcheck) and scan all *.sh files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,10 +507,16 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #320 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job only reads the repo
+        # (manifest, README and rustdoc checks); it never pushes back and
+        # fetches no private submodule, so the persisted credential would only
+        # widen the blast radius of a compromised later step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         # dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ on:
       - milestone/*
   workflow_dispatch:
 
+# Issue #334 — the heaviest gate in the repo: one run compiles the workspace
+# several times over (quality + rust-gates). Every `synchronize` push to an open
+# PR — including the bot pushes from `version-increment`/`auto-format` — queued
+# a fresh run on top of one still compiling, so a few rapid pushes stacked runs
+# several deep. Keying the group on the workflow *and* the ref keeps one live
+# run per branch and cancels the superseded ones, whose results nobody reads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # Issue #311 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, shellcheck, bash -n, codespell); it never pushes, so it must
+    # not inherit the repository's broad default write scopes.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment, auto-format]
+    # Issue #309 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, git pull, cargo deny/fmt/clippy/test/doc); it never pushes, so
+    # it must not inherit the repository's broad default write scopes.
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: "-D warnings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,30 @@ jobs:
       - name: Lint gate (cargo clippy)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  # Issue #307 — TypeScript basic-validity gate. Runs on every push to Develop
+  # AND every pull request (no PR-only guard), so a syntax or type error in the
+  # committed .ts helpers cannot land unnoticed. Basic validity only — this is
+  # not a style or lint gate. The same script backs the local quality.sh run.
+  typescript-gate:
+    name: TypeScript validity gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Deno
+        # denoland/setup-deno@v2.0.5
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+        with:
+          deno-version: "2.9.3"
+
+      - name: Type-check TypeScript sources (deno check)
+        run: |
+          chmod +x scripts/typescript-check.sh
+          ./scripts/typescript-check.sh
+
   scripts-and-spelling:
     name: Scripts & spelling
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,11 +352,16 @@ jobs:
     name: Lint & Compile Gates
     runs-on: ubuntu-latest
     timeout-minutes: 45 # cargo fmt/clippy/check across the workspace
-    # Issue #143 — explicit Rust lint + compile/syntax gates that run on every
-    # push to Develop AND every pull request. Deliberately independent of the
-    # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
-    # (which skip those jobs) are still gated against lint regressions and
-    # syntax errors. The full `quality` job remains the comprehensive PR gate.
+    # Issue #143 — explicit Rust lint + compile/syntax gates. Deliberately
+    # independent of the PR-only auto-bump / auto-format jobs above, so direct
+    # pushes to Develop (which skip those jobs) are still gated against lint
+    # regressions and syntax errors.
+    # Issue #337 — on pull requests the `quality` job already runs the identical
+    # clippy invocation (which compiles the workspace, subsuming `cargo check`),
+    # so running this job there compiled and linted the workspace twice per PR
+    # in separate jobs with separate caches. Scope it to the events `quality`
+    # does not cover; `quality` stays the comprehensive PR gate.
+    if: github.event_name != 'pull_request'
     # Issue #310 — least privilege: this job only checks out and compiles/lints
     # the repo, so read-only contents is all the GITHUB_TOKEN needs.
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,12 @@ jobs:
     name: wasm64 Memory64 smoke test
     runs-on: ubuntu-latest
     timeout-minutes: 10 # single deno smoke test
+    # Issue #331 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, install Deno, run one committed smoke test); it never writes,
+    # so it must not inherit the repository's broad default write scopes.
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,14 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #332 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job only reads the repo
+        # (install Deno, run one committed smoke test); it never pushes back
+        # and fetches no private submodule, so leaving the credential on disk
+        # would only widen the blast radius of a compromised step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Install Deno
         # denoland/setup-deno@v2.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   version-increment:
     name: Auto-increment Versions
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # version bump + push
     if: github.event_name == 'pull_request'
     permissions:
       contents: write
@@ -163,6 +164,7 @@ jobs:
   version-gate:
     name: Breaking-change version gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # version comparison only
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     permissions:
@@ -208,6 +210,7 @@ jobs:
   auto-format:
     name: Auto-format Code
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # cargo fmt + push
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     permissions:
@@ -264,6 +267,7 @@ jobs:
   quality:
     name: Quality Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # cargo build + clippy + tests + docs
     if: github.event_name == 'pull_request'
     needs: [version-increment, auto-format]
     # Issue #309 — least-privilege GITHUB_TOKEN. This job only reads the repo
@@ -337,6 +341,7 @@ jobs:
   rust-gates:
     name: Lint & Compile Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # cargo fmt/clippy/check across the workspace
     # Issue #143 — explicit Rust lint + compile/syntax gates that run on every
     # push to Develop AND every pull request. Deliberately independent of the
     # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
@@ -390,6 +395,7 @@ jobs:
   typescript-gate:
     name: TypeScript validity gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # deno check over committed .ts helpers
 
     steps:
       - name: Checkout code
@@ -410,6 +416,7 @@ jobs:
   scripts-and-spelling:
     name: Scripts & spelling
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # shellcheck + bats + codespell
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     # Issue #311 — least-privilege GITHUB_TOKEN. This job only reads the repo
@@ -469,6 +476,7 @@ jobs:
   wasm64-memory64-smoke:
     name: wasm64 Memory64 smoke test
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # single deno smoke test
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
@@ -500,6 +508,7 @@ jobs:
   validation:
     name: Project Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # cargo metadata + manifest/doc checks
     if: github.event_name == 'pull_request'
     needs: [version-increment]
     # Issue #313 — least-privilege GITHUB_TOKEN. This job only reads the repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,13 @@ jobs:
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # Issue #312 — least-privilege GITHUB_TOKEN. A reusable-workflow caller with
+    # no permissions block hands the called workflow the repository's broad
+    # default scopes. Grant only what security.yml needs: read the repo
+    # (checkout, cargo audit) plus the dependency-review PR comment summary.
+    permissions:
+      contents: read
+      pull-requests: write
     with:
       include-dependency-review: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,15 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #318 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job only compiles and lints;
+        # it never pushes back and fetches no private submodule, so the
+        # persisted credential would only widen the blast radius of a
+        # compromised later step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         # dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - Develop
+      # Issue #327 — milestone sub-issue PRs target a shared milestone/<slug>
+      # branch; `*` never crosses `/`, so this single-level glob gates them too.
+      - milestone/*
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,10 @@ jobs:
     # PR-only auto-bump / auto-format jobs above, so direct pushes to Develop
     # (which skip those jobs) are still gated against lint regressions and
     # syntax errors. The full `quality` job remains the comprehensive PR gate.
+    # Issue #310 — least privilege: this job only checks out and compiles/lints
+    # the repo, so read-only contents is all the GITHUB_TOKEN needs.
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: "-D warnings"
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # secret scan over full history
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          # Issue #321 — gitleaks only scans the checked-out tree; it never
+          # pushes back or fetches private submodules, so the GITHUB_TOKEN
+          # must not be persisted to .git/config where a later step could
+          # read it.
+          persist-credentials: false
 
       # Install the gitleaks CLI from a version-pinned release tarball with
       # SHA-256 verification. Bump GITLEAKS_VERSION + GITLEAKS_SHA256

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,6 +17,12 @@ on:
     # sub-issue PRs too, not just the single rollup PR into the default branch.
     branches: ["*", "milestone/*"]
 
+# Issue #334 — one live secret scan per branch. The scan covers full history, so
+# a superseded run duplicates work already redone by its replacement.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,7 +11,11 @@ name: Gitleaks
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #328 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this secret scan runs on milestone
+    # sub-issue PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
 
 permissions:
   contents: read

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,7 +6,11 @@ name: Markdown Lint
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #329 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this lint gate runs on milestone
+    # sub-issue PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # lint-only: markdownlint-cli2 over docs
     steps:
       # actions/checkout@v6.0.2 — Issue #97/#99: bumped off Node 20 (EOL 2026-09-16).
       # Issue #322 — `persist-credentials: false` keeps the workflow

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -17,7 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # actions/checkout@v6.0.2 — Issue #97/#99: bumped off Node 20 (EOL 2026-09-16).
+      # Issue #322 — `persist-credentials: false` keeps the workflow
+      # GITHUB_TOKEN out of .git/config. This job only lints Markdown and
+      # validates Mermaid blocks: it never pushes back and fetches no private
+      # submodule, so leaving the credential on disk would only widen the blast
+      # radius of a compromised step.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       # actions/setup-node@v6.4.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,10 +1,13 @@
 name: Markdown Lint
 
+# Issue #316 — PR-only, matching actionlint.yml/gitleaks.yml/semgrep.yml. As a
+# lint gate it already runs on the PR; re-running it on push to Develop would
+# duplicate that run, burning CI minutes for no new signal.
+
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [Develop]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,6 +13,12 @@ on:
     branches: ["*", "milestone/*"]
   workflow_dispatch:
 
+# Issue #334 — one live lint run per branch; superseded runs lint a commit that
+# no longer exists on the PR head.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,15 @@ jobs:
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2
+        # Issue #323 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job cuts the tag and publishes
+        # the release via `gh` using GH_TOKEN from the environment, and its git
+        # operations (`git ls-remote origin`) target a public repo that needs
+        # no credential, so the persisted token would be pure blast radius.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Decide whether this version needs a release
         id: gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Tag and release on version bump
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # tag + gh release create
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # cargo audit + dependency review
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,6 +8,12 @@ on:
     # PRs too, not just the single rollup PR into the default branch.
     branches: ["*", "milestone/*"]
 
+# Issue #334 — one live SAST scan per branch. Each run pulls the semgrep
+# container before scanning, so stacked runs are expensive as well as redundant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,7 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20 # container pull + full SAST scan
     container:
-      image: semgrep/semgrep
+      # Issue #335 — a bare image name resolves to the mutable `:latest` tag,
+      # which the registry owner (or anyone who compromises that account) can
+      # re-point at any time; the new image would then run with this job's
+      # GITHUB_TOKEN, SEMGREP_APP_TOKEN and checked-out source. Pin by digest
+      # so the image is immutable, same as `uses:` SHA pins (Issue #77).
+      # semgrep/semgrep:1.170.1 — `:latest` as of 2026-07. Refresh with
+      # `docker buildx imagetools inspect semgrep/semgrep:latest`.
+      image: semgrep/semgrep@sha256:98c2572fced2474539fd27cab3207ebd8e95e4e7aab4c3b381fdc5e2641d9941
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,11 @@ name: Semgrep
 
 on:
   pull_request:
-    branches: ["*"]
+    # Issue #330 — GitHub branch-filter globs treat `*` as "any chars except
+    # /", so a bare "*" never matches milestone/<slug> feature branches. Add an
+    # explicit "milestone/*" pattern so this scan runs on milestone sub-issue
+    # PRs too, not just the single rollup PR into the default branch.
+    branches: ["*", "milestone/*"]
 
 permissions:
   contents: read

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - run: semgrep ci --config p/default
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # container pull + full SAST scan
     container:
       image: semgrep/semgrep
     steps:

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -52,6 +52,10 @@ jobs:
           # actively-exploited advisory (Issue #124 — see SECURITY.md).
           VIBE_BUMP_QUARANTINE_HOURS: ${{ inputs.emergency_bypass == true && '0' || vars.VIBE_BUMP_QUARANTINE_HOURS || '24' }}
         run: |
+          # pipefail is mandatory: without it `| tee` masks a bump-deps.sh
+          # failure as success and the workflow opens a PR claiming gates
+          # passed that never ran clean (Issue #336).
+          set -euo pipefail
           # bump-deps.sh applies the release-age quarantine, then runs
           # cargo audit + dual native/wasm builds. A non-zero exit means the
           # bump is unsafe; the worker reverts per the contract.

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -22,6 +22,7 @@ jobs:
   upgrade:
     name: Upgrade dependencies and create PR
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # cargo upgrade + full build/test before PR
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -21,7 +21,14 @@ jobs:
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2
+        # Issue #325 — `persist-credentials: false` keeps the workflow
+        # GITHUB_TOKEN out of .git/config. This job builds the bundle and
+        # publishes the per-commit Release via `gh` using GH_TOKEN from the
+        # environment; it never pushes back through the git remote, so the
+        # persisted token would be pure blast radius for any later step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain (with wasm32 target)
         # dtolnay/rust-toolchain@stable

--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     name: Build and publish wasm_activation bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # wasm-pack release build + bundle publish
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -513,7 +513,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -705,18 +705,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ cargo test --workspace
 cargo bench -p neat-core --bench hot_paths
 ```
 
+The committed TypeScript helpers under `tests/` carry their own basic-validity
+gate (Issue #307): `./scripts/typescript-check.sh` type-checks every `.ts` file
+with `deno check`. It runs inside `./quality.sh` and as the CI `typescript-gate`
+job on every push and pull request, so a syntax or type error fails the build.
+Basic validity only — it is not a style or lint gate, and it requires
+[Deno](https://docs.deno.com/runtime/getting_started/installation/).
+
 ## Cargo features
 
 | Feature | Default | Effect |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sequenceDiagram
 | `deny.toml` | `cargo deny` (licences, advisories, bans). |
 | `neat-core/benches/` | Opt-in Criterion harnesses: `hot_paths` (core hot paths) and `parallel_scoring` (data-parallel scoring, needs `--features parallel`); see `neat-core/benches/README.md`. |
 | `quality.sh` | Local gate (fmt, clippy, tests, doc, deny, bats). |
-| `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop` and every pull request**; the `quality` job is the full PR pipeline. |
+| `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop`** (and `workflow_dispatch`); on pull requests the `quality` job — the full PR pipeline — runs the same clippy gate, so `rust-gates` is skipped there rather than compiling the workspace twice (Issue #337). |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build ([Vibe Coder](#glossary-vibe-coder) hook). |
 | `.github/dependabot.yml` | Advisory-triggered security-update fast lane — raises a fix PR the moment a RustSec/OSV advisory lands, independent of the weekly bump. |
 | `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`). |

--- a/docs/archive/pr-summaries/pr-summary-307.md
+++ b/docs/archive/pr-summaries/pr-summary-307.md
@@ -1,0 +1,94 @@
+# TypeScript CI validity gate (Issue #307)
+
+## Summary
+
+CI had no basic-validity gate for the committed TypeScript sources: only
+`tests/wasm64_memory64_smoke_test.ts` was ever executed (by the
+`wasm64-memory64-smoke` job), so a syntax or type error in any of the other five
+`.ts` helpers under `tests/` could land on `Develop` unnoticed.
+
+This adds a repo-owned gate — `scripts/typescript-check.sh` — that type-checks
+every `.ts` file in the tree with `deno check`, and wires it into both the local
+`./quality.sh` run and a new CI job. Basic validity only; this is not a style or
+lint gate. Following the repository-isolation rule, the gate is committed to and
+enforced by this repository — no shared cross-repo Action is introduced.
+
+Closes #307.
+
+## What changed
+
+- **`scripts/typescript-check.sh`** (new) — discovers all `.ts` files under a
+  root directory (default: repo root), excluding `target/`, `.git/` and
+  `node_modules/`, and runs `deno check` over them. Fails loud when `deno` is
+  absent (exit 1 with install guidance) rather than skipping the check and
+  reporting green.
+- **`.github/workflows/ci.yml`** — new `typescript-gate` job. Like `rust-gates`,
+  it carries no PR-only guard, so it runs on direct pushes to `Develop` as well
+  as on every pull request. Deno is pinned to `2.9.3` via the already
+  SHA-pinned `denoland/setup-deno` action.
+- **`quality.sh`** — invokes the same script, so the local gate mirrors CI.
+- **`README.md`** — documents the gate under **Build**.
+
+```mermaid
+flowchart LR
+    A["push to Develop / pull request"] --> B["typescript-gate job"]
+    B --> C["scripts/typescript-check.sh"]
+    D["local ./quality.sh"] --> C
+    C --> E{"deno installed?"}
+    E -- no --> F["exit 1 — fail loud"]
+    E -- yes --> G["deno check **/*.ts"]
+    G -- "syntax / type error" --> H["build fails"]
+    G -- clean --> I["gate passes"]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot.
+
+The gate demonstrably rejects a broken file. A temporary `tests/perf/_gate_demo.ts`
+containing `export function broken(: number {` produced:
+
+```text
+typescript-check: checking 7 TypeScript file(s) with deno check
+error: SyntaxError: Unexpected token `:`. Expected yield, an identifier, [ or {
+  |
+1 | export function broken(: number {
+  |                        ~
+EXIT=1
+```
+
+With that file removed, the repository's six real TypeScript sources pass:
+
+```text
+typescript-check: checking 6 TypeScript file(s) with deno check
+typescript-check: all TypeScript files passed basic validity
+```
+
+`./quality.sh < /dev/null` passes end to end (196 → 204 bats tests, full
+`cargo` gate green), and `actionlint .github/workflows/ci.yml` is clean.
+
+## Test Plan
+
+New "what" tests in `tests/scripts/typescript_check.bats` — each builds a real
+throwaway tree and asserts on the gate's exit status:
+
+- `a valid TypeScript file passes the gate`
+- `a syntax error fails the gate` (regression test for the missing gate)
+- `a type error fails the gate`
+- `a tree with no TypeScript files passes and says so`
+- `build artefacts under target/ are not checked`
+- `a missing deno fails loud rather than skipping the check`
+- `a non-existent root directory is rejected`
+- `the repository's own TypeScript sources pass the gate`
+
+## Security self-check
+
+- Input validation: the sole argument is validated as an existing directory
+  before use; file paths are passed to `deno check` as an argv array, never
+  interpolated into a shell string.
+- No secrets or hidden files staged; the workflow YAML is the only `.github/`
+  path touched.
+- No new dependencies; Deno is pinned to `2.9.3` via the existing SHA-pinned
+  `denoland/setup-deno` action.
+- Failures surface as non-zero exits with context — no swallowed errors, no
+  silent fallback.

--- a/docs/archive/pr-summaries/pr-summary-309.md
+++ b/docs/archive/pr-summaries/pr-summary-309.md
@@ -1,0 +1,57 @@
+# Add least-privilege `permissions:` block to CI `quality` job
+
+## Summary
+
+The `quality` job in `.github/workflows/ci.yml` declared no `permissions:`
+block at either workflow or job level, so it silently inherited the
+repository's broad default `GITHUB_TOKEN` scopes (often `contents: write` and
+more). If any step were compromised, the token could act with those broad
+scopes. The `quality` job is read-only — it checks out the repo, runs
+`git pull`, and executes `cargo deny / fmt / clippy / test / doc`; it never
+pushes. It now declares an explicit least-privilege grant:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Closes #309.
+
+## Change
+
+```mermaid
+flowchart LR
+    A[quality job] -->|before| B[inherits default token<br/>contents: write + more]
+    A -->|after| C[permissions:<br/>contents: read]
+```
+
+Scope was kept to the `quality` job named in the issue — other jobs already
+declare their own `permissions:` blocks where they need elevated scopes
+(`version-increment`, `auto-format`, `version-gate`).
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via
+new bats tests plus the existing actionlint gate, which validates the workflow
+on disk:
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 quality job declares an explicit permissions block
+ok 3 quality job grants contents: read (least privilege, no write)
+```
+
+`tests/scripts/rust_gates_workflow.bats`, `actionlint_workflow.bats`,
+`workflow_sha_pinning.bats` and `workflow_script_injection.bats` all continue to
+pass (23/23), confirming the workflow remains valid, SHA-pinned, and
+injection-safe.
+
+## Test Plan
+
+- Added `tests/scripts/ci_quality_permissions.bats`:
+  - `quality job declares an explicit permissions block` — fails against the
+    unfixed workflow (reproduces #309), passes after the fix.
+  - `quality job grants contents: read (least privilege, no write)` — asserts
+    `contents: read` and that the job holds no `write` scope.
+- Re-ran the workflow-related bats suites to confirm no regression.

--- a/docs/archive/pr-summaries/pr-summary-310.md
+++ b/docs/archive/pr-summaries/pr-summary-310.md
@@ -1,0 +1,38 @@
+## Summary
+
+The `rust-gates` job in `.github/workflows/ci.yml` declared no `permissions:` block at
+either job or workflow level, so it inherited the repository's broad default
+`GITHUB_TOKEN` scopes. The job only checks out the repo and runs `cargo check` /
+`cargo clippy`, so it now declares the least-privilege grant `contents: read`.
+Closes #310.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by a new bats
+suite that parses the committed workflow YAML and asserts the observable CI
+contract (job holds an explicit `permissions:` block, `contents: read`, and no
+write scopes). The suite failed before the workflow edit and passes after:
+
+```text
+1..3
+ok 1 ci workflow file exists
+ok 2 rust-gates job declares an explicit permissions block
+ok 3 rust-gates job grants contents: read (least privilege, no write)
+```
+
+`./quality.sh` passes cleanly.
+
+```mermaid
+flowchart LR
+    A[CI run] --> B["job: rust-gates"]
+    B --> C["permissions: contents: read"]
+    C --> D["cargo check / cargo clippy"]
+    C -. "no write scopes" .-> E[repo contents protected]
+```
+
+## Test Plan
+
+- Added `tests/scripts/ci_rust_gates_permissions.bats` (3 tests) — mirrors the
+  Issue #309 `quality`-job suite; regression test that fails against the
+  unfixed workflow and passes after the fix.
+- Existing `bats tests/scripts` and full `./quality.sh` gate re-run green.

--- a/docs/archive/pr-summaries/pr-summary-311.md
+++ b/docs/archive/pr-summaries/pr-summary-311.md
@@ -1,0 +1,45 @@
+## Summary
+
+Added an explicit least-privilege `permissions:` block to the `scripts-and-spelling`
+job in `.github/workflows/ci.yml`. The job previously declared no `permissions:`
+block at either workflow or job level, so it silently inherited the repository's
+broad default `GITHUB_TOKEN` scopes. This job only reads the repo (checkout,
+shellcheck, `bash -n`, codespell) and never pushes, so `contents: read` is the
+correct least-privilege grant. Closes #311.
+
+This mirrors the fix applied to the sibling `quality` job in Issue #309.
+
+```mermaid
+flowchart LR
+    A[GITHUB_TOKEN default: broad write] -->|before| B[scripts-and-spelling job]
+    C["permissions:\n  contents: read"] -->|after| B
+    B --> D[checkout / shellcheck / bash -n / codespell]
+```
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via a
+new BATS test that parses `.github/workflows/ci.yml` with `python3`/`yaml` and
+asserts the job-level (or workflow-level) `permissions:` block grants
+`contents: read` with no `write` scopes.
+
+Test run (after the fix):
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 scripts-and-spelling job declares an explicit permissions block
+ok 3 scripts-and-spelling job grants contents: read (least privilege, no write)
+```
+
+`./quality.sh` passes cleanly: `✅ All quality checks passed!`
+
+## Test Plan
+
+- Added `tests/scripts/ci_scripts_and_spelling_permissions.bats`:
+  - `ci workflow file exists`
+  - `scripts-and-spelling job declares an explicit permissions block` — fails
+    against the unfixed workflow, passes after.
+  - `scripts-and-spelling job grants contents: read (least privilege, no write)`
+    — asserts `contents: read` and that no scope is granted `write`.
+- Confirmed the test failed before the workflow change and passes after (TDD).

--- a/docs/archive/pr-summaries/pr-summary-312.md
+++ b/docs/archive/pr-summaries/pr-summary-312.md
@@ -1,0 +1,43 @@
+## Summary
+
+The `security` job in `.github/workflows/ci.yml` calls the reusable workflow
+`.github/workflows/security.yml` but declared no `permissions:` block, so it
+handed the called workflow the repository's broad default `GITHUB_TOKEN`
+scopes. It now declares the least-privilege set the called workflow actually
+needs — `contents: read` (checkout, `cargo audit`) plus `pull-requests: write`
+(the `dependency-review` PR comment summary). Closes #312.
+
+```mermaid
+flowchart LR
+    A["ci.yml job: security"] -->|"uses:"| B["security.yml (reusable)"]
+    A -. before: no permissions → broad repo defaults .-> C["GITHUB_TOKEN"]
+    A -->|"after: contents read + pull-requests write"| C
+```
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified via
+the new BATS suite (failing before the workflow edit, passing after) and a full
+`./quality.sh` run, which completed with `✅ All quality checks passed!`.
+
+Before the fix:
+
+```
+not ok 2 security job declares an explicit permissions block
+not ok 3 security job grants only the scopes the reusable workflow needs
+not ok 4 caller scopes cover every scope the called workflow declares
+```
+
+After the fix: all 4 tests pass.
+
+## Test Plan
+
+- Added `tests/scripts/ci_security_permissions.bats`:
+  - `security job declares an explicit permissions block` — regression test for
+    the reported finding.
+  - `security job grants only the scopes the reusable workflow needs` —
+    `contents: read`, with `pull-requests` the only write scope.
+  - `caller scopes cover every scope the called workflow declares` — the caller
+    grant is not weaker than anything `security.yml` requires, so the reusable
+    workflow keeps working.
+- Existing suites unchanged; `./quality.sh` passes.

--- a/docs/archive/pr-summaries/pr-summary-313.md
+++ b/docs/archive/pr-summaries/pr-summary-313.md
@@ -1,0 +1,54 @@
+# PR Summary — Issue #313
+
+## Summary
+
+The `validation` job in `.github/workflows/ci.yml` declared no `permissions:`
+block, at either job or workflow level, so it inherited the repository's broad
+default `GITHUB_TOKEN` scopes. The job is read-only — checkout, `cargo
+metadata`, and manifest/README/rustdoc file checks — so it now declares the
+least-privilege scope it actually needs:
+
+```yaml
+permissions:
+  contents: read
+```
+
+This follows the same per-job pattern already applied to `quality` (#310),
+`scripts-and-spelling` (#311), `rust-gates`, and `security` (#312).
+Closes #313.
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified by the
+new bats suite, which parses the committed workflow YAML and asserts on the
+observable CI contract:
+
+```
+$ bats tests/scripts/ci_validation_permissions.bats
+1..3
+ok 1 ci workflow file exists
+ok 2 validation job declares an explicit permissions block
+ok 3 validation job grants read-only contents and no write scopes
+```
+
+All three permission assertions failed before the workflow change and pass
+after it. Full `./quality.sh` run passes cleanly.
+
+```mermaid
+flowchart LR
+    A["PR event"] --> B["job: validation"]
+    B --> C{"permissions: block?"}
+    C -- "before: none" --> D["inherits broad default<br/>GITHUB_TOKEN scopes"]
+    C -- "after: contents: read" --> E["least-privilege token<br/>read-only, no write scopes"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/ci_validation_permissions.bats`:
+  - `ci workflow file exists`
+  - `validation job declares an explicit permissions block` — regression test
+    for #313; fails against the unfixed workflow.
+  - `validation job grants read-only contents and no write scopes` — asserts
+    `contents: read` and that no scope is granted `write`.
+- Ran `./quality.sh < /dev/null` — all checks pass (bats, shellcheck,
+  `cargo test --workspace`, clippy, docs, release build).

--- a/docs/archive/pr-summaries/pr-summary-314.md
+++ b/docs/archive/pr-summaries/pr-summary-314.md
@@ -1,0 +1,44 @@
+## Summary
+
+`.github/workflows/actionlint.yml` triggered on both `pull_request` and `push` to
+`Develop`. As a lint/check gate it already runs on the PR, so the post-merge push
+run was a duplicate — burning CI minutes and able to leave a red tick on the
+default branch for a check that already passed. Dropped the `push:` trigger,
+keeping `pull_request` and adding `workflow_dispatch` for manual re-runs. This
+matches the existing PR-only checkers `gitleaks.yml` and `semgrep.yml`.
+Deploy/publish workflows (`release.yml`, `wasm-bundle.yml`) and the main `ci.yml`
+build are untouched — they must keep firing on push. Closes #314.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+existing BATS suite (`bats tests/scripts/actionlint_workflow.bats`, 7/7 passing,
+including the local `actionlint` sanity run over every workflow on disk) and a
+clean `./quality.sh`.
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        P1[PR opened] --> A1[actionlint run]
+        M1[merge → push Develop] --> A2[actionlint run again — duplicate]
+    end
+    subgraph after["After"]
+        P2[PR opened] --> A3[actionlint run]
+        M2[merge → push Develop] --> N2[no run]
+        D2[workflow_dispatch] --> A4[actionlint run]
+    end
+```
+
+## Test Plan
+
+- Modified `tests/scripts/actionlint_workflow.bats::"actionlint workflow gates PRs
+  only and does not re-run on push to Develop"` (previously *"...triggers on PRs
+  and on pushes to Develop"*). **Documented business-logic change:** the old
+  assertion required `Develop` in the `push.branches` list, which is exactly the
+  behaviour this issue removes; the test now asserts `pull_request` is still a
+  trigger and that `Develop` is absent from any `push.branches` filter. It failed
+  against the unfixed workflow and passes after the change. No tests were removed
+  or commented out.
+- All 7 tests in `tests/scripts/actionlint_workflow.bats` pass.
+- `./quality.sh` passes cleanly (fmt, clippy, deny, workspace tests, doc, release
+  build).

--- a/docs/archive/pr-summaries/pr-summary-316.md
+++ b/docs/archive/pr-summaries/pr-summary-316.md
@@ -1,0 +1,44 @@
+## Summary
+
+`.github/workflows/markdown-lint.yml` triggered on both `pull_request` and `push`
+to `Develop`. As a lint/check gate it already runs on the PR, so the post-merge
+push run was a duplicate — burning CI minutes and able to leave a red tick on the
+default branch for a check that already passed. Dropped the `push:` trigger,
+keeping `pull_request` and adding `workflow_dispatch` for manual re-runs. This
+matches the PR-only checkers `actionlint.yml` (Issue #314), `gitleaks.yml` and
+`semgrep.yml`. Deploy/publish workflows (`release.yml`, `wasm-bundle.yml`) and the
+main `ci.yml` build are untouched — they must keep firing on push. Closes #316.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+existing BATS suite (`bats tests/scripts/markdown_lint_workflow.bats`, 10/10
+passing, including the local `markdownlint-cli2` run over the current tree) and a
+clean `./quality.sh`.
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        P1[PR opened] --> A1[markdownlint run]
+        M1[merge → push Develop] --> A2[markdownlint run again — duplicate]
+    end
+    subgraph after["After"]
+        P2[PR opened] --> A3[markdownlint run]
+        M2[merge → push Develop] --> N2[no run]
+        D2[workflow_dispatch] --> A4[markdownlint run]
+    end
+```
+
+## Test Plan
+
+- Modified `tests/scripts/markdown_lint_workflow.bats::"markdown-lint workflow
+  gates PRs only and does not re-run on push to Develop"` (previously
+  *"...triggers on PRs and on pushes to Develop"*). **Documented business-logic
+  change:** the old assertion required `Develop` in the `push.branches` list,
+  which is exactly the behaviour this issue removes; the test now asserts
+  `pull_request` is still a trigger and that `Develop` is absent from any
+  `push.branches` filter. It failed against the unfixed workflow and passes after
+  the change. No tests were removed or commented out.
+- All 10 tests in `tests/scripts/markdown_lint_workflow.bats` pass.
+- `./quality.sh` passes cleanly (shellcheck, bats, TypeScript check, fmt, clippy,
+  deny, workspace tests, doc, release build).

--- a/docs/archive/pr-summaries/pr-summary-317.md
+++ b/docs/archive/pr-summaries/pr-summary-317.md
@@ -1,0 +1,45 @@
+## Summary
+
+The `actionlint` job checked out the repo with `actions/checkout` defaults, which writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. Every later step in the job — including a compromised dependency or injected script — could read it and act as the token. The job only lints workflow files: it never pushes back and fetches no private submodule, so the persisted credential was pure blast radius.
+
+Added `persist-credentials: false` to the checkout step in `.github/workflows/actionlint.yml`. Closes #317.
+
+## Evidence
+
+CI/workflow change — no web interface to screenshot. Verified via the repo's bats workflow tests and `./quality.sh`.
+
+Failing before the fix, passing after:
+
+```
+not ok 7 actionlint workflow checkout does not persist credentials on disk   # before
+ok 7 actionlint workflow checkout does not persist credentials on disk       # after
+```
+
+Full suite after the fix:
+
+```
+1..8
+ok 1 actionlint workflow file exists
+ok 2 actionlint workflow is valid YAML
+ok 3 actionlint workflow gates PRs only and does not re-run on push to Develop
+ok 4 actionlint workflow exposes a job that runs the actionlint binary
+ok 5 actionlint workflow pins third-party actions to commit SHAs
+ok 6 actionlint workflow pins both version and SHA-256 for the CLI install
+ok 7 actionlint workflow checkout does not persist credentials on disk
+ok 8 actionlint passes against the current workflows on disk
+```
+
+`./quality.sh < /dev/null` → `✅ All quality checks passed!`
+
+```mermaid
+flowchart LR
+    A[actions/checkout] -->|default| B[".git/config holds GITHUB_TOKEN"]
+    B --> C[any later step can read it]
+    A -->|persist-credentials: false| D["no token on disk"]
+    D --> E[compromised step gains nothing]
+```
+
+## Test Plan
+
+- Added `tests/scripts/actionlint_workflow.bats::actionlint workflow checkout does not persist credentials on disk` — parses the workflow YAML and asserts every `actions/checkout` step in the `actionlint` job sets `with.persist-credentials: false`. Reproduces #317 (fails against the unfixed workflow, passes after).
+- Existing tests in the same file unchanged and still passing.

--- a/docs/archive/pr-summaries/pr-summary-318.md
+++ b/docs/archive/pr-summaries/pr-summary-318.md
@@ -1,0 +1,40 @@
+## Summary
+
+The `rust-gates` job in `.github/workflows/ci.yml` checked out the repository
+without `persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
+including a compromised dependency or injected script — could read it and act as
+the token. The job only checks out, compiles (`cargo check`) and lints
+(`cargo clippy`): it never pushes back to the repository and fetches no private
+submodule, so the persisted credential was pure blast radius.
+
+Added `persist-credentials: false` to that checkout step, matching the existing
+treatment of the `actionlint` workflow (Issue #317). Closes #318.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+```mermaid
+flowchart LR
+    A[rust-gates job starts] --> B["actions/checkout"]
+    B -->|before| C["GITHUB_TOKEN written to .git/config"]
+    C --> D["readable by every later step"]
+    B -->|after: persist-credentials false| E["no credential on disk"]
+    E --> F["cargo check / cargo clippy"]
+```
+
+Verified with the repository's own gates:
+
+- `bats tests/scripts/rust_gates_workflow.bats` — 8/8 pass (the new test fails
+  against the unfixed workflow and passes after the change).
+- `./quality.sh < /dev/null` — passes cleanly.
+
+## Test Plan
+
+- Added `tests/scripts/rust_gates_workflow.bats::"ci rust-gates checkout does
+  not persist credentials on disk"` — parses `ci.yml`, locates every
+  `actions/checkout` step in the `rust-gates` job and asserts
+  `with.persist-credentials is False`. This is a regression test: it failed
+  before the workflow change and passes after it.
+- All pre-existing tests in that file remain unchanged and still pass.

--- a/docs/archive/pr-summaries/pr-summary-319.md
+++ b/docs/archive/pr-summaries/pr-summary-319.md
@@ -1,0 +1,37 @@
+## Summary
+
+Harden the `scripts-and-spelling` CI job so `actions/checkout` no longer
+persists the workflow `GITHUB_TOKEN` into `.git/config`. Added
+`persist-credentials: false` to the checkout step in `.github/workflows/ci.yml`.
+
+The job only runs shellcheck, `bash -n` syntax checks and codespell — it never
+pushes back to the repository and fetches no private submodule — so it does not
+need the persisted credential. Dropping it narrows the blast radius of any
+later compromised step in the job. Closes #319.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+- `.github/workflows/ci.yml`:381 now sets `persist-credentials: false` on the
+  `scripts-and-spelling` checkout step.
+- YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → `YAML OK`.
+
+```mermaid
+flowchart LR
+    A["actions/checkout"] --> B{"persist-credentials?"}
+    B -- "false (new)" --> C["GITHUB_TOKEN not written to .git/config"]
+    B -- "true (default, before)" --> D["token in .git/config — readable by any later step"]
+    C --> E["shellcheck / bash -n / codespell"]
+```
+
+## Test Plan
+
+No unit test applies: this is a workflow-YAML security-hardening change with no
+Rust or shell code path to exercise. Asserting the setting via a source grep
+would be a "how" test (implementation-detail assertion), which `AGENTS.md`
+explicitly discourages. Verification performed instead:
+
+- Confirmed the setting sits under the correct `scripts-and-spelling` checkout
+  step (single `persist-credentials` occurrence, line 381).
+- Validated the workflow still parses as valid YAML.

--- a/docs/archive/pr-summaries/pr-summary-320.md
+++ b/docs/archive/pr-summaries/pr-summary-320.md
@@ -1,0 +1,50 @@
+## Summary
+
+The CI `validation` job checked out the repository without
+`persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Every later step in that
+job — including a compromised dependency or an injected script — could read it
+and act as the token.
+
+The job is read-only (manifest, README and rustdoc checks): it never pushes back
+and fetches no private submodule, so the persisted credential was pure blast
+radius. Added `persist-credentials: false` to the job's checkout step, mirroring
+the hardening already applied to `rust-gates` (Issue #318) and `actionlint`
+(Issue #317).
+
+Closes #320.
+
+## Evidence
+
+Backend/CI-configuration change — there is no web interface to screenshot.
+Verified by a new bats gate that parses `.github/workflows/ci.yml` and asserts
+the observable contract:
+
+```
+$ bats tests/scripts/validation_workflow.bats   # before the fix
+ok 1 ci workflow defines a validation job
+not ok 2 ci validation checkout does not persist credentials on disk
+
+$ bats tests/scripts                            # after the fix
+216 passing, 0 failing
+
+$ ./quality.sh < /dev/null
+✅ All quality checks passed!
+```
+
+```mermaid
+flowchart LR
+    A["actions/checkout"] -->|"default"| B["GITHUB_TOKEN written to .git/config"]
+    B --> C["any later step can read the token"]
+    A -->|"persist-credentials: false"| D["no credential on disk"]
+    D --> E["read-only validation steps run unchanged"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/validation_workflow.bats`:
+  - `ci workflow defines a validation job` — guards the job name the second
+    test targets, so a rename fails loudly rather than silently passing.
+  - `ci validation checkout does not persist credentials on disk` — regression
+    test that fails against the unfixed workflow and passes after the fix.
+- Re-ran the full `bats tests/scripts` suite (216 tests) and `./quality.sh`.

--- a/docs/archive/pr-summaries/pr-summary-321.md
+++ b/docs/archive/pr-summaries/pr-summary-321.md
@@ -1,0 +1,55 @@
+## Summary
+
+Hardened the `gitleaks` CI job so the workflow's `GITHUB_TOKEN` is no longer
+persisted to disk. The `actions/checkout` step now sets
+`persist-credentials: false`, preventing the token from being written into
+`.git/config` as an auth header where a later step (or a compromised
+dependency) could read it and act as the token. The `gitleaks` job only scans
+the checked-out tree — it never pushes back to the repository or fetches
+private submodules — so the persisted credential is unnecessary and only
+widens the blast radius of a compromised step.
+
+Closes #321.
+
+## Change
+
+`.github/workflows/gitleaks.yml` — added `persist-credentials: false` to the
+checkout step (alongside the existing `fetch-depth: 0`, which gitleaks needs
+for full-history scanning):
+
+```yaml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+```
+
+```mermaid
+flowchart LR
+    A[checkout] -->|persist-credentials: false| B[no token in .git/config]
+    B --> C[gitleaks detect: read-only scan]
+    C --> D[no credential exposed to later steps]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. The affected job is a
+security scanner that reads the working tree; the change removes a persisted
+credential and does not alter scan behaviour (`fetch-depth: 0` is retained so
+gitleaks still scans full history).
+
+Verification:
+
+- `./quality.sh < /dev/null` → `✅ All quality checks passed!` (full Rust
+  workspace: fmt, clippy, deny, tests, doc, release build).
+- YAML remains valid; the only downstream consumers of the checkout are the
+  gitleaks install and `gitleaks detect`, neither of which uses the
+  `GITHUB_TOKEN`.
+
+## Test Plan
+
+No Rust code changed, so no `cargo` test is applicable to this workflow-only
+security hardening. The `job permissions` are already `contents: read`, and the
+gitleaks job performs no `git push` / submodule fetch, so dropping the
+persisted credential cannot break the pipeline. Confirmed the full quality gate
+stays green after the change.

--- a/docs/archive/pr-summaries/pr-summary-322.md
+++ b/docs/archive/pr-summaries/pr-summary-322.md
@@ -1,0 +1,41 @@
+# Job `markdownlint` checkout persists credentials — harden `markdown-lint.yml`
+
+## Summary
+
+The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job could read it and act as the token. This job only
+lints Markdown and validates Mermaid blocks — it never pushes back to the
+repository and fetches no private submodule — so the persisted credential was
+pure blast radius.
+
+Added `persist-credentials: false` to the checkout step, matching the
+established convention already applied to `actionlint.yml`, `gitleaks.yml`, and
+`ci.yml` (Issues #317–#320). Closes #322.
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|token written to .git/config| B[later step reads token]
+    C[checkout persist-credentials:false] -->|no token on disk| D[compromised step has nothing to steal]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the bats
+workflow test suite:
+
+- Added `markdown-lint workflow checkout does not persist credentials on disk`
+  to `tests/scripts/markdown_lint_workflow.bats`, which parses the workflow YAML
+  and asserts every `actions/checkout` step in the `markdownlint` job sets
+  `persist-credentials: false`.
+- Regression check: the new test **fails** against the unfixed workflow (`not ok
+  6 ... checkout does not persist credentials`) and **passes** after the fix.
+- Full `./quality.sh` run passes cleanly.
+
+## Test Plan
+
+- `tests/scripts/markdown_lint_workflow.bats` — new
+  `markdown-lint workflow checkout does not persist credentials on disk` test
+  (11/11 pass).
+- `./quality.sh < /dev/null` — all quality checks pass.

--- a/docs/archive/pr-summaries/pr-summary-323.md
+++ b/docs/archive/pr-summaries/pr-summary-323.md
@@ -1,0 +1,29 @@
+## Summary
+
+The `release` job's `actions/checkout` step ran without `persist-credentials: false`, so `actions/checkout` wrote the workflow `GITHUB_TOKEN` into `.git/config` as an auth header — leaving a usable credential on disk for every later step in the job. This job cuts the semver tag and publishes the GitHub release via `gh` using `GH_TOKEN` from the environment, and its only git-over-network operation (`git ls-remote origin`) targets this **public** repository, which needs no credential. The persisted token was therefore pure blast radius.
+
+Added `persist-credentials: false` to the release job's checkout step, matching the pattern already applied across this repo's other workflows (Issues #317, #318, #320, #322). Closes #323.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the `release_sbom.bats` "what" test suite (parses `release.yml` and asserts observable workflow behaviour) and the full `./quality.sh` gate.
+
+```mermaid
+flowchart LR
+    A[actions/checkout] -->|before| B["writes GITHUB_TOKEN\ninto .git/config"]
+    B --> C["any later step can read\nand act as the token"]
+    A -->|after: persist-credentials false| D["no token on disk"]
+    D --> E["gh uses GH_TOKEN from env;\ngit ls-remote hits public repo"]
+```
+
+Test run:
+
+```
+ok 6 release workflow checkout does not persist credentials on disk
+```
+
+## Test Plan
+
+- Added `tests/scripts/release_sbom.bats::"release workflow checkout does not persist credentials on disk"` — parses `release.yml` and asserts every `actions/checkout@` step in the `release` job sets `persist-credentials: false`. Fails against the unfixed workflow, passes after the fix.
+- Ran `bats tests/scripts/release_sbom.bats` — 7/7 pass.
+- Ran `./quality.sh` — all quality checks pass.

--- a/docs/archive/pr-summaries/pr-summary-324.md
+++ b/docs/archive/pr-summaries/pr-summary-324.md
@@ -1,0 +1,41 @@
+## Summary
+
+Job `semgrep` in `.github/workflows/semgrep.yml` ran `actions/checkout` without
+`persist-credentials: false`, so the workflow `GITHUB_TOKEN` was written into
+`.git/config` as an auth header. The job only checks out the repo and runs
+`semgrep ci` — it never pushes back to the repository or fetches private
+submodules — so it does not need the persisted credential. Added
+`persist-credentials: false` to the checkout step so the token is not written to
+disk, reducing the blast radius of any compromised later step. Closes #324.
+
+## Evidence
+
+Backend/CI-only change — there is no web interface to screenshot. Verification:
+
+- `actionlint .github/workflows/semgrep.yml` — no findings.
+- YAML parses cleanly (`yaml.safe_load`).
+- `./quality.sh` — all quality checks passed (workspace build, clippy, tests).
+
+```mermaid
+flowchart LR
+    A[checkout] -->|persist-credentials: false| B[.git/config has no token]
+    B --> C[semgrep ci runs]
+    C --> D[compromised step cannot read GITHUB_TOKEN from disk]
+```
+
+Diff:
+
+```yaml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+```
+
+## Test Plan
+
+- The change is a GitHub Actions workflow configuration hardening; no Rust code
+  paths are affected, so no unit tests apply.
+- Validated the workflow statically with `actionlint` (clean) and confirmed the
+  YAML parses.
+- Ran `./quality.sh` to confirm the workspace still builds, lints, and tests
+  green.

--- a/docs/archive/pr-summaries/pr-summary-325.md
+++ b/docs/archive/pr-summaries/pr-summary-325.md
@@ -1,0 +1,52 @@
+## Summary
+
+Hardened the `publish` job's checkout in `.github/workflows/wasm-bundle.yml` by
+adding `persist-credentials: false`. By default `actions/checkout` writes the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
+step in the job — including a compromised dependency — can read it and act as
+the token.
+
+The `publish` job never pushes back through the git remote: it builds the
+`wasm_activation` bundle and publishes the per-commit Release exclusively via the
+`gh` CLI using `GH_TOKEN` from the environment (`Publish per-commit Release` and
+`Verify published bundle` steps). It also fetches no private submodules. The
+persisted checkout credential is therefore unused and only widens the blast
+radius of a compromised step, so disabling it is safe.
+
+This mirrors the same hardening already applied across the repo's other
+workflows (Issues #317–#324: `actionlint.yml`, `ci.yml`, `gitleaks.yml`,
+`markdown-lint.yml`, `release.yml`, `semgrep.yml`).
+
+Closes #325.
+
+## Evidence
+
+Backend/CI configuration change — no web interface to screenshot.
+
+Validation performed:
+
+- The workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"` → `YAML OK`).
+- Manual data-flow review confirms the `publish` job uses `GH_TOKEN` (env) for
+  every GitHub operation and performs no `git push`/private-submodule fetch that
+  would need the persisted credential.
+
+```mermaid
+flowchart LR
+    A[checkout\npersist-credentials: false] --> B[build wasm bundle]
+    B --> C[gh release create\nGH_TOKEN env]
+    C --> D[gh release download\nverify — GH_TOKEN env]
+    style A fill:#d4f7d4
+```
+
+The token is no longer written to `.git/config`; the release/verify steps rely
+on `GH_TOKEN` from the environment, which is unaffected.
+
+## Test Plan
+
+No unit tests apply — this is a declarative GitHub Actions workflow security
+setting with no callable function to exercise (consistent with the merged
+sibling PRs #352–#354 for Issues #322–#324). Verified by:
+
+- YAML schema/parse validation of `.github/workflows/wasm-bundle.yml`.
+- Review confirming the checkout credential is genuinely unused by the job,
+  ruling out the false-positive case called out in the issue.

--- a/docs/archive/pr-summaries/pr-summary-326.md
+++ b/docs/archive/pr-summaries/pr-summary-326.md
@@ -1,0 +1,48 @@
+## Summary
+
+The `actionlint.yml` CI quality workflow gated pull requests with a
+`pull_request.branches` filter of `["*"]`. GitHub branch-filter globbing treats
+`*` as "any characters except `/`", so the pattern never matched
+`milestone/<slug>` feature branches. Milestone sub-issue PRs — which target a
+shared `milestone/<name>` branch under the planning delivery workflow — merged
+without the actionlint gate ever running; the gap was only caught later by the
+single rollup PR into the default branch.
+
+Added an explicit `milestone/*` pattern to the filter so the lint gate runs on
+milestone PRs too, while the existing `*` keeps matching `Develop`, `main`, and
+other single-segment branches. Milestone branch names are `milestone/<slug>`
+with no nested slashes, so the single-level `milestone/*` glob is sufficient.
+
+Closes #326.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+behavioural bats test below, which reimplements GitHub's filter globbing (`**`
+crosses `/`, `*` does not) and asserts the configured patterns match a real
+milestone branch name while still matching the default branches.
+
+```mermaid
+flowchart LR
+    A["milestone/clean-up-23-jul PR"] --> B{"branches filter"}
+    B -- "before: [\"*\"] — * stops at /" --> C["gate SKIPPED ✗"]
+    B -- "after: [\"*\", \"milestone/*\"]" --> D["actionlint runs ✓"]
+```
+
+Test run:
+
+```
+ok 4 actionlint workflow pull_request filter matches milestone branches
+ok 9 actionlint passes against the current workflows on disk
+```
+
+## Test Plan
+
+- Added `actionlint workflow pull_request filter matches milestone branches` to
+  `tests/scripts/actionlint_workflow.bats`. It parses the workflow's
+  `pull_request.branches` filter and, using GitHub's glob semantics, asserts a
+  milestone branch (`milestone/clean-up-23-jul`) matches a pattern and that
+  `Develop`/`main` still match. This test fails against the old `["*"]` filter
+  and passes after the fix.
+- Full `tests/scripts/actionlint_workflow.bats` suite: 9 passing.
+- `./quality.sh` passes cleanly (Rust workspace tests, docs, release build).

--- a/docs/archive/pr-summaries/pr-summary-327.md
+++ b/docs/archive/pr-summaries/pr-summary-327.md
@@ -1,0 +1,59 @@
+## Summary
+
+The CI quality workflow (`.github/workflows/ci.yml`) gated PRs with a
+`pull_request.branches` filter of `[Develop]` only. GitHub branch-filter globs
+treat `*` as "any character except `/`", so milestone sub-issue PRs targeting a
+shared `milestone/<slug>` branch never matched the filter — the fmt/clippy/deny/
+test/doc gate silently skipped them, and they merged into the milestone branch
+unchecked until the single rollup PR into `Develop` finally exercised the gate.
+
+Added `milestone/*` to the filter so the quality gate runs on milestone PRs too,
+while still gating PRs into `Develop`. Milestone branch names are
+`milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
+glob is sufficient. Closes #327.
+
+This mirrors the same fix already applied to `actionlint.yml` (Issue #326).
+
+```mermaid
+flowchart LR
+    A["sub-issue PR<br/>→ milestone/clean-up-23-jul"] --> B{"pull_request.branches<br/>matches?"}
+    B -- "before: [Develop] only" --> C["gate SKIPPED<br/>merges unchecked"]
+    B -- "after: adds milestone/*" --> D["CI quality gate runs<br/>fmt/clippy/deny/test/doc"]
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via a new
+bats test that models GitHub's branch-glob semantics (`*` does not cross `/`)
+and asserts the filter matches `milestone/clean-up-23-jul` while still matching
+`Develop`.
+
+Before the fix (test 3 fails):
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 ci workflow is valid YAML
+not ok 3 ci workflow pull_request filter matches milestone branches
+```
+
+After the fix:
+
+```
+1..3
+ok 1 ci workflow file exists
+ok 2 ci workflow is valid YAML
+ok 3 ci workflow pull_request filter matches milestone branches
+```
+
+`./quality.sh` passes cleanly (bash syntax, shellcheck, bats, TypeScript gate,
+fmt/clippy/deny, workspace tests, doc, release build).
+
+## Test Plan
+
+- Added `tests/scripts/ci_workflow.bats`:
+  - `ci workflow file exists` — the workflow YAML is present.
+  - `ci workflow is valid YAML` — it parses.
+  - `ci workflow pull_request filter matches milestone branches` — regression
+    test reproducing #327: fails against the unfixed `[Develop]` filter, passes
+    once `milestone/*` is added; also asserts `Develop` still matches.

--- a/docs/archive/pr-summaries/pr-summary-328.md
+++ b/docs/archive/pr-summaries/pr-summary-328.md
@@ -1,0 +1,66 @@
+# Run the gitleaks secret scan on milestone PRs (Issue #328)
+
+## Summary
+
+`.github/workflows/gitleaks.yml` triggered on `pull_request` with
+`branches: ["*"]`. GitHub branch-filter globbing treats `*` as "any character
+except `/`", so the filter never matched a `milestone/<slug>` branch. Milestone
+sub-issue PRs target a shared `milestone/<slug>` branch, so the secret scan was
+silently skipped on every one of them — the leak would only be caught later by
+the single rollup PR into the default branch.
+
+Added an explicit `milestone/*` pattern to the filter
+(`branches: ["*", "milestone/*"]`), mirroring the fix already landed for
+`actionlint.yml` (Issue #326) and `ci.yml` (Issue #327). Milestone branch names
+carry no nested slashes, so the single-level glob is sufficient.
+
+Closes #328.
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified by
+the bats suite plus a local `actionlint` run over the edited workflow (clean).
+
+Trigger coverage before and after:
+
+```mermaid
+flowchart LR
+    A["PR → Develop / main"] --> G["gitleaks scan runs"]
+    B["PR → milestone/&lt;slug&gt;"] -.->|before: `*` never crosses `/`| S["scan skipped ❌"]
+    B ==>|after: `milestone/*` added| G
+```
+
+Test run after the fix:
+
+```text
+1..7
+ok 1 gitleaks.yml does not use the Node-based gitleaks-action
+ok 2 gitleaks.yml installs gitleaks from a version-pinned release URL
+ok 3 gitleaks.yml verifies the gitleaks tarball with sha256sum -c
+ok 4 gitleaks.yml declares a 64-hex GITLEAKS_SHA256 env var
+ok 5 gitleaks.yml declares a semver GITLEAKS_VERSION env var
+ok 6 gitleaks.yml pull_request filter matches milestone branches
+ok 7 gitleaks.yml invokes the gitleaks CLI
+```
+
+Before the workflow edit, test 6 failed (`not ok 6`) — a genuine
+red-then-green regression test.
+
+`./quality.sh < /dev/null` passes cleanly (exit 0).
+
+## Test Plan
+
+- Added `tests/scripts/gitleaks_pinned_install.bats::"gitleaks.yml
+  pull_request filter matches milestone branches"` — parses the workflow YAML,
+  re-implements GitHub's filter glob semantics (`*` does not cross `/`, `**`
+  does), and asserts the `pull_request.branches` patterns match
+  `milestone/clean-up-23-jul` while still matching `Develop` and `main`.
+- Existing gitleaks workflow tests unchanged and still passing; no tests were
+  removed or disabled.
+
+## Security Self-Check
+
+- No secrets or hidden files staged — only `.github/workflows/gitleaks.yml`
+  (allowlisted workflow YAML), a bats test, and this summary.
+- Change strictly widens a CI gate's coverage; no permissions, tokens, or
+  script behaviour altered.

--- a/docs/archive/pr-summaries/pr-summary-329.md
+++ b/docs/archive/pr-summaries/pr-summary-329.md
@@ -1,0 +1,60 @@
+# PR Summary — Issue #329
+
+## Summary
+
+`.github/workflows/markdown-lint.yml` gated pull requests with
+`branches: ["*"]`. GitHub branch-filter globs treat `*` as "any characters
+except `/`", so that pattern never matched a `milestone/<slug>` branch. Every
+milestone sub-issue PR merged into the shared milestone branch without the
+Markdown lint gate running — the gap only surfaced later on the single rollup PR
+into the default branch.
+
+Added an explicit `milestone/*` pattern to the filter
+(`branches: ["*", "milestone/*"]`), matching the fixes already landed for
+actionlint (#326), the CI quality workflow (#327), and gitleaks (#328).
+Milestone branch names are `milestone/<slug>` with no nested slashes, so the
+single-level glob is sufficient.
+
+Closes #329.
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified by
+the bats suite below.
+
+Branch-filter coverage before and after:
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — branches: [\"*\"]"]
+        B1["PR → Develop"] --> BG["markdown lint runs"]
+        B2["PR → milestone/clean-up-23-jul"] -.->|no pattern matches| BS["gate skipped"]
+    end
+    subgraph After["After — branches: [\"*\", \"milestone/*\"]"]
+        A1["PR → Develop"] --> AG["markdown lint runs"]
+        A2["PR → milestone/clean-up-23-jul"] --> AG
+    end
+```
+
+Full `./quality.sh` run passes (`✅ All quality checks passed!`), and the
+targeted suite is green:
+
+```text
+1..12
+ok 4 markdown-lint workflow pull_request filter matches milestone branches
+...
+```
+
+The new test fails against the unfixed workflow (confirmed before applying the
+fix) and passes after it.
+
+## Test Plan
+
+- Added `tests/scripts/markdown_lint_workflow.bats::"markdown-lint workflow
+  pull_request filter matches milestone branches"` — parses the workflow YAML,
+  reimplements GitHub's filter globbing (`*` does not cross `/`, `**` does), and
+  asserts that at least one pattern matches `milestone/clean-up-23-jul` while
+  `Develop` and `main` still match. This is the regression test for #329.
+- Re-ran the whole `tests/scripts/markdown_lint_workflow.bats` suite (12/12
+  pass) to confirm no existing behaviour regressed.
+- Ran `./quality.sh < /dev/null` — all checks pass.

--- a/docs/archive/pr-summaries/pr-summary-330.md
+++ b/docs/archive/pr-summaries/pr-summary-330.md
@@ -1,0 +1,60 @@
+# Semgrep workflow now gates milestone PRs (Issue #330)
+
+## Summary
+
+`.github/workflows/semgrep.yml` filtered pull requests on `branches: ["*"]`.
+GitHub branch-filter globs treat `*` as "any chars **except** `/`", so a bare
+`"*"` never matches a `milestone/<slug>` branch. Milestone sub-issue PRs target
+a shared `milestone/<name>` branch, so every one of them merged without the
+Semgrep scan running — the gap only surfaced later on the single rollup PR into
+the default branch.
+
+Added an explicit `milestone/*` pattern so the scan runs on milestone sub-issue
+PRs too. This mirrors the fixes already landed for `gitleaks.yml` (Issue #328)
+and `markdown-lint.yml` (Issue #329). Closes #330.
+
+```mermaid
+flowchart LR
+    A["sub-issue PR<br/>→ milestone/clean-up-23-jul"] -->|before: '*' does not cross '/'| B["Semgrep skipped ❌"]
+    A -->|after: 'milestone/*' matches| C["Semgrep runs ✅"]
+    C --> D["rollup PR → Develop"]
+    D --> E["Semgrep runs ✅"]
+```
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot.
+
+`tests/scripts/semgrep_workflow.bats` expands the workflow's branch patterns
+using GitHub's own globbing rules (`**` crosses `/`, `*` does not) and asserts
+`milestone/clean-up-23-jul` matches while `Develop` and `main` still do.
+
+Before the fix:
+
+```text
+not ok 2 semgrep.yml pull_request filter matches milestone branches
+```
+
+After the fix:
+
+```text
+1..3
+ok 1 semgrep.yml exists and is valid YAML
+ok 2 semgrep.yml pull_request filter matches milestone branches
+ok 3 semgrep.yml runs the semgrep scan on pull requests
+```
+
+`./quality.sh` passes cleanly (bats, shellcheck, deno check, clippy, cargo
+test, doc, release build), and `actionlint .github/workflows/semgrep.yml`
+reports no findings.
+
+## Test Plan
+
+- Added `tests/scripts/semgrep_workflow.bats`:
+  - `semgrep.yml exists and is valid YAML`
+  - `semgrep.yml pull_request filter matches milestone branches` — the
+    regression test for this issue; fails against the unfixed workflow.
+  - `semgrep.yml runs the semgrep scan on pull requests` — guards against the
+    filter being "fixed" on a workflow that no longer scans anything.
+- Picked up automatically by `quality.sh` (`bats tests/scripts`) and the CI
+  bats gate; no existing tests were modified or removed.

--- a/docs/archive/pr-summaries/pr-summary-331.md
+++ b/docs/archive/pr-summaries/pr-summary-331.md
@@ -1,0 +1,58 @@
+# Least-privilege `permissions:` for the `wasm64-memory64-smoke` CI job
+
+## Summary
+
+The `wasm64-memory64-smoke` job in `.github/workflows/ci.yml` declared no
+`permissions:` block at either job or workflow level, so it inherited the
+repository's broad default `GITHUB_TOKEN` scopes (typically `contents: write`
+and more). The job only checks out the repo, installs Deno, and runs one
+committed smoke test — it never writes — so it now declares the least-privilege
+set it actually needs: `contents: read`. Closes #331.
+
+This follows the same pattern already applied to `quality`, `rust-gates`,
+`scripts-and-spelling`, `security`, and `validation` (Issues #311–#313).
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by the new
+bats contract test, which parses `ci.yml` as YAML and asserts on the resolved
+permissions of the job (job-level block, falling back to workflow-level).
+
+Test run before the fix (red):
+
+```text
+1..3
+ok 1 ci workflow file exists
+not ok 2 wasm64-memory64-smoke job declares an explicit permissions block
+not ok 3 wasm64-memory64-smoke job grants read-only contents and no write scopes
+```
+
+Test run after the fix (green):
+
+```text
+1..3
+ok 1 ci workflow file exists
+ok 2 wasm64-memory64-smoke job declares an explicit permissions block
+ok 3 wasm64-memory64-smoke job grants read-only contents and no write scopes
+```
+
+`./quality.sh` passes cleanly (`✅ All quality checks passed!`).
+
+```mermaid
+flowchart LR
+    A["wasm64-memory64-smoke job"] --> B{"permissions: block?"}
+    B -- "before: none" --> C["inherits repo default scopes<br/>(often contents: write)"]
+    B -- "after: contents: read" --> D["least-privilege token<br/>no write scopes"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/ci_wasm64_memory64_smoke_permissions.bats`:
+  - `ci workflow file exists`
+  - `wasm64-memory64-smoke job declares an explicit permissions block` — fails
+    against the unfixed workflow, passes after the fix (regression test).
+  - `wasm64-memory64-smoke job grants read-only contents and no write scopes` —
+    asserts `contents: read` and that no scope is granted `write`.
+- No existing tests were modified or removed; full `./quality.sh` gate
+  (rustfmt, clippy, cargo-deny, bats, workspace tests, docs, release build)
+  passes.

--- a/docs/archive/pr-summaries/pr-summary-332.md
+++ b/docs/archive/pr-summaries/pr-summary-332.md
@@ -1,0 +1,55 @@
+# PR Summary — Issue #332
+
+## Summary
+
+The `wasm64-memory64-smoke` job in `.github/workflows/ci.yml` checked out the
+repository without `persist-credentials: false`, so `actions/checkout` wrote the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header. Every later step
+in that job — including a compromised action or injected script — could read the
+credential and act as the token. The job is read-only (checkout, install Deno,
+run one committed Memory64 smoke test): it never pushes back and fetches no
+private submodule, so the persisted credential was pure blast radius.
+
+`persist-credentials: false` is now set on that checkout step, keeping the token
+off disk. Closes #332.
+
+## Evidence
+
+This is a CI-workflow security-hardening change with no web interface, so no
+screenshot applies. Verification is by test: a new BATS suite parses `ci.yml` as
+YAML and asserts the observable CI contract — every `actions/checkout` step in
+the `wasm64-memory64-smoke` job sets `persist-credentials: false`. The test
+failed against the unfixed workflow and passes after the change.
+
+```text
+$ bats tests/scripts/ci_wasm64_memory64_smoke_checkout.bats   # before the fix
+ok 1 ci workflow defines a wasm64-memory64-smoke job
+not ok 2 ci wasm64-memory64-smoke checkout does not persist credentials on disk
+
+$ bats tests/scripts/ci_wasm64_memory64_smoke_checkout.bats   # after the fix
+ok 1 ci workflow defines a wasm64-memory64-smoke job
+ok 2 ci wasm64-memory64-smoke checkout does not persist credentials on disk
+```
+
+```mermaid
+flowchart LR
+    A["actions/checkout"] -->|"default"| B[".git/config holds GITHUB_TOKEN"]
+    B --> C["any later step can read it"]
+    A -->|"persist-credentials: false"| D["no credential on disk"]
+    D --> E["smoke test runs read-only"]
+```
+
+`./quality.sh` passes cleanly (fmt, clippy, deny, shellcheck, BATS, workspace
+tests, docs, release build).
+
+## Test Plan
+
+- Added `tests/scripts/ci_wasm64_memory64_smoke_checkout.bats`:
+  - `ci workflow defines a wasm64-memory64-smoke job` — the job still exists
+    under the expected key.
+  - `ci wasm64-memory64-smoke checkout does not persist credentials on disk` —
+    regression test that fails on the unfixed workflow; every checkout step in
+    the job must set `persist-credentials: false`.
+- Existing `tests/scripts/ci_wasm64_memory64_smoke_permissions.bats` (Issue
+  #331) continues to pass, confirming the least-privilege `permissions:` block
+  is untouched.

--- a/docs/archive/pr-summaries/pr-summary-333.md
+++ b/docs/archive/pr-summaries/pr-summary-333.md
@@ -1,0 +1,91 @@
+# PR Summary — Issue #333
+
+## Summary
+
+None of the jobs across the repository's 9 workflow files declared a job-level
+`timeout-minutes:`, so every job inherited GitHub's default of **6 hours**. A
+wedged step — a hung `cargo` build, a stalled network fetch in `bump-deps.sh`,
+a `deno test` waiting on stdin — held a runner for the full six hours, burning
+the Actions minutes quota and blocking queued runs.
+
+Every runner job now declares an explicit budget, sized generously above its
+normal wall clock and annotated with what it covers. `Closes #333`.
+
+| Workflow | Job | `timeout-minutes` |
+| --- | --- | --- |
+| `ci.yml` | `version-increment` | 15 |
+| `ci.yml` | `version-gate` | 10 |
+| `ci.yml` | `auto-format` | 20 |
+| `ci.yml` | `quality` | 45 |
+| `ci.yml` | `rust-gates` | 45 |
+| `ci.yml` | `typescript-gate` | 10 |
+| `ci.yml` | `scripts-and-spelling` | 15 |
+| `ci.yml` | `wasm64-memory64-smoke` | 10 |
+| `ci.yml` | `validation` | 15 |
+| `security.yml` | `security` | 30 |
+| `actionlint.yml` | `actionlint` | 10 |
+| `gitleaks.yml` | `gitleaks` | 15 |
+| `markdown-lint.yml` | `markdownlint` | 10 |
+| `release.yml` | `release` | 15 |
+| `semgrep.yml` | `semgrep` | 20 |
+| `upgrade-dependencies.yml` | `upgrade` | 45 |
+| `wasm-bundle.yml` | `publish` | 45 |
+
+### Reusable-workflow caller carve-out
+
+`ci.yml`'s `security` job is a reusable-workflow **caller**
+(`uses: ./.github/workflows/security.yml`). GitHub rejects `timeout-minutes` on
+a calling job, so the budget lives on the called workflow's own `security` job
+instead — which bounds the caller just the same.
+
+```mermaid
+flowchart LR
+    A["ci.yml job: security"] -->|"uses: ./.github/workflows/security.yml"| B["security.yml job: security"]
+    A -.->|"timeout-minutes rejected by GitHub"| X["✗"]
+    B --> C["timeout-minutes: 30 — bounds both"]
+```
+
+## Evidence
+
+Backend/CI-configuration change only — there is no web interface to
+screenshot. Verified by the test suite and by `actionlint`:
+
+- `bats tests/scripts` — **231 tests, 0 failures** (4 of them new, see below).
+- `actionlint -no-color -ignore 'SC2016' .github/workflows/*.yml` — exit 0,
+  confirming no `timeout-minutes` landed anywhere GitHub would reject it.
+- `./quality.sh < /dev/null` — passed cleanly end to end (shellcheck, bats,
+  `deno check`, codespell, `cargo deny`, fmt, clippy, check, tests, docs,
+  release build).
+
+The new tests fail against the pre-fix tree and pass after the change:
+
+```text
+# before
+not ok 1 every runner job in every workflow declares a job-level timeout-minutes
+not ok 3 compile-heavy jobs budget at least 30 minutes
+
+# after
+ok 1 every runner job in every workflow declares a job-level timeout-minutes
+ok 2 every declared timeout-minutes is a positive integer no greater than 60
+ok 3 compile-heavy jobs budget at least 30 minutes
+ok 4 reusable-workflow callers carry no timeout-minutes and the callee does
+```
+
+## Test Plan
+
+Added `tests/scripts/workflow_job_timeouts.bats` — "what" tests that parse the
+workflow YAML and assert on the effective configuration, not on source text:
+
+1. `every runner job in every workflow declares a job-level timeout-minutes` —
+   regression test for the reported defect; covers all workflows, so a new
+   workflow added later without a budget fails CI.
+2. `every declared timeout-minutes is a positive integer no greater than 60` —
+   edge case: rejects `0`, negatives, booleans, strings, and runaway budgets.
+3. `compile-heavy jobs budget at least 30 minutes` — guards the other
+   direction, so a later edit cannot starve `quality`, `rust-gates`,
+   `security`, `upgrade`, or `publish` mid-build.
+4. `reusable-workflow callers carry no timeout-minutes and the callee does` —
+   error path: pins the GitHub restriction that would otherwise produce an
+   invalid workflow, and asserts the callee still carries a budget.
+
+No existing tests were modified or removed.

--- a/docs/archive/pr-summaries/pr-summary-334.md
+++ b/docs/archive/pr-summaries/pr-summary-334.md
@@ -1,0 +1,105 @@
+# PR Summary — Issue #334
+
+## Summary
+
+Added a top-level `concurrency:` group with `cancel-in-progress: true` to the
+five pile-up-prone PR/push gates — `ci.yml`, `actionlint.yml`, `gitleaks.yml`,
+`markdown-lint.yml` and `semgrep.yml`. Every `synchronize` push to an open PR
+previously queued a fresh run while the previous one was still compiling; on
+`ci.yml`, where a single run compiles the workspace several times over, a few
+rapid pushes (including the bot pushes from `version-increment`/`auto-format`)
+stacked runs several deep, burning runner minutes on results nobody reads.
+Each group is keyed on `github.workflow` **and** `github.ref`, so one live run
+is kept per workflow per branch and no workflow can cancel another's run.
+
+`release.yml` and `wasm-bundle.yml` are deliberately left uncancelled: both
+publish a per-version tag or per-commit bundle that downstream consumers pin by
+SHA, and cancelling a superseded run would silently skip an artefact. The
+reusable `security.yml` declares no group of its own — it runs inside the
+caller's context, so its own group would let one caller cancel another caller's
+in-flight scan.
+
+Closes #334.
+
+## Evidence
+
+Workflow/CI change with no web interface to screenshot. Verified by parsing the
+committed workflow YAML in a new bats suite (below) and by `actionlint`, which
+reports no new findings for the five edited files.
+
+Before — every push starts a new run and the old one keeps compiling:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Push to PR branch
+    participant GA as GitHub Actions
+    Dev->>GA: push A
+    GA->>GA: run 1 (full cargo build) …
+    Dev->>GA: push B (synchronize)
+    GA->>GA: run 2 starts — run 1 still compiling
+    Dev->>GA: push C (bot: version-increment)
+    GA->>GA: run 3 starts — runs 1 and 2 still compiling
+    Note over GA: 3 concurrent runs, only run 3's result is read
+```
+
+After — the group keeps one live run per workflow per ref:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Push to PR branch
+    participant GA as GitHub Actions
+    Dev->>GA: push A
+    GA->>GA: run 1 in group CI-refs/pull/N/merge
+    Dev->>GA: push B (synchronize)
+    GA-->>GA: cancel run 1 (superseded)
+    GA->>GA: run 2 in same group
+    Dev->>GA: push C (bot: version-increment)
+    GA-->>GA: cancel run 2 (superseded)
+    GA->>GA: run 3 in same group
+    Note over GA: 1 concurrent run; publishers keep every run
+```
+
+Local run of the new suite:
+
+```text
+$ bats tests/scripts/workflow_concurrency_groups.bats < /dev/null
+1..4
+ok 1 pile-up-prone workflows cancel superseded runs per ref
+ok 2 each gated workflow's concurrency group is distinct for the same ref
+ok 3 publishing workflows never cancel in-progress runs
+ok 4 the reusable security workflow declares no concurrency group
+```
+
+Full gate: `bats tests/scripts` → 240 passing, 0 failing; `./quality.sh` exits 0
+(fmt, clippy `-D warnings`, cargo-deny, `cargo test --workspace`, docs, release
+build).
+
+## Test Plan
+
+Added `tests/scripts/workflow_concurrency_groups.bats` — "what" tests that parse
+the workflow YAML and assert on the effective configuration, not on source text:
+
+- **`pile-up-prone workflows cancel superseded runs per ref`** — each of the
+  five gates declares a `concurrency` mapping whose group references both
+  `github.workflow` and `github.ref`, with `cancel-in-progress: true`. This is
+  the regression test: it fails against the pre-fix workflows (verified — it
+  reported "no top-level concurrency mapping" for all five) and passes after.
+- **`each gated workflow's concurrency group is distinct for the same ref`** —
+  resolves `github.workflow` to each workflow's declared `name` and asserts no
+  two workflows land in the same group, so gitleaks can never cancel CI.
+- **`publishing workflows never cancel in-progress runs`** — `release.yml` and
+  `wasm-bundle.yml` must not set `cancel-in-progress: true` at workflow or job
+  level (edge case: no group at all is also acceptable).
+- **`the reusable security workflow declares no concurrency group`** —
+  `security.yml` stays a `workflow_call` workflow with no group of its own.
+
+No existing tests were modified or removed.
+
+## Security Self-Check
+
+- No secrets, credentials or `.config*.json` files staged; the only hidden paths
+  touched are `.github/workflows/*.yml`, which the allowlist permits.
+- No new dependencies, network calls, shell interpolation or user input surface —
+  the change is five declarative YAML keys plus a test file.
+- `cancel-in-progress` is scoped away from the publishing workflows, so no
+  signed/attested artefact can be skipped by a cancellation.

--- a/docs/archive/pr-summaries/pr-summary-335.md
+++ b/docs/archive/pr-summaries/pr-summary-335.md
@@ -1,0 +1,103 @@
+# Pin the Semgrep container image by digest (Issue #335)
+
+## Summary
+
+`.github/workflows/semgrep.yml` ran its `semgrep` job inside a container
+referenced by the bare image name `semgrep/semgrep`, which resolves to the
+mutable `:latest` tag. The registry owner — or anyone who compromises the
+`semgrep/semgrep` Docker Hub account — can re-point that tag at any time, and
+the substituted image would then execute with this job's `GITHUB_TOKEN`,
+`SEMGREP_APP_TOKEN` and the fully checked-out source in scope. It was the last
+mutable third-party reference in the repo's workflows: `uses:` steps are pinned
+to 40-char commit SHAs (Issue #77) and CLI installs to SHA-256-verified
+tarballs (Issues #78/#96/#99).
+
+The image is now pinned by digest — content-addressed and immutable — with the
+human-readable tag kept in a comment, and a new workflow-wide bats gate keeps
+any future container or service image from regressing to a mutable reference.
+
+Closes #335.
+
+## Changes
+
+- **`.github/workflows/semgrep.yml`** — `image: semgrep/semgrep` →
+  `image: semgrep/semgrep@sha256:98c2572f…d9941`, the digest `:latest`
+  currently resolves to (`semgrep/semgrep:1.170.1`). A comment records the tag
+  and the `docker buildx imagetools inspect semgrep/semgrep:latest` command
+  used to refresh it, so the digest is bumped deliberately on the same cadence
+  as the other pinned tools.
+- **`tests/scripts/workflow_container_pinning.bats`** (new) — a repo-wide gate,
+  not a semgrep-specific one: every job `container:` and `services:` image in
+  every workflow must be pinned as `@sha256:<64-hex>` and carry a version
+  comment.
+
+## Evidence
+
+This is a CI/workflow change with no web interface, so there is no screenshot
+to capture. The evidence is the bats suite: the new digest gate fails against
+the unfixed workflow and passes after the pin.
+
+Before the fix (red — TDD):
+
+```text
+not ok 1 every job container and service image is pinned to a sha256 digest
+# Unpinned container images:
+#   semgrep.yml job=semgrep container=semgrep/semgrep
+ok 2 every digest-pinned image carries a human-readable version comment
+ok 3 digest regex rejects bare image names and mutable tags
+```
+
+After the fix (green), and the full shell suite alongside it:
+
+```text
+1..3
+ok 1 every job container and service image is pinned to a sha256 digest
+ok 2 every digest-pinned image carries a human-readable version comment
+ok 3 digest regex rejects bare image names and mutable tags
+
+$ bats tests/scripts   # full suite
+243 passing, 0 failing
+```
+
+The attack this closes, and where the pin cuts it:
+
+```mermaid
+flowchart LR
+    A["semgrep job starts"] --> B{"image ref"}
+    B -- "semgrep/semgrep (:latest, mutable)" --> C["registry resolves tag at run time"]
+    C --> D["re-pointed tag → attacker image"]
+    D --> E["runs with GITHUB_TOKEN + SEMGREP_APP_TOKEN + source"]
+    B -- "semgrep/semgrep@sha256:98c2572f… (immutable)" --> F["content-addressed pull"]
+    F --> G["digest mismatch → pull fails loud"]
+    F --> H["exact reviewed image runs"]
+```
+
+## Test Plan
+
+Added `tests/scripts/workflow_container_pinning.bats`:
+
+- `every job container and service image is pinned to a sha256 digest` —
+  parses every workflow's YAML and asserts each job `container:`/`services:`
+  image ref matches `@sha256:<64-hex>`. This is the regression test: it fails
+  against the pre-fix `image: semgrep/semgrep` and passes after the pin.
+- `every digest-pinned image carries a human-readable version comment` — a
+  digest alone is unreviewable, so the tag must be named inline or on the line
+  above.
+- `digest regex rejects bare image names and mutable tags` — behavioural check
+  that the gate rejects `semgrep/semgrep`, `:latest`, a plain `:1.170.1` tag
+  and a truncated digest, so a weakened regex is caught.
+
+Existing `tests/scripts/semgrep_workflow.bats` still passes unchanged (valid
+YAML, milestone branch filter, scan step) — no test was modified or removed.
+
+## Security self-check
+
+- **Input validation** — no new runtime input surface; the change is a workflow
+  image ref.
+- **Secrets** — no secrets staged; only `.github/workflows/semgrep.yml` (the
+  worker holds the `workflow` OAuth scope) and a new test file.
+- **Injection surface** — none added; no new `run:` blocks or context
+  interpolation.
+- **Dependencies** — the container is an external dependency pinned to an
+  immutable digest published 2026-07-21, comfortably outside the 24h
+  quarantine window.

--- a/docs/archive/pr-summaries/pr-summary-336.md
+++ b/docs/archive/pr-summaries/pr-summary-336.md
@@ -1,0 +1,86 @@
+# PR Summary — Issue #336
+
+## Summary
+
+`.github/workflows/upgrade-dependencies.yml` ran its "Refresh dependencies via
+`bump-deps.sh` (quarantine-aware)" step under GitHub's default `bash -e` — `-e`
+but **no `pipefail`**. Because the command pipes into `tee upgrade.log`, the
+step's exit status was `tee`'s (always 0), so a non-zero exit from
+`bump-deps.sh` (release-age quarantine violation, `cargo audit` advisory, or a
+failed native/wasm build) was swallowed. The workflow then proceeded to open a
+PR whose body asserts the bumps "have passed `cargo audit` plus dual
+native/wasm builds" — a claim that could be false, silently re-opening the
+supply-chain window Issue #76 closed.
+
+Added `set -euo pipefail` to that step so the pipeline reports the script's
+failure. `tee` still captures the log the PR body pastes. The PR-path caller in
+`ci.yml` already set `set -euo pipefail`, so only this scheduled path changed.
+
+Closes #336.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Evidence is the new
+behavioural bats suite, which executes the workflow step's real script.
+
+Failure signal before and after the fix:
+
+```mermaid
+flowchart LR
+    A["bump-deps.sh exits 7"] --> B{"pipefail set?"}
+    B -- "before: no" --> C["pipeline status = tee's 0"]
+    C --> D["step green → PR claims gates passed"]
+    B -- "after: yes" --> E["pipeline status = 7"]
+    E --> F["step fails → no misleading PR"]
+```
+
+Tests fail against the unfixed workflow and pass after the fix:
+
+```text
+# before (workflow without pipefail)
+not ok 1 a failing bump-deps.sh fails the scheduled upgrade step
+ok 2 a passing bump-deps.sh keeps the scheduled upgrade step green
+ok 3 the scheduled upgrade step still captures bump-deps.sh output to upgrade.log
+not ok 4 every piped run: block in upgrade-dependencies.yml runs under pipefail
+
+# after
+ok 1 a failing bump-deps.sh fails the scheduled upgrade step
+ok 2 a passing bump-deps.sh keeps the scheduled upgrade step green
+ok 3 the scheduled upgrade step still captures bump-deps.sh output to upgrade.log
+ok 4 every piped run: block in upgrade-dependencies.yml runs under pipefail
+```
+
+Full suite: `bats tests/scripts` — 247 passing, 0 failing.
+`./quality.sh < /dev/null` — "All quality checks passed!".
+
+## Test Plan
+
+New `tests/scripts/workflow_pipefail.bats` — "what" tests that parse the
+workflow, extract the step's actual `run:` body, and execute it under the exact
+shell GitHub would use (`bash -e` with no `shell:`, `bash --noprofile --norc
+-eo pipefail` when `shell: bash` is declared), with a stub `bump-deps.sh`:
+
+- `a failing bump-deps.sh fails the scheduled upgrade step` — regression test
+  for #336; stub exits 7, step must exit non-zero.
+- `a passing bump-deps.sh keeps the scheduled upgrade step green` — stub exits
+  0, step must stay green (guards against over-strict `-e` breakage).
+- `the scheduled upgrade step still captures bump-deps.sh output to
+  upgrade.log` — `tee` still writes the log the PR body pastes, including the
+  `--quarantine-hours 24` argument.
+- `every piped run: block in upgrade-dependencies.yml runs under pipefail` —
+  forward guard so a future piped command in this workflow cannot reintroduce
+  the swallowed exit status.
+
+No existing tests were modified or removed.
+
+## Security Self-Check
+
+- Input validation: no new external input paths.
+- Secrets: only the workflow YAML and a bats file are staged; no `.env` /
+  `.config*.json`.
+- Injection surface: the test harness heredocs are quoted (`<<'PY'`), so
+  GitHub `${{ … }}` expressions are never evaluated by the shell; the stub runs
+  in `$BATS_TEST_TMPDIR`.
+- Error handling: the change makes failures louder, not quieter — a masked
+  failure is now surfaced as a failed step.
+- Dependencies: none added.

--- a/docs/archive/pr-summaries/pr-summary-337.md
+++ b/docs/archive/pr-summaries/pr-summary-337.md
@@ -1,0 +1,81 @@
+## Summary
+
+`.github/workflows/ci.yml` ran the identical lint recipe twice on every pull
+request: job `quality` step "Run linter" and job `rust-gates` step "Lint gate
+(cargo clippy)" both invoked
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`, plus a
+`cargo check --workspace --all-targets --all-features` that clippy's own
+compilation already subsumes. Two jobs with separate caches compiled and linted
+the whole workspace, roughly doubling the heaviest part of the CI bill on every
+PR.
+
+`rust-gates` is now scoped to the events `quality` does not cover
+(`if: github.event_name != 'pull_request'`), which preserves its stated purpose
+from Issue #143 — gating direct pushes to `Develop`, which skip the PR-only
+jobs — while `quality` stays the comprehensive PR gate (fmt, deny, clippy,
+tests, docs). `Lint & Compile Gates` is not a required status check in
+`.github/rulesets/develop.json`, so skipping it on PRs does not block merges.
+
+Closes #337.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by the
+`bats` contract tests over the parsed workflow YAML.
+
+```mermaid
+flowchart TD
+    subgraph Before
+        P1[pull_request] --> Q1["quality: clippy -D warnings"]
+        P1 --> R1["rust-gates: cargo check + clippy -D warnings"]
+        U1[push to Develop] --> R1
+    end
+    subgraph After
+        P2[pull_request] --> Q2["quality: clippy -D warnings"]
+        U2["push to Develop / workflow_dispatch"] --> R2["rust-gates: cargo check + clippy -D warnings"]
+    end
+```
+
+Test run (`bats tests/scripts/rust_gates_workflow.bats`) — the new test fails
+against the unfixed workflow and passes after the change:
+
+```text
+1..9
+ok 1 ci workflow file exists
+ok 2 ci workflow is valid YAML
+ok 3 ci workflow triggers on PRs and on pushes to Develop
+ok 4 ci workflow runs a clippy lint gate with -D warnings
+ok 5 ci workflow runs an explicit compile/syntax gate (cargo check or build)
+ok 6 ci workflow gates lint + compile on push (not pull_request only)
+ok 7 exactly one job runs the clippy lint gate on a pull_request event
+ok 8 ci workflow pins third-party actions to commit SHAs
+ok 9 ci rust-gates checkout does not persist credentials on disk
+```
+
+Full suite: `bats tests/scripts` — 248/248 pass. `./quality.sh` passes cleanly.
+`actionlint .github/workflows/ci.yml` reports no findings.
+
+## Test Plan
+
+- **Added** `tests/scripts/rust_gates_workflow.bats::"exactly one job runs the
+  clippy lint gate on a pull_request event"` — regression test for the
+  duplicate gate. It parses `ci.yml`, keeps the jobs whose `if:` allows a
+  `pull_request` event, and asserts exactly one of them carries a
+  `cargo clippy … -D warnings` step. Fails against the unfixed workflow (two
+  jobs), passes after.
+- **Modified** (documented business-logic change)
+  `tests/scripts/rust_gates_workflow.bats::"ci workflow gates lint + compile on
+  push (not pull_request only)"` — it previously asserted the gate job's `if:`
+  text did not contain the substring `pull_request`, which cannot distinguish
+  `github.event_name == 'pull_request'` (PR only — the condition it meant to
+  reject) from `github.event_name != 'pull_request'` (everything *but* a PR —
+  which satisfies the same contract). It now evaluates the condition against a
+  `push` event via a shared `runs_on(job, event)` helper, so it still asserts
+  the same observable outcome: direct pushes to `Develop` hit the lint +
+  compile gate. No test was removed or commented out.
+- **Unchanged and still passing**: the compile/syntax-gate test (clippy's own
+  compilation covers PRs; `rust-gates` still runs `cargo check --all-targets`
+  on pushes), the SHA-pinning test, the `persist-credentials` test
+  (Issue #318), and `ci_rust_gates_permissions.bats` (Issue #310).
+- Documentation: the `ci.yml` row in `README.md` now describes which events
+  each job gates.

--- a/quality.sh
+++ b/quality.sh
@@ -47,6 +47,10 @@ else
     echo "   Install with: brew install bats-core  (or your package manager)"
 fi
 
+# TypeScript basic-validity gate (Issue #307) — mirrors the CI typescript-gate job.
+echo "🧾 Checking TypeScript sources (deno check)..."
+./scripts/typescript-check.sh </dev/null
+
 # Optional: codespell (CI runs this; install: pip install codespell)
 if command -v codespell &>/dev/null; then
     echo "📖 Running codespell..."

--- a/scripts/typescript-check.sh
+++ b/scripts/typescript-check.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# typescript-check.sh — basic-validity gate for TypeScript sources (Issue #307).
+#
+# Usage: typescript-check.sh [root-dir]
+#
+# Type-checks every .ts file under <root-dir> (default: the repository root)
+# with `deno check`, so a syntax or type error fails the build instead of
+# landing on Develop unnoticed. Basic validity only — this is not a style or
+# lint gate.
+#
+# This repository commits its own gate; there is no shared cross-repo Action.
+set -euo pipefail
+
+# Fail loud: a missing toolchain must never be reconciled as a passing gate.
+# Checked first so the diagnostic survives a stripped PATH.
+if ! command -v deno &>/dev/null; then
+  echo "typescript-check: deno is required — install: https://docs.deno.com/runtime/getting_started/installation/" >&2
+  exit 1
+fi
+
+root="${1:-$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)}"
+
+if [ ! -d "$root" ]; then
+  echo "typescript-check: not a directory: $root" >&2
+  exit 2
+fi
+
+files=()
+while IFS= read -r file; do
+  files+=("$file")
+done < <(find "$root" -name '*.ts' -type f \
+  -not -path '*/target/*' \
+  -not -path '*/.git/*' \
+  -not -path '*/node_modules/*' | sort)
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "typescript-check: no TypeScript files found under $root — nothing to check"
+  exit 0
+fi
+
+echo "typescript-check: checking ${#files[@]} TypeScript file(s) with deno check"
+deno check "${files[@]}" </dev/null
+echo "typescript-check: all TypeScript files passed basic validity"

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -8,6 +8,7 @@
 #   - third-party actions are SHA-pinned (consistent with Issue #77),
 #   - the install step pins both version and SHA-256 (supply-chain hygiene
 #     mirroring gitleaks.yml from Issue #99 and wasm-pack from Issue #78),
+#   - the checkout step does not persist the GITHUB_TOKEN on disk (Issue #317),
 #   - if `actionlint` is installed locally, it passes against the current
 #     workflows on disk (behavioural sanity check).
 
@@ -120,6 +121,32 @@ assert re.match(r"^[0-9a-f]{64}$", str(sha256)), sha256
 # The run script must invoke sha256sum -c to verify the downloaded asset.
 run_script = step.get("run", "")
 assert "sha256sum" in run_script and "-c" in run_script, run_script
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Issue #317 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. This job only lints workflow files: it never pushes back to
+# the repository and fetches no private submodule, so the credential is pure
+# blast radius.
+@test "actionlint workflow checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["actionlint"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
 PY
   [ "$status" -eq 0 ]
 }

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -50,6 +50,52 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #326 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["*"] never matches milestone/<slug> and the gate silently skips those PRs.
+# The filter must match milestone branches so the lint gate runs on them too.
+@test "actionlint workflow pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "actionlint workflow exposes a job that runs the actionlint binary" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -29,7 +29,7 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "actionlint workflow triggers on PRs and on pushes to Develop" {
+@test "actionlint workflow gates PRs only and does not re-run on push to Develop" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
@@ -40,9 +40,11 @@ data = yaml.safe_load(open("$WORKFLOW"))
 triggers = data.get("on") or data.get(True)
 assert triggers is not None, data
 assert "pull_request" in triggers, triggers
-push = triggers.get("push") or {}
-branches = push.get("branches") or []
-assert "Develop" in branches, branches
+# Issue #314 — a lint/check workflow gates the PR; re-running it on push to
+# the default branch duplicates the run that already gated the merge.
+push = triggers.get("push")
+branches = (push or {}).get("branches") or []
+assert "Develop" not in branches, branches
 PY
   [ "$status" -eq 0 ]
 }

--- a/tests/scripts/ci_quality_permissions.bats
+++ b/tests/scripts/ci_quality_permissions.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Tests for the CI `quality` job least-privilege token scopes (Issue #309).
+#
+# Contract under test: the `quality` job in .github/workflows/ci.yml must
+# declare an explicit `permissions:` block so it does not silently inherit the
+# repository's broad default GITHUB_TOKEN scopes. The job only reads the repo
+# (checkout + git pull + cargo checks), so `contents: read` is the correct
+# least-privilege grant.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "quality job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["quality"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "quality job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "quality job grants contents: read (least privilege, no write)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["quality"]
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: no scope may be granted write on the quality (read-only) job.
+writes = [k for k, v in perms.items() if v == "write"]
+assert not writes, f"quality job must not hold write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_rust_gates_permissions.bats
+++ b/tests/scripts/ci_rust_gates_permissions.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Tests for the CI `rust-gates` job least-privilege token scopes (Issue #310).
+#
+# Contract under test: the `rust-gates` job in .github/workflows/ci.yml must
+# declare an explicit `permissions:` block so it does not silently inherit the
+# repository's broad default GITHUB_TOKEN scopes. The job only reads the repo
+# (checkout + cargo check/clippy), so `contents: read` is the correct
+# least-privilege grant.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "rust-gates job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["rust-gates"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "rust-gates job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "rust-gates job grants contents: read (least privilege, no write)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["rust-gates"]
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: no scope may be granted write on the rust-gates (read-only) job.
+writes = [k for k, v in perms.items() if v == "write"]
+assert not writes, f"rust-gates job must not hold write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_scripts_and_spelling_permissions.bats
+++ b/tests/scripts/ci_scripts_and_spelling_permissions.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# Tests for the CI `scripts-and-spelling` job least-privilege token scopes
+# (Issue #311).
+#
+# Contract under test: the `scripts-and-spelling` job in
+# .github/workflows/ci.yml must declare an explicit `permissions:` block so it
+# does not silently inherit the repository's broad default GITHUB_TOKEN scopes.
+# The job only reads the repo (checkout + shellcheck/bash -n/codespell); it
+# never pushes, so `contents: read` is the correct least-privilege grant.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "scripts-and-spelling job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["scripts-and-spelling"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "scripts-and-spelling job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "scripts-and-spelling job grants contents: read (least privilege, no write)" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["scripts-and-spelling"]
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: no scope may be granted write on this read-only job.
+writes = [k for k, v in perms.items() if v == "write"]
+assert not writes, f"scripts-and-spelling job must not hold write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_security_permissions.bats
+++ b/tests/scripts/ci_security_permissions.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Tests for the CI `security` job least-privilege token scopes (Issue #312).
+#
+# Contract under test: the `security` job in .github/workflows/ci.yml calls the
+# reusable workflow .github/workflows/security.yml. A caller job with no
+# `permissions:` block hands the called workflow the repository's broad default
+# GITHUB_TOKEN scopes, so the caller must declare the least-privilege set the
+# called workflow actually needs: `contents: read` (checkout, cargo audit) plus
+# `pull-requests: write` (dependency-review PR comment summary).
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+  CALLED="${REPO_ROOT}/.github/workflows/security.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "security job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["security"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "security job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "security job grants only the scopes the reusable workflow needs" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["security"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+# Least privilege: dependency-review's PR comment is the only write needed.
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == ["pull-requests"], f"unexpected write scopes on security job: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "caller scopes cover every scope the called workflow declares" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+caller = yaml.safe_load(open("$WORKFLOW"))["jobs"]["security"]
+called = yaml.safe_load(open("$CALLED"))["jobs"]["security"]
+caller_perms = caller.get("permissions") or {}
+called_perms = called.get("permissions") or {}
+rank = {"none": 0, "read": 1, "write": 2}
+for scope, level in called_perms.items():
+    got = caller_perms.get(scope, "none")
+    assert rank[got] >= rank[level], (
+        f"caller grants {scope}: {got}, called workflow needs {level}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_validation_permissions.bats
+++ b/tests/scripts/ci_validation_permissions.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Tests for the CI `validation` job least-privilege token scopes (Issue #313).
+#
+# Contract under test: the `validation` job in .github/workflows/ci.yml only
+# reads the repository (checkout, cargo metadata, grep/wc file checks). With no
+# `permissions:` block it inherits the repository's broad default GITHUB_TOKEN
+# scopes, so it must declare the least-privilege set it actually needs:
+# `contents: read` and no write scopes at all.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "validation job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["validation"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "validation job has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "validation job grants read-only contents and no write scopes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["validation"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == [], f"validation is read-only; unexpected write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_wasm64_memory64_smoke_checkout.bats
+++ b/tests/scripts/ci_wasm64_memory64_smoke_checkout.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Tests for the CI `wasm64-memory64-smoke` job checkout hardening (Issue #332).
+#
+# The contract under test IS the CI wiring: actions/checkout writes the
+# workflow GITHUB_TOKEN into .git/config by default, leaving a usable
+# credential on disk for every later step in the job. The
+# `wasm64-memory64-smoke` job only checks out the repo, installs Deno and runs
+# one committed read-only smoke test — it never pushes back and fetches no
+# private submodule — so the persisted credential is pure blast radius.
+#
+# Asserts on observable outcomes:
+#   - ci.yml parses as YAML and defines a `wasm64-memory64-smoke` job,
+#   - every actions/checkout step in that job sets persist-credentials: false.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow defines a wasm64-memory64-smoke job" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+assert "wasm64-memory64-smoke" in data["jobs"], sorted(data["jobs"])
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci wasm64-memory64-smoke checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["wasm64-memory64-smoke"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in wasm64-memory64-smoke"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_wasm64_memory64_smoke_permissions.bats
+++ b/tests/scripts/ci_wasm64_memory64_smoke_permissions.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for the CI `wasm64-memory64-smoke` job least-privilege token scopes
+# (Issue #331).
+#
+# Contract under test: the `wasm64-memory64-smoke` job in
+# .github/workflows/ci.yml only reads the repository (checkout, install Deno,
+# run one committed smoke test). With no `permissions:` block it inherits the
+# repository's broad default GITHUB_TOKEN scopes, so it must declare the
+# least-privilege set it actually needs: `contents: read` and no write scopes.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "wasm64-memory64-smoke job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["wasm64-memory64-smoke"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "wasm64-memory64-smoke has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "wasm64-memory64-smoke job grants read-only contents and no write scopes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["wasm64-memory64-smoke"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == [], f"wasm64-memory64-smoke is read-only; unexpected write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/ci_workflow.bats
+++ b/tests/scripts/ci_workflow.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# Tests for the CI quality workflow branch filters (Issue #327).
+#
+# Asserts on observable outcomes:
+#   - the workflow YAML file exists and parses,
+#   - its pull_request branch filter matches milestone/<slug> feature branches
+#     as well as the existing default branch, so the quality gate runs on
+#     milestone sub-issue PRs (Issue #327).
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "ci workflow is valid YAML" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml,sys; yaml.safe_load(open('$WORKFLOW'))"
+  [ "$status" -eq 0 ]
+}
+
+# Issue #327 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["Develop"] never matches milestone/<slug> and the quality gate silently skips
+# those PRs. The filter must match milestone branches so the gate runs on them
+# too, while still matching the existing default branch.
+@test "ci workflow pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+# YAML parses bare 'on:' as boolean True in some loaders; tolerate both.
+triggers = data.get("on") or data.get(True)
+assert triggers is not None, data
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branch must still match.
+assert any(matches(p, "Develop") for p in patterns), (
+    f"no branch pattern matches 'Develop': {patterns}"
+)
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/gitleaks_pinned_install.bats
+++ b/tests/scripts/gitleaks_pinned_install.bats
@@ -62,6 +62,52 @@ strip_comments() {
   [ "$status" -eq 0 ]
 }
 
+# Issue #328 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["*"] never matches milestone/<slug> and the secret scan silently skips those
+# PRs. The filter must match milestone branches so the gate runs on them too.
+@test "gitleaks.yml pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WF"))
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "gitleaks.yml invokes the gitleaks CLI" {
   [ -f "$WF" ]
   # Either `./gitleaks detect …` (binary extracted to CWD) or

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -23,7 +23,7 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "markdown-lint workflow triggers on PRs and on pushes to Develop" {
+@test "markdown-lint workflow gates PRs only and does not re-run on push to Develop" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
@@ -34,9 +34,11 @@ data = yaml.safe_load(open("$WORKFLOW"))
 triggers = data.get("on") or data.get(True)
 assert triggers is not None, data
 assert "pull_request" in triggers, triggers
-push = triggers.get("push") or {}
-branches = push.get("branches") or []
-assert "Develop" in branches, branches
+# Issue #316 — a lint/check workflow gates the PR; re-running it on push to
+# the default branch duplicates the run that already gated the merge.
+push = triggers.get("push")
+branches = (push or {}).get("branches") or []
+assert "Develop" not in branches, branches
 PY
   [ "$status" -eq 0 ]
 }

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -76,6 +76,32 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #322 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. This job only lints Markdown and validates Mermaid blocks:
+# it never pushes back to the repository and fetches no private submodule, so
+# the credential is pure blast radius.
+@test "markdown-lint workflow checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["markdownlint"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "markdown-lint workflow does not pin actions/setup-node to a deprecated Node 20 SHA" {
   # Regression test for Issue #98 — actions/setup-node@v4
   # (SHA 49933ea5288caeca8642d1e84afbd3f7d6820020) ships the Node 20

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -43,6 +43,52 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #329 — milestone sub-issue PRs target a shared milestone/<slug> branch.
+# GitHub branch-filter globs treat `*` as "any chars except /", so a filter of
+# ["*"] never matches milestone/<slug> and this lint gate silently skips those
+# PRs. The filter must match milestone branches so the gate runs on them too.
+@test "markdown-lint workflow pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "markdown-lint workflow exposes a markdownlint job that runs markdownlint-cli2" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"

--- a/tests/scripts/release_sbom.bats
+++ b/tests/scripts/release_sbom.bats
@@ -86,6 +86,33 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Issue #323 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. The release job cuts the tag and publishes the release via
+# `gh` with GH_TOKEN from the environment, and its git operations
+# (`git ls-remote origin`) target a public repository that needs no credential,
+# so the persisted token is pure blast radius.
+@test "release workflow checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["release"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "SBOM is generated before the Release is published" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"

--- a/tests/scripts/rust_gates_workflow.bats
+++ b/tests/scripts/rust_gates_workflow.bats
@@ -15,6 +15,8 @@
 #   - a job invokes an explicit compile/syntax gate (cargo check / cargo build),
 #   - the gate job runs on push (not restricted to pull_request only), so direct
 #     pushes to Develop are gated too,
+#   - exactly one job lints on a pull_request event (Issue #337 — no duplicate
+#     clippy gate),
 #   - third-party actions in the gate job are SHA-pinned (Issue #77),
 #   - the gate job's checkout does not persist the GITHUB_TOKEN on disk
 #     (Issue #318).
@@ -22,6 +24,41 @@
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
   WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+
+  # Shared Python helpers, interpolated into the heredocs below. `runs_on`
+  # answers the observable question "would this job run for event X?" —
+  # replacing an earlier substring check on the `if:` text, which could not
+  # tell `github.event_name == 'pull_request'` (PR only) from
+  # `github.event_name != 'pull_request'` (everything but a PR).
+  read -r -d '' HELPERS <<'HELPERS_PY' || true
+import re
+
+def runs_on(job, event):
+    cond = str(job.get("if", "")).strip()
+    if not cond:
+        return True
+    expr = cond
+    if expr.startswith("${{") and expr.endswith("}}"):
+        expr = expr[3:-2].strip()
+    m = re.fullmatch(r"github\.event_name\s*(==|!=)\s*'([^']+)'", expr)
+    if not m:  # unrecognised condition — assume the job runs
+        return True
+    op, value = m.groups()
+    return event == value if op == "==" else event != value
+
+def has_lint(job):
+    return any(
+        "cargo clippy" in s.get("run", "") and "-D warnings" in s.get("run", "")
+        for s in job.get("steps", [])
+    )
+
+def has_compile(job):
+    return any(
+        ("cargo check" in s.get("run", "") or "cargo build" in s.get("run", ""))
+        and "--all-targets" in s.get("run", "")
+        for s in job.get("steps", [])
+    )
+HELPERS_PY
 }
 
 @test "ci workflow file exists" {
@@ -96,33 +133,40 @@ PY
   fi
   run python3 - <<PY
 import yaml
+$HELPERS
 data = yaml.safe_load(open("$WORKFLOW"))
 
-def has_lint(job):
-    return any(
-        "cargo clippy" in s.get("run", "") and "-D warnings" in s.get("run", "")
-        for s in job.get("steps", [])
-    )
-
-def has_compile(job):
-    return any(
-        ("cargo check" in s.get("run", "") or "cargo build" in s.get("run", ""))
-        and "--all-targets" in s.get("run", "")
-        for s in job.get("steps", [])
-    )
-
-# At least one job must carry BOTH gates and must not be restricted to
-# pull_request only, so direct pushes to Develop are gated too.
+# At least one job must carry BOTH gates and must actually run on a push
+# event, so direct pushes to Develop are gated too.
 gate_jobs = [
     job for job in data["jobs"].values()
     if has_lint(job) and has_compile(job)
 ]
 assert gate_jobs, "no single job carries both the lint and compile gates"
-runs_on_push = [
-    job for job in gate_jobs
-    if "pull_request" not in str(job.get("if", ""))
+runs_on_push = [job for job in gate_jobs if runs_on(job, "push")]
+assert runs_on_push, "lint+compile gate job does not run on push events"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Issue #337 — `quality` and `rust-gates` both ran the identical
+# `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+# on every pull request, compiling the whole workspace twice in separate jobs
+# with separate caches. Exactly one job must lint a PR; `rust-gates` keeps its
+# stated purpose by running on the events `quality` does not cover.
+@test "exactly one job runs the clippy lint gate on a pull_request event" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+$HELPERS
+data = yaml.safe_load(open("$WORKFLOW"))
+linting = [
+    name for name, job in data["jobs"].items()
+    if has_lint(job) and runs_on(job, "pull_request")
 ]
-assert runs_on_push, "lint+compile gate job is restricted to pull_request only"
+assert len(linting) == 1, f"expected exactly one PR lint job, got {linting}"
 PY
   [ "$status" -eq 0 ]
 }

--- a/tests/scripts/rust_gates_workflow.bats
+++ b/tests/scripts/rust_gates_workflow.bats
@@ -15,7 +15,9 @@
 #   - a job invokes an explicit compile/syntax gate (cargo check / cargo build),
 #   - the gate job runs on push (not restricted to pull_request only), so direct
 #     pushes to Develop are gated too,
-#   - third-party actions in the gate job are SHA-pinned (Issue #77).
+#   - third-party actions in the gate job are SHA-pinned (Issue #77),
+#   - the gate job's checkout does not persist the GITHUB_TOKEN on disk
+#     (Issue #318).
 
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
@@ -139,6 +141,32 @@ for job in data["jobs"].values():
         if uses is None:
             continue
         assert sha_re.match(uses), f"action not SHA-pinned: {uses}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Issue #318 — actions/checkout writes the workflow GITHUB_TOKEN into
+# .git/config by default, leaving a usable credential on disk for every later
+# step in the job. The rust-gates job only checks out, compiles and lints: it
+# never pushes back to the repository and fetches no private submodule, so the
+# persisted credential is pure blast radius.
+@test "ci rust-gates checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["rust-gates"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in rust-gates"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
 PY
   [ "$status" -eq 0 ]
 }

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Tests for the Semgrep GitHub Actions workflow.
+#
+# Issue #330 — milestone sub-issue PRs target a shared `milestone/<slug>`
+# branch. GitHub branch-filter globs treat `*` as "any chars except /", so a
+# filter of ["*"] never matches `milestone/<slug>` and this scan silently
+# skips those PRs; the gap only surfaces on the single rollup PR into the
+# default branch.
+#
+# These are "what" tests — they assert on the YAML the runner will execute,
+# not on commentary or surrounding prose.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WF="${REPO_ROOT}/.github/workflows/semgrep.yml"
+}
+
+@test "semgrep.yml exists and is valid YAML" {
+  [ -f "$WF" ]
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 -c "import yaml; yaml.safe_load(open('$WF'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "semgrep.yml pull_request filter matches milestone branches" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WF"))
+# YAML parses bare 'on:' as boolean True in some loaders; tolerate both.
+triggers = data.get("on") or data.get(True)
+pr = triggers["pull_request"]
+patterns = pr.get("branches") or []
+assert patterns, f"pull_request has no branches filter: {pr}"
+
+def matches(pattern, branch):
+    # GitHub filter globbing: ** crosses '/', * does not.
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern[i + 1 : i + 2] == "*":
+                regex += ".*"
+                i += 2
+                continue
+            regex += "[^/]*"
+        else:
+            regex += re.escape(c)
+        i += 1
+    return re.fullmatch(regex, branch) is not None
+
+branch = "milestone/clean-up-23-jul"
+assert any(matches(p, branch) for p in patterns), (
+    f"no branch pattern matches {branch!r}: {patterns}"
+)
+# The existing default branches must still match.
+for keep in ("Develop", "main"):
+    assert any(matches(p, keep) for p in patterns), (
+        f"no branch pattern matches {keep!r}: {patterns}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "semgrep.yml runs the semgrep scan on pull requests" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WF"))
+job = data["jobs"]["semgrep"]
+runs = [s.get("run", "") for s in job["steps"]]
+assert any("semgrep" in r for r in runs), runs
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/typescript_check.bats
+++ b/tests/scripts/typescript_check.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for scripts/typescript-check.sh — the TypeScript basic-validity gate
+# (Issue #307).
+#
+# These are "what" tests: each builds a throwaway tree of real .ts files, runs
+# the gate over it, and asserts on the exit status the gate reports.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SCRIPT="${REPO_ROOT}/scripts/typescript-check.sh"
+  WORK="$(mktemp -d)"
+  cd "$WORK"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+require_deno() {
+  if ! command -v deno &>/dev/null; then
+    skip "deno not installed"
+  fi
+}
+
+@test "a valid TypeScript file passes the gate" {
+  require_deno
+  cat >good.ts <<'TS'
+export function add(a: number, b: number): number {
+  return a + b;
+}
+TS
+  run "$SCRIPT" "$WORK"
+  [ "$status" -eq 0 ]
+}
+
+@test "a syntax error fails the gate" {
+  require_deno
+  cat >broken.ts <<'TS'
+export function broken(: number {
+  return
+TS
+  run "$SCRIPT" "$WORK"
+  [ "$status" -ne 0 ]
+}
+
+@test "a type error fails the gate" {
+  require_deno
+  cat >mistyped.ts <<'TS'
+export const count: number = "not a number";
+TS
+  run "$SCRIPT" "$WORK"
+  [ "$status" -ne 0 ]
+}
+
+@test "a tree with no TypeScript files passes and says so" {
+  require_deno
+  echo "not typescript" >notes.md
+  run "$SCRIPT" "$WORK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no TypeScript files"* ]]
+}
+
+@test "build artefacts under target/ are not checked" {
+  require_deno
+  mkdir -p target/debug
+  cat >target/debug/generated.ts <<'TS'
+export function broken(: number {
+TS
+  run "$SCRIPT" "$WORK"
+  [ "$status" -eq 0 ]
+}
+
+@test "a missing deno fails loud rather than skipping the check" {
+  cat >good.ts <<'TS'
+export const answer: number = 42;
+TS
+  run env PATH=/nonexistent "$BASH" "$SCRIPT" "$WORK"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"deno is required"* ]]
+}
+
+@test "a non-existent root directory is rejected" {
+  run "$SCRIPT" "$WORK/does-not-exist"
+  [ "$status" -ne 0 ]
+}
+
+@test "the repository's own TypeScript sources pass the gate" {
+  require_deno
+  run "$SCRIPT" "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/validation_workflow.bats
+++ b/tests/scripts/validation_workflow.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Tests for the CI `validation` job checkout hardening (Issue #320).
+#
+# The contract under test IS the CI wiring: actions/checkout writes the
+# workflow GITHUB_TOKEN into .git/config by default, leaving a usable
+# credential on disk for every later step in the job. The `validation` job only
+# checks out the repo and runs read-only manifest/README/rustdoc checks — it
+# never pushes back and fetches no private submodule — so the persisted
+# credential is pure blast radius.
+#
+# Asserts on observable outcomes:
+#   - ci.yml parses as YAML and defines a `validation` job,
+#   - every actions/checkout step in that job sets persist-credentials: false.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow defines a validation job" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+assert "validation" in data["jobs"], sorted(data["jobs"])
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "ci validation checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["validation"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in validation"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/workflow_concurrency_groups.bats
+++ b/tests/scripts/workflow_concurrency_groups.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# Tests for top-level `concurrency:` groups on pile-up-prone workflows (Issue #334).
+#
+# Rationale: every `synchronize` push to an open PR queues a fresh run while the
+# previous one is still compiling. Without a concurrency group the superseded
+# runs keep burning runner minutes producing results nobody reads — and on
+# `ci.yml`, where a single run compiles the workspace several times over, a few
+# rapid pushes (including the bot pushes from `version-increment`/`auto-format`)
+# stack runs several deep.
+#
+# Publishing workflows are deliberately excluded from `cancel-in-progress: true`:
+# `release.yml` cuts a `v<version>` tag and `wasm-bundle.yml` publishes a
+# per-commit bundle, so cancelling a superseded run would silently skip an
+# artefact downstream consumers pin by SHA.
+#
+# These are "what" tests: they parse the YAML and assert on the observable
+# effective configuration each workflow declares, not on source text. The
+# heredocs are quoted (`<<'PY'`) and the directory arrives through the
+# environment, so GitHub `${{ … }}` expressions survive into Python untouched.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "pile-up-prone workflows cancel superseded runs per ref" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import os, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+GATES = [
+    "ci.yml",
+    "actionlint.yml",
+    "gitleaks.yml",
+    "markdown-lint.yml",
+    "semgrep.yml",
+]
+
+bad = []
+for filename in GATES:
+    path = os.path.join(workflows_dir, filename)
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    concurrency = data.get("concurrency")
+    if not isinstance(concurrency, dict):
+        bad.append(f"{filename}: no top-level concurrency mapping")
+        continue
+    group = concurrency.get("group", "")
+    if "github.workflow" not in group:
+        bad.append(f"{filename}: group must include github.workflow, got {group!r}")
+    if "github.ref" not in group:
+        bad.append(f"{filename}: group must include github.ref, got {group!r}")
+    if concurrency.get("cancel-in-progress") is not True:
+        bad.append(
+            f"{filename}: cancel-in-progress must be true, got "
+            f"{concurrency.get('cancel-in-progress')!r}"
+        )
+
+if bad:
+    sys.stderr.write("Concurrency gate failures:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Two distinct workflows must never share a queue: a group keyed only on the ref
+# would let a gitleaks run cancel the CI run for the same branch.
+@test "each gated workflow's concurrency group is distinct for the same ref" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import glob, os, re, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+groups = {}
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    concurrency = data.get("concurrency")
+    if not isinstance(concurrency, dict):
+        continue
+    # `github.workflow` resolves to the workflow's own name, so substituting the
+    # declared name models the group each workflow actually joins at run time.
+    resolved = re.sub(
+        r"\$\{\{\s*github\.workflow\s*\}\}", data["name"], concurrency["group"]
+    )
+    groups.setdefault(resolved, []).append(os.path.basename(path))
+
+collisions = {g: f for g, f in groups.items() if len(f) > 1}
+if collisions:
+    sys.stderr.write(f"Colliding concurrency groups: {collisions}\n")
+    sys.exit(1)
+assert groups, "expected at least one workflow to declare a concurrency group"
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Publishing workflows produce artefacts downstream consumers pin by SHA or
+# version; a cancelled run silently skips one.
+@test "publishing workflows never cancel in-progress runs" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import os, sys, yaml
+
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+PUBLISHERS = ["release.yml", "wasm-bundle.yml"]
+
+bad = []
+for filename in PUBLISHERS:
+    path = os.path.join(workflows_dir, filename)
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    concurrency = data.get("concurrency")
+    if concurrency is not None:
+        if not isinstance(concurrency, dict):
+            bad.append(f"{filename}: concurrency must be a mapping, got {concurrency!r}")
+        elif concurrency.get("cancel-in-progress") is True:
+            bad.append(f"{filename}: cancel-in-progress must not be true")
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        job_concurrency = job.get("concurrency") if isinstance(job, dict) else None
+        if isinstance(job_concurrency, dict) and job_concurrency.get("cancel-in-progress") is True:
+            bad.append(f"{filename} job={job_name}: cancel-in-progress must not be true")
+
+if bad:
+    sys.stderr.write("Publishing workflow failures:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# A reusable workflow runs inside the caller's context; giving it its own group
+# would let one caller cancel another caller's in-flight security scan.
+@test "the reusable security workflow declares no concurrency group" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<'PY'
+import os, sys, yaml
+
+with open(os.path.join(os.environ["WORKFLOWS_DIR"], "security.yml")) as fh:
+    data = yaml.safe_load(fh)
+
+# PyYAML resolves the bare `on:` key to the boolean True.
+triggers = data.get("on", data.get(True))
+assert "workflow_call" in triggers, "security.yml must stay reusable"
+if "concurrency" in data:
+    sys.stderr.write("security.yml must not declare its own concurrency group\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/workflow_container_pinning.bats
+++ b/tests/scripts/workflow_container_pinning.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# Tests for digest-pinning of job container/service images across every
+# workflow (Issue #335).
+#
+# Rationale: a bare image name such as `semgrep/semgrep` resolves to the
+# mutable `:latest` tag. The registry owner — or anyone who compromises that
+# Docker Hub account — can re-point the tag at any time, and the new image
+# then executes with whatever the job holds in scope (GITHUB_TOKEN,
+# SEMGREP_APP_TOKEN, the checked-out source). This is the same substitution
+# class already closed for `uses:` steps by 40-char commit SHAs (Issue #77)
+# and for CLI installs by SHA-256-verified tarballs (Issues #78/#96/#99).
+# Pinning by `@sha256:<64-hex>` makes the image content-addressed and
+# immutable.
+#
+# These are "what" tests: they parse the YAML and assert on observable
+# outcomes (the resolved image ref shape), not on source-text heuristics.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "every job container and service image is pinned to a sha256 digest" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, re, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+digest_re = re.compile(r"^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}$")
+
+def image_of(spec):
+    """A container/service entry is either a bare image string or a mapping."""
+    if isinstance(spec, str):
+        return spec
+    if isinstance(spec, dict):
+        return spec.get("image")
+    return None
+
+failures = []
+files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
+assert files, f"no workflow files found in {workflows_dir}"
+
+for path in files:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict):
+            continue
+        refs = [("container", image_of(job.get("container")))]
+        for svc_name, svc in (job.get("services", {}) or {}).items():
+            refs.append((f"services.{svc_name}", image_of(svc)))
+        for where, image in refs:
+            if not image:
+                continue
+            if not digest_re.match(image):
+                failures.append(
+                    f"{os.path.basename(path)} job={job_name} {where}={image}"
+                )
+
+if failures:
+    sys.stderr.write("Unpinned container images:\n  " + "\n  ".join(failures) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "every digest-pinned image carries a human-readable version comment" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, re, sys
+
+workflows_dir = "$WORKFLOWS_DIR"
+image_re = re.compile(r"^(\s*)image:\s*([^\s#]+)(?:\s*#\s*(.+))?\s*$")
+
+failures = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        lines = fh.readlines()
+    for i, line in enumerate(lines):
+        m = image_re.match(line)
+        if not m:
+            continue
+        if "@sha256:" not in m.group(2):
+            continue
+        if m.group(3):  # inline trailing comment
+            continue
+        # Otherwise the tag must be named in a comment directly above.
+        if i > 0 and lines[i - 1].strip().startswith("#"):
+            continue
+        failures.append(
+            f"{os.path.basename(path)}:{i + 1}: missing version comment for {m.group(2)}"
+        )
+
+if failures:
+    sys.stderr.write("Missing image version comments:\n  " + "\n  ".join(failures) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Behavioural sanity check: the digest regex must reject the mutable forms
+# this gate exists to keep out. If someone weakens it, this test fails.
+@test "digest regex rejects bare image names and mutable tags" {
+  run python3 - <<PY
+import re
+digest_re = re.compile(r"^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}\$")
+bad = [
+    "semgrep/semgrep",
+    "semgrep/semgrep:latest",
+    "semgrep/semgrep:1.170.1",
+    "ghcr.io/owner/image:v1",
+    "semgrep/semgrep@sha256:deadbeef",
+]
+for ref in bad:
+    assert not digest_re.match(ref), f"regex incorrectly accepted {ref}"
+
+good = [
+    "semgrep/semgrep@sha256:" + "a" * 64,
+    "ghcr.io/owner/image:1.2.3@sha256:" + "0" * 64,
+]
+for ref in good:
+    assert digest_re.match(ref), f"regex incorrectly rejected {ref}"
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/workflow_job_timeouts.bats
+++ b/tests/scripts/workflow_job_timeouts.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# Tests for job-level `timeout-minutes` across every workflow (Issue #333).
+#
+# Rationale: a job with no `timeout-minutes` inherits GitHub's default of
+# 6 hours. A wedged step (a hung `cargo` build, a stalled network fetch in
+# `bump-deps.sh`, a `deno test` waiting on stdin) then holds a runner for six
+# hours, burning the Actions minutes quota and blocking queued runs. An
+# explicit per-job budget kills the wedge in minutes instead.
+#
+# These are "what" tests: they parse the YAML and assert on the observable
+# effective configuration (the timeout each job declares), not on source text.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+}
+
+@test "every runner job in every workflow declares a job-level timeout-minutes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+missing = []
+files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
+assert files, f"no workflow files found in {workflows_dir}"
+
+for path in files:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict):
+            continue
+        # Reusable-workflow callers cannot set timeout-minutes (GitHub rejects
+        # the key); the called workflow's own job carries the budget.
+        if "uses" in job:
+            continue
+        if "timeout-minutes" not in job:
+            missing.append(f"{os.path.basename(path)} job={job_name}")
+
+if missing:
+    sys.stderr.write("Jobs without timeout-minutes:\n  " + "\n  ".join(missing) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "every declared timeout-minutes is a positive integer no greater than 60" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+bad = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict) or "timeout-minutes" not in job:
+            continue
+        value = job["timeout-minutes"]
+        if not isinstance(value, int) or isinstance(value, bool) or not 1 <= value <= 60:
+            bad.append(f"{os.path.basename(path)} job={job_name} timeout-minutes={value!r}")
+
+if bad:
+    sys.stderr.write("Out-of-range timeout-minutes:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# The compile-heavy jobs need a bigger budget than the lint jobs: a cold
+# `cargo build --release` plus clippy, tests and docs can legitimately run for
+# half an hour. Guard both directions so a future edit cannot starve them.
+@test "compile-heavy jobs budget at least 30 minutes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+HEAVY = {
+    "ci.yml": ["quality", "rust-gates"],
+    "security.yml": ["security"],
+    "upgrade-dependencies.yml": ["upgrade"],
+    "wasm-bundle.yml": ["publish"],
+}
+
+bad = []
+for filename, job_names in HEAVY.items():
+    path = os.path.join(workflows_dir, filename)
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    jobs = data.get("jobs", {}) or {}
+    for job_name in job_names:
+        assert job_name in jobs, f"{filename}: expected job {job_name}"
+        value = jobs[job_name].get("timeout-minutes")
+        if not isinstance(value, int) or value < 30:
+            bad.append(f"{filename} job={job_name} timeout-minutes={value!r}")
+
+if bad:
+    sys.stderr.write("Compile-heavy jobs under-budgeted:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}
+
+# GitHub rejects `timeout-minutes` on a job that calls a reusable workflow.
+# The budget must live on the called workflow's own job instead, so assert the
+# caller stays clean and the callee carries a timeout.
+@test "reusable-workflow callers carry no timeout-minutes and the callee does" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+callers = []
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if isinstance(job, dict) and "uses" in job:
+            callers.append((os.path.basename(path), job_name, job))
+
+assert callers, "expected at least one reusable-workflow caller (ci.yml security)"
+offenders = [
+    f"{f} job={j}" for f, j, job in callers if "timeout-minutes" in job
+]
+if offenders:
+    sys.stderr.write("Callers must not set timeout-minutes:\n  " + "\n  ".join(offenders) + "\n")
+    sys.exit(1)
+
+# The called workflow must budget its own job, or the caller is unbounded.
+with open(os.path.join(workflows_dir, "security.yml")) as fh:
+    called = yaml.safe_load(fh)
+assert isinstance(called["jobs"]["security"].get("timeout-minutes"), int)
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/workflow_pipefail.bats
+++ b/tests/scripts/workflow_pipefail.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# Regression tests for Issue #336 — a failing `bump-deps.sh` must fail the
+# scheduled upgrade step.
+#
+# GitHub runs a `run:` block with no `shell:` override under `bash -e {0}` —
+# `-e` but *not* `pipefail`. In `cmd | tee upgrade.log` the pipeline's status is
+# `tee`'s (always 0), so a non-zero exit from `bump-deps.sh` (quarantine
+# violation, `cargo audit` advisory, failed native/wasm build) is swallowed and
+# the workflow goes on to open a PR asserting the bumps passed those gates.
+#
+# These are "what" tests: they extract the step's real script from the workflow,
+# execute it under the same shell GitHub would use with a stub `bump-deps.sh`,
+# and assert on the observed exit status — not on source text.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+  UPGRADE_WF="${WORKFLOWS_DIR}/upgrade-dependencies.yml"
+  WORK="${BATS_TEST_TMPDIR}/step"
+  mkdir -p "$WORK"
+}
+
+# Write the named step's script to $WORK/step.sh and the argv GitHub would
+# launch it with to $WORK/shell.cmd.
+extract_step() {
+  python3 - "$1" "$2" "$WORK" <<'PY'
+import os, sys, yaml
+
+workflow, needle, out = sys.argv[1:4]
+with open(workflow) as fh:
+    data = yaml.safe_load(fh)
+
+def declared_shell(step, job):
+    for scope in (step, job.get("defaults", {}).get("run", {}),
+                  (data.get("defaults") or {}).get("run", {})):
+        if scope.get("shell"):
+            return scope["shell"]
+    return None
+
+for job in (data.get("jobs") or {}).values():
+    for step in job.get("steps") or []:
+        if needle not in (step.get("name") or "") or "run" not in step:
+            continue
+        body = step["run"]
+        assert "${{" not in body, "step body interpolates a GitHub expression"
+        shell = declared_shell(step, job)
+        # GitHub: no `shell:` → `bash -e {0}`; `shell: bash` → `bash
+        # --noprofile --norc -eo pipefail {0}`.
+        argv = {
+            None: "bash -e",
+            "bash": "bash --noprofile --norc -eo pipefail",
+        }.get(shell)
+        assert argv, f"unsupported shell for this harness: {shell!r}"
+        with open(os.path.join(out, "step.sh"), "w") as fh:
+            fh.write(body)
+        with open(os.path.join(out, "shell.cmd"), "w") as fh:
+            fh.write(argv)
+        sys.exit(0)
+
+sys.exit(f"no step named like {needle!r} with a run: block in {workflow}")
+PY
+}
+
+# Run the extracted step with a stub `bump-deps.sh` that exits $1.
+run_step_with_stub() {
+  cat >"${WORK}/bump-deps.sh" <<EOF
+#!/usr/bin/env bash
+echo "stub bump-deps.sh invoked: \$*"
+exit $1
+EOF
+  chmod +x "${WORK}/bump-deps.sh"
+  read -r -a shell_argv <"${WORK}/shell.cmd"
+  (
+    cd "$WORK" || exit 1
+    VIBE_BUMP_QUARANTINE_HOURS=24 "${shell_argv[@]}" step.sh
+  )
+}
+
+@test "a failing bump-deps.sh fails the scheduled upgrade step" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  extract_step "$UPGRADE_WF" "Refresh dependencies via bump-deps.sh"
+  run run_step_with_stub 7
+  [ "$status" -ne 0 ]
+}
+
+@test "a passing bump-deps.sh keeps the scheduled upgrade step green" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  extract_step "$UPGRADE_WF" "Refresh dependencies via bump-deps.sh"
+  run run_step_with_stub 0
+  [ "$status" -eq 0 ]
+}
+
+# The PR body pastes upgrade.log, so tee must keep capturing output.
+@test "the scheduled upgrade step still captures bump-deps.sh output to upgrade.log" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  extract_step "$UPGRADE_WF" "Refresh dependencies via bump-deps.sh"
+  run run_step_with_stub 0
+  [ "$status" -eq 0 ]
+  run cat "${WORK}/upgrade.log"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stub bump-deps.sh invoked"* ]]
+  [[ "$output" == *"--quarantine-hours 24"* ]]
+}
+
+# Guard the whole workflow, not just today's step: any future piped command
+# here would inherit the same swallowed-exit-status bug.
+@test "every piped run: block in upgrade-dependencies.yml runs under pipefail" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - "$UPGRADE_WF" <<'PY'
+import re, sys, yaml
+
+workflow = sys.argv[1]
+with open(workflow) as fh:
+    data = yaml.safe_load(fh)
+
+bad = []
+for job_name, job in (data.get("jobs") or {}).items():
+    for step in job.get("steps") or []:
+        body = step.get("run")
+        if not body:
+            continue
+        code = "\n".join(
+            line for line in body.splitlines() if not line.strip().startswith("#")
+        )
+        # Ignore `||` and GitHub expressions when looking for a real pipeline.
+        scanned = re.sub(r"\|\||\$\{\{.*?\}\}", "", code)
+        if "|" not in scanned:
+            continue
+        shell = step.get("shell") or job.get("defaults", {}).get("run", {}).get("shell")
+        if shell == "bash" or re.search(r"^\s*set\s+-\S*o?\s*.*pipefail", code, re.M):
+            continue
+        bad.append(f"{job_name}: {step.get('name')!r} pipes without pipefail")
+
+if bad:
+    sys.stderr.write("Swallowed pipeline exit status:\n  " + "\n  ".join(bad) + "\n")
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Milestone: Clean up 23 Jul

This PR merges the completed milestone branch into Develop.
Closes #370

### Issues addressed
- #337: 🟢 Duplicate clippy gate: `quality` and `rust-gates` both lint every PR (`.github/workflows/ci.yml`)
- #336: 🟡 `bump-deps.sh` failure exit swallowed by `| tee` — no `pipefail` (`.github/workflows/upgrade-dependencies.yml:57-58`)
- #335: 🟡 Semgrep container image pinned to a mutable tag (`.github/workflows/semgrep.yml:14`)
- #334: 🟡 Missing `concurrency:` groups on pile-up-prone workflows (`.github/workflows/ci.yml` + 4 others)
- #333: 🟡 No job-level `timeout-minutes` on any job across all 9 workflows
- #332: 🟠 Job `wasm64-memory64-smoke` checkout persists credentials (`.github/workflows/ci.yml`)
- #331: 🟠 Job `wasm64-memory64-smoke` has no `permissions:` block (`.github/workflows/ci.yml`)
- #330: 🟠 CI quality workflow skips milestone PRs (`.github/workflows/semgrep.yml`)
- #329: 🟠 CI quality workflow skips milestone PRs (`.github/workflows/markdown-lint.yml`)
- #328: 🟠 CI quality workflow skips milestone PRs (`.github/workflows/gitleaks.yml`)
- #327: 🟠 CI quality workflow skips milestone PRs (`.github/workflows/ci.yml`)
- #326: 🟠 CI quality workflow skips milestone PRs (`.github/workflows/actionlint.yml`)
- #325: 🟠 Job `publish` checkout persists credentials (`.github/workflows/wasm-bundle.yml`)
- #324: 🟠 Job `semgrep` checkout persists credentials (`.github/workflows/semgrep.yml`)
- #323: 🟠 Job `release` checkout persists credentials (`.github/workflows/release.yml`)
- #322: 🟠 Job `markdownlint` checkout persists credentials (`.github/workflows/markdown-lint.yml`)
- #321: 🟠 Job `gitleaks` checkout persists credentials (`.github/workflows/gitleaks.yml`)
- #320: 🟠 Job `validation` checkout persists credentials (`.github/workflows/ci.yml`)
- #319: 🟠 Job `scripts-and-spelling` checkout persists credentials (`.github/workflows/ci.yml`)
- #318: 🟠 Job `rust-gates` checkout persists credentials (`.github/workflows/ci.yml`)
- #317: 🟠 Job `actionlint` checkout persists credentials (`.github/workflows/actionlint.yml`)
- #316: 🟡 Test/lint workflow triggers on push to `Develop` (`.github/workflows/markdown-lint.yml`)
- #315: 🟡 Test/lint workflow triggers on push to `Develop` (`.github/workflows/ci.yml`)
- #314: 🟡 Test/lint workflow triggers on push to `Develop` (`.github/workflows/actionlint.yml`)
- #313: 🟠 Job `validation` has no `permissions:` block (`.github/workflows/ci.yml`)
- #312: 🟠 Job `security` has no `permissions:` block (`.github/workflows/ci.yml`)
- #311: 🟠 Job `scripts-and-spelling` has no `permissions:` block (`.github/workflows/ci.yml`)
- #310: 🟠 Job `rust-gates` has no `permissions:` block (`.github/workflows/ci.yml`)
- #309: 🟠 Job `quality` has no `permissions:` block (`.github/workflows/ci.yml`)
- #307: 🔴 Missing CI validity gate for `typescript`

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.