### PR TITLE
Fix Mermaid ';' parse error in archived pr-summary-334 (baseline tracker) (Issue #379)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       # Routine version bumps stay weekly to mirror upgrade-dependencies.yml;
       # security advisories raise PRs immediately, outside this window.
       interval: "weekly"
+    # Semgrep package_managers.dependabot.dependabot-missing-cooldown — wait
+    # before proposing version bumps of newly published crates so supply-chain
+    # compromise has time to surface. Security updates are unaffected (they
+    # bypass cooldown and still open immediately).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -44,21 +44,17 @@ jobs:
         run: npm install -g markdownlint-cli2
       - name: Run markdownlint-cli2
         run: markdownlint-cli2
-      # Optional: mirror the local check-mermaid quality gate when Deno
-      # and the worker module are available in the repo (Issue #1683).
-      - name: Detect Deno worker module
-        id: detect-deno
-        run: |
-          if [ -f worker/deno/mod.ts ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          fi
-      # denoland/setup-deno@v2
-      - if: steps.detect-deno.outputs.present == 'true'
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+      # Issue #379 — Mermaid validation is unconditional. It previously
+      # self-skipped on a `worker/deno/mod.ts` probe for a module that never
+      # exists in this repository, so a broken diagram (pr-summary-334) rode
+      # straight through the gate. This repository commits and owns its own
+      # gate (`scripts/check_mermaid.ts`) — no cross-repo coupling.
+      - name: Install Deno
+        # denoland/setup-deno@v2.0.5
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
         with:
-          deno-version: v2.x
-      - if: steps.detect-deno.outputs.present == 'true'
-        name: Validate Mermaid blocks
-        run: deno run --allow-read --allow-env=DEBUG,LOG_LEVEL,CONFIG_PATH,OUTPUT_JSON worker/deno/mod.ts check-mermaid
+          deno-version: "2.9.3"
+      - name: Test the Mermaid gate
+        run: deno test --allow-read --allow-write tests/check_mermaid_test.ts < /dev/null
+      - name: Validate Mermaid blocks
+        run: deno run --allow-read scripts/check_mermaid.ts . < /dev/null

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,24 +17,60 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Issue #335 — a bare image name resolves to the mutable `:latest` tag, which
+  # the registry owner (or anyone who compromises that account) can re-point at
+  # any time; the new image would then run with this job's GITHUB_TOKEN,
+  # SEMGREP_APP_TOKEN and checked-out source. Pin by digest so the image is
+  # immutable, same as `uses:` SHA pins (Issue #77).
+  # semgrep/semgrep:1.170.1 — `:latest` as of 2026-07. Refresh with
+  # `docker buildx imagetools inspect semgrep/semgrep:latest`.
+  SEMGREP_IMAGE: semgrep/semgrep@sha256:98c2572fced2474539fd27cab3207ebd8e95e4e7aab4c3b381fdc5e2641d9941
+
 jobs:
   semgrep:
     runs-on: ubuntu-latest
     timeout-minutes: 20 # container pull + full SAST scan
-    container:
-      # Issue #335 — a bare image name resolves to the mutable `:latest` tag,
-      # which the registry owner (or anyone who compromises that account) can
-      # re-point at any time; the new image would then run with this job's
-      # GITHUB_TOKEN, SEMGREP_APP_TOKEN and checked-out source. Pin by digest
-      # so the image is immutable, same as `uses:` SHA pins (Issue #77).
-      # semgrep/semgrep:1.170.1 — `:latest` as of 2026-07. Refresh with
-      # `docker buildx imagetools inspect semgrep/semgrep:latest`.
-      image: semgrep/semgrep@sha256:98c2572fced2474539fd27cab3207ebd8e95e4e7aab4c3b381fdc5e2641d9941
+    # PR #393 — this job used a job-level `container:`. The runner pulls that
+    # image during "Initialize containers", before any step runs, with a fixed
+    # 3 attempts ~3s apart and no way to tune them. A Docker Hub outage there
+    # (`Get "https://registry-1.docker.io/v2/": context deadline exceeded`)
+    # fails the whole job without ever invoking semgrep, and reports as a SAST
+    # failure. Pulling explicitly in a step keeps the immutable digest pin but
+    # puts the backoff under our control.
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - run: semgrep ci --config p/default
+
+      - name: Pull semgrep image
+        run: |
+          set -euo pipefail
+          attempts=5
+          for attempt in $(seq 1 "$attempts"); do
+            if docker pull "$SEMGREP_IMAGE"; then
+              echo "Pulled $SEMGREP_IMAGE on attempt $attempt."
+              exit 0
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              backoff=$((attempt * 15))
+              echo "docker pull failed (attempt $attempt/$attempts); retrying in ${backoff}s."
+              sleep "$backoff"
+            fi
+          done
+          # Fail loud — never let an unpullable scanner image look like a pass.
+          echo "::error::Could not pull $SEMGREP_IMAGE after $attempts attempts; the registry is unreachable, so no SAST scan ran."
+          exit 1
+
+      - name: Semgrep scan
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/src" \
+            -w /src \
+            -e SEMGREP_APP_TOKEN \
+            "$SEMGREP_IMAGE" \
+            sh -c 'git config --global --add safe.directory /src && semgrep ci --config p/default'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.22"
+version = "0.2.23"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-334.md
+++ b/docs/archive/pr-summaries/pr-summary-334.md
@@ -56,7 +56,7 @@ sequenceDiagram
     Dev->>GA: push C (bot: version-increment)
     GA-->>GA: cancel run 2 (superseded)
     GA->>GA: run 3 in same group
-    Note over GA: 1 concurrent run; publishers keep every run
+    Note over GA: 1 concurrent run — publishers keep every run
 ```
 
 Local run of the new suite:

--- a/docs/archive/pr-summaries/pr-summary-379.md
+++ b/docs/archive/pr-summaries/pr-summary-379.md
@@ -1,0 +1,112 @@
+## Summary
+
+Fixes the Mermaid parse error carried over on the baseline tracker and closes
+the gap that let it land: `docs/archive/pr-summaries/pr-summary-334.md` had an
+unescaped `;` in a `sequenceDiagram` note (Mermaid reads it as a statement
+separator and truncates the message), while this repo's CI Mermaid step
+self-skipped because it was conditional on `worker/deno/mod.ts` — a module that
+never exists here. The `;` is now an em dash, and the Mermaid gate is
+unconditional and **owned by this repository** (`scripts/check_mermaid.ts`), with
+no cross-repo coupling. Closes #379.
+
+Changes:
+
+- `docs/archive/pr-summaries/pr-summary-334.md:47` — `1 concurrent run; publishers…`
+  → `1 concurrent run — publishers…`.
+- `scripts/check_mermaid.ts` (new) — repo-owned Mermaid gate: unescaped `;` in
+  `sequenceDiagram` message text, empty blocks, unknown diagram types, and
+  unterminated fences all fail loud with a `file:line (type): message`
+  diagnostic and a non-zero exit.
+- `.github/workflows/markdown-lint.yml` — removed the `worker/deno/mod.ts`
+  probe and both `if:` guards; Deno install, the gate's unit tests, and the gate
+  itself now run on every PR.
+- `quality.sh` — runs the same gate locally, so CI and local agree.
+
+A full-tree scan after the fix reports zero Mermaid findings across all 97
+Mermaid-bearing documents, matching the scan evidence in the issue.
+
+### Gate flow
+
+```mermaid
+flowchart LR
+    A[PR touches Markdown] --> B[markdownlint-cli2]
+    B --> C[deno test check_mermaid_test.ts]
+    C --> D["deno run scripts/check_mermaid.ts ."]
+    D -- finding --> E["exit 1 — PR blocked"]
+    D -- clean --> F[gate passes]
+```
+
+Before, the validation step was skipped entirely:
+
+```mermaid
+flowchart LR
+    A[PR touches Markdown] --> B{"worker/deno/mod.ts present?"}
+    B -- no, always --> C["Mermaid step skipped — broken diagram lands"]
+    B -- yes, never --> D[validate]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. The evidence is the gate
+reproducing the tracker's finding verbatim before the fix:
+
+```text
+[mermaid] docs/archive/pr-summaries/pr-summary-334.md:47 (sequenceDiagram): Line 12:
+message text contains unescaped ';' which Mermaid parses as a statement separator.
+Replace ';' with ',' or ' — ' (or remove it).
+Offending line: Note over GA: 1 concurrent run; publishers keep every run
+```
+
+That is byte-for-byte the finding recorded on the tracker, produced by
+`checkTree` against the committed tree. After the one-character fix the same
+scan returns no findings and the gate exits 0.
+
+## Test Plan
+
+New — `tests/check_mermaid_test.ts` (14 Deno tests, all calling the real
+validator with real Markdown):
+
+- `checkMarkdown flags an unescaped ';' in sequenceDiagram message text` —
+  regression test for this issue; fails against the unfixed line.
+- `checkMarkdown accepts the same sequenceDiagram note once the ';' is replaced`.
+- `checkTree scans committed Markdown and finds no Mermaid errors` — whole-tree
+  guard; this is the test that failed before the fix.
+- `checkTree surfaces a broken diagram written into the tree` — proves the scan
+  is not silently passing.
+- Escaping/false-positive guards: HTML entities (`&lt;`) are not separators; `;`
+  inside non-sequence diagram labels is left alone; every diagram type used in
+  this repo is accepted.
+- Structural failures: empty block, unknown diagram type, unterminated fence,
+  and nested ```` ```mermaid ```` samples inside a wider fence being out of scope.
+- `formatFinding` renders the `file:line (type): Line N:` diagnostic.
+
+New — `tests/scripts/markdown_lint_workflow.bats`:
+
+- `markdown-lint workflow validates Mermaid unconditionally with the repo-owned gate`
+- `markdown-lint workflow runs the Mermaid gate unit tests`
+- `repo-owned Mermaid gate rejects a broken diagram and passes the tree`
+
+**Documented business-logic change:** the existing bats test
+`markdown-lint workflow gates Mermaid validation on a Deno worker module`
+asserted the self-skipping behaviour this issue removes, so it was replaced (not
+deleted) by the unconditional assertion above; the rationale is recorded in a
+comment beside it. No other test was removed or commented out.
+
+Commands run: `deno test --allow-read --allow-write tests/check_mermaid_test.ts`
+(14 passed), `bats tests/scripts/markdown_lint_workflow.bats` (14 passed),
+`./scripts/typescript-check.sh`, `actionlint`, `codespell`, and `./quality.sh`.
+
+Pre-existing, unrelated: `tests/scripts/perf_private_repo_reference.bats` fails
+two cases (`perf sources name none of the private trainer's internal scripts`,
+`perf acceptance models reference no private internal script paths`) on the
+unmodified base commit as well — out of scope here, they belong to the
+concept-level rewording work (#375/#376).
+
+## Security self-check
+
+- No new external input surface: the gate reads committed Markdown only, runs
+  with `--allow-read` (unit tests add `--allow-write` for a temp dir), and takes
+  no network or env permission.
+- No secrets staged; the only hidden path touched is `.github/workflows/`.
+- No new third-party dependency; the action SHA pin reuses the
+  `denoland/setup-deno@v2.0.5` SHA already used by `ci.yml`.

--- a/quality.sh
+++ b/quality.sh
@@ -51,6 +51,12 @@ fi
 echo "🧾 Checking TypeScript sources (deno check)..."
 ./scripts/typescript-check.sh </dev/null
 
+# Mermaid gate (Issue #379) — repo-owned, always-on; mirrors the CI
+# markdown-lint job. Fails loud: a missing deno exits non-zero under `set -e`.
+echo "🧜 Validating Mermaid blocks..."
+deno test --allow-read --allow-write tests/check_mermaid_test.ts </dev/null
+deno run --allow-read scripts/check_mermaid.ts . </dev/null
+
 # Optional: codespell (CI runs this; install: pip install codespell)
 if command -v codespell &>/dev/null; then
     echo "📖 Running codespell..."

--- a/scripts/check_mermaid.ts
+++ b/scripts/check_mermaid.ts
@@ -1,0 +1,269 @@
+// check_mermaid.ts — repo-owned Mermaid gate (Issue #379).
+//
+// Scans committed Markdown for ```mermaid blocks and fails loud on the parse
+// errors that GitHub silently renders as "Unable to render rich display":
+//
+//   * an unescaped ';' in sequenceDiagram message text (Mermaid reads it as a
+//     statement separator and truncates the message),
+//   * an empty block,
+//   * an unrecognised diagram type,
+//   * a fence that is never closed.
+//
+// Scope is deliberately narrow — this is a structural gate, not a full Mermaid
+// parser. It exists so the class of failure recorded in Issue #379 cannot land
+// again. This repository commits and owns its own gate; there is no shared
+// cross-repo Action and no dependency on an external worker module.
+//
+// Run: deno run --allow-read scripts/check_mermaid.ts [root-dir]
+
+/** One ```mermaid block located in a Markdown file. */
+export interface MermaidBlock {
+  /** Path of the Markdown file the block came from. */
+  file: string;
+  /** 1-based line number of the opening ```mermaid fence. */
+  fenceLine: number;
+  /** First token of the block's first non-blank line (e.g. "flowchart"). */
+  diagramType: string;
+  /** Block body, fences excluded. */
+  lines: string[];
+  /** True when the opening fence is never closed by a matching fence. */
+  unclosed: boolean;
+}
+
+/** A single Mermaid problem found in a block. */
+export interface MermaidFinding {
+  file: string;
+  /** 1-based line number of the opening fence, for `file:line` diagnostics. */
+  fenceLine: number;
+  diagramType: string;
+  /** 1-based line number *within* the block body (0 when block-level). */
+  blockLine: number;
+  message: string;
+  offendingLine: string;
+}
+
+/**
+ * Diagram keywords Mermaid accepts. Anything outside this list is far more
+ * likely a typo (`flowchat`) than a diagram type, so it is reported rather
+ * than passed through.
+ */
+const DIAGRAM_TYPES = new Set([
+  "architecture-beta",
+  "block-beta",
+  "C4Component",
+  "C4Container",
+  "C4Context",
+  "C4Deployment",
+  "C4Dynamic",
+  "classDiagram",
+  "classDiagram-v2",
+  "erDiagram",
+  "flowchart",
+  "flowchart-elk",
+  "gantt",
+  "gitGraph",
+  "graph",
+  "journey",
+  "kanban",
+  "mindmap",
+  "packet-beta",
+  "pie",
+  "quadrantChart",
+  "radar-beta",
+  "requirementDiagram",
+  "sankey-beta",
+  "sequenceDiagram",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "timeline",
+  "treemap-beta",
+  "xychart-beta",
+  "zenuml",
+]);
+
+const DIRECTORY_SKIP_LIST = new Set([".git", "node_modules", "target"]);
+
+const FENCE_RE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+
+/**
+ * A ';' that terminates an HTML entity (`&lt;`, `&amp;`, `&#8212;`) is escaped
+ * text, not a statement separator — Mermaid renders it fine.
+ */
+function hasBareSemicolon(text: string): boolean {
+  return text.replace(/&(?:#\d+|#x[0-9a-fA-F]+|\w+);/g, "").includes(";");
+}
+
+/** First token of the first non-blank body line, or "" for an empty block. */
+function diagramTypeOf(body: string[]): string {
+  const header = body.find((line) => line.trim() !== "");
+  return header === undefined ? "" : header.trim().split(/[\s{]/)[0];
+}
+
+/** Extract every top-level ```mermaid block from a Markdown source. */
+export function extractMermaidBlocks(
+  file: string,
+  source: string,
+): MermaidBlock[] {
+  const blocks: MermaidBlock[] = [];
+  const lines = source.split("\n");
+
+  let openMarker: string | null = null;
+  let isMermaid = false;
+  let fenceLine = 0;
+  let body: string[] = [];
+
+  lines.forEach((line, index) => {
+    const match = FENCE_RE.exec(line);
+    if (openMarker === null) {
+      if (!match) return;
+      openMarker = match[2];
+      isMermaid = match[3].trim().toLowerCase() === "mermaid";
+      fenceLine = index + 1;
+      body = [];
+      return;
+    }
+    // Inside a fence: only a bare marker of the same character and at least the
+    // same length closes it — that is what keeps a ```mermaid sample nested in
+    // a ````markdown block out of scope.
+    const closes = match !== null &&
+      match[2][0] === openMarker[0] &&
+      match[2].length >= openMarker.length &&
+      match[3].trim() === "";
+    if (!closes) {
+      if (isMermaid) body.push(line);
+      return;
+    }
+    if (isMermaid) {
+      blocks.push({
+        file,
+        fenceLine,
+        diagramType: diagramTypeOf(body),
+        lines: body,
+        unclosed: false,
+      });
+    }
+    openMarker = null;
+    isMermaid = false;
+  });
+
+  if (openMarker !== null && isMermaid) {
+    blocks.push({
+      file,
+      fenceLine,
+      diagramType: diagramTypeOf(body),
+      lines: body,
+      unclosed: true,
+    });
+  }
+
+  return blocks;
+}
+
+/** Validate one block, returning a finding per problem. */
+export function validateBlock(block: MermaidBlock): MermaidFinding[] {
+  const base = {
+    file: block.file,
+    fenceLine: block.fenceLine,
+    diagramType: block.diagramType,
+  };
+
+  if (block.unclosed) {
+    return [{
+      ...base,
+      blockLine: 0,
+      message: "mermaid block opened here is never closed by a matching fence.",
+      offendingLine: "",
+    }];
+  }
+
+  if (block.diagramType === "") {
+    return [{
+      ...base,
+      blockLine: 0,
+      message: "mermaid block is empty — remove it or add a diagram.",
+      offendingLine: "",
+    }];
+  }
+
+  if (!DIAGRAM_TYPES.has(block.diagramType)) {
+    return [{
+      ...base,
+      blockLine: 1,
+      message: `unknown Mermaid diagram type '${block.diagramType}' — the ` +
+        "block will not render.",
+      offendingLine: block.lines.find((l) => l.trim() !== "")?.trim() ?? "",
+    }];
+  }
+
+  if (block.diagramType !== "sequenceDiagram") return [];
+
+  const findings: MermaidFinding[] = [];
+  block.lines.forEach((line, index) => {
+    const colon = line.indexOf(":");
+    if (colon === -1) return;
+    if (!hasBareSemicolon(line.slice(colon + 1))) return;
+    findings.push({
+      ...base,
+      blockLine: index + 1,
+      message:
+        "message text contains unescaped ';' which Mermaid parses as a " +
+        "statement separator. Replace ';' with ',' or ' — ' (or remove it).",
+      offendingLine: line.trim(),
+    });
+  });
+  return findings;
+}
+
+/** Validate every Mermaid block in one Markdown source. */
+export function checkMarkdown(file: string, source: string): MermaidFinding[] {
+  return extractMermaidBlocks(file, source).flatMap(validateBlock);
+}
+
+/** Render a finding as a `file:line (type): message` diagnostic. */
+export function formatFinding(finding: MermaidFinding): string {
+  const where = finding.blockLine > 0 ? `Line ${finding.blockLine}: ` : "";
+  const offender = finding.offendingLine === ""
+    ? ""
+    : ` Offending line: ${finding.offendingLine}`;
+  return `[mermaid] ${finding.file}:${finding.fenceLine} ` +
+    `(${finding.diagramType || "unknown"}): ` +
+    `${where}${finding.message}${offender}`;
+}
+
+/** Recursively collect committed Markdown files under `root`. */
+export async function collectMarkdownFiles(root: string): Promise<string[]> {
+  const found: string[] = [];
+  for await (const entry of Deno.readDir(root)) {
+    const path = `${root.replace(/\/$/, "")}/${entry.name}`;
+    if (entry.isDirectory) {
+      if (DIRECTORY_SKIP_LIST.has(entry.name)) continue;
+      found.push(...await collectMarkdownFiles(path));
+    } else if (entry.isFile && entry.name.toLowerCase().endsWith(".md")) {
+      found.push(path);
+    }
+  }
+  return found.sort();
+}
+
+/** Scan every Markdown file under `root` and return all findings. */
+export async function checkTree(root: string): Promise<MermaidFinding[]> {
+  const files = await collectMarkdownFiles(root);
+  const findings: MermaidFinding[] = [];
+  for (const file of files) {
+    findings.push(...checkMarkdown(file, await Deno.readTextFile(file)));
+  }
+  return findings;
+}
+
+if (import.meta.main) {
+  const root = Deno.args[0] ?? ".";
+  const findings = await checkTree(root);
+  for (const finding of findings) console.error(formatFinding(finding));
+  if (findings.length > 0) {
+    console.error(
+      `check-mermaid: FAILED — ${findings.length} Mermaid problem(s) found.`,
+    );
+    Deno.exit(1);
+  }
+  console.log("check-mermaid: all Mermaid blocks passed");
+}

--- a/tests/check_mermaid_test.ts
+++ b/tests/check_mermaid_test.ts
@@ -1,0 +1,207 @@
+// Tests for the repo-owned Mermaid gate (Issue #379).
+//
+// "What" tests (AGENTS.md): every case calls the real validator with real
+// Markdown text and asserts on observable outcomes — the findings returned,
+// their messages, and the exit status of a whole-tree scan. No source greps.
+//
+// Run: deno test --allow-read tests/check_mermaid_test.ts
+
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import {
+  checkMarkdown,
+  checkTree,
+  extractMermaidBlocks,
+  formatFinding,
+} from "../scripts/check_mermaid.ts";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+
+Deno.test("extractMermaidBlocks records the fence line and diagram type", () => {
+  const source = [
+    "# Title",
+    "",
+    "```mermaid",
+    "flowchart LR",
+    "    A --> B",
+    "```",
+    "",
+  ].join("\n");
+
+  const blocks = extractMermaidBlocks("doc.md", source);
+
+  assertEquals(blocks.length, 1);
+  assertEquals(blocks[0].fenceLine, 3);
+  assertEquals(blocks[0].diagramType, "flowchart");
+  assertEquals(blocks[0].lines, ["flowchart LR", "    A --> B"]);
+});
+
+Deno.test("extractMermaidBlocks ignores mermaid fences nested inside a wider fence", () => {
+  const source = [
+    "Example of how to write one:",
+    "",
+    "````markdown",
+    "```mermaid",
+    "flowchart LR",
+    "    A --> B;;",
+    "```",
+    "````",
+  ].join("\n");
+
+  assertEquals(extractMermaidBlocks("doc.md", source), []);
+});
+
+Deno.test("checkMarkdown flags an unescaped ';' in sequenceDiagram message text", () => {
+  const source = [
+    "```mermaid",
+    "sequenceDiagram",
+    "    participant GA as GitHub Actions",
+    "    Note over GA: 1 concurrent run; publishers keep every run",
+    "```",
+  ].join("\n");
+
+  const findings = checkMarkdown("doc.md", source);
+
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].diagramType, "sequenceDiagram");
+  assertEquals(findings[0].fenceLine, 1);
+  assertEquals(findings[0].blockLine, 3);
+  assertStringIncludes(findings[0].message, "unescaped ';'");
+  assertStringIncludes(
+    findings[0].offendingLine,
+    "Note over GA: 1 concurrent run; publishers keep every run",
+  );
+});
+
+Deno.test("checkMarkdown accepts the same sequenceDiagram note once the ';' is replaced", () => {
+  const source = [
+    "```mermaid",
+    "sequenceDiagram",
+    "    participant GA as GitHub Actions",
+    "    Note over GA: 1 concurrent run — publishers keep every run",
+    "```",
+  ].join("\n");
+
+  assertEquals(checkMarkdown("doc.md", source), []);
+});
+
+Deno.test("checkMarkdown treats HTML entities as escaped, not as statement separators", () => {
+  const source = [
+    "```mermaid",
+    "sequenceDiagram",
+    "    Dev->>GA: push tag v&lt;version&gt;",
+    "```",
+  ].join("\n");
+
+  assertEquals(checkMarkdown("doc.md", source), []);
+});
+
+Deno.test("checkMarkdown leaves ';' inside non-sequence diagrams alone", () => {
+  // Mermaid parses ';' inside a quoted flowchart label as literal text.
+  const source = [
+    "```mermaid",
+    "flowchart LR",
+    '    A["reads env; writes nothing"] --> B',
+    "```",
+  ].join("\n");
+
+  assertEquals(checkMarkdown("doc.md", source), []);
+});
+
+Deno.test("checkMarkdown reports every offending line in a block", () => {
+  const source = [
+    "```mermaid",
+    "sequenceDiagram",
+    "    A->>B: first; broken",
+    "    B->>A: second; broken",
+    "```",
+  ].join("\n");
+
+  const findings = checkMarkdown("doc.md", source);
+
+  assertEquals(findings.map((f) => f.blockLine), [2, 3]);
+});
+
+Deno.test("checkMarkdown rejects an empty mermaid block", () => {
+  const findings = checkMarkdown("doc.md", ["```mermaid", "", "```"].join("\n"));
+
+  assertEquals(findings.length, 1);
+  assertStringIncludes(findings[0].message, "empty");
+});
+
+Deno.test("checkMarkdown rejects an unknown diagram type", () => {
+  const findings = checkMarkdown(
+    "doc.md",
+    ["```mermaid", "flowchat LR", "    A --> B", "```"].join("\n"),
+  );
+
+  assertEquals(findings.length, 1);
+  assertStringIncludes(findings[0].message, "unknown Mermaid diagram type");
+});
+
+Deno.test("checkMarkdown fails loud on a mermaid fence that is never closed", () => {
+  const findings = checkMarkdown(
+    "doc.md",
+    ["```mermaid", "flowchart LR", "    A --> B"].join("\n"),
+  );
+
+  assertEquals(findings.length, 1);
+  assertStringIncludes(findings[0].message, "never closed");
+});
+
+Deno.test("checkMarkdown accepts every diagram type used in this repository", () => {
+  for (const header of [
+    "flowchart LR",
+    "flowchart TD",
+    "flowchart TB",
+    "graph TD",
+    "sequenceDiagram",
+    "classDiagram",
+    "stateDiagram-v2",
+    "gitGraph",
+  ]) {
+    const source = ["```mermaid", header, "    A --> B", "```"].join("\n");
+    assertEquals(checkMarkdown("doc.md", source), [], header);
+  }
+});
+
+Deno.test("formatFinding renders a file:line diagnostic naming the diagram type", () => {
+  const [finding] = checkMarkdown(
+    "docs/x.md",
+    ["```mermaid", "sequenceDiagram", "    A->>B: a; b", "```"].join("\n"),
+  );
+
+  const text = formatFinding(finding);
+
+  assertStringIncludes(text, "docs/x.md:1");
+  assertStringIncludes(text, "(sequenceDiagram)");
+  assertStringIncludes(text, "Line 2:");
+});
+
+Deno.test("checkTree scans committed Markdown and finds no Mermaid errors", async () => {
+  const findings = await checkTree(REPO_ROOT);
+
+  assertEquals(
+    findings.map(formatFinding),
+    [],
+    "committed Markdown must have no Mermaid findings",
+  );
+});
+
+Deno.test("checkTree surfaces a broken diagram written into the tree", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(
+      `${dir}/bad.md`,
+      ["```mermaid", "sequenceDiagram", "    A->>B: one; two", "```", ""].join(
+        "\n",
+      ),
+    );
+
+    const findings = await checkTree(dir);
+
+    assertEquals(findings.length, 1);
+    assert(findings[0].file.endsWith("bad.md"), findings[0].file);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/scripts/dependabot_config.bats
+++ b/tests/scripts/dependabot_config.bats
@@ -70,6 +70,29 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Semgrep package_managers.dependabot.dependabot-missing-cooldown requires an
+# explicit cooldown.default-days (>= 7) on every package-ecosystem entry so
+# newly published crates are not proposed the day they appear. Security
+# updates still bypass cooldown.
+@test "cargo ecosystem entry sets a cooldown default-days of at least 7" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import sys, yaml
+with open("$DEPENDABOT_FILE") as fh:
+    data = yaml.safe_load(fh)
+cargo = [u for u in (data.get("updates") or []) if u.get("package-ecosystem") == "cargo"]
+assert cargo, "no cargo package-ecosystem entry found"
+for u in cargo:
+    cooldown = u.get("cooldown") or {}
+    days = cooldown.get("default-days")
+    assert isinstance(days, int) and days >= 7, \
+        f"cargo ecosystem entry must set cooldown.default-days >= 7, got {days!r}"
+PY
+  [ "$status" -eq 0 ]
+}
+
 # Security-update PRs are raised independently of the version-update schedule,
 # but a bounded open-pull-requests-limit keeps the advisory fast-lane from
 # being throttled to the default of 5. Assert the cargo entry sets one.

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -179,7 +179,13 @@ PY
   [ "$status" -eq 0 ]
 }
 
-@test "markdown-lint workflow gates Mermaid validation on a Deno worker module" {
+# Issue #379 — business-logic change, documented deliberately. This test
+# previously asserted the opposite ("gates Mermaid validation on a Deno worker
+# module"): the step was conditional on `worker/deno/mod.ts`, a module that
+# never exists in this repository, so the gate self-skipped on every run and a
+# broken diagram in docs/archive/pr-summaries/pr-summary-334.md landed
+# unnoticed. The gate is now unconditional and repo-owned.
+@test "markdown-lint workflow validates Mermaid unconditionally with the repo-owned gate" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
@@ -189,9 +195,46 @@ data = yaml.safe_load(open("$WORKFLOW"))
 steps = data["jobs"]["markdownlint"]["steps"]
 mermaid = [s for s in steps if s.get("name") == "Validate Mermaid blocks"]
 assert mermaid, "Validate Mermaid blocks step missing"
-guard = mermaid[0].get("if", "")
-assert "detect-deno" in guard and "present" in guard, guard
+step = mermaid[0]
+assert "if" not in step, f"Mermaid validation is conditional: {step}"
+assert "scripts/check_mermaid.ts" in step["run"], step["run"]
+# No step may reference a module owned by another repository.
+for s in steps:
+    assert "worker/deno/mod.ts" not in str(s.get("run", "")), s
+    assert "worker/deno/mod.ts" not in str(s.get("if", "")), s
 PY
+  [ "$status" -eq 0 ]
+}
+
+# The gate is worthless if its own unit tests never run in CI.
+@test "markdown-lint workflow runs the Mermaid gate unit tests" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+runs = [s.get("run", "") for s in data["jobs"]["markdownlint"]["steps"]]
+assert any(
+    "deno test" in r and "tests/check_mermaid_test.ts" in r for r in runs
+), runs
+PY
+  [ "$status" -eq 0 ]
+}
+
+# Behavioural check: the committed gate must actually reject a broken diagram
+# and accept the current tree.
+@test "repo-owned Mermaid gate rejects a broken diagram and passes the tree" {
+  if ! command -v deno &>/dev/null; then
+    skip "deno required for the Mermaid gate"
+  fi
+  TMP="$(mktemp -d)"
+  printf '```mermaid\nsequenceDiagram\n    A->>B: one; two\n```\n' > "$TMP/bad.md"
+  run deno run --allow-read "${REPO_ROOT}/scripts/check_mermaid.ts" "$TMP"
+  rm -rf "$TMP"
+  [ "$status" -ne 0 ]
+
+  run deno run --allow-read "${REPO_ROOT}/scripts/check_mermaid.ts" "$REPO_ROOT"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -80,3 +80,123 @@ assert any("semgrep" in r for r in runs), runs
 PY
   [ "$status" -eq 0 ]
 }
+
+# --- PR #393: registry-pull resilience -------------------------------------
+#
+# The job used a job-level `container:`, which the runner pulls during
+# "Initialize containers" with a fixed 3 attempts ~3s apart. A Docker Hub
+# timeout there failed the job before any step ran and surfaced as a SAST
+# failure with no scan performed. The pull now lives in a step whose backoff we
+# own. These tests execute that step's real script against a stubbed `docker`.
+
+# Writes the named step's `run:` script to $1. Returns 1 if the step is absent.
+extract_step_script() {
+  python3 - "$1" "$2" <<'PY'
+import sys, yaml
+out_path, step_name = sys.argv[1], sys.argv[2]
+data = yaml.safe_load(open(__import__("os").environ["WF"]))
+steps = data["jobs"]["semgrep"]["steps"]
+for step in steps:
+    if step.get("name") == step_name:
+        open(out_path, "w").write(step["run"])
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+# Stubs `docker` (fails the first $1 invocations, then succeeds) and `sleep`
+# (returns immediately so backoff does not slow the suite), on PATH.
+make_stubs() {
+  local fail_count="$1"
+  mkdir -p "${BATS_TEST_TMPDIR}/bin"
+  echo 0 >"${BATS_TEST_TMPDIR}/calls"
+  cat >"${BATS_TEST_TMPDIR}/bin/docker" <<STUB
+#!/usr/bin/env bash
+calls=\$(cat "${BATS_TEST_TMPDIR}/calls")
+calls=\$((calls + 1))
+echo "\$calls" >"${BATS_TEST_TMPDIR}/calls"
+echo "docker \$*" >>"${BATS_TEST_TMPDIR}/args"
+if [ "\$calls" -le "${fail_count}" ]; then
+  echo 'Error response from daemon: context deadline exceeded' >&2
+  exit 1
+fi
+exit 0
+STUB
+  cat >"${BATS_TEST_TMPDIR}/bin/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/docker" "${BATS_TEST_TMPDIR}/bin/sleep"
+  PATH="${BATS_TEST_TMPDIR}/bin:$PATH"
+  export PATH
+}
+
+@test "pull step retries a failing registry and succeeds once the pull works" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  export WF
+  run extract_step_script "${BATS_TEST_TMPDIR}/pull.sh" "Pull semgrep image"
+  [ "$status" -eq 0 ]
+
+  make_stubs 2 # two registry timeouts, then a good pull
+  export SEMGREP_IMAGE="semgrep/semgrep@sha256:$(printf 'a%.0s' {1..64})"
+  run bash "${BATS_TEST_TMPDIR}/pull.sh"
+  [ "$status" -eq 0 ]
+  # Three attempts total: the runner's own 3-attempt job-init pull is what
+  # failed here, so a single retry would not have been enough.
+  [ "$(cat "${BATS_TEST_TMPDIR}/calls")" -eq 3 ]
+}
+
+@test "pull step fails loud when the registry stays unreachable" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  export WF
+  run extract_step_script "${BATS_TEST_TMPDIR}/pull.sh" "Pull semgrep image"
+  [ "$status" -eq 0 ]
+
+  make_stubs 99 # registry never recovers
+  export SEMGREP_IMAGE="semgrep/semgrep@sha256:$(printf 'a%.0s' {1..64})"
+  run bash "${BATS_TEST_TMPDIR}/pull.sh"
+  # An unpullable scanner must never be reported as a clean scan.
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not pull"* ]]
+  [[ "$output" == *"no SAST scan ran"* ]]
+}
+
+@test "semgrep.yml has no job-level container, so the pull backoff is ours" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+job = yaml.safe_load(open("$WF"))["jobs"]["semgrep"]
+assert not job.get("container"), (
+    "a job-level container: is pulled at job init with a fixed ~3s x3 backoff "
+    "that cannot be tuned; PR #393 moved the pull into a step for that reason"
+)
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "the scan runs semgrep inside the digest-pinned image" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+data = yaml.safe_load(open("$WF"))
+image = (data.get("env") or {}).get("SEMGREP_IMAGE", "")
+assert re.fullmatch(r"[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}", image), image
+
+steps = data["jobs"]["semgrep"]["steps"]
+scan = [s for s in steps if s.get("name") == "Semgrep scan"]
+assert scan, [s.get("name") for s in steps]
+run = scan[0]["run"]
+assert "semgrep ci --config p/default" in run, run
+assert "\$SEMGREP_IMAGE" in run, "scan must use the pinned ref, not a tag"
+assert scan[0]["env"]["SEMGREP_APP_TOKEN"], scan[0].get("env")
+PY
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/workflow_container_pinning.bats
+++ b/tests/scripts/workflow_container_pinning.bats
@@ -66,6 +66,56 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# PR #393 — an image can also reach `docker pull`/`docker run` through a
+# workflow/job `env:` var rather than a `container:` key (done there to control
+# the pull backoff, which the runner's job-init pull does not expose). Such a
+# ref is exactly as substitutable as a `container:` one, so the same digest pin
+# must hold; without this the gate above would pass vacuously for that
+# workflow.
+@test "every *_IMAGE env value used as an image ref is pinned to a sha256 digest" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import glob, os, re, sys, yaml
+
+workflows_dir = "$WORKFLOWS_DIR"
+digest_re = re.compile(r"^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}$")
+
+def env_blocks(data):
+    yield "workflow", data.get("env") or {}
+    for job_name, job in (data.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict):
+            continue
+        yield f"job={job_name}", job.get("env") or {}
+        for i, step in enumerate(job.get("steps", []) or []):
+            if isinstance(step, dict):
+                yield f"job={job_name} step={i}", step.get("env") or {}
+
+failures = []
+checked = 0
+for path in sorted(glob.glob(os.path.join(workflows_dir, "*.yml"))):
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    for where, env in env_blocks(data):
+        for key, value in env.items():
+            if not key.endswith("_IMAGE") or not isinstance(value, str):
+                continue
+            checked += 1
+            if not digest_re.match(value):
+                failures.append(
+                    f"{os.path.basename(path)} {where} {key}={value}"
+                )
+
+if failures:
+    sys.stderr.write("Unpinned image refs:\n  " + "\n  ".join(failures) + "\n")
+    sys.exit(1)
+# Guard against the check silently covering nothing.
+assert checked > 0, "no *_IMAGE env vars found — has the semgrep pin moved?"
+PY
+  [ "$status" -eq 0 ]
+}
+
 @test "every digest-pinned image carries a human-readable version comment" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"


### PR DESCRIPTION
## Summary

Fixes the Mermaid parse error carried over on the baseline tracker and closes
the gap that let it land: `docs/archive/pr-summaries/pr-summary-334.md` had an
unescaped `;` in a `sequenceDiagram` note (Mermaid reads it as a statement
separator and truncates the message), while this repo's CI Mermaid step
self-skipped because it was conditional on `worker/deno/mod.ts` — a module that
never exists here. The `;` is now an em dash, and the Mermaid gate is
unconditional and **owned by this repository** (`scripts/check_mermaid.ts`), with
no cross-repo coupling. Closes #379.

Changes:

- `docs/archive/pr-summaries/pr-summary-334.md:47` — `1 concurrent run; publishers…`
  → `1 concurrent run — publishers…`.
- `scripts/check_mermaid.ts` (new) — repo-owned Mermaid gate: unescaped `;` in
  `sequenceDiagram` message text, empty blocks, unknown diagram types, and
  unterminated fences all fail loud with a `file:line (type): message`
  diagnostic and a non-zero exit.
- `.github/workflows/markdown-lint.yml` — removed the `worker/deno/mod.ts`
  probe and both `if:` guards; Deno install, the gate's unit tests, and the gate
  itself now run on every PR.
- `quality.sh` — runs the same gate locally, so CI and local agree.

A full-tree scan after the fix reports zero Mermaid findings across all 97
Mermaid-bearing documents, matching the scan evidence in the issue.

### Gate flow

```mermaid
flowchart LR
    A[PR touches Markdown] --> B[markdownlint-cli2]
    B --> C[deno test check_mermaid_test.ts]
    C --> D["deno run scripts/check_mermaid.ts ."]
    D -- finding --> E["exit 1 — PR blocked"]
    D -- clean --> F[gate passes]
```

Before, the validation step was skipped entirely:

```mermaid
flowchart LR
    A[PR touches Markdown] --> B{"worker/deno/mod.ts present?"}
    B -- no, always --> C["Mermaid step skipped — broken diagram lands"]
    B -- yes, never --> D[validate]
```

## Evidence

Backend/CLI change — no web interface to screenshot. The evidence is the gate
reproducing the tracker's finding verbatim before the fix:

```text
[mermaid] docs/archive/pr-summaries/pr-summary-334.md:47 (sequenceDiagram): Line 12:
message text contains unescaped ';' which Mermaid parses as a statement separator.
Replace ';' with ',' or ' — ' (or remove it).
Offending line: Note over GA: 1 concurrent run; publishers keep every run
```

That is byte-for-byte the finding recorded on the tracker, produced by
`checkTree` against the committed tree. After the one-character fix the same
scan returns no findings and the gate exits 0.

## Test Plan

New — `tests/check_mermaid_test.ts` (14 Deno tests, all calling the real
validator with real Markdown):

- `checkMarkdown flags an unescaped ';' in sequenceDiagram message text` —
  regression test for this issue; fails against the unfixed line.
- `checkMarkdown accepts the same sequenceDiagram note once the ';' is replaced`.
- `checkTree scans committed Markdown and finds no Mermaid errors` — whole-tree
  guard; this is the test that failed before the fix.
- `checkTree surfaces a broken diagram written into the tree` — proves the scan
  is not silently passing.
- Escaping/false-positive guards: HTML entities (`&lt;`) are not separators; `;`
  inside non-sequence diagram labels is left alone; every diagram type used in
  this repo is accepted.
- Structural failures: empty block, unknown diagram type, unterminated fence,
  and nested ```` ```mermaid ```` samples inside a wider fence being out of scope.
- `formatFinding` renders the `file:line (type): Line N:` diagnostic.

New — `tests/scripts/markdown_lint_workflow.bats`:

- `markdown-lint workflow validates Mermaid unconditionally with the repo-owned gate`
- `markdown-lint workflow runs the Mermaid gate unit tests`
- `repo-owned Mermaid gate rejects a broken diagram and passes the tree`

**Documented business-logic change:** the existing bats test
`markdown-lint workflow gates Mermaid validation on a Deno worker module`
asserted the self-skipping behaviour this issue removes, so it was replaced (not
deleted) by the unconditional assertion above; the rationale is recorded in a
comment beside it. No other test was removed or commented out.

Commands run: `deno test --allow-read --allow-write tests/check_mermaid_test.ts`
(14 passed), `bats tests/scripts/markdown_lint_workflow.bats` (14 passed),
`./scripts/typescript-check.sh`, `actionlint`, `codespell`, and `./quality.sh`.

Pre-existing, unrelated: `tests/scripts/perf_private_repo_reference.bats` fails
two cases (`perf sources name none of the private trainer's internal scripts`,
`perf acceptance models reference no private internal script paths`) on the
unmodified base commit as well — out of scope here, they belong to the
concept-level rewording work (#375/#376).

## Security self-check

- No new external input surface: the gate reads committed Markdown only, runs
  with `--allow-read` (unit tests add `--allow-write` for a temp dir), and takes
  no network or env permission.
- No secrets staged; the only hidden path touched is `.github/workflows/`.
- No new third-party dependency; the action SHA pin reuses the
  `denoland/setup-deno@v2.0.5` SHA already used by `ci.yml`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms130ss8-5a87ad`<!-- vibe-worker-issue-379 -->