### PR TITLE
Reword GRQ-cluster provenance mentions in benches to concept level (Issue #376)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.21"
+version = "0.2.22"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-376.md
+++ b/docs/archive/pr-summaries/pr-summary-376.md
@@ -1,0 +1,72 @@
+# Reword GRQ-cluster provenance mentions in benches to concept level
+
+## Summary
+
+NEAT-AI-core is a **public** repository, but the benchmark suite's docs and
+comments repeatedly named the **private** `stSoftwareAU/GRQ-cluster` repository
+(and the `GRQ` host class) as the provenance of the synthetic bench fixtures —
+e.g. `GRQ-cluster/network.json`, `GRQ-cluster/performance.csv`, "GRQ host
+class". The fixtures are synthesised in code (no private data is committed), so
+those private paths added nothing a public reader could use while exposing the
+layout of a private production repo (check 3 of the private-repo-reference
+audit).
+
+This change rewords the enumerated textual mentions to **concept level** with
+**no bench logic or number changes**:
+
+- The fixture is now described as *"the committed production creature topology
+  (1,666 non-input neurons, 21,513 synapses, 2,461 inputs)"*.
+- The record-count calibration is now *"derived from committed production-run
+  telemetry (a 32-generation production run)"* rather than named private CSV/JSON
+  paths.
+- The host class is stated as the concrete hardware — *"Apple M4 Pro class"* —
+  instead of *"GRQ host class"*.
+- The cross-repo wiring note (`BASELINE.md`) is de-named to *"a WorkerPool
+  idle-tail change and a host-flags change in the downstream production repos"*.
+
+Files touched: `neat-core/benches/BASELINE.md`,
+`neat-core/benches/common/mod.rs`, `neat-core/benches/README.md`,
+`neat-core/tests/bench_fixtures.rs`.
+
+Closes #376.
+
+## Scope note
+
+The issue enumerated the `GRQ`/`GRQ-cluster` mentions in the four bench files;
+those are all reworded. The lowercase test-function name
+`production_exact_matches_committed_grq_topology` was **not** in the enumerated
+list and is referenced by an archived, point-in-time PR summary
+(`docs/archive/pr-summaries/pr-summary-286.md`); it is left unchanged to stay
+within scope and avoid a dangling reference in that historical record. Other
+`GRQ` mentions in archived PR summaries are historical records for other issues
+and are out of scope here.
+
+## Evidence
+
+Backend/docs-only change — no web interface to screenshot. Verification is by
+grep plus the existing bench-fixture test suite and a bench compile:
+
+```mermaid
+flowchart LR
+    A["private names:<br/>GRQ-cluster/network.json,<br/>GRQ-cluster/performance.csv,<br/>GRQ host class"] --> B["concept-level reword"]
+    B --> C["committed production creature topology,<br/>committed production-run telemetry,<br/>Apple M4 Pro class"]
+```
+
+- No enumerated `GRQ` mention remains in the four bench files:
+  `grep -rn "GRQ" neat-core/benches/ neat-core/tests/bench_fixtures.rs` → no
+  matches.
+- Bench fixture tests still pass (comments only changed):
+  `cargo test -p neat-core --test bench_fixtures` → **15 passed; 0 failed**.
+- Benches still compile (they include `benches/common/mod.rs`):
+  `cargo bench -p neat-core --no-run --features parallel` → **Finished**.
+
+## Test Plan
+
+- Ran `cargo test -p neat-core --test bench_fixtures` — all 15 tests pass,
+  confirming the reworded comments did not alter fixture behaviour.
+- Ran `cargo bench -p neat-core --no-run --features parallel` — benches compile,
+  confirming the `common/mod.rs` doc-comment edits are valid.
+- Ran `./quality.sh` — the only failures (`perf sources name none of the private
+  trainer's internal scripts`, `perf acceptance models reference no private
+  internal script paths`) are **pre-existing on the base branch**, concern
+  `tests/perf` (unrelated to benches), and are not introduced by this change.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -16,7 +16,7 @@ affected group against this file, with matching host/toolchain metadata.
 Every neuron in the `production` / `production_2x` / `production_exact` fixtures
 is uniformly `SquashType::Tanh` (`benches/common/mod.rs`), asserted by
 `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`. Real
-GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so read every
+production creatures also run `Gelu`/`Mish` (scalar `libm`), so read every
 `scoring`/`production` A/B below with two corrections in mind:
 
 - **Squash-vectorisation deltas are a lower bound.** Varied-squash creatures
@@ -27,7 +27,7 @@ GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so read every
   optimisation shows no delta on this fixture — that is a fixture artefact, not
   evidence the lever is worthless on real creatures.
 
-The real `GRQ-cluster/network.json` is not on the build host, so it cannot be
+The real production `network.json` is not on the build host, so it cannot be
 A/B'd here directly; re-run against the pinned creature to confirm on the real
 varied-squash topology.
 
@@ -35,7 +35,7 @@ varied-squash topology.
 
 | Field | Value |
 | --- | --- |
-| Host class | Apple Silicon (GRQ host class) |
+| Host class | Apple Silicon (Apple M4 Pro class) |
 | CPU | Apple M4 Pro — 12 cores (8 performance + 4 efficiency) |
 | Logical cores (`available_parallelism`) | 12 |
 | RAM | 24 GB |
@@ -53,9 +53,9 @@ deviation on the same host indicates the fixed-seed setup is broken.
 `parallel_scoring` and the `hot_paths` `scoring` group score
 `PRODUCTION_SCORING_RECORDS = 4096` records per iteration (defined in
 `benches/common/mod.rs`), replacing the prior uncalibrated 2048-record token
-batch. Derivation, from the committed GRQ-cluster telemetry
-(`GRQ-cluster/performance.csv`, the 32-generation production run whose totals
-match `result.json`: `generations = 32`, `total_time_ms = 3,042,879`,
+batch. Derivation, from committed production-run telemetry
+(a 32-generation production run whose totals
+match the run summary: `generations = 32`, `total_time_ms = 3,042,879`,
 `fitnessMs = 2,901,473` — ~95% of wall clock):
 
 | Quantity | Value | Source |
@@ -107,7 +107,7 @@ sequential `score_records` path, an internal consistency check on the fixture.
 
 ## Production-exact topology baseline (Issue #286)
 
-Dated anchor for the **exact** committed `GRQ-cluster/network.json` topology —
+Dated anchor for the **exact** committed production creature topology —
 **1,666 non-input neurons, 21,513 synapses, 2,461 inputs** (4,127 total neurons,
 one output). Unlike the `production` shape's ~13-average `VariedAround` fan-in,
 the `production_exact` shape uses `FanIn::ExactTotal(21_513)`, which spreads the
@@ -116,7 +116,7 @@ Bresenham-interleaved) so the synapse count reproduces the real model to the
 synapse. Seeded synthesis is deterministic and asserted exact by
 `tests/bench_fixtures.rs::production_exact_matches_committed_grq_topology`.
 
-**Measured 2026-07-18** on the same GRQ host class, toolchain **rustc 1.97.0**
+**Measured 2026-07-18** on the same Apple M4 Pro host class, toolchain **rustc 1.97.0**
 (the earlier `production`/`production_2x` rows above were taken on rustc 1.96.0,
 so compare across sections only within a lane, not across toolchains).
 
@@ -196,7 +196,7 @@ rounds of the *same* prebuilt bench binaries, capturing the unchanged
 stayed flat across old/new (34.65 µs vs 34.71 µs mean), confirming the `scoring`
 delta is the code change, not thermal drift.
 
-**Measured 2026-07-18**, GRQ host class (Apple M4 Pro), rustc 1.97.0,
+**Measured 2026-07-18**, Apple M4 Pro host class, rustc 1.97.0,
 `--release`, 4 alternating rounds (Criterion `--sample-size 60`):
 
 | `production_exact` (median) | old | new | change |
@@ -230,7 +230,8 @@ and, decisively, by using idle cores the single-threaded wasm32 lane cannot.
 This is a **positive result**; the core-side native path
 (`score_records_parallel` with its sequential/wasm32 fallback) is ready, and the
 production wiring is raised
-cross-repo (NEAT-AI #3399 WorkerPool idle-tail, GRQ #3400 flags) per the issue's
+cross-repo (a WorkerPool idle-tail change and a host-flags change in the
+downstream production repos) per the issue's
 one-root-cause-one-repo rule — this issue owns only the neat-core native path,
 benchmark, and this decision.
 
@@ -250,7 +251,7 @@ count:
   x86, NEON on ARM), scored through a fixed-size rayon pool of 1 or 12 workers
   via `score_records_parallel`.
 
-### Measured 2026-07-18 — GRQ host class
+### Measured 2026-07-18 — Apple M4 Pro host class
 
 Apple M4 Pro (8P + 4E, 12 logical cores), 24 GB, macOS (arm64), rustc 1.97.0,
 `--release`. 4096 records (one production shard; see the record-count

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -54,8 +54,8 @@ can be misleading.
 | `production_2x` | 4922 | 3346 | 8268 | 2 | ~13 (varied) | ~43.5k |
 | `production_exact` | 2461 | 1666 | 4127 | 1 | ~12.9 (exact) | **21,513** |
 
-`production_exact` (Issue #286) pins the fixture to the committed
-`GRQ-cluster/network.json` topology — 1,666 non-input neurons, **exactly**
+`production_exact` (Issue #286) pins the fixture to the committed production
+creature topology — 1,666 non-input neurons, **exactly**
 21,513 synapses, 2,461 inputs — so the Criterion baseline is anchored to the
 real production model rather than `production`'s ~13-average approximation.
 Unlike the `VariedAround` shapes it uses `FanIn::ExactTotal`, which distributes
@@ -78,7 +78,7 @@ test.
 > / `production_exact` shapes is built with `SquashType::Tanh`
 > (`benches/common/mod.rs`), locked
 > by `tests/bench_fixtures.rs::production_fixture_squash_is_homogeneous_tanh`.
-> Real GRQ creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
+> Real production creatures also run `Gelu`/`Mish` (scalar `libm`), so on this fixture
 > squash-vectorisation deltas are a **lower bound** and branch-prediction levers
 > are **unmeasurable** (a homogeneous squash lets the predictor nail the
 > one-arm `match`). See [`BASELINE.md`](BASELINE.md) for the full caveat.
@@ -133,7 +133,7 @@ only in pool size.
 
 The batch is `PRODUCTION_SCORING_RECORDS` records (defined in
 `benches/common/mod.rs` and shared with the `hot_paths` `scoring` group). That
-count is **calibrated to production record volume** — one GRQ-cluster training
+count is **calibrated to production record volume** — one production training
 shard, ~4.3k records — rather than an arbitrary token batch. The derivation is
 documented in [`BASELINE.md`](BASELINE.md).
 

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -57,7 +57,7 @@ pub enum FanIn {
     VariedAround(usize),
     /// Distribute *exactly* this many synapses across the non-input neurons, as
     /// evenly as possible. Used by the `production_exact` shape (Issue #286) so
-    /// the fixture reproduces the committed `GRQ-cluster/network.json` synapse
+    /// the fixture reproduces the committed production creature's synapse
     /// count to the synapse, not just its ~13 average. See
     /// [`FanIn::exact_schedule`].
     ExactTotal(usize),
@@ -141,8 +141,8 @@ impl NetSpec {
 /// a huge input layer, a modest neuron count and a sparse ~13 average fan-in,
 /// which is gather-bound in a way the dense shapes are not. `production_2x`
 /// doubles neurons and synapses to cover #175's "or larger creatures" clause.
-/// `production_exact` (Issue #286) pins the fixture to the committed
-/// `GRQ-cluster/network.json` topology — 1,666 non-input neurons, 21,513
+/// `production_exact` (Issue #286) pins the fixture to the committed production
+/// creature topology — 1,666 non-input neurons, 21,513
 /// synapses, 2,461 inputs — to the synapse, giving the Criterion baseline a
 /// reproducible production-topology anchor.
 pub const NETWORKS: [NetSpec; 6] = [
@@ -185,7 +185,7 @@ pub const NETWORKS: [NetSpec; 6] = [
     },
     NetSpec {
         label: "production_exact",
-        // Exact GRQ-cluster/network.json topology (Issue #286): 2461 inputs +
+        // Exact production creature topology (Issue #286): 2461 inputs +
         // 1666 non-input neurons = 4127 total, exactly 21,513 synapses. Unlike
         // `production`'s ~13-average VariedAround, ExactTotal pins the synapse
         // count to the committed production model so the baseline is anchored to
@@ -278,11 +278,11 @@ pub fn build_inputs(n: usize, seed: u64) -> Vec<f32> {
 }
 
 /// Production-representative record count for the scoring throughput benches
-/// (Issue #228), calibrated to the committed GRQ-cluster telemetry rather than
+/// (Issue #228), calibrated to committed production-run telemetry rather than
 /// an arbitrary token batch.
 ///
-/// Derivation (from `GRQ-cluster/performance.csv`, the 32-generation production
-/// run whose totals match `result.json`):
+/// Derivation (from the 32-generation production
+/// run whose totals match the run summary):
 ///
 /// - `training_data_size_bytes` = 22,097,375,712 across
 ///   `training_data_files` = 520 shards.

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -40,7 +40,7 @@ fn production_shapes_are_registered_with_expected_dimensions() {
 #[test]
 fn production_exact_matches_committed_grq_topology() {
     // Issue #286: the `production_exact` fixture must reproduce the committed
-    // GRQ-cluster/network.json topology to the synapse — 1,666 non-input
+    // production creature topology to the synapse — 1,666 non-input
     // neurons, 21,513 synapses, 2,461 inputs — so the Criterion baseline is
     // anchored to the real production model rather than a ~13-average estimate.
     let spec = spec("production_exact");
@@ -197,7 +197,7 @@ fn varied_fan_in_actually_varies_unlike_fixed_shapes() {
 fn production_fixture_squash_is_homogeneous_tanh() {
     // The BASELINE.md / README.md "Fixture caveat" (Issue #261) rests on the
     // production/production_2x fixtures being uniformly `Tanh`. That homogeneity
-    // makes squash-vectorisation deltas a lower bound (real GRQ creatures also
+    // makes squash-vectorisation deltas a lower bound (real production creatures also
     // run scalar-`libm` Gelu/Mish) and makes branch-prediction levers
     // unmeasurable on the fixture (the predictor already nails a one-arm match).
     // If a future change diversifies the fixture squash, this test fails so the


### PR DESCRIPTION
# Reword GRQ-cluster provenance mentions in benches to concept level

## Summary

NEAT-AI-core is a **public** repository, but the benchmark suite's docs and
comments repeatedly named the **private** `stSoftwareAU/GRQ-cluster` repository
(and the `GRQ` host class) as the provenance of the synthetic bench fixtures —
e.g. `GRQ-cluster/network.json`, `GRQ-cluster/performance.csv`, "GRQ host
class". The fixtures are synthesised in code (no private data is committed), so
those private paths added nothing a public reader could use while exposing the
layout of a private production repo (check 3 of the private-repo-reference
audit).

This change rewords the enumerated textual mentions to **concept level** with
**no bench logic or number changes**:

- The fixture is now described as *"the committed production creature topology
  (1,666 non-input neurons, 21,513 synapses, 2,461 inputs)"*.
- The record-count calibration is now *"derived from committed production-run
  telemetry (a 32-generation production run)"* rather than named private CSV/JSON
  paths.
- The host class is stated as the concrete hardware — *"Apple M4 Pro class"* —
  instead of *"GRQ host class"*.
- The cross-repo wiring note (`BASELINE.md`) is de-named to *"a WorkerPool
  idle-tail change and a host-flags change in the downstream production repos"*.

Files touched: `neat-core/benches/BASELINE.md`,
`neat-core/benches/common/mod.rs`, `neat-core/benches/README.md`,
`neat-core/tests/bench_fixtures.rs`.

Closes #376.

## Scope note

The issue enumerated the `GRQ`/`GRQ-cluster` mentions in the four bench files;
those are all reworded. The lowercase test-function name
`production_exact_matches_committed_grq_topology` was **not** in the enumerated
list and is referenced by an archived, point-in-time PR summary
(`docs/archive/pr-summaries/pr-summary-286.md`); it is left unchanged to stay
within scope and avoid a dangling reference in that historical record. Other
`GRQ` mentions in archived PR summaries are historical records for other issues
and are out of scope here.

## Evidence

Backend/docs-only change — no web interface to screenshot. Verification is by
grep plus the existing bench-fixture test suite and a bench compile:

```mermaid
flowchart LR
    A["private names:<br/>GRQ-cluster/network.json,<br/>GRQ-cluster/performance.csv,<br/>GRQ host class"] --> B["concept-level reword"]
    B --> C["committed production creature topology,<br/>committed production-run telemetry,<br/>Apple M4 Pro class"]
```

- No enumerated `GRQ` mention remains in the four bench files:
  `grep -rn "GRQ" neat-core/benches/ neat-core/tests/bench_fixtures.rs` → no
  matches.
- Bench fixture tests still pass (comments only changed):
  `cargo test -p neat-core --test bench_fixtures` → **15 passed; 0 failed**.
- Benches still compile (they include `benches/common/mod.rs`):
  `cargo bench -p neat-core --no-run --features parallel` → **Finished**.

## Test Plan

- Ran `cargo test -p neat-core --test bench_fixtures` — all 15 tests pass,
  confirming the reworded comments did not alter fixture behaviour.
- Ran `cargo bench -p neat-core --no-run --features parallel` — benches compile,
  confirming the `common/mod.rs` doc-comment edits are valid.
- Ran `./quality.sh` — the only failures (`perf sources name none of the private
  trainer's internal scripts`, `perf acceptance models reference no private
  internal script paths`) are **pre-existing on the base branch**, concern
  `tests/perf` (unrelated to benches), and are not introduced by this change.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms10cotw-49c782`<!-- vibe-worker-issue-376 -->