### PR TITLE
[perf] Flat-slice record input for batched scoring, and wire TrainingDataset::evaluate_mse onto it (Issue #386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ the full dataset never re-crosses the JS↔WASM boundary after the initial load.
 - WASM shims (`training_data_load` / `_evaluate_mse` / `_free` / `_byte_len` /
   `_peak_bytes`) carry byte counts and record indices as `u64` (JS `BigInt`), so
   the surface is Memory64-ready for the >4 GB jobs the milestone targets.
+- `TrainingDataset::evaluate_mse` bounds-checks the batch **once** and hands the
+  contiguous SoA input slice straight to the flat batched scoring path
+  (Issue #386) — no per-record `Vec`, no per-record bounds check, full 8-record
+  interleaved SIMD. That is a **~4–5×** speed-up over the previous
+  one-record-at-a-time `activate` loop at production shard volume; see
+  [`neat-core/benches/BASELINE.md`](neat-core/benches/BASELINE.md).
 
 Lane (d) — Issue #299 — verifies the downstream adoption end-to-end: the
 production trainer's launch script injects a **RAM-aware**
@@ -137,6 +143,34 @@ let outputs = net.score_records(&records, num_outputs);
 // same results, in input order.
 let outputs = net.score_records_parallel(&records, num_outputs);
 ```
+
+### Flat record input (Issue #386)
+
+Both the input and the output of a scoring batch have a flat, contiguous
+contract. Record `i`'s inputs are `inputs[i * stride .. i * stride + stride]`
+and its outputs are `out[i * num_outputs .. (i + 1) * num_outputs]`. Callers
+that already hold a contiguous buffer — the `TrainingDataset` offload lane
+above, or anything reading a packed `.bin` shard — pass it straight through,
+skipping the one-heap-allocation-per-record the `&[Vec<f32>]` signature forces
+(4,096 allocations for a ~40 MiB production shard). A `stride` narrower than the
+network's input arity zero-fills the uncovered inputs, exactly as a short `Vec`
+does.
+
+```rust
+// One contiguous buffer of records * stride values — no per-record Vec.
+let outputs = net.score_records_flat(&inputs, stride, num_outputs);
+
+// Same, into a caller-owned buffer, or across the rayon pool.
+net.score_records_flat_into(&inputs, stride, num_outputs, &mut out);
+let outputs = net.score_records_parallel_flat(&inputs, stride, num_outputs);
+```
+
+The `&[Vec<f32>]` entry points remain and drive the identical kernel, so the two
+layouts are **bit-identical** — asserted across the 8-record group boundary and
+both dispatch arms by
+[`tests/flat_record_scoring_parity.rs`](neat-core/tests/flat_record_scoring_parity.rs).
+A malformed batch (zero `stride`, or a buffer that is not a whole number of
+records) **panics** rather than silently mis-slicing every record.
 
 ```mermaid
 flowchart LR

--- a/docs/archive/pr-summaries/pr-summary-386.md
+++ b/docs/archive/pr-summaries/pr-summary-386.md
@@ -1,0 +1,196 @@
+# Flat-slice record input for batched scoring, and `evaluate_mse` wired onto it (Issue #386)
+
+## Summary
+
+Two related gaps around record **input** layout are closed. Closes #386.
+
+1. **The batched scorer only took `&[Vec<f32>]`.** Issue #229 flattened the
+   scoring *output* to one contiguous buffer, but the input stayed a vector of
+   per-record vectors — one heap allocation per record for the caller (4,096
+   allocations for a ~40 MiB production shard) and a `Vec` header to
+   pointer-chase on every lane load, even though the kernels only ever read a
+   record as `&[f32]`. The fused-loss lane next door
+   (`mse_sum_batch_packed`) already took a flat packed buffer, so the two entry
+   points disagreed on layout for no reason.
+
+   Added the matching flat **input** contract: record `i`'s inputs are
+   `inputs[i * stride .. i * stride + stride]`.
+
+   - `CompiledNetwork::score_records_flat(inputs, stride, num_outputs)`
+   - `CompiledNetwork::score_records_flat_into(inputs, stride, num_outputs, out)`
+   - `CompiledNetwork::score_records_parallel_flat(inputs, stride, num_outputs)`
+
+   `score_batch_into` now takes a `RecordBatch` describing either layout, and the
+   `&[Vec<f32>]` entry points are unchanged wrappers over the same kernel — so
+   existing callers and benches are unaffected and both layouts are
+   **bit-identical**.
+
+2. **The WASM dataset offload path bypassed the batched kernel entirely.**
+   `TrainingDataset` (Issue #298) already stores inputs contiguously in SoA
+   layout and hands out zero-copy slices, yet `evaluate_mse` scored **one record
+   at a time** through `activate`: re-bounds-checking per record, allocating a
+   fresh `Vec<f32>` per record via `to_vec()` (exactly the per-record allocation
+   #229 removed, reintroduced on the >4 GB Memory64 lane), and never touching the
+   8-record interleaved SIMD path from #230/#287.
+
+   It now bounds-checks the batch **once**, takes `input_batch(start, count)` as
+   a single slice, and drives it through the flat batched path in 1024-record
+   chunks — a multiple of the 8-record SIMD group, so grouping and results are
+   unchanged while the scratch output buffer stays a bounded constant no matter
+   how many records the Memory64 lane asks for.
+
+Fail-loud (Issue #3234): a zero `stride` or a buffer that is not a whole number
+of records **panics** with a specific message rather than silently mis-slicing
+every record.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    subgraph BEFORE["before"]
+        D1["TrainingDataset<br/>contiguous SoA inputs"] --> R1["record_inputs(i)<br/>bounds-check per record"]
+        R1 --> A1["activate()<br/>fresh Vec per record"]
+        A1 --> M1["MSE accumulate"]
+    end
+    subgraph AFTER["after"]
+        D2["TrainingDataset<br/>contiguous SoA inputs"] --> R2["input_batch(start, count)<br/>bounds-check once"]
+        R2 --> A2["score_batch_into<br/>RecordBatch::Flat<br/>8-record interleaved SIMD"]
+        A2 --> M2["MSE accumulate"]
+    end
+```
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Evidence is
+benchmarks plus the TDD suites below.
+
+### Benchmarks
+
+Performance task, so benchmarks came **first**: the `dataset_evaluate_mse` group
+was added and baselined against the unchanged implementation before any code
+changed.
+
+**Methodology.** Separate `cargo bench` invocations on this laptop drift by more
+than the effect being measured on the smaller groups (a naive single-shot A/B
+reported a bogus 40% "regression" on `parallel_scoring` that alternating rounds
+disproved). So the A/B follows the #287 protocol: alternating old/new rounds of
+the *same* prebuilt bench binaries, run back to back, with the untouched
+`forward_pass` benchmark captured alongside as a drift control.
+
+Apple M4, macOS 26.5.2, rustc 1.97.0, `--release`, Criterion 0.8
+`--sample-size 10 --measurement-time 5 --warm-up-time 1`, 4096 records per
+iteration (`PRODUCTION_SCORING_RECORDS`). Figures are the mean of the
+alternating rounds. Recorded in
+[`neat-core/benches/BASELINE.md`](../../../neat-core/benches/BASELINE.md).
+
+`dataset_evaluate_mse` — the change under test:
+
+| benchmark | before | after | change |
+| --- | --- | --- | --- |
+| `dataset_evaluate_mse/production` | 330.3 ms | 69.9 ms | **−78.8% (≈4.7×)** |
+| `dataset_evaluate_mse/production_2x` | 686.7 ms | 149.7 ms | **−78.2% (≈4.6×)** |
+| `dataset_evaluate_mse/production_exact` | 283.6 ms | 69.6 ms | **−75.5% (≈4.1×)** |
+
+Drift + no-regression controls — all must be flat, and are. The `scoring` group
+is the gate on the `&[Vec<f32>]` wrapper: it routes through the same rewritten
+kernel and must not pay for the new input layout.
+
+| control | before | after | change |
+| --- | --- | --- | --- |
+| `forward_pass/production_exact` | 48.10 µs | 49.42 µs | flat |
+| `scoring/production` | 74.25 ms | 72.87 ms | flat |
+| `scoring/production_2x` | 165.17 ms | 163.06 ms | flat |
+| `scoring/production_exact` | 70.72 ms | 69.90 ms | flat |
+| `parallel_scoring/production_exact` `1_core` | 71.5 ms | 69.4 ms | flat |
+| `parallel_scoring/production_exact` `12_cores` | 41.4 ms | 43.3 ms | flat (see note) |
+
+> The `12_cores` lane builds a fresh `ThreadPoolBuilder` per iteration and is
+> scheduler-sensitive: across six alternating rounds old spanned 38.0–47.2 ms and
+> new spanned 36.4–51.4 ms, so the ~5% mean gap sits well inside the run-to-run
+> spread. The clean `1_core` signal is flat-to-slightly-better.
+
+New `scoring_flat` group — same shard, same kernel, flat input layout, so the
+delta against `scoring` isolates the per-record `Vec` header indirection. Both
+fixtures are built outside the timed loop, so the caller-side
+one-allocation-per-record the `&[Vec<f32>]` signature forces is *additional*
+saving not counted here:
+
+| benchmark | `scoring` | `scoring_flat` | change |
+| --- | --- | --- | --- |
+| `production` | 72.87 ms | 70.34 ms | −3.5% |
+| `production_2x` | 163.06 ms | 149.70 ms | −8.2% |
+
+## Test Plan
+
+TDD — every suite below was written first and observed failing (the
+`score_records_flat` tests failed to compile; the allocation test failed with
+`delta 900`, i.e. exactly one allocation per record).
+
+Added `neat-core/tests/flat_record_scoring_parity.rs`:
+
+- `flat_input_matches_per_record_on_the_interleaved_arm` — bit-identity at
+  record counts 0, 1, 7, 8, 9, 12 on the all-standard-squash (record-interleaved)
+  dispatch arm.
+- `flat_input_matches_per_record_on_the_aggregate_squash_arm` — same counts on
+  the aggregate-squash per-lane fallback arm.
+- `flat_input_matches_per_record_at_production_shard_width` — bit-identity at
+  production input width (2,461 inputs).
+- `flat_input_zero_fills_a_stride_narrower_than_the_network` — a stride shorter
+  than the network's input arity zero-fills, matching the short-`Vec` behaviour.
+- `flat_input_into_writes_the_same_buffer_as_the_allocating_entry_point`.
+- `parallel_flat_input_matches_the_sequential_flat_path`.
+- `flat_input_rejects_a_zero_stride` / `flat_input_rejects_a_ragged_buffer` —
+  fail-loud panics on a malformed batch.
+
+Added `neat-core/tests/evaluate_mse_allocations.rs` (modelled on
+`tests/scoring_allocations.rs`, counting global allocator):
+
+- `evaluate_mse_has_no_per_record_allocation` — evaluating 10× the records must
+  not allocate ~10× more. Failed at `delta 900` before the fix; constant after.
+
+Added to `neat-core/tests/wasm_dataset_offload.rs`:
+
+- `evaluate_mse_matches_the_per_record_reference_across_group_boundaries` — the
+  pre-#386 per-record implementation is retained in the test file as the
+  equivalence oracle; asserted within the documented `f32` SIMD tolerance
+  (2e-3) at counts 0, 1, 7, 8, 9, 12, 100.
+- `evaluate_mse_matches_the_per_record_reference_on_an_offset_batch` — guards the
+  start-offset arithmetic.
+- `evaluate_mse_returns_zero_for_an_empty_batch` — the `count == 0` path.
+- `evaluate_mse_rejects_an_empty_batch_starting_past_the_end` — a zero-count
+  batch is still bounds-checked.
+
+The existing shape-mismatch and out-of-range error-path tests, the determinism
+test, and the load → evaluate → free leak gate are unchanged and still pass. No
+existing test was modified or removed.
+
+Added `dataset_evaluate_mse` and `scoring_flat` bench groups to
+`neat-core/benches/hot_paths.rs`.
+
+### Quality gate
+
+`./quality.sh`: `cargo build`, `cargo fmt`, `cargo clippy --workspace
+--all-targets --all-features -- -D warnings`, `cargo check`, `cargo test
+--workspace --lib --tests --all-features` (32 test binaries, all green),
+`cargo doc` with `RUSTDOCFLAGS="-D warnings"`, and `cargo build --release` all
+pass. markdownlint, the Mermaid gate and shellcheck pass.
+
+> **Pre-existing bats failures, unrelated to this change.** `perf sources name
+> none of the private trainer's internal scripts` (#138) and `perf acceptance
+> models reference no private internal script paths` (#151) fail identically on
+> the base branch with these changes stashed — they flag private-trainer script
+> names in the perf acceptance models, untouched here. They are not introduced or
+> affected by this PR.
+
+### Security self-check
+
+- **Input validation** — the new public entry points validate `stride` (non-zero)
+  and buffer length (whole number of records) before slicing, and
+  `score_records_flat_into` validates the output buffer length. All fail loud.
+- **Secrets** — none staged; no `.env`/`.config*.json` touched.
+- **Injection surface** — none: no SQL, shell, filesystem or HTTP calls added.
+- **`unsafe`** — none added. The change is pure safe Rust; the SIMD soundness
+  invariants in `AGENTS.md` are untouched.
+- **Error handling** — `evaluate_mse` keeps its typed `DatasetError` returns; no
+  internal state leaks into messages.
+- **Dependencies** — none added or changed.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -260,6 +260,85 @@ the vectorised path, so they gain at least as much.
 > comparable within this section's own old/new pair, which is what the
 > gain claim rests on.
 
+## Flat-slice record **input** for batched scoring (Issue #386)
+
+Issue #229 flattened the scoring *output* to one contiguous buffer, but the
+*input* stayed a `&[Vec<f32>]` — one heap allocation per record for the caller and a
+`Vec` header to pointer-chase on every lane load, even though the kernels only
+ever read a record as `&[f32]`. #386 adds the matching flat *input* contract
+(`score_records_flat` / `_flat_into` / `score_records_parallel_flat`): record
+`i`'s inputs are `inputs[i * stride .. i * stride + stride]`, mirroring the flat
+output layout and the packed buffer the fused loss lane already takes
+(`mse_sum_batch_packed`). The `&[Vec<f32>]` entry points are unchanged wrappers
+over the same kernel, so both layouts are **bit-identical**
+(`tests/flat_record_scoring_parity.rs`).
+
+The real win is `TrainingDataset::evaluate_mse` (the >4 GB Memory64 offload lane
+from #298). It stored inputs contiguously in SoA layout yet scored **one record
+at a time** through `activate` — re-bounds-checking per record, allocating a
+fresh `Vec<f32>` per record via `to_vec()` (exactly the per-record allocation
+removed by #229), and never touching the 8-record interleaved SIMD path from
+issues #230/#287. It now bounds-checks once, takes `input_batch(start, count)` as a
+single slice, and drives it through the flat batched path in 1024-record chunks
+(a multiple of the 8-record SIMD group, so grouping and results are unchanged
+while the scratch output buffer stays a bounded constant).
+
+**Methodology.** Same alternating-rounds protocol as #287 above, because
+separate `cargo bench` invocations on this laptop drift by more than the effect
+being measured on the smaller groups: old/new rounds of the *same* prebuilt
+bench binaries, run back to back, with the untouched `forward_pass` benchmark
+captured alongside as a drift control.
+
+**Measured 2026-07-26**, Apple M4 (the #384 host — see the host note above),
+rustc 1.97.0, `--release`, Criterion
+`--sample-size 10 --measurement-time 5 --warm-up-time 1`.
+
+`dataset_evaluate_mse` (4096 records/iteration), mean of the alternating rounds:
+
+| benchmark (mean of rounds) | old | new | change |
+| --- | --- | --- | --- |
+| `dataset_evaluate_mse/production` | 330.3 ms | 69.9 ms | **−78.8% (≈4.7×)** |
+| `dataset_evaluate_mse/production_2x` | 686.7 ms | 149.7 ms | **−78.2% (≈4.6×)** |
+| `dataset_evaluate_mse/production_exact` | 283.6 ms | 69.6 ms | **−75.5% (≈4.1×)** |
+
+Drift controls — both must be flat, and are:
+
+| control (mean of rounds) | old | new | change |
+| --- | --- | --- | --- |
+| `forward_pass/production_exact` | 48.10 µs | 49.42 µs | flat |
+| `scoring/production` (4096) | 74.25 ms | 72.87 ms | flat |
+| `scoring/production_2x` (4096) | 165.17 ms | 163.06 ms | flat |
+| `scoring/production_exact` (4096) | 70.72 ms | 69.90 ms | flat |
+
+The `scoring` group is the no-regression gate for the `&[Vec<f32>]` wrapper: it
+routes through the same rewritten kernel and must not pay for the new input
+layout. It does not.
+
+`scoring_flat` is the new group scoring the *same* shard through the flat input
+entry point, so the delta against `scoring` isolates the per-record `Vec` header
+indirection (both fixtures are built outside the timed loop, so the caller-side
+one-allocation-per-record the `&[Vec<f32>]` signature forces is *additional*
+saving not counted here):
+
+| benchmark (mean of rounds) | `scoring` | `scoring_flat` | change |
+| --- | --- | --- | --- |
+| `production` (4096) | 72.87 ms | 70.34 ms | −3.5% |
+| `production_2x` (4096) | 163.06 ms | 149.70 ms | −8.2% |
+
+`parallel_scoring` was A/B'd the same way (6 alternating rounds on
+`production_exact`, prebuilt old/new binaries) and is flat — as expected, since
+it drives the identical `score_batch_into`:
+
+| `parallel_scoring/production_exact` | old (mean) | new (mean) | change |
+| --- | --- | --- | --- |
+| `1_core` | 71.5 ms | 69.4 ms | flat |
+| `12_cores` | 41.4 ms | 43.3 ms | flat (within a ±25% run-to-run spread) |
+
+> **12-core noise.** The `12_cores` lane builds a fresh `ThreadPoolBuilder` per
+> iteration and is scheduler-sensitive; across six alternating rounds old spanned
+> 38.0–47.2 ms and new spanned 36.4–51.4 ms, so the ~5% mean gap is well inside
+> the spread. The clean `1_core` signal is flat-to-slightly-better.
+
 ## Native (`--features parallel`) vs wasm32 scoring lane — decision (Issue #288)
 
 The `parallel` feature (rayon, #179) has always compiled the native

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -22,6 +22,8 @@ There are two bench targets:
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` (all shapes), production-sized `mse_sum_batch_packed` (`mse_sum_production`, Issue #384) | 8-record: same five shapes; `mse_sum_production`: `production`, `production_2x`, `production_exact` |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
 | `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
+| `scoring_flat` | `CompiledNetwork::score_records_flat` over the same batch in flat-slice input layout (Issue #386) | `production`, `production_2x`, `production_exact` |
+| `dataset_evaluate_mse` | `TrainingDataset::evaluate_mse` over a production-sized batch (Issue #386) | `production`, `production_2x`, `production_exact` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -30,6 +32,12 @@ through one creature via `score_records`, so `hot_paths` reports single-core
 scoring throughput at production record volume alongside the parallel harness.
 It covers only the gather-bound `production` shapes and is reachable with the
 `production` filter (`--bench hot_paths -- production`).
+
+`scoring_flat` scores the *same* shard through the flat-slice input entry point
+(Issue #386), so the delta against `scoring` isolates the cost of the per-record
+`Vec` header indirection. `dataset_evaluate_mse` measures the WASM
+dataset-offload evaluation call (Issue #298) end to end at the same record
+volume — bounds check, forward pass and MSE accumulation.
 
 Networks and inputs are built **once** outside the timed closure from a
 fixed-seed PRNG with fixed topologies, and `criterion::black_box` guards inputs

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -24,7 +24,9 @@ use neat_core::simd::{
 use neat_core::squash::{SquashType, apply_squash};
 use neat_core::squash_simd::squash_x4;
 use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
+use neat_core::training_data::TrainingDataConfig;
 use neat_core::unsquash::apply_unsquash;
+use neat_core::wasm_dataset::TrainingDataset;
 
 /// Deterministic network/backprop fixtures, shared with the `bench_fixtures`
 /// integration test (Issue #176) so the production-scale builders are exercised
@@ -194,6 +196,91 @@ fn bench_scoring(c: &mut Criterion) {
                 });
             },
         );
+    }
+    group.finish();
+}
+
+/// Flat-slice record **input** scoring — `score_records_flat` over the same
+/// production shard the `scoring` group scores as `&[Vec<f32>]` (Issue #386).
+///
+/// Same kernel, same records, same output layout; only the input layout differs,
+/// so the delta against `scoring` is the cost of the per-record `Vec` header
+/// pointer-chase on each lane load. The one-heap-allocation-per-record the
+/// `&[Vec<f32>]` signature forces on the *caller* is not measured here (both
+/// fixtures are built outside the timed loop) — it is pure additional saving for
+/// callers that already hold a contiguous buffer.
+fn bench_scoring_flat(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scoring_flat");
+    for spec in NETWORKS
+        .iter()
+        .filter(|s| s.label.starts_with("production"))
+    {
+        let net = build_network(spec, 0x5EED);
+        let stride = net.num_inputs();
+        let inputs: Vec<f32> = build_records(stride, PRODUCTION_SCORING_RECORDS)
+            .into_iter()
+            .flatten()
+            .collect();
+        let num_outputs = spec.num_outputs;
+        group.throughput(Throughput::Elements(PRODUCTION_SCORING_RECORDS as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(spec.label),
+            &inputs,
+            |b, inputs| {
+                b.iter(|| {
+                    let out = net.score_records_flat(
+                        black_box(inputs),
+                        black_box(stride),
+                        black_box(num_outputs),
+                    );
+                    black_box(out);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Dataset-offload evaluation — `TrainingDataset::evaluate_mse` over a
+/// production-sized batch (Issue #386).
+///
+/// The WASM offload lane (Issue #298) already stores its inputs contiguously in
+/// SoA layout, so this group measures the cost of the whole
+/// bounds-check → forward-pass → MSE-accumulate call at
+/// [`PRODUCTION_SCORING_RECORDS`] volume — the per-generation unit of work the
+/// Memory64 lane performs. Sized identically to the `scoring` group so the two
+/// are directly comparable.
+fn bench_dataset_evaluate_mse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dataset_evaluate_mse");
+    for spec in NETWORKS
+        .iter()
+        .filter(|s| s.label.starts_with("production"))
+    {
+        let mut net = build_network(spec, 0x5EED);
+        let inputs: Vec<f32> = build_records(spec.num_inputs, PRODUCTION_SCORING_RECORDS)
+            .into_iter()
+            .flatten()
+            .collect();
+        let targets = build_inputs(
+            PRODUCTION_SCORING_RECORDS * spec.num_outputs,
+            0x7A46_0E75_0000,
+        );
+        let dataset = TrainingDataset::from_soa(
+            inputs,
+            targets,
+            TrainingDataConfig::new(spec.num_inputs, spec.num_outputs),
+        )
+        .expect("dataset fixture should be well-formed");
+
+        group.throughput(Throughput::Elements(PRODUCTION_SCORING_RECORDS as u64));
+        group.bench_function(BenchmarkId::from_parameter(spec.label), |b| {
+            b.iter(|| {
+                let mse = dataset
+                    .evaluate_mse(&mut net, 0, black_box(PRODUCTION_SCORING_RECORDS))
+                    .expect("batch is in range");
+                black_box(mse);
+            });
+        });
     }
     group.finish();
 }
@@ -375,6 +462,8 @@ criterion_group!(
     bench_batched_scoring,
     bench_backprop,
     bench_scoring,
+    bench_scoring_flat,
+    bench_dataset_evaluate_mse,
     bench_activation_primitives,
 );
 criterion_main!(benches);

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -54,6 +54,59 @@ use crate::synapse_type::SynapseType;
 /// Number of records processed per SIMD batch (one lane each).
 pub(crate) const SCORING_LANES: usize = 8;
 
+/// Input source for a batched scoring pass (Issue #386).
+///
+/// Both variants are scored through the **same** kernels, so the flat entry
+/// points are bit-identical to the nested ones on identical data:
+///
+/// - [`RecordInput::Nested`] wraps the legacy `&[Vec<f32>]` — one heap
+///   allocation per record — kept so existing callers and benches are
+///   unaffected.
+/// - [`RecordInput::Flat`] wraps one contiguous buffer: record `i`'s inputs are
+///   `inputs[i * stride .. i * stride + stride]`, mirroring the flat *output*
+///   contract (Issue #229) and the fused-loss lane's packed input
+///   (`mse_sum_batch_packed`). No per-record allocation and no `Vec`-header
+///   pointer-chase on each lane load.
+#[derive(Clone, Copy)]
+pub(crate) enum RecordInput<'a> {
+    /// Legacy vector-of-vectors layout.
+    Nested(&'a [Vec<f32>]),
+    /// Flat contiguous layout with a fixed per-record `stride`.
+    Flat {
+        /// Contiguous input buffer holding `len()` records back to back.
+        inputs: &'a [f32],
+        /// Elements per record; record `i` is `inputs[i*stride .. i*stride+stride]`.
+        stride: usize,
+    },
+}
+
+impl RecordInput<'_> {
+    /// Number of records this source yields.
+    #[inline]
+    fn len(&self) -> usize {
+        match self {
+            RecordInput::Nested(records) => records.len(),
+            RecordInput::Flat { inputs, stride } => {
+                if *stride == 0 {
+                    0
+                } else {
+                    inputs.len() / *stride
+                }
+            }
+        }
+    }
+
+    /// Inputs for record `i` as a contiguous slice. Callers only ever pass
+    /// `i < len()`, so both arms index in range.
+    #[inline]
+    fn record(&self, i: usize) -> &[f32] {
+        match self {
+            RecordInput::Nested(records) => &records[i],
+            RecordInput::Flat { inputs, stride } => &inputs[i * *stride..i * *stride + *stride],
+        }
+    }
+}
+
 /// Reusable per-worker scratch for the batched scoring forward pass.
 ///
 /// Owning the buffers here lets the sequential path allocate once for a whole
@@ -220,7 +273,7 @@ impl CompiledNetwork {
     pub(crate) fn score_batch_into(
         &self,
         scratch: &mut BatchScratch,
-        records: &[Vec<f32>],
+        records: RecordInput,
         num_outputs: usize,
         out: &mut [f32],
     ) {
@@ -269,7 +322,7 @@ impl CompiledNetwork {
     fn score_batch_interleaved(
         &self,
         scratch: &mut BatchScratch,
-        records: &[Vec<f32>],
+        records: RecordInput,
         num_outputs: usize,
         out: &mut [f32],
     ) {
@@ -290,7 +343,7 @@ impl CompiledNetwork {
         while base + L <= n {
             // Transpose L records into the interleaved buffer.
             for l in 0..L {
-                let rec = &records[base + l];
+                let rec = records.record(base + l);
                 let in_len = rec.len().min(num_inputs);
                 for i in 0..in_len {
                     inter[i * L + l] = rec[i];
@@ -318,7 +371,7 @@ impl CompiledNetwork {
         // Bit-identical to `activate`, so a lone or partial trailing group keeps
         // the strict single-record parity guarantee.
         while base < n {
-            load_record(tail_act, &records[base], num_inputs);
+            load_record(tail_act, records.record(base), num_inputs);
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
                 tail_act[actual_idx] = neuron_activation_scalar(&self.synapses, tail_act, neuron);
@@ -389,7 +442,7 @@ impl CompiledNetwork {
     fn score_batch_per_lane(
         &self,
         scratch: &mut BatchScratch,
-        records: &[Vec<f32>],
+        records: RecordInput,
         num_outputs: usize,
         out: &mut [f32],
     ) {
@@ -404,14 +457,14 @@ impl CompiledNetwork {
 
         // ---- 8-record batches ------------------------------------------------
         while base + 8 <= n {
-            load_record(act0, &records[base], num_inputs);
-            load_record(act1, &records[base + 1], num_inputs);
-            load_record(act2, &records[base + 2], num_inputs);
-            load_record(act3, &records[base + 3], num_inputs);
-            load_record(act4, &records[base + 4], num_inputs);
-            load_record(act5, &records[base + 5], num_inputs);
-            load_record(act6, &records[base + 6], num_inputs);
-            load_record(act7, &records[base + 7], num_inputs);
+            load_record(act0, records.record(base), num_inputs);
+            load_record(act1, records.record(base + 1), num_inputs);
+            load_record(act2, records.record(base + 2), num_inputs);
+            load_record(act3, records.record(base + 3), num_inputs);
+            load_record(act4, records.record(base + 4), num_inputs);
+            load_record(act5, records.record(base + 5), num_inputs);
+            load_record(act6, records.record(base + 6), num_inputs);
+            load_record(act7, records.record(base + 7), num_inputs);
 
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
@@ -508,10 +561,10 @@ impl CompiledNetwork {
 
         // ---- 4-record batch (0 or 1 of them) ---------------------------------
         if base + 4 <= n {
-            load_record(act0, &records[base], num_inputs);
-            load_record(act1, &records[base + 1], num_inputs);
-            load_record(act2, &records[base + 2], num_inputs);
-            load_record(act3, &records[base + 3], num_inputs);
+            load_record(act0, records.record(base), num_inputs);
+            load_record(act1, records.record(base + 1), num_inputs);
+            load_record(act2, records.record(base + 2), num_inputs);
+            load_record(act3, records.record(base + 3), num_inputs);
 
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
@@ -588,7 +641,7 @@ impl CompiledNetwork {
         // Exact single-record path so tail records are bit-identical to the
         // reference.
         while base < n {
-            load_record(act0, &records[base], num_inputs);
+            load_record(act0, records.record(base), num_inputs);
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
                 act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -86,13 +86,7 @@ impl RecordInput<'_> {
     fn len(&self) -> usize {
         match self {
             RecordInput::Nested(records) => records.len(),
-            RecordInput::Flat { inputs, stride } => {
-                if *stride == 0 {
-                    0
-                } else {
-                    inputs.len() / *stride
-                }
-            }
+            RecordInput::Flat { inputs, stride } => inputs.len().checked_div(*stride).unwrap_or(0),
         }
     }
 

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -54,6 +54,71 @@ use crate::synapse_type::SynapseType;
 /// Number of records processed per SIMD batch (one lane each).
 pub(crate) const SCORING_LANES: usize = 8;
 
+/// Input records for one scoring batch, in either supported layout (Issue #386).
+///
+/// The kernels below only ever need `&[f32]` per record, so both layouts feed
+/// the *same* forward pass and produce bit-identical results:
+///
+/// - [`RecordBatch::PerRecord`] — one owned `Vec<f32>` per record, the original
+///   layout kept for existing callers.
+/// - [`RecordBatch::Flat`] — a single contiguous buffer where record `i`
+///   occupies `inputs[i * stride .. i * stride + stride]`, mirroring the flat
+///   *output* contract from Issue #229 and the packed input layout the fused
+///   loss lane already takes ([`crate::loss::mse_sum_batch_packed`]). Callers
+///   that already hold a contiguous buffer — the WASM dataset offload path
+///   ([`crate::wasm_dataset::TrainingDataset`]) — pass it straight through with
+///   no per-record allocation and no re-marshalling.
+#[derive(Clone, Copy)]
+pub(crate) enum RecordBatch<'a> {
+    /// One owned vector per record.
+    PerRecord(&'a [Vec<f32>]),
+    /// Records packed contiguously at a fixed stride.
+    Flat {
+        /// Packed inputs — exactly `record_count * stride` values.
+        inputs: &'a [f32],
+        /// Values per record. Non-zero, and a divisor of `inputs.len()`.
+        stride: usize,
+    },
+}
+
+impl<'a> RecordBatch<'a> {
+    /// Build a flat-layout batch, failing loud (Issue #3234) on a stride that
+    /// cannot describe records at all or a buffer that is not a whole number of
+    /// records — either would silently mis-slice every record downstream.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `stride` is zero or `inputs.len()` is not a multiple of it.
+    #[inline]
+    pub(crate) fn flat(inputs: &'a [f32], stride: usize) -> Self {
+        assert!(stride > 0, "flat record stride must be greater than zero");
+        assert!(
+            inputs.len().is_multiple_of(stride),
+            "flat record buffer of {} values is not a whole number of records at stride {stride}",
+            inputs.len()
+        );
+        Self::Flat { inputs, stride }
+    }
+
+    /// Number of records in the batch.
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::PerRecord(records) => records.len(),
+            Self::Flat { inputs, stride } => inputs.len() / stride,
+        }
+    }
+
+    /// Inputs for record `index`.
+    #[inline]
+    pub(crate) fn record(&self, index: usize) -> &'a [f32] {
+        match self {
+            Self::PerRecord(records) => &records[index],
+            Self::Flat { inputs, stride } => &inputs[index * stride..(index + 1) * stride],
+        }
+    }
+}
+
 /// Reusable per-worker scratch for the batched scoring forward pass.
 ///
 /// Owning the buffers here lets the sequential path allocate once for a whole
@@ -199,7 +264,11 @@ fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
 }
 
 impl CompiledNetwork {
-    /// Score a contiguous slice of records through the batched SIMD path.
+    /// Score a batch of records through the batched SIMD path.
+    ///
+    /// `records` may be in either input layout ([`RecordBatch`]) — per-record
+    /// `Vec`s or one contiguous flat buffer at a fixed stride. The kernels read
+    /// each record as `&[f32]`, so the two layouts are bit-identical.
     ///
     /// Record `i` (0-based within `records`) writes its outputs to
     /// `out[i * num_outputs .. (i + 1) * num_outputs]`; `out` must be exactly
@@ -220,7 +289,7 @@ impl CompiledNetwork {
     pub(crate) fn score_batch_into(
         &self,
         scratch: &mut BatchScratch,
-        records: &[Vec<f32>],
+        records: RecordBatch<'_>,
         num_outputs: usize,
         out: &mut [f32],
     ) {
@@ -269,7 +338,7 @@ impl CompiledNetwork {
     fn score_batch_interleaved(
         &self,
         scratch: &mut BatchScratch,
-        records: &[Vec<f32>],
+        records: RecordBatch<'_>,
         num_outputs: usize,
         out: &mut [f32],
     ) {
@@ -290,7 +359,7 @@ impl CompiledNetwork {
         while base + L <= n {
             // Transpose L records into the interleaved buffer.
             for l in 0..L {
-                let rec = &records[base + l];
+                let rec = records.record(base + l);
                 let in_len = rec.len().min(num_inputs);
                 for i in 0..in_len {
                     inter[i * L + l] = rec[i];
@@ -318,7 +387,7 @@ impl CompiledNetwork {
         // Bit-identical to `activate`, so a lone or partial trailing group keeps
         // the strict single-record parity guarantee.
         while base < n {
-            load_record(tail_act, &records[base], num_inputs);
+            load_record(tail_act, records.record(base), num_inputs);
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
                 tail_act[actual_idx] = neuron_activation_scalar(&self.synapses, tail_act, neuron);
@@ -389,7 +458,7 @@ impl CompiledNetwork {
     fn score_batch_per_lane(
         &self,
         scratch: &mut BatchScratch,
-        records: &[Vec<f32>],
+        records: RecordBatch<'_>,
         num_outputs: usize,
         out: &mut [f32],
     ) {
@@ -404,14 +473,14 @@ impl CompiledNetwork {
 
         // ---- 8-record batches ------------------------------------------------
         while base + 8 <= n {
-            load_record(act0, &records[base], num_inputs);
-            load_record(act1, &records[base + 1], num_inputs);
-            load_record(act2, &records[base + 2], num_inputs);
-            load_record(act3, &records[base + 3], num_inputs);
-            load_record(act4, &records[base + 4], num_inputs);
-            load_record(act5, &records[base + 5], num_inputs);
-            load_record(act6, &records[base + 6], num_inputs);
-            load_record(act7, &records[base + 7], num_inputs);
+            load_record(act0, records.record(base), num_inputs);
+            load_record(act1, records.record(base + 1), num_inputs);
+            load_record(act2, records.record(base + 2), num_inputs);
+            load_record(act3, records.record(base + 3), num_inputs);
+            load_record(act4, records.record(base + 4), num_inputs);
+            load_record(act5, records.record(base + 5), num_inputs);
+            load_record(act6, records.record(base + 6), num_inputs);
+            load_record(act7, records.record(base + 7), num_inputs);
 
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
@@ -508,10 +577,10 @@ impl CompiledNetwork {
 
         // ---- 4-record batch (0 or 1 of them) ---------------------------------
         if base + 4 <= n {
-            load_record(act0, &records[base], num_inputs);
-            load_record(act1, &records[base + 1], num_inputs);
-            load_record(act2, &records[base + 2], num_inputs);
-            load_record(act3, &records[base + 3], num_inputs);
+            load_record(act0, records.record(base), num_inputs);
+            load_record(act1, records.record(base + 1), num_inputs);
+            load_record(act2, records.record(base + 2), num_inputs);
+            load_record(act3, records.record(base + 3), num_inputs);
 
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
@@ -588,7 +657,7 @@ impl CompiledNetwork {
         // Exact single-record path so tail records are bit-identical to the
         // reference.
         while base < n {
-            load_record(act0, &records[base], num_inputs);
+            load_record(act0, records.record(base), num_inputs);
             for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
                 let actual_idx = num_inputs + neuron_idx;
                 act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -43,8 +43,19 @@
 //! `[i * num_outputs .. (i + 1) * num_outputs]`. This flat buffer is written
 //! through [`CompiledNetwork::activate_into`], so the batch performs a **single**
 //! output allocation instead of one heap allocation per record.
+//!
+//! # Input layout (Issue #386)
+//!
+//! The `_flat` entry points ([`CompiledNetwork::score_records_flat`],
+//! [`CompiledNetwork::score_records_flat_into`],
+//! [`CompiledNetwork::score_records_parallel_flat`]) take the **inputs** in the
+//! matching flat layout: record `i`'s inputs are
+//! `inputs[i * stride .. i * stride + stride]`. Callers that already hold a
+//! contiguous buffer skip the one-heap-allocation-per-record marshalling the
+//! `&[Vec<f32>]` signatures force. The `&[Vec<f32>]` entry points remain, and
+//! both layouts feed the identical kernel, so their results are bit-identical.
 
-use crate::batch_scoring::BatchScratch;
+use crate::batch_scoring::{BatchScratch, RecordBatch};
 use crate::network::CompiledNetwork;
 
 /// Records per rayon task on the parallel path. A multiple of 8 so every task's
@@ -74,9 +85,72 @@ impl CompiledNetwork {
     /// building for `wasm32`, and the reference path the parallel results must
     /// match exactly.
     pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
-        let mut outputs = vec![0.0f32; records.len() * num_outputs];
+        self.score_batch_alloc(RecordBatch::PerRecord(records), num_outputs)
+    }
+
+    /// Score every record from one **flat** input buffer, returning a single flat
+    /// output buffer (Issue #386).
+    ///
+    /// Record `i`'s inputs are `inputs[i * stride .. i * stride + stride]` and
+    /// its outputs occupy `out[i * num_outputs .. (i + 1) * num_outputs]` — the
+    /// input layout mirrors the flat output contract from Issue #229 and the
+    /// packed buffer the fused loss lane already takes
+    /// ([`crate::loss::mse_sum_batch_packed`]). Callers that already hold a
+    /// contiguous buffer (the WASM dataset offload path) pass it straight
+    /// through: no heap allocation per record, no `Vec` header to pointer-chase
+    /// on each lane load, no re-marshalling.
+    ///
+    /// Results are **bit-identical** to [`CompiledNetwork::score_records`] on the
+    /// same data — both drive the same batched kernel, which only ever reads a
+    /// record as `&[f32]`. A `stride` shorter than the network's input arity
+    /// zero-fills the uncovered inputs, exactly as a short `Vec` does.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `stride` is zero or `inputs.len()` is not a multiple of
+    /// `stride` — a malformed batch fails loud rather than mis-slicing every
+    /// record (Issue #3234).
+    pub fn score_records_flat(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+    ) -> Vec<f32> {
+        self.score_batch_alloc(RecordBatch::flat(inputs, stride), num_outputs)
+    }
+
+    /// [`CompiledNetwork::score_records_flat`] writing into a caller-supplied
+    /// output buffer instead of allocating one.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a malformed `inputs`/`stride` pair (see
+    /// [`CompiledNetwork::score_records_flat`]), or if `out` is not exactly
+    /// `record_count * num_outputs` long.
+    pub fn score_records_flat_into(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        let batch = RecordBatch::flat(inputs, stride);
+        assert_eq!(
+            out.len(),
+            batch.len() * num_outputs,
+            "output buffer must hold exactly record_count * num_outputs values"
+        );
         let mut scratch = BatchScratch::new(self.num_neurons);
-        self.score_batch_into(&mut scratch, records, num_outputs, &mut outputs);
+        self.score_batch_into(&mut scratch, batch, num_outputs, out);
+    }
+
+    /// Allocate the flat output buffer and drive `batch` through the batched
+    /// forward pass — the single sequential implementation shared by the
+    /// per-record and flat-slice entry points.
+    fn score_batch_alloc(&self, batch: RecordBatch<'_>, num_outputs: usize) -> Vec<f32> {
+        let mut outputs = vec![0.0f32; batch.len() * num_outputs];
+        let mut scratch = BatchScratch::new(self.num_neurons);
+        self.score_batch_into(&mut scratch, batch, num_outputs, &mut outputs);
         outputs
     }
 
@@ -106,7 +180,12 @@ impl CompiledNetwork {
             .for_each_init(
                 || BatchScratch::new(self.num_neurons),
                 |scratch, (out_chunk, rec_chunk)| {
-                    self.score_batch_into(scratch, rec_chunk, num_outputs, out_chunk)
+                    self.score_batch_into(
+                        scratch,
+                        RecordBatch::PerRecord(rec_chunk),
+                        num_outputs,
+                        out_chunk,
+                    )
                 },
             );
         outputs
@@ -119,5 +198,67 @@ impl CompiledNetwork {
     #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
     pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         self.score_records(records, num_outputs)
+    }
+
+    /// Flat-input counterpart of [`CompiledNetwork::score_records_parallel`]
+    /// (Issue #386): record `i`'s inputs are
+    /// `inputs[i * stride .. i * stride + stride]`, scored across the `rayon`
+    /// thread pool into one flat output buffer in input order.
+    ///
+    /// Chunk boundaries are a multiple of the 8-record batch size and the
+    /// forward pass carries no cross-record state, so results are identical to
+    /// [`CompiledNetwork::score_records_flat`] regardless of thread count.
+    ///
+    /// Available with the `parallel` feature on native targets; elsewhere it
+    /// falls back to the sequential flat path.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a malformed `inputs`/`stride` pair (see
+    /// [`CompiledNetwork::score_records_flat`]).
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    pub fn score_records_parallel_flat(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+    ) -> Vec<f32> {
+        use rayon::prelude::*;
+        let record_count = RecordBatch::flat(inputs, stride).len();
+        let mut outputs = vec![0.0f32; record_count * num_outputs];
+        outputs
+            .par_chunks_mut(PARALLEL_CHUNK_RECORDS * num_outputs)
+            .zip(inputs.par_chunks(PARALLEL_CHUNK_RECORDS * stride))
+            .for_each_init(
+                || BatchScratch::new(self.num_neurons),
+                |scratch, (out_chunk, in_chunk)| {
+                    self.score_batch_into(
+                        scratch,
+                        RecordBatch::flat(in_chunk, stride),
+                        num_outputs,
+                        out_chunk,
+                    )
+                },
+            );
+        outputs
+    }
+
+    /// Sequential fallback for
+    /// [`CompiledNetwork::score_records_parallel_flat`] when the `parallel`
+    /// feature is disabled or building for `wasm32`. Same signature and
+    /// identical results — just single-threaded.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a malformed `inputs`/`stride` pair (see
+    /// [`CompiledNetwork::score_records_flat`]).
+    #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+    pub fn score_records_parallel_flat(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+    ) -> Vec<f32> {
+        self.score_records_flat(inputs, stride, num_outputs)
     }
 }

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -101,8 +101,17 @@ impl CompiledNetwork {
     /// same data — but takes zero-copy contiguous input, so a caller that already
     /// holds a packed buffer (e.g. [`crate::wasm_dataset::TrainingDataset`]) pays
     /// no per-record `Vec` allocation and no `Vec`-header pointer-chase.
-    pub fn score_records_flat(&self, inputs: &[f32], stride: usize, num_outputs: usize) -> Vec<f32> {
-        let num_records = if stride == 0 { 0 } else { inputs.len() / stride };
+    pub fn score_records_flat(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+    ) -> Vec<f32> {
+        let num_records = if stride == 0 {
+            0
+        } else {
+            inputs.len() / stride
+        };
         let mut outputs = vec![0.0f32; num_records * num_outputs];
         self.score_records_flat_into(inputs, stride, num_outputs, &mut outputs);
         outputs
@@ -185,7 +194,11 @@ impl CompiledNetwork {
         num_outputs: usize,
     ) -> Vec<f32> {
         use rayon::prelude::*;
-        let num_records = if stride == 0 { 0 } else { inputs.len() / stride };
+        let num_records = if stride == 0 {
+            0
+        } else {
+            inputs.len() / stride
+        };
         let mut outputs = vec![0.0f32; num_records * num_outputs];
         if stride == 0 {
             return outputs;

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -44,7 +44,7 @@
 //! through [`CompiledNetwork::activate_into`], so the batch performs a **single**
 //! output allocation instead of one heap allocation per record.
 
-use crate::batch_scoring::BatchScratch;
+use crate::batch_scoring::{BatchScratch, RecordInput};
 use crate::network::CompiledNetwork;
 
 /// Records per rayon task on the parallel path. A multiple of 8 so every task's
@@ -76,8 +76,56 @@ impl CompiledNetwork {
     pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         let mut outputs = vec![0.0f32; records.len() * num_outputs];
         let mut scratch = BatchScratch::new(self.num_neurons);
-        self.score_batch_into(&mut scratch, records, num_outputs, &mut outputs);
+        self.score_batch_into(
+            &mut scratch,
+            RecordInput::Nested(records),
+            num_outputs,
+            &mut outputs,
+        );
         outputs
+    }
+
+    /// Score every record from one **flat** contiguous input buffer, returning a
+    /// single flat output buffer (Issue #386).
+    ///
+    /// Record `i`'s inputs are `inputs[i * stride .. i * stride + stride]`, and
+    /// its outputs occupy `out[i * num_outputs .. (i + 1) * num_outputs]` — the
+    /// same flat output contract as [`CompiledNetwork::score_records`], and the
+    /// same layout the fused-loss lane's packed input uses
+    /// (`mse_sum_batch_packed`). The number of records is `inputs.len() /
+    /// stride`; any trailing partial record (when `stride` does not divide
+    /// `inputs.len()`) is ignored, mirroring `mse_sum_batch_packed`.
+    ///
+    /// This drives the **identical** batched SIMD kernels as the nested
+    /// [`CompiledNetwork::score_records`] path — the two are bit-identical on the
+    /// same data — but takes zero-copy contiguous input, so a caller that already
+    /// holds a packed buffer (e.g. [`crate::wasm_dataset::TrainingDataset`]) pays
+    /// no per-record `Vec` allocation and no `Vec`-header pointer-chase.
+    pub fn score_records_flat(&self, inputs: &[f32], stride: usize, num_outputs: usize) -> Vec<f32> {
+        let num_records = if stride == 0 { 0 } else { inputs.len() / stride };
+        let mut outputs = vec![0.0f32; num_records * num_outputs];
+        self.score_records_flat_into(inputs, stride, num_outputs, &mut outputs);
+        outputs
+    }
+
+    /// Flat-input scoring into a caller-owned output buffer (Issue #386).
+    ///
+    /// `out` must be exactly `(inputs.len() / stride) * num_outputs` long. Lets a
+    /// caller reuse one output buffer across batches without re-allocating.
+    pub fn score_records_flat_into(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+        out: &mut [f32],
+    ) {
+        let mut scratch = BatchScratch::new(self.num_neurons);
+        self.score_batch_into(
+            &mut scratch,
+            RecordInput::Flat { inputs, stride },
+            num_outputs,
+            out,
+        );
     }
 
     /// Score every record across the `rayon` thread pool, writing into a single
@@ -106,10 +154,76 @@ impl CompiledNetwork {
             .for_each_init(
                 || BatchScratch::new(self.num_neurons),
                 |scratch, (out_chunk, rec_chunk)| {
-                    self.score_batch_into(scratch, rec_chunk, num_outputs, out_chunk)
+                    self.score_batch_into(
+                        scratch,
+                        RecordInput::Nested(rec_chunk),
+                        num_outputs,
+                        out_chunk,
+                    )
                 },
             );
         outputs
+    }
+
+    /// Flat-input counterpart of [`CompiledNetwork::score_records_parallel`]
+    /// (Issue #386): score a flat contiguous input buffer across the `rayon`
+    /// pool into one flat output buffer in input order.
+    ///
+    /// Record `i`'s inputs are `inputs[i * stride .. i * stride + stride]` and
+    /// its outputs live in `out[i * num_outputs ..]`. Input and output are split
+    /// into aligned `PARALLEL_CHUNK_RECORDS`-record chunks (a multiple of the
+    /// SIMD batch), so every record lands on the same primitive as the
+    /// sequential [`CompiledNetwork::score_records_flat`] and the results are
+    /// bit-identical regardless of thread count.
+    ///
+    /// Available with the `parallel` feature on native targets.
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    pub fn score_records_flat_parallel(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+    ) -> Vec<f32> {
+        use rayon::prelude::*;
+        let num_records = if stride == 0 { 0 } else { inputs.len() / stride };
+        let mut outputs = vec![0.0f32; num_records * num_outputs];
+        if stride == 0 {
+            return outputs;
+        }
+        // Score only whole records; ignore any trailing partial record so the
+        // input chunks are exact record multiples (mirrors `score_records_flat`).
+        let scored_inputs = &inputs[..num_records * stride];
+        outputs
+            .par_chunks_mut(PARALLEL_CHUNK_RECORDS * num_outputs)
+            .zip(scored_inputs.par_chunks(PARALLEL_CHUNK_RECORDS * stride))
+            .for_each_init(
+                || BatchScratch::new(self.num_neurons),
+                |scratch, (out_chunk, in_chunk)| {
+                    self.score_batch_into(
+                        scratch,
+                        RecordInput::Flat {
+                            inputs: in_chunk,
+                            stride,
+                        },
+                        num_outputs,
+                        out_chunk,
+                    )
+                },
+            );
+        outputs
+    }
+
+    /// Sequential fallback for [`CompiledNetwork::score_records_flat_parallel`]
+    /// when the `parallel` feature is disabled or building for `wasm32`. Same
+    /// signature and identical results — just single-threaded.
+    #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+    pub fn score_records_flat_parallel(
+        &self,
+        inputs: &[f32],
+        stride: usize,
+        num_outputs: usize,
+    ) -> Vec<f32> {
+        self.score_records_flat(inputs, stride, num_outputs)
     }
 
     /// Sequential fallback for [`CompiledNetwork::score_records_parallel`] when

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -107,11 +107,7 @@ impl CompiledNetwork {
         stride: usize,
         num_outputs: usize,
     ) -> Vec<f32> {
-        let num_records = if stride == 0 {
-            0
-        } else {
-            inputs.len() / stride
-        };
+        let num_records = inputs.len().checked_div(stride).unwrap_or(0);
         let mut outputs = vec![0.0f32; num_records * num_outputs];
         self.score_records_flat_into(inputs, stride, num_outputs, &mut outputs);
         outputs
@@ -194,11 +190,7 @@ impl CompiledNetwork {
         num_outputs: usize,
     ) -> Vec<f32> {
         use rayon::prelude::*;
-        let num_records = if stride == 0 {
-            0
-        } else {
-            inputs.len() / stride
-        };
+        let num_records = inputs.len().checked_div(stride).unwrap_or(0);
         let mut outputs = vec![0.0f32; num_records * num_outputs];
         if stride == 0 {
             return outputs;

--- a/neat-core/src/wasm_dataset.rs
+++ b/neat-core/src/wasm_dataset.rs
@@ -33,8 +33,17 @@
 //! network/dataset shape mismatch surfaces immediately rather than degrading
 //! into a silent wrong result.
 
+use crate::batch_scoring::{BatchScratch, RecordBatch};
 use crate::network::CompiledNetwork;
 use crate::training_data::TrainingDataConfig;
+
+/// Records scored per [`TrainingDataset::evaluate_mse`] chunk.
+///
+/// A multiple of the 8-record SIMD group, so chunking does not change which
+/// records are grouped (and therefore does not change the result), while keeping
+/// the scratch output buffer a bounded, constant size no matter how large the
+/// requested batch is — the >4 GB Memory64 lane can ask for millions of records.
+const EVAL_CHUNK_RECORDS: usize = 1024;
 
 /// Errors from the training-data offload path.
 #[derive(Debug, PartialEq)]
@@ -264,34 +273,60 @@ impl TrainingDataset {
     /// and the batch bounds are supplied per call — the training arrays never
     /// re-cross the boundary. Fails loud on an out-of-range batch or a
     /// network/dataset input-arity mismatch.
+    ///
+    /// The batch is bounds-checked **once** and then driven through the flat
+    /// batched scoring path (Issue #386): the SoA input buffer is already in the
+    /// layout [`CompiledNetwork::score_records_flat`] wants, so it is handed over
+    /// as one slice — no per-record `Vec`, no per-record bounds check, and the
+    /// full 8-record interleaved SIMD path (Issues #230 / #287) instead of the
+    /// single-record `activate` kernel. Records are scored in fixed-size chunks
+    /// (a multiple of the 8-record SIMD group, so grouping is unchanged) to keep
+    /// the scratch output buffer bounded on the >4 GB Memory64 offload lane.
+    ///
+    /// Numerics: the batched path re-associates the `f32` weighted sums and uses
+    /// the vectorised squash, so the result matches the per-record reference
+    /// within the documented SIMD tolerance (see [`crate::batch_scoring`]) rather
+    /// than bit-for-bit. The MSE itself still accumulates in `f64`.
     pub fn evaluate_mse(
         &self,
         network: &mut CompiledNetwork,
         start: usize,
         count: usize,
     ) -> Result<f32, DatasetError> {
-        if network.num_inputs != self.num_inputs() {
+        let num_inputs = self.num_inputs();
+        let num_outputs = self.num_outputs();
+        if network.num_inputs != num_inputs {
             return Err(DatasetError::ShapeMismatch {
                 network_inputs: network.num_inputs,
-                dataset_inputs: self.num_inputs(),
+                dataset_inputs: num_inputs,
             });
         }
-        // Bounds-check the whole batch up front (fail loud before any work).
-        self.batch_bounds(start, count, self.num_inputs())?;
-        self.batch_bounds(start, count, self.num_outputs())?;
+        // Bounds-check the whole batch once, up front (fail loud before any
+        // work), then read it as two contiguous slices.
+        let inputs = self.input_batch(start, count)?;
+        let targets = self.target_batch(start, count)?;
 
         if count == 0 {
             return Ok(0.0);
         }
 
-        let num_outputs = self.num_outputs();
+        let mut scratch = BatchScratch::new(network.num_neurons);
+        let mut outputs = vec![0.0f32; EVAL_CHUNK_RECORDS.min(count) * num_outputs];
         let mut squared_error_sum = 0.0f64;
-        for offset in 0..count {
-            let index = start + offset;
-            let inputs = self.record_inputs(index)?;
-            let targets = self.record_outputs(index)?;
-            let outputs = network.activate(inputs, num_outputs);
-            for (predicted, expected) in outputs.iter().zip(targets.iter()) {
+
+        for (input_chunk, target_chunk) in inputs
+            .chunks(EVAL_CHUNK_RECORDS * num_inputs)
+            .zip(targets.chunks(EVAL_CHUNK_RECORDS * num_outputs))
+        {
+            let chunk_records = input_chunk.len() / num_inputs;
+            let predicted = &mut outputs[..chunk_records * num_outputs];
+            network.score_batch_into(
+                &mut scratch,
+                RecordBatch::flat(input_chunk, num_inputs),
+                num_outputs,
+                predicted,
+            );
+            for (predicted, expected) in predicted.iter().zip(target_chunk.iter()) {
                 let diff = f64::from(*predicted) - f64::from(*expected);
                 squared_error_sum += diff * diff;
             }

--- a/neat-core/src/wasm_dataset.rs
+++ b/neat-core/src/wasm_dataset.rs
@@ -264,6 +264,15 @@ impl TrainingDataset {
     /// and the batch bounds are supplied per call — the training arrays never
     /// re-cross the boundary. Fails loud on an out-of-range batch or a
     /// network/dataset input-arity mismatch.
+    ///
+    /// The whole batch is scored through the **flat batched SIMD path** (Issue
+    /// #386): the contiguous SoA input slice for the batch is driven through
+    /// [`CompiledNetwork::score_records_flat`] in one call — one bounds check,
+    /// no per-record `Vec` allocation, and the same 8-record interleaved SIMD
+    /// kernel the rest of the crate uses. Standard-squash results therefore
+    /// match the prior per-record `activate` path within the batched SIMD `f32`
+    /// tolerance rather than bit-for-bit (see [`crate::batch_scoring`]); the
+    /// scalar tail (`count % 8`) stays exact.
     pub fn evaluate_mse(
         &self,
         network: &mut CompiledNetwork,
@@ -276,25 +285,25 @@ impl TrainingDataset {
                 dataset_inputs: self.num_inputs(),
             });
         }
-        // Bounds-check the whole batch up front (fail loud before any work).
-        self.batch_bounds(start, count, self.num_inputs())?;
-        self.batch_bounds(start, count, self.num_outputs())?;
+        // One bounds check for the whole batch's inputs and targets (fail loud
+        // before any scoring); the returned slices are contiguous SoA runs.
+        let inputs = self.input_batch(start, count)?;
+        let targets = self.target_batch(start, count)?;
 
         if count == 0 {
             return Ok(0.0);
         }
 
+        let num_inputs = self.num_inputs();
         let num_outputs = self.num_outputs();
+        // Score the entire batch in one flat call — record `i`'s outputs land in
+        // `outputs[i * num_outputs ..]`, aligned with the SoA `targets` slice.
+        let outputs = network.score_records_flat(inputs, num_inputs, num_outputs);
+
         let mut squared_error_sum = 0.0f64;
-        for offset in 0..count {
-            let index = start + offset;
-            let inputs = self.record_inputs(index)?;
-            let targets = self.record_outputs(index)?;
-            let outputs = network.activate(inputs, num_outputs);
-            for (predicted, expected) in outputs.iter().zip(targets.iter()) {
-                let diff = f64::from(*predicted) - f64::from(*expected);
-                squared_error_sum += diff * diff;
-            }
+        for (predicted, expected) in outputs.iter().zip(targets.iter()) {
+            let diff = f64::from(*predicted) - f64::from(*expected);
+            squared_error_sum += diff * diff;
         }
 
         let terms = (count * num_outputs) as f64;

--- a/neat-core/tests/evaluate_mse_allocations.rs
+++ b/neat-core/tests/evaluate_mse_allocations.rs
@@ -1,0 +1,109 @@
+//! Allocation-count regression for the dataset-offload evaluation path (Issue #386).
+//!
+//! `TrainingDataset::evaluate_mse` used to score **one record at a time** via
+//! `CompiledNetwork::activate`, whose `to_vec()` allocates a fresh output `Vec`
+//! per record — exactly the per-record allocation Issue #229 removed from
+//! `score_records`, reintroduced on the >4 GB Memory64 offload lane. It now
+//! drives the flat batched path instead, so its allocation count is **constant**
+//! in the record count.
+//!
+//! Modelled on `tests/scoring_allocations.rs`: a counting global allocator
+//! measures two evaluations whose record counts differ 10×; a per-record
+//! allocation would show up as a proportional delta.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use neat_core::network::CompiledNetwork;
+use neat_core::squash::SquashType;
+use neat_core::training_data::TrainingDataConfig;
+use neat_core::wasm_dataset::TrainingDataset;
+
+/// Global allocator forwarding to the system allocator while counting every
+/// allocation. Only the count is observed.
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: forwarding an unchanged layout to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr`/`layout` came from `System.alloc` above.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Single `Tanh` output neuron summing every input — enough topology to drive
+/// the batched forward pass, small enough that the fixture build is cheap.
+fn summing_tanh_network(num_inputs: usize) -> CompiledNetwork {
+    let mut data = Vec::new();
+    data.extend_from_slice(&((num_inputs + 1) as u32).to_le_bytes());
+    data.extend_from_slice(&(num_inputs as u32).to_le_bytes());
+    data.extend_from_slice(&0.05_f64.to_le_bytes());
+    data.push(SquashType::Tanh as u8);
+    data.push(0); // is_constant
+    data.extend_from_slice(&(num_inputs as u16).to_le_bytes());
+    for from_index in 0..num_inputs as u16 {
+        data.extend_from_slice(&from_index.to_le_bytes());
+        data.push(0); // synapse_type
+        data.push(0); // padding
+        data.extend_from_slice(&0.3_f64.to_le_bytes());
+    }
+    CompiledNetwork::new(&data).expect("network should parse")
+}
+
+/// Deterministic dataset of `count` records: `num_inputs` inputs + 1 target.
+fn dataset(num_inputs: usize, count: usize) -> TrainingDataset {
+    let inputs: Vec<f32> = (0..count * num_inputs)
+        .map(|i| (i as f32 * 0.019).sin() * 0.7)
+        .collect();
+    let targets: Vec<f32> = (0..count).map(|r| (r as f32 * 0.011).cos()).collect();
+    TrainingDataset::from_soa(inputs, targets, TrainingDataConfig::new(num_inputs, 1))
+        .expect("fixture should be well-formed")
+}
+
+/// Allocations consumed by one `evaluate_mse` call over the whole dataset.
+fn allocs_for(dataset: &TrainingDataset, network: &mut CompiledNetwork) -> usize {
+    let count = dataset.num_records();
+    let before = ALLOC_COUNT.load(Ordering::Relaxed);
+    let mse = dataset
+        .evaluate_mse(network, 0, count)
+        .expect("batch is in range");
+    std::hint::black_box(mse);
+    ALLOC_COUNT.load(Ordering::Relaxed) - before
+}
+
+#[test]
+fn evaluate_mse_has_no_per_record_allocation() {
+    let num_inputs = 16;
+    let mut net = summing_tanh_network(num_inputs);
+    let small = dataset(num_inputs, 100);
+    let large = dataset(num_inputs, 1000);
+
+    // Warm up any one-off lazy initialisation so it is not counted below.
+    std::hint::black_box(allocs_for(&small, &mut net));
+
+    let small_allocs = allocs_for(&small, &mut net);
+    let large_allocs = allocs_for(&large, &mut net);
+
+    // The per-record `activate` path allocated one output `Vec` per record, so
+    // 10× the records allocated ~900 more times. The batched flat path allocates
+    // a constant handful (lane scratch + a bounded output buffer) regardless of
+    // record count. A generous threshold separates "constant" from "grows with
+    // records" without being brittle to allocator/harness noise.
+    let delta = large_allocs.saturating_sub(small_allocs);
+    assert!(
+        delta < 50,
+        "evaluating 10× the records allocated {large_allocs} vs {small_allocs} \
+         (delta {delta}); expected a constant count — per-record allocation has \
+         regressed into evaluate_mse"
+    );
+}

--- a/neat-core/tests/flat_record_scoring_parity.rs
+++ b/neat-core/tests/flat_record_scoring_parity.rs
@@ -1,0 +1,224 @@
+//! Parity guard for the flat-slice record-**input** scoring path (Issue #386).
+//!
+//! `score_records` takes one owned `Vec<f32>` per record; `score_records_flat`
+//! takes a single contiguous buffer where record `i` occupies
+//! `inputs[i * stride .. i * stride + stride]` — mirroring the flat *output*
+//! contract Issue #229 established. Both must drive the identical batched
+//! kernel, so their results are **bit-identical**, not merely close.
+//!
+//! These are "what" tests: they score real networks through both public entry
+//! points and compare the returned buffers. Record counts straddle the
+//! 8-record SIMD group boundary (0, 1, 7, 8, 9, 12) plus a production-width
+//! shard, and both dispatch arms are covered — the record-interleaved fast path
+//! (all-standard squash) and the aggregate-squash per-lane fallback. A stride
+//! or offset slip shows up as wrong lane values at the 7/9/12 remainder counts.
+
+use neat_core::squash::SquashType;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+#[path = "../benches/common/mod.rs"]
+#[allow(dead_code)]
+mod common;
+
+use common::{NETWORKS, NetSpec, build_network, build_records};
+
+/// Record counts either side of the 8-record SIMD group boundary, including the
+/// empty batch and the 4-record-group + scalar-tail split (12).
+const COUNTS: [usize; 6] = [0, 1, 7, 8, 9, 12];
+
+/// Records at production input width for the shard-scale case. Large enough to
+/// span many full 8-record groups plus a non-empty scalar tail, small enough to
+/// stay well inside the 120 s unit-test budget in a debug build.
+const SHARD_RECORDS: usize = 259;
+
+/// Build a two-hidden-plus-one-output feedforward network where every non-input
+/// neuron uses `squash` (mirrors `interleaved_scoring_parity.rs`).
+fn build_local_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.25 - 0.09 * (i as f32) + 0.05 * (h as f32),
+                from_index: i as u16,
+                synapse_type: 0,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.03 * (h as f32) - 0.01,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    synapses.push(SynapseData {
+        weight: 0.7,
+        from_index: num_inputs as u16,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.5,
+        from_index: num_inputs as u16 + 1,
+        synapse_type: 0,
+    });
+    neurons.push(NeuronData {
+        bias: 0.02,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Deterministic distinct records of `width` values each, so a lane or stride
+/// mix-up cannot hide behind repeated rows.
+fn records(width: usize, count: usize) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|r| {
+            (0..width)
+                .map(|i| ((r * 7 + i * 3) as f32 * 0.017).sin() * 0.9)
+                .collect()
+        })
+        .collect()
+}
+
+/// Pack per-record vectors into the flat `record * stride` layout.
+fn flatten(recs: &[Vec<f32>]) -> Vec<f32> {
+    recs.iter().flat_map(|r| r.iter().copied()).collect()
+}
+
+fn spec(label: &str) -> &'static NetSpec {
+    NETWORKS
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
+}
+
+/// Assert the two entry points agree bit-for-bit across every boundary count.
+fn assert_flat_matches_per_record(net: &CompiledNetwork, width: usize, num_outputs: usize) {
+    for &count in &COUNTS {
+        let recs = records(width, count);
+        let flat = flatten(&recs);
+        let from_flat = net.score_records_flat(&flat, width, num_outputs);
+        let from_vecs = net.score_records(&recs, num_outputs);
+        assert_eq!(
+            from_flat.len(),
+            count * num_outputs,
+            "count {count}: flat output length"
+        );
+        assert_eq!(
+            from_flat, from_vecs,
+            "count {count}: flat-slice input must be bit-identical to per-record input"
+        );
+    }
+}
+
+#[test]
+fn flat_input_matches_per_record_on_the_interleaved_arm() {
+    // All-Tanh network → no aggregate neurons → record-interleaved fast path.
+    let net = build_local_network(12, SquashType::Tanh);
+    assert_flat_matches_per_record(&net, 12, 1);
+}
+
+#[test]
+fn flat_input_matches_per_record_on_the_aggregate_squash_arm() {
+    // A Maximum network has aggregate neurons → per-lane fallback dispatch.
+    let net = build_local_network(12, SquashType::Maximum);
+    assert_flat_matches_per_record(&net, 12, 1);
+}
+
+#[test]
+fn flat_input_matches_per_record_at_production_shard_width() {
+    let s = spec("production");
+    let net = build_network(s, 0x5EED);
+    let recs = build_records(net.num_inputs(), SHARD_RECORDS);
+    let flat = flatten(&recs);
+    assert_eq!(
+        net.score_records_flat(&flat, net.num_inputs(), s.num_outputs),
+        net.score_records(&recs, s.num_outputs),
+        "production-width shard must be bit-identical across input layouts"
+    );
+}
+
+#[test]
+fn flat_input_zero_fills_a_stride_narrower_than_the_network() {
+    // A record shorter than the network's input arity is zero-filled, exactly as
+    // the per-record path does for a short `Vec`.
+    let net = build_local_network(12, SquashType::Tanh);
+    let short = records(5, 9);
+    let flat = flatten(&short);
+    assert_eq!(
+        net.score_records_flat(&flat, 5, 1),
+        net.score_records(&short, 1),
+        "a narrow stride must zero-fill the uncovered inputs"
+    );
+}
+
+#[test]
+fn flat_input_into_writes_the_same_buffer_as_the_allocating_entry_point() {
+    let net = build_local_network(12, SquashType::Tanh);
+    let recs = records(12, 9);
+    let flat = flatten(&recs);
+    let mut out = vec![f32::NAN; 9];
+    net.score_records_flat_into(&flat, 12, 1, &mut out);
+    assert_eq!(out, net.score_records_flat(&flat, 12, 1));
+}
+
+#[test]
+fn parallel_flat_input_matches_the_sequential_flat_path() {
+    let s = spec("production");
+    let net = build_network(s, 0x5EED);
+    let recs = build_records(net.num_inputs(), SHARD_RECORDS);
+    let flat = flatten(&recs);
+    assert_eq!(
+        net.score_records_parallel_flat(&flat, net.num_inputs(), s.num_outputs),
+        net.score_records_flat(&flat, net.num_inputs(), s.num_outputs),
+        "the parallel flat path must be deterministic and match the sequential one"
+    );
+}
+
+#[test]
+#[should_panic(expected = "stride must be greater than zero")]
+fn flat_input_rejects_a_zero_stride() {
+    // Fail loud (Issue #3234): a zero stride cannot describe records at all.
+    let net = build_local_network(12, SquashType::Tanh);
+    net.score_records_flat(&[0.0, 1.0], 0, 1);
+}
+
+#[test]
+#[should_panic(expected = "not a whole number of records")]
+fn flat_input_rejects_a_ragged_buffer() {
+    // Fail loud: a buffer that is not a multiple of the stride is malformed.
+    let net = build_local_network(12, SquashType::Tanh);
+    net.score_records_flat(&[0.0; 7], 3, 1);
+}

--- a/neat-core/tests/wasm_dataset_offload.rs
+++ b/neat-core/tests/wasm_dataset_offload.rs
@@ -9,6 +9,7 @@
 //! wrappers over exactly this API).
 
 use neat_core::network::CompiledNetwork;
+use neat_core::squash::SquashType;
 use neat_core::training_data::TrainingDataConfig;
 use neat_core::wasm_dataset::{DatasetError, DatasetRegistry, TrainingDataset};
 
@@ -40,12 +41,136 @@ fn summing_identity_network(num_inputs: usize, bias: f64) -> CompiledNetwork {
     CompiledNetwork::new(&data).expect("network should parse")
 }
 
+/// Build a compiled network with `num_inputs` inputs and a single `Tanh` output
+/// neuron summing every input (weight 1.0) plus `bias`.
+///
+/// Unlike the identity network this is non-linear, so the batched SIMD path's
+/// vectorised squash is genuinely exercised rather than collapsing to exact
+/// arithmetic — the equivalence assertions below therefore mean something.
+fn summing_tanh_network(num_inputs: usize, bias: f64) -> CompiledNetwork {
+    let mut data = Vec::new();
+    let num_neurons = (num_inputs + 1) as u32;
+    data.extend_from_slice(&num_neurons.to_le_bytes());
+    data.extend_from_slice(&(num_inputs as u32).to_le_bytes());
+
+    data.extend_from_slice(&bias.to_le_bytes()); // bias f64
+    data.push(SquashType::Tanh as u8); // squash TANH
+    data.push(0); // is_constant = false
+    data.extend_from_slice(&(num_inputs as u16).to_le_bytes()); // num_synapses
+
+    for from_index in 0..num_inputs as u16 {
+        data.extend_from_slice(&from_index.to_le_bytes());
+        data.push(0); // synapse_type
+        data.push(0); // padding
+        data.extend_from_slice(&0.35_f64.to_le_bytes()); // weight f64
+    }
+
+    CompiledNetwork::new(&data).expect("network should parse")
+}
+
 /// Pack interleaved records (each: inputs then outputs) into `.bin` bytes.
 fn pack(records: &[Vec<f32>]) -> Vec<u8> {
     records
         .iter()
         .flat_map(|r| r.iter().flat_map(|v| v.to_le_bytes()))
         .collect()
+}
+
+/// Per-record reference MSE — the pre-#386 implementation, retained here as the
+/// equivalence oracle for the batched rewrite. Scores one record at a time via
+/// the single-record `activate` path and accumulates in `f64`.
+fn reference_mse(
+    dataset: &TrainingDataset,
+    network: &mut CompiledNetwork,
+    start: usize,
+    count: usize,
+) -> f32 {
+    if count == 0 {
+        return 0.0;
+    }
+    let num_outputs = dataset.num_outputs();
+    let mut squared_error_sum = 0.0f64;
+    for offset in 0..count {
+        let index = start + offset;
+        let inputs = dataset.record_inputs(index).unwrap();
+        let targets = dataset.record_outputs(index).unwrap();
+        let outputs = network.activate(inputs, num_outputs);
+        for (predicted, expected) in outputs.iter().zip(targets.iter()) {
+            let diff = f64::from(*predicted) - f64::from(*expected);
+            squared_error_sum += diff * diff;
+        }
+    }
+    (squared_error_sum / (count * num_outputs) as f64) as f32
+}
+
+/// Deterministic dataset of `count` records, `num_inputs` inputs + 1 target.
+fn synthetic_dataset(num_inputs: usize, count: usize) -> TrainingDataset {
+    let records: Vec<Vec<f32>> = (0..count)
+        .map(|r| {
+            let mut row: Vec<f32> = (0..num_inputs)
+                .map(|i| ((r * 5 + i * 3) as f32 * 0.021).sin() * 0.8)
+                .collect();
+            row.push(((r * 11) as f32 * 0.013).cos() * 0.5);
+            row
+        })
+        .collect();
+    TrainingDataset::from_packed_bytes(&pack(&records), TrainingDataConfig::new(num_inputs, 1))
+        .expect("fixture should be well-formed")
+}
+
+/// SIMD tolerance the batched vectorised squash/weighted sums already carry
+/// (Issue #230 / #243), applied to the `f32` MSE.
+const MSE_TOL: f32 = 2e-3;
+
+#[test]
+fn evaluate_mse_matches_the_per_record_reference_across_group_boundaries() {
+    // Record counts straddling the 8-record SIMD group boundary, so the group
+    // path, the 4-record group and the exact scalar tail are all covered.
+    for &count in &[0usize, 1, 7, 8, 9, 12, 100] {
+        let dataset = synthetic_dataset(6, count.max(1));
+        let mut net = summing_tanh_network(6, 0.1);
+        let want = reference_mse(&dataset, &mut net, 0, count);
+        let got = dataset.evaluate_mse(&mut net, 0, count).unwrap();
+        assert!(
+            (got - want).abs() <= MSE_TOL,
+            "count {count}: batched MSE {got} vs per-record reference {want}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_mse_matches_the_per_record_reference_on_an_offset_batch() {
+    // A mid-dataset batch must read from the right offset, not from record 0.
+    let dataset = synthetic_dataset(6, 40);
+    let mut net = summing_tanh_network(6, 0.1);
+    let want = reference_mse(&dataset, &mut net, 11, 21);
+    let got = dataset.evaluate_mse(&mut net, 11, 21).unwrap();
+    assert!(
+        (got - want).abs() <= MSE_TOL,
+        "offset batch MSE {got} vs per-record reference {want}"
+    );
+}
+
+#[test]
+fn evaluate_mse_returns_zero_for_an_empty_batch() {
+    let dataset = synthetic_dataset(4, 8);
+    let mut net = summing_tanh_network(4, 0.0);
+    assert_eq!(dataset.evaluate_mse(&mut net, 0, 0).unwrap(), 0.0);
+}
+
+#[test]
+fn evaluate_mse_rejects_an_empty_batch_starting_past_the_end() {
+    // A zero-count batch is still bounds-checked — `start` must be in range.
+    let dataset = synthetic_dataset(4, 8);
+    let mut net = summing_tanh_network(4, 0.0);
+    assert_eq!(
+        dataset.evaluate_mse(&mut net, 9, 0).unwrap_err(),
+        DatasetError::BatchOutOfRange {
+            start: 9,
+            count: 0,
+            num_records: 8,
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Flat-slice record input for batched scoring, and `evaluate_mse` wired onto it (Issue #386)

## Summary

Two related gaps around record **input** layout are closed. Closes #386.

1. **The batched scorer only took `&[Vec<f32>]`.** Issue #229 flattened the
   scoring *output* to one contiguous buffer, but the input stayed a vector of
   per-record vectors — one heap allocation per record for the caller (4,096
   allocations for a ~40 MiB production shard) and a `Vec` header to
   pointer-chase on every lane load, even though the kernels only ever read a
   record as `&[f32]`. The fused-loss lane next door
   (`mse_sum_batch_packed`) already took a flat packed buffer, so the two entry
   points disagreed on layout for no reason.

   Added the matching flat **input** contract: record `i`'s inputs are
   `inputs[i * stride .. i * stride + stride]`.

   - `CompiledNetwork::score_records_flat(inputs, stride, num_outputs)`
   - `CompiledNetwork::score_records_flat_into(inputs, stride, num_outputs, out)`
   - `CompiledNetwork::score_records_parallel_flat(inputs, stride, num_outputs)`

   `score_batch_into` now takes a `RecordBatch` describing either layout, and the
   `&[Vec<f32>]` entry points are unchanged wrappers over the same kernel — so
   existing callers and benches are unaffected and both layouts are
   **bit-identical**.

2. **The WASM dataset offload path bypassed the batched kernel entirely.**
   `TrainingDataset` (Issue #298) already stores inputs contiguously in SoA
   layout and hands out zero-copy slices, yet `evaluate_mse` scored **one record
   at a time** through `activate`: re-bounds-checking per record, allocating a
   fresh `Vec<f32>` per record via `to_vec()` (exactly the per-record allocation
   #229 removed, reintroduced on the >4 GB Memory64 lane), and never touching the
   8-record interleaved SIMD path from #230/#287.

   It now bounds-checks the batch **once**, takes `input_batch(start, count)` as
   a single slice, and drives it through the flat batched path in 1024-record
   chunks — a multiple of the 8-record SIMD group, so grouping and results are
   unchanged while the scratch output buffer stays a bounded constant no matter
   how many records the Memory64 lane asks for.

Fail-loud (Issue #3234): a zero `stride` or a buffer that is not a whole number
of records **panics** with a specific message rather than silently mis-slicing
every record.

### Data flow

```mermaid
flowchart LR
    subgraph BEFORE["before"]
        D1["TrainingDataset<br/>contiguous SoA inputs"] --> R1["record_inputs(i)<br/>bounds-check per record"]
        R1 --> A1["activate()<br/>fresh Vec per record"]
        A1 --> M1["MSE accumulate"]
    end
    subgraph AFTER["after"]
        D2["TrainingDataset<br/>contiguous SoA inputs"] --> R2["input_batch(start, count)<br/>bounds-check once"]
        R2 --> A2["score_batch_into<br/>RecordBatch::Flat<br/>8-record interleaved SIMD"]
        A2 --> M2["MSE accumulate"]
    end
```

## Evidence

Backend/library change — no web interface to screenshot. Evidence is
benchmarks plus the TDD suites below.

### Benchmarks

Performance task, so benchmarks came **first**: the `dataset_evaluate_mse` group
was added and baselined against the unchanged implementation before any code
changed.

**Methodology.** Separate `cargo bench` invocations on this laptop drift by more
than the effect being measured on the smaller groups (a naive single-shot A/B
reported a bogus 40% "regression" on `parallel_scoring` that alternating rounds
disproved). So the A/B follows the #287 protocol: alternating old/new rounds of
the *same* prebuilt bench binaries, run back to back, with the untouched
`forward_pass` benchmark captured alongside as a drift control.

Apple M4, macOS 26.5.2, rustc 1.97.0, `--release`, Criterion 0.8
`--sample-size 10 --measurement-time 5 --warm-up-time 1`, 4096 records per
iteration (`PRODUCTION_SCORING_RECORDS`). Figures are the mean of the
alternating rounds. Recorded in
[`neat-core/benches/BASELINE.md`](../../../neat-core/benches/BASELINE.md).

`dataset_evaluate_mse` — the change under test:

| benchmark | before | after | change |
| --- | --- | --- | --- |
| `dataset_evaluate_mse/production` | 330.3 ms | 69.9 ms | **−78.8% (≈4.7×)** |
| `dataset_evaluate_mse/production_2x` | 686.7 ms | 149.7 ms | **−78.2% (≈4.6×)** |
| `dataset_evaluate_mse/production_exact` | 283.6 ms | 69.6 ms | **−75.5% (≈4.1×)** |

Drift + no-regression controls — all must be flat, and are. The `scoring` group
is the gate on the `&[Vec<f32>]` wrapper: it routes through the same rewritten
kernel and must not pay for the new input layout.

| control | before | after | change |
| --- | --- | --- | --- |
| `forward_pass/production_exact` | 48.10 µs | 49.42 µs | flat |
| `scoring/production` | 74.25 ms | 72.87 ms | flat |
| `scoring/production_2x` | 165.17 ms | 163.06 ms | flat |
| `scoring/production_exact` | 70.72 ms | 69.90 ms | flat |
| `parallel_scoring/production_exact` `1_core` | 71.5 ms | 69.4 ms | flat |
| `parallel_scoring/production_exact` `12_cores` | 41.4 ms | 43.3 ms | flat (see note) |

> The `12_cores` lane builds a fresh `ThreadPoolBuilder` per iteration and is
> scheduler-sensitive: across six alternating rounds old spanned 38.0–47.2 ms and
> new spanned 36.4–51.4 ms, so the ~5% mean gap sits well inside the run-to-run
> spread. The clean `1_core` signal is flat-to-slightly-better.

New `scoring_flat` group — same shard, same kernel, flat input layout, so the
delta against `scoring` isolates the per-record `Vec` header indirection. Both
fixtures are built outside the timed loop, so the caller-side
one-allocation-per-record the `&[Vec<f32>]` signature forces is *additional*
saving not counted here:

| benchmark | `scoring` | `scoring_flat` | change |
| --- | --- | --- | --- |
| `production` | 72.87 ms | 70.34 ms | −3.5% |
| `production_2x` | 163.06 ms | 149.70 ms | −8.2% |

## Test Plan

TDD — every suite below was written first and observed failing (the
`score_records_flat` tests failed to compile; the allocation test failed with
`delta 900`, i.e. exactly one allocation per record).

Added `neat-core/tests/flat_record_scoring_parity.rs`:

- `flat_input_matches_per_record_on_the_interleaved_arm` — bit-identity at
  record counts 0, 1, 7, 8, 9, 12 on the all-standard-squash (record-interleaved)
  dispatch arm.
- `flat_input_matches_per_record_on_the_aggregate_squash_arm` — same counts on
  the aggregate-squash per-lane fallback arm.
- `flat_input_matches_per_record_at_production_shard_width` — bit-identity at
  production input width (2,461 inputs).
- `flat_input_zero_fills_a_stride_narrower_than_the_network` — a stride shorter
  than the network's input arity zero-fills, matching the short-`Vec` behaviour.
- `flat_input_into_writes_the_same_buffer_as_the_allocating_entry_point`.
- `parallel_flat_input_matches_the_sequential_flat_path`.
- `flat_input_rejects_a_zero_stride` / `flat_input_rejects_a_ragged_buffer` —
  fail-loud panics on a malformed batch.

Added `neat-core/tests/evaluate_mse_allocations.rs` (modelled on
`tests/scoring_allocations.rs`, counting global allocator):

- `evaluate_mse_has_no_per_record_allocation` — evaluating 10× the records must
  not allocate ~10× more. Failed at `delta 900` before the fix; constant after.

Added to `neat-core/tests/wasm_dataset_offload.rs`:

- `evaluate_mse_matches_the_per_record_reference_across_group_boundaries` — the
  pre-#386 per-record implementation is retained in the test file as the
  equivalence oracle; asserted within the documented `f32` SIMD tolerance
  (2e-3) at counts 0, 1, 7, 8, 9, 12, 100.
- `evaluate_mse_matches_the_per_record_reference_on_an_offset_batch` — guards the
  start-offset arithmetic.
- `evaluate_mse_returns_zero_for_an_empty_batch` — the `count == 0` path.
- `evaluate_mse_rejects_an_empty_batch_starting_past_the_end` — a zero-count
  batch is still bounds-checked.

The existing shape-mismatch and out-of-range error-path tests, the determinism
test, and the load → evaluate → free leak gate are unchanged and still pass. No
existing test was modified or removed.

Added `dataset_evaluate_mse` and `scoring_flat` bench groups to
`neat-core/benches/hot_paths.rs`.

### Quality gate

`./quality.sh`: `cargo build`, `cargo fmt`, `cargo clippy --workspace
--all-targets --all-features -- -D warnings`, `cargo check`, `cargo test
--workspace --lib --tests --all-features` (32 test binaries, all green),
`cargo doc` with `RUSTDOCFLAGS="-D warnings"`, and `cargo build --release` all
pass. markdownlint, the Mermaid gate and shellcheck pass.

> **Pre-existing bats failures, unrelated to this change.** `perf sources name
> none of the private trainer's internal scripts` (#138) and `perf acceptance
> models reference no private internal script paths` (#151) fail identically on
> the base branch with these changes stashed — they flag private-trainer script
> names in the perf acceptance models, untouched here. They are not introduced or
> affected by this PR.

### Security self-check

- **Input validation** — the new public entry points validate `stride` (non-zero)
  and buffer length (whole number of records) before slicing, and
  `score_records_flat_into` validates the output buffer length. All fail loud.
- **Secrets** — none staged; no `.env`/`.config*.json` touched.
- **Injection surface** — none: no SQL, shell, filesystem or HTTP calls added.
- **`unsafe`** — none added. The change is pure safe Rust; the SIMD soundness
  invariants in `AGENTS.md` are untouched.
- **Error handling** — `evaluate_mse` keeps its typed `DatasetError` returns; no
  internal state leaks into messages.
- **Dependencies** — none added or changed.



## Milestone
This PR is part of the **#383 Please suggest performance or memory efficiency improvements** milestone and targets the `milestone/383-please-suggest-performance-or-memory-efficienc` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms16i2af-68ceb6`<!-- vibe-worker-issue-386 -->