### PR TITLE
[perf] scan_available_connections: drop the n² matrix, pre-size the result (Issue #387)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-387.md
+++ b/docs/archive/pr-summaries/pr-summary-387.md
@@ -1,0 +1,174 @@
+# [perf] `scan_available_connections` — drop the n² matrix, pre-size the result
+
+## Summary
+
+`scan_available_connections` (`neat-core/src/topology_ops.rs`) answered "does
+this connection already exist?" from a **dense `n × n` boolean matrix**. On the
+production topology (n = 1,666) that is a **2.78 MB zeroed allocation per call**
+to record 21,513 synapses — a fill factor under 0.8%. It then built the result
+with `Vec::new()` and no `reserve`, so the ~11 MB flat pair list grew through a
+realloc-and-memcpy chain. This is a mutation-time helper, so both costs are paid
+repeatedly across the population every generation.
+
+Both wins from the issue are taken:
+
+1. **The matrix is gone.** Existence is answered from a compressed per-`from`
+   run of existing targets — an `O(n + synapses)` adjacency built once, then
+   merge-walked against the candidate range `[start_to, n)`. Only edges the scan
+   could ever emit are retained (`to > from`, `to >= num_inputs`, both endpoints
+   in range), which drops backward, self and out-of-range synapses exactly as
+   the old matrix lookup did. Scratch memory is `O(n + synapses)` instead of
+   `O(n²)`.
+2. **The result is pre-sized.** The exact candidate count is computed up front
+   in `O(n + synapses)` — no `O(n²)` pre-pass — from the candidate span minus a
+   constant-neuron prefix sum minus the distinct existing targets in range. The
+   result vector is then `Vec::with_capacity`'d once at its final length.
+
+**Contract is unchanged.** Same pairs, same order, same defensive bail-outs.
+Sorted input is *not* required — each per-`from` run is sorted on build, so an
+unsorted or duplicate-bearing edge list yields the same answer. Per the issue,
+no `scan_available_connections_count()` / sampled variant was added; that is a
+cross-repo API change for the caller side.
+
+Closes #387.
+
+## Evidence
+
+This is a backend library change with no web interface, so there is no
+screenshot. Evidence is benchmark and allocation measurement.
+
+### A/B at the production anchor — n = 1,666 with 21,513 synapses
+
+Same fixture, same release build, single call, measured under a tracking global
+allocator. Both implementations returned the **identical 1,345,957 pairs**.
+
+| Metric | Before (`n²` matrix) | After (#387) | Delta |
+| --- | --- | --- | --- |
+| Peak live bytes | 27,941,380 B (26.65 MB) | 10,887,048 B (10.38 MB) | **−61%** |
+| Allocations | 22 | 5 | **−77%** |
+| Wall clock | 4.55 ms | 1.66 ms | **−63%** |
+| Result size | 10,767,656 B | 10,767,656 B | unchanged |
+
+The 10.38 MB floor *is* the result vector (10.77 MB reported as live bytes
+includes the exact-size allocation). Everything above it — the 2.78 MB matrix
+and the realloc chain's transient second buffer — is gone.
+
+### Criterion — new `topology_ops` group in `hot_paths`
+
+`cargo bench -p neat-core --bench hot_paths -- topology_ops`, before and after
+on the same machine:
+
+| Case | Before (median) | After (median) | Change (Criterion) |
+| --- | --- | --- | --- |
+| `n1666_21513` | 6.5395 ms | 4.0470 ms | **−38.1%** (p = 0.00) |
+| `n4127_21513` | 24.377 ms | 15.222 ms | **−37.6%** (p = 0.00) |
+
+`n1666_21513` is the anchor named in the issue (1,666 neurons, 21,513
+synapses); `n4127_21513` puts the same synapse count on the full
+`production_exact` neuron count. Throughput is reported per candidate slot
+(`n²`), so a reintroduced dense matrix or realloc chain shows up directly on the
+next run.
+
+### Where the memory went
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — O(n²) memory"]
+        A1["synapses (21,513)"] --> B1["dense n × n bool matrix<br/>2.78 MB zeroed"]
+        B1 --> C1["O(n²) cell scan"]
+        C1 --> D1["Vec::new() → realloc chain<br/>peak 26.65 MB"]
+    end
+    subgraph After["After — O(n + synapses) memory"]
+        A2["synapses (21,513)"] --> B2["per-from target runs<br/>(CSR adjacency, sorted)"]
+        B2 --> C2["exact candidate count<br/>O(n + synapses)"]
+        C2 --> D2["Vec::with_capacity(exact)<br/>peak 10.38 MB"]
+        B2 --> E2["merge-walk emit<br/>(cursor never rewinds)"]
+        E2 --> D2
+    end
+```
+
+### Failing-first verification
+
+The differential test was validated by deliberately perturbing the new
+implementation and confirming the suite goes red:
+
+| Perturbation | Result |
+| --- | --- |
+| Drop the duplicate-edge guard in the counting pass | `scan_available_connections_matches_reference_on_random_topologies` **FAILED** |
+| Merge-walk cursor advances on `<=` instead of `<` | 5 of 8 `scan_available*` tests **FAILED**, including the randomised differential test |
+
+Both perturbations were reverted before commit.
+
+## Test Plan
+
+New tests in the `tests` module of `neat-core/src/topology_ops.rs`, all
+differential against `reference_scan_available_connections` — the pre-#387
+dense-matrix implementation retained verbatim as the oracle:
+
+- `scan_available_connections_matches_reference_on_random_topologies` —
+  asserts a byte-identical `Vec<u32>` (same pairs, **same order**) across 1,344
+  randomised topologies: `num_neurons` ∈ {1, 2, 3, 5, 9, 16, 31} × `num_inputs`
+  ∈ {0, 1, n/2, **n**} × density ∈ {**0 (empty synapse list)**, 15, 60,
+  **100 (fully connected)**} × duplicate rate ∈ {0, 30} × constant rate ∈ {0,
+  25, **100 (all targets constant)**} × {sorted, shuffled}. `num_inputs = 0`
+  and `num_inputs = 1` cover `from < num_inputs`.
+- `scan_available_connections_matches_reference_with_out_of_range_and_duplicate_edges`
+  — duplicates, self-connections, backward edges and out-of-range endpoints in
+  one hostile edge list.
+- `scan_available_connections_matches_reference_with_short_is_constant_buffer` —
+  `is_constant` shorter than `num_neurons`.
+- `scan_available_connections_num_inputs_equals_num_neurons_is_empty` —
+  `num_inputs == num_neurons`.
+- `scan_available_connections_unsorted_edges_match_sorted_equivalent` — the
+  rewrite does not depend on the caller having sorted the edge list.
+
+New integration test `neat-core/tests/topology_ops_allocations.rs`:
+
+- `scan_available_connections_peak_allocation_tracks_result_size` — a tracking
+  global allocator asserts peak live bytes stay within `result + 1 MiB` and the
+  allocation count stays ≤ 16 at n = 1,666 / 21,513 synapses. Fails against the
+  old implementation (peak 26.65 MB vs an 11.8 MB budget).
+
+Existing defensive tests unchanged and still green:
+
+- `scan_available_connections_mismatched_lengths_returns_empty`
+- `scan_available_connections_huge_neuron_count_returns_empty` — the `n * n`
+  plausibility bound is retained (it is no longer an allocation size, but it
+  still rejects a neuron count whose forward-pair space could never be
+  materialised)
+- `scan_available_simple`, `scan_skips_constant`
+
+New Criterion group `topology_ops` in `neat-core/benches/hot_paths.rs`, with
+`neat-core/benches/README.md` updated to document it.
+
+No existing tests were commented out, removed or modified.
+
+## Quality gate
+
+`cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D
+warnings`, `cargo check`, `cargo test --workspace --lib --tests --all-features`
+(all 33 test binaries green), `cargo doc -D warnings`, `cargo build --release`,
+`deno check`, the Mermaid gate and codespell all pass.
+
+**Pre-existing, unrelated gate failure.** `./quality.sh`'s bats stage is red on
+a clean tree — `git stash` confirms it fails without this change. Two Issue #375
+public-safety assertions (`perf sources name none of the private trainer's
+internal scripts`, `perf acceptance models reference no private internal script
+paths`) fire on four comments left in `tests/perf/learn_flags_wiring.ts` by
+#382. CI does not run bats, so it has gone unnoticed. Out of scope of this PR;
+filed as **stSoftwareAU/NEAT-AI-core#397**.
+
+## Security self-check
+
+- **Input validation** — the two malformed-buffer bail-outs are retained
+  unchanged (mismatched `from`/`to` lengths, implausible `num_neurons`); a new
+  `checked_mul` guard refuses a candidate count whose result vector could not be
+  addressed, returning an empty `Vec` rather than aborting.
+- **Injection surface / output encoding / auth** — not applicable; pure
+  in-process computation over caller-supplied slices, no new I/O, no new
+  endpoint.
+- **Memory safety** — no `unsafe` added. All indexing is checked; the
+  merge-walk cursor is bounded by the run end on every access, and a
+  `debug_assert` pins the emitted pair count to the pre-computed capacity.
+- **Secrets** — none staged; no hidden files touched.
+- **Dependencies** — none added.

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -24,6 +24,7 @@ There are two bench targets:
 | `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
 | `scoring_flat` | `CompiledNetwork::score_records_flat` over the same batch in flat-slice input layout (Issue #386) | `production`, `production_2x`, `production_exact` |
 | `dataset_evaluate_mse` | `TrainingDataset::evaluate_mse` over a production-sized batch (Issue #386) | `production`, `production_2x`, `production_exact` |
+| `topology_ops` | `scan_available_connections` — the mutation-time availability scan (Issue #387) | `n1666_21513`, `n4127_21513` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -32,6 +33,15 @@ through one creature via `score_records`, so `hot_paths` reports single-core
 scoring throughput at production record volume alongside the parallel harness.
 It covers only the gather-bound `production` shapes and is reachable with the
 `production` filter (`--bench hot_paths -- production`).
+
+The `topology_ops` group (Issue #387) covers the mutation-time helpers, which
+are not per-record hot paths but are paid repeatedly across the population every
+generation. Its topologies are built locally in `hot_paths.rs` (they are edge
+lists, not `CompiledNetwork`s): `n1666_21513` is the anchor named in #387 —
+1,666 neurons carrying 21,513 synapses, a fill factor under 0.8% — and
+`n4127_21513` puts the same synapse count on the full `production_exact` neuron
+count. Throughput is reported per candidate slot (`n²`), so a reintroduced dense
+`n × n` existence matrix or result-vector realloc chain shows up directly.
 
 `scoring_flat` scores the *same* shard through the flat-slice input entry point
 (Issue #386), so the delta against `scoring` isolates the cost of the per-record

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -24,6 +24,7 @@ use neat_core::simd::{
 use neat_core::squash::{SquashType, apply_squash};
 use neat_core::squash_simd::squash_x4;
 use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
+use neat_core::topology_ops::scan_available_connections;
 use neat_core::training_data::TrainingDataConfig;
 use neat_core::unsquash::apply_unsquash;
 use neat_core::wasm_dataset::TrainingDataset;
@@ -299,6 +300,120 @@ const SQUASH_SPREAD: [SquashType; 10] = [
     SquashType::Gaussian,
 ];
 
+/// A deterministic sorted forward-only topology for the topology-ops group.
+///
+/// Emits exactly `num_synapses` synapses spread as evenly as possible over the
+/// non-input neurons, each drawing sources from strictly earlier neurons, so the
+/// `(from, to)` list comes out ascending-sorted exactly as `validate_topology`
+/// requires. Mirrors the production creature's shape at the neuron count the
+/// mutation-time scan actually sees.
+struct TopologySpec {
+    label: &'static str,
+    num_neurons: usize,
+    num_inputs: usize,
+    num_synapses: usize,
+}
+
+/// Topology shapes for `scan_available_connections` (Issue #387).
+///
+/// `n1666_21513` is the production anchor named in the issue: 1,666 neurons
+/// carrying 21,513 synapses — a fill factor under 0.8%, which is what made the
+/// old dense `n × n` matrix so wasteful.
+const TOPOLOGIES: [TopologySpec; 2] = [
+    TopologySpec {
+        label: "n1666_21513",
+        num_neurons: 1666,
+        num_inputs: 100,
+        num_synapses: 21_513,
+    },
+    TopologySpec {
+        label: "n4127_21513",
+        num_neurons: 4127,
+        num_inputs: 2461,
+        num_synapses: 21_513,
+    },
+];
+
+/// Build `(from_indices, to_indices, is_constant)` for a [`TopologySpec`].
+fn build_topology(spec: &TopologySpec) -> (Vec<u32>, Vec<u32>, Vec<u8>) {
+    let mut rng = Lcg::new(0x7061_7468);
+    let num_non_inputs = spec.num_neurons - spec.num_inputs;
+    // Per-target fan-in, distributed as evenly as the synapse budget allows.
+    let base = spec.num_synapses / num_non_inputs;
+    let remainder = spec.num_synapses % num_non_inputs;
+
+    let mut from_indices = Vec::with_capacity(spec.num_synapses);
+    let mut to_indices = Vec::with_capacity(spec.num_synapses);
+    // Collect per-`from` target lists so the emitted pairs come out sorted by
+    // `from` then `to`, matching the ordering contract the scan relies on.
+    let mut per_from: Vec<Vec<u32>> = vec![Vec::new(); spec.num_neurons];
+
+    for offset in 0..num_non_inputs {
+        let to = spec.num_inputs + offset;
+        let want = base + usize::from(offset < remainder);
+        let fan = want.min(to);
+        let mut drawn = 0usize;
+        let mut attempts = 0usize;
+        while drawn < fan && attempts < fan * 8 {
+            attempts += 1;
+            let from = rng.next_below(to);
+            if per_from[from].contains(&(to as u32)) {
+                continue;
+            }
+            per_from[from].push(to as u32);
+            drawn += 1;
+        }
+    }
+
+    for (from, targets) in per_from.iter_mut().enumerate() {
+        targets.sort_unstable();
+        for &to in targets.iter() {
+            from_indices.push(from as u32);
+            to_indices.push(to);
+        }
+    }
+
+    // A handful of constant neurons, matching the production mix.
+    let mut is_constant = vec![0u8; spec.num_neurons];
+    for i in 0..spec.num_neurons {
+        if i >= spec.num_inputs && i % 97 == 0 {
+            is_constant[i] = 1;
+        }
+    }
+
+    (from_indices, to_indices, is_constant)
+}
+
+/// Mutation-time topology ops — `scan_available_connections` (Issue #387).
+fn bench_topology_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("topology_ops");
+    for spec in &TOPOLOGIES {
+        let (from_indices, to_indices, is_constant) = build_topology(spec);
+        let num_neurons = spec.num_neurons as u32;
+        let num_inputs = spec.num_inputs as u32;
+        // One element per candidate slot the scan has to consider.
+        group.throughput(Throughput::Elements(
+            (spec.num_neurons * spec.num_neurons) as u64,
+        ));
+        group.bench_function(
+            BenchmarkId::new("scan_available_connections", spec.label),
+            |b| {
+                b.iter(|| {
+                    let out = scan_available_connections(
+                        black_box(&from_indices),
+                        black_box(&to_indices),
+                        black_box(&is_constant),
+                        black_box(num_neurons),
+                        black_box(num_inputs),
+                    );
+                    black_box(out);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 /// Activation primitives — `weighted_sum_simd` family plus squash/unsquash.
 fn bench_activation_primitives(c: &mut Criterion) {
     // weighted_sum_simd family over a representative synapse block.
@@ -465,5 +580,6 @@ criterion_group!(
     bench_scoring_flat,
     bench_dataset_evaluate_mse,
     bench_activation_primitives,
+    bench_topology_ops,
 );
 criterion_main!(benches);

--- a/neat-core/src/topology_ops.rs
+++ b/neat-core/src/topology_ops.rs
@@ -143,14 +143,50 @@ pub fn validate_topology(from_indices: &[u32], to_indices: &[u32]) -> Vec<i32> {
     vec![VALID, 0]
 }
 
+/// First `to` index the availability scan considers for a given `from`.
+///
+/// Forward-only (`to > from`) and never targeting an input neuron
+/// (`to >= num_inputs`), so the scan starts at whichever bound is higher.
+#[inline]
+fn scan_start_to(from_idx: usize, input_count: usize) -> usize {
+    if from_idx + 1 > input_count {
+        from_idx + 1
+    } else {
+        input_count
+    }
+}
+
+/// Whether `to_idx` is a constant neuron the scan must skip.
+///
+/// Indices beyond `is_constant` are treated as non-constant, preserving the
+/// original bounds-tolerant behaviour on a short `is_constant` buffer.
+#[inline]
+fn scan_is_constant(is_constant: &[u8], to_idx: usize) -> bool {
+    to_idx < is_constant.len() && is_constant[to_idx] != 0
+}
+
 /// Scan for available forward-only connection slots.
 ///
 /// Returns all `(from, to)` pairs where `from < to`, `to >= num_inputs`, the
-/// target neuron is not constant, and no connection already exists. Uses a
-/// flat boolean array for O(1) existence checks.
+/// target neuron is not constant, and no connection already exists.
+///
+/// Issue #387 — existence is answered from a compressed per-`from` run of
+/// existing targets (an `O(n + synapses)` adjacency built once), merge-walked
+/// against the candidate range. The previous implementation allocated a dense
+/// `n × n` boolean matrix for the same answer: 2.78 MB zeroed per call on the
+/// production topology to record ~21.5k synapses, a fill factor under 0.8%.
+/// The candidate count is also computed up front so the result vector is
+/// allocated exactly once at its final size instead of growing through a
+/// realloc chain. Output — pairs and their order — is unchanged.
+///
+/// Sorted input is *not* required: each per-`from` run is sorted on build, so
+/// an unsorted or duplicate-bearing edge list yields the same answer.
 ///
 /// # Returns
-/// Flattened `[from, to, from, to, ...]` pairs.
+/// Flattened `[from, to, from, to, ...]` pairs. Returns an empty vector for
+/// malformed input — mismatched `from`/`to` lengths, an implausibly large
+/// `num_neurons`, or a candidate count whose result vector could not be
+/// addressed — rather than panicking (which would trap under WASM).
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub fn scan_available_connections(
     from_indices: &[u32],
@@ -162,45 +198,136 @@ pub fn scan_available_connections(
     let n = num_neurons as usize;
     let input_count = num_inputs as usize;
 
-    // Issue NEAT-AI #2659 — defensive bail-out before the O(n^2)
-    // allocation. A length mismatch or pathologically large
-    // `num_neurons` previously caused a multiplication panic (and so a
-    // WASM trap) instead of a defined empty result.
+    // Issue NEAT-AI #2659 — defensive bail-out. A length mismatch or a
+    // pathologically large `num_neurons` previously caused a multiplication
+    // panic (and so a WASM trap) instead of a defined empty result. The
+    // `n * n` plausibility bound is retained: it is no longer an allocation
+    // size, but it still rejects a neuron count whose forward-pair space
+    // could never be materialised.
     if from_indices.len() != to_indices.len() {
         return Vec::new();
     }
-    let conn_set_len = match n.checked_mul(n) {
-        Some(v) if v <= isize::MAX as usize => v,
-        _ => return Vec::new(),
-    };
+    if n.checked_mul(n).is_none_or(|v| v > isize::MAX as usize) {
+        return Vec::new();
+    }
+    if n == 0 {
+        return Vec::new();
+    }
 
-    let mut conn_set = vec![false; conn_set_len];
+    // -----------------------------------------------------------------
+    // Compressed adjacency: for each `from`, the ascending run of existing
+    // targets that could ever block a candidate. Only pairs the scan can
+    // actually emit are retained (`to > from`, `to >= input_count`,
+    // both endpoints in range), which drops backward, self and
+    // out-of-range synapses exactly as the old matrix lookup did.
+    // -----------------------------------------------------------------
+    let mut starts = vec![0usize; n + 1];
     for i in 0..from_indices.len() {
         let from = from_indices[i] as usize;
         let to = to_indices[i] as usize;
-        if from < n && to < n {
-            conn_set[from * n + to] = true;
+        if from < n && to < n && to > from && to >= input_count {
+            starts[from + 1] += 1;
         }
     }
+    for f in 0..n {
+        starts[f + 1] += starts[f];
+    }
+    let mut cursor = starts.clone();
+    let mut targets = vec![0u32; starts[n]];
+    for i in 0..from_indices.len() {
+        let from = from_indices[i] as usize;
+        let to = to_indices[i] as usize;
+        if from < n && to < n && to > from && to >= input_count {
+            targets[cursor[from]] = to as u32;
+            cursor[from] += 1;
+        }
+    }
+    // Each run is already ascending for a `validate_topology`-clean edge
+    // list, so this is an O(run) insertion-sort pass in the common case; it
+    // is what lets an unsorted list fall through to the same answer.
+    for f in 0..n {
+        targets[starts[f]..starts[f + 1]].sort_unstable();
+    }
 
-    let mut available = Vec::new();
+    // Prefix sums of constant neurons, so "how many constants in
+    // [start_to, n)?" is O(1) per `from`.
+    let mut const_prefix = vec![0u32; n + 1];
+    for j in 0..n {
+        const_prefix[j + 1] = const_prefix[j] + u32::from(scan_is_constant(is_constant, j));
+    }
 
+    // -----------------------------------------------------------------
+    // Exact candidate count — O(n + synapses), no O(n^2) pre-pass. For each
+    // `from` the candidate range is [start_to, n); subtract the constants in
+    // that range and the distinct existing (non-constant) targets in it.
+    // The two subtracted sets are disjoint, so the result never underflows.
+    // -----------------------------------------------------------------
+    let mut total_pairs: usize = 0;
     for from_idx in 0..n {
-        let start_to = if from_idx + 1 > input_count {
-            from_idx + 1
-        } else {
-            input_count
-        };
-        for to_idx in start_to..n {
-            if to_idx < is_constant.len() && is_constant[to_idx] != 0 {
+        let start_to = scan_start_to(from_idx, input_count);
+        if start_to >= n {
+            continue;
+        }
+        let span = n - start_to;
+        let constants = (const_prefix[n] - const_prefix[start_to]) as usize;
+        let mut blocked = 0usize;
+        let mut previous: Option<u32> = None;
+        for k in starts[from_idx]..starts[from_idx + 1] {
+            let target = targets[k];
+            // A duplicate edge blocks the same slot once.
+            if previous == Some(target) {
                 continue;
             }
-            if !conn_set[from_idx * n + to_idx] {
-                available.push(from_idx as u32);
-                available.push(to_idx as u32);
+            previous = Some(target);
+            if !scan_is_constant(is_constant, target as usize) {
+                blocked += 1;
             }
         }
+        total_pairs += span - constants - blocked;
     }
+
+    // Flattened pairs: two `u32` per candidate. Refuse rather than abort if
+    // the exact result could not be addressed.
+    let capacity = match total_pairs.checked_mul(2) {
+        Some(c)
+            if c.checked_mul(size_of::<u32>())
+                .is_some_and(|b| b <= isize::MAX as usize) =>
+        {
+            c
+        }
+        _ => return Vec::new(),
+    };
+
+    let mut available: Vec<u32> = Vec::with_capacity(capacity);
+
+    for from_idx in 0..n {
+        let start_to = scan_start_to(from_idx, input_count);
+        if start_to >= n {
+            continue;
+        }
+        // Merge-walk: `to_idx` ascends, so the run cursor only moves forward.
+        let mut p = starts[from_idx];
+        let end = starts[from_idx + 1];
+        for to_idx in start_to..n {
+            if scan_is_constant(is_constant, to_idx) {
+                continue;
+            }
+            while p < end && (targets[p] as usize) < to_idx {
+                p += 1;
+            }
+            if p < end && targets[p] as usize == to_idx {
+                continue;
+            }
+            available.push(from_idx as u32);
+            available.push(to_idx as u32);
+        }
+    }
+
+    debug_assert_eq!(
+        available.len(),
+        capacity,
+        "pre-sized capacity must match the emitted pair count"
+    );
 
     available
 }
@@ -795,6 +922,257 @@ mod tests {
     // -----------------------------------------------------------------------
     // scan_available_connections (Issue #1959)
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Differential coverage for the Issue #387 rewrite.
+    //
+    // `reference_scan_available_connections` is the pre-#387 dense `n × n`
+    // boolean-matrix implementation, kept verbatim as the oracle. The
+    // optimised implementation must return a byte-identical `Vec<u32>` —
+    // same pairs, same order — for every topology below.
+    // -----------------------------------------------------------------------
+
+    /// Pre-#387 implementation: dense `n × n` boolean matrix, O(n^2) scan.
+    /// Retained only as the differential-test oracle.
+    fn reference_scan_available_connections(
+        from_indices: &[u32],
+        to_indices: &[u32],
+        is_constant: &[u8],
+        num_neurons: u32,
+        num_inputs: u32,
+    ) -> Vec<u32> {
+        let n = num_neurons as usize;
+        let input_count = num_inputs as usize;
+
+        if from_indices.len() != to_indices.len() {
+            return Vec::new();
+        }
+        let conn_set_len = match n.checked_mul(n) {
+            Some(v) if v <= isize::MAX as usize => v,
+            _ => return Vec::new(),
+        };
+
+        let mut conn_set = vec![false; conn_set_len];
+        for i in 0..from_indices.len() {
+            let from = from_indices[i] as usize;
+            let to = to_indices[i] as usize;
+            if from < n && to < n {
+                conn_set[from * n + to] = true;
+            }
+        }
+
+        let mut available = Vec::new();
+
+        for from_idx in 0..n {
+            let start_to = if from_idx + 1 > input_count {
+                from_idx + 1
+            } else {
+                input_count
+            };
+            for to_idx in start_to..n {
+                if to_idx < is_constant.len() && is_constant[to_idx] != 0 {
+                    continue;
+                }
+                if !conn_set[from_idx * n + to_idx] {
+                    available.push(from_idx as u32);
+                    available.push(to_idx as u32);
+                }
+            }
+        }
+
+        available
+    }
+
+    /// SplitMix64-style deterministic PRNG so the randomised cases are
+    /// reproducible across runs and platforms.
+    struct TestRng(u64);
+
+    impl TestRng {
+        fn next_u64(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+
+        fn below(&mut self, bound: usize) -> usize {
+            if bound == 0 {
+                0
+            } else {
+                (self.next_u64() % bound as u64) as usize
+            }
+        }
+    }
+
+    /// A randomised topology under test.
+    struct RandomTopology {
+        from: Vec<u32>,
+        to: Vec<u32>,
+        is_constant: Vec<u8>,
+        num_neurons: u32,
+        num_inputs: u32,
+    }
+
+    /// Build a random topology. `density` is the percentage of *all* forward
+    /// `(from, to)` pairs that carry a synapse — 0 gives an empty synapse
+    /// list, 100 gives a fully-connected forward graph. `duplicate_rate` is
+    /// the percentage of emitted edges repeated a second time. `sorted`
+    /// controls whether the emitted edge list is in `validate_topology` order
+    /// or deliberately shuffled (the defensive path).
+    fn random_topology(
+        rng: &mut TestRng,
+        num_neurons: u32,
+        num_inputs: u32,
+        density: u32,
+        duplicate_rate: u32,
+        constant_rate: u32,
+        sorted: bool,
+    ) -> RandomTopology {
+        let n = num_neurons as usize;
+        let mut from = Vec::new();
+        let mut to = Vec::new();
+        for f in 0..n {
+            for t in (f + 1)..n {
+                if (rng.below(100) as u32) >= density {
+                    continue;
+                }
+                from.push(f as u32);
+                to.push(t as u32);
+                // Duplicates stay adjacent, so a sorted list remains sorted.
+                if (rng.below(100) as u32) < duplicate_rate {
+                    from.push(f as u32);
+                    to.push(t as u32);
+                }
+            }
+        }
+
+        if !sorted {
+            // Fisher–Yates over the pair list, keeping `from`/`to` aligned.
+            for i in (1..from.len()).rev() {
+                let j = rng.below(i + 1);
+                from.swap(i, j);
+                to.swap(i, j);
+            }
+        }
+
+        let is_constant = (0..n)
+            .map(|_| u8::from((rng.below(100) as u32) < constant_rate))
+            .collect();
+
+        RandomTopology {
+            from,
+            to,
+            is_constant,
+            num_neurons,
+            num_inputs,
+        }
+    }
+
+    fn assert_matches_reference(case: &str, topology: &RandomTopology) {
+        let expected = reference_scan_available_connections(
+            &topology.from,
+            &topology.to,
+            &topology.is_constant,
+            topology.num_neurons,
+            topology.num_inputs,
+        );
+        let actual = scan_available_connections(
+            &topology.from,
+            &topology.to,
+            &topology.is_constant,
+            topology.num_neurons,
+            topology.num_inputs,
+        );
+        assert_eq!(actual, expected, "divergence from reference for {case}");
+    }
+
+    #[test]
+    fn scan_available_connections_matches_reference_on_random_topologies() {
+        let mut rng = TestRng(0x5EED_1234_ABCD_0001);
+
+        for num_neurons in [1u32, 2, 3, 5, 9, 16, 31] {
+            for num_inputs in [0u32, 1, num_neurons / 2, num_neurons] {
+                if num_inputs > num_neurons {
+                    continue;
+                }
+                // density 0 = empty synapse list, 100 = fully connected.
+                for density in [0u32, 15, 60, 100] {
+                    for duplicate_rate in [0u32, 30] {
+                        for constant_rate in [0u32, 25, 100] {
+                            for sorted in [true, false] {
+                                let topology = random_topology(
+                                    &mut rng,
+                                    num_neurons,
+                                    num_inputs,
+                                    density,
+                                    duplicate_rate,
+                                    constant_rate,
+                                    sorted,
+                                );
+                                let case = format!(
+                                    "n={num_neurons} inputs={num_inputs} density={density} \
+                                     dup={duplicate_rate} const={constant_rate} sorted={sorted}"
+                                );
+                                assert_matches_reference(&case, &topology);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn scan_available_connections_matches_reference_with_out_of_range_and_duplicate_edges() {
+        // Duplicates, self-connections, backward edges and out-of-range
+        // endpoints must all be tolerated identically to the reference.
+        let topology = RandomTopology {
+            from: vec![0, 0, 1, 2, 2, 3, 4, 99, 2],
+            to: vec![3, 3, 3, 2, 4, 1, 4, 4, 500],
+            is_constant: vec![0, 1, 0, 0, 0],
+            num_neurons: 5,
+            num_inputs: 2,
+        };
+        assert_matches_reference("hostile edge list", &topology);
+    }
+
+    #[test]
+    fn scan_available_connections_matches_reference_with_short_is_constant_buffer() {
+        // `is_constant` shorter than `num_neurons`: indices past the end are
+        // treated as non-constant by both implementations.
+        let topology = RandomTopology {
+            from: vec![0, 1],
+            to: vec![2, 3],
+            is_constant: vec![0, 1],
+            num_neurons: 6,
+            num_inputs: 2,
+        };
+        assert_matches_reference("short is_constant", &topology);
+    }
+
+    #[test]
+    fn scan_available_connections_num_inputs_equals_num_neurons_is_empty() {
+        // Every neuron is an input, so no candidate `to` exists.
+        let from: [u32; 0] = [];
+        let to: [u32; 0] = [];
+        let is_const = [0u8; 4];
+        let result = scan_available_connections(&from, &to, &is_const, 4, 4);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_available_connections_unsorted_edges_match_sorted_equivalent() {
+        // The rewrite must not depend on the caller having sorted the edge
+        // list: the same edges in a different order give the same answer.
+        let is_const = [0u8; 6];
+        let sorted =
+            scan_available_connections(&[0u32, 0, 1, 2], &[3u32, 4, 3, 5], &is_const, 6, 2);
+        let shuffled =
+            scan_available_connections(&[2u32, 0, 1, 0], &[5u32, 4, 3, 3], &is_const, 6, 2);
+        assert_eq!(sorted, shuffled);
+        assert!(!sorted.is_empty());
+    }
 
     #[test]
     fn scan_available_simple() {

--- a/neat-core/tests/topology_ops_allocations.rs
+++ b/neat-core/tests/topology_ops_allocations.rs
@@ -1,0 +1,160 @@
+//! Allocation regression for `scan_available_connections` (Issue #387).
+//!
+//! The pre-#387 implementation answered "does this connection already exist?"
+//! from a dense `n × n` boolean matrix — 2.78 MB zeroed per call at the
+//! production topology (n = 1,666) to record 21,513 synapses, a fill factor
+//! under 0.8% — and then grew the result with `Vec::new()`, reallocating and
+//! copying its way up to an ~11 MB flat pair list.
+//!
+//! Both costs are observable without touching the implementation: a counting
+//! global allocator measures the peak concurrently-live bytes and the number of
+//! allocations across one scan. A reintroduced `n²` matrix shows up as peak
+//! bytes well above the result size; a reintroduced realloc chain shows up as
+//! both a peak overshoot (old and new buffers live at once) and a large
+//! allocation count.
+//!
+//! Modelled on `tests/scoring_allocations.rs`.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use neat_core::topology_ops::scan_available_connections;
+
+/// Global allocator forwarding to the system allocator while tracking live
+/// bytes, peak live bytes, and the allocation count.
+///
+/// `realloc` is deliberately *not* forwarded to `System.realloc` — the default
+/// `GlobalAlloc::realloc` allocates, copies and frees, which is the behaviour a
+/// growing `Vec` must be assumed to have. That makes the peak figure
+/// deterministic across platforms instead of depending on whether the system
+/// allocator happened to extend a block in place.
+struct TrackingAllocator;
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        let live = LIVE_BYTES.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+        PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+        // SAFETY: forwarding an unchanged layout to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        let live = LIVE_BYTES.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+        PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+        // SAFETY: forwarding an unchanged layout to the system allocator.
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+        // SAFETY: `ptr`/`layout` came from an `alloc` call above.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+/// Production anchor from Issue #387: 1,666 neurons carrying 21,513 synapses.
+const PRODUCTION_NEURONS: usize = 1666;
+const PRODUCTION_SYNAPSES: usize = 21_513;
+const PRODUCTION_INPUTS: usize = 100;
+
+/// Deterministic SplitMix64 draw so the fixture is reproducible.
+fn next_u64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Sorted forward-only production-shaped topology.
+fn production_topology() -> (Vec<u32>, Vec<u32>, Vec<u8>) {
+    let mut state = 0x7061_7468_u64;
+    let num_non_inputs = PRODUCTION_NEURONS - PRODUCTION_INPUTS;
+    let base = PRODUCTION_SYNAPSES / num_non_inputs;
+    let remainder = PRODUCTION_SYNAPSES % num_non_inputs;
+
+    let mut per_from: Vec<Vec<u32>> = vec![Vec::new(); PRODUCTION_NEURONS];
+    for offset in 0..num_non_inputs {
+        let to = PRODUCTION_INPUTS + offset;
+        let fan = (base + usize::from(offset < remainder)).min(to);
+        let mut drawn = 0usize;
+        let mut attempts = 0usize;
+        while drawn < fan && attempts < fan * 8 + 16 {
+            attempts += 1;
+            let from = (next_u64(&mut state) % to as u64) as usize;
+            if per_from[from].contains(&(to as u32)) {
+                continue;
+            }
+            per_from[from].push(to as u32);
+            drawn += 1;
+        }
+    }
+
+    let mut from_indices = Vec::new();
+    let mut to_indices = Vec::new();
+    for (from, targets) in per_from.iter_mut().enumerate() {
+        targets.sort_unstable();
+        for &to in targets.iter() {
+            from_indices.push(from as u32);
+            to_indices.push(to);
+        }
+    }
+
+    let is_constant = (0..PRODUCTION_NEURONS)
+        .map(|i| u8::from(i >= PRODUCTION_INPUTS && i % 97 == 0))
+        .collect();
+
+    (from_indices, to_indices, is_constant)
+}
+
+#[test]
+fn scan_available_connections_peak_allocation_tracks_result_size() {
+    let (from_indices, to_indices, is_constant) = production_topology();
+
+    LIVE_BYTES.store(0, Ordering::Relaxed);
+    PEAK_BYTES.store(0, Ordering::Relaxed);
+    ALLOC_COUNT.store(0, Ordering::Relaxed);
+
+    let available = scan_available_connections(
+        &from_indices,
+        &to_indices,
+        &is_constant,
+        PRODUCTION_NEURONS as u32,
+        PRODUCTION_INPUTS as u32,
+    );
+
+    let peak = PEAK_BYTES.load(Ordering::Relaxed);
+    let allocations = ALLOC_COUNT.load(Ordering::Relaxed);
+    let result_bytes = available.len() * size_of::<u32>();
+
+    assert!(!available.is_empty(), "scan should find candidate slots");
+
+    // The result itself is unavoidable. Everything else — the old `n²` matrix
+    // (2.78 MB here) and the realloc chain's transient second buffer (~50% of
+    // the result) — must be gone. 1 MiB of headroom covers the O(n) scratch
+    // (adjacency, prefix sums, ~21.5k targets) with room to spare.
+    let budget = result_bytes + (1 << 20);
+    assert!(
+        peak <= budget,
+        "peak allocation {peak} B exceeded budget {budget} B \
+         (result {result_bytes} B, n = {PRODUCTION_NEURONS}); \
+         an n^2 matrix or a realloc chain has been reintroduced"
+    );
+
+    // The result vector is pre-sized, so it is allocated exactly once. A
+    // growth chain over an ~11 MB vector would be ~21 allocations on its own.
+    assert!(
+        allocations <= 16,
+        "expected a handful of allocations, saw {allocations}; \
+         the result vector is no longer pre-sized"
+    );
+}


### PR DESCRIPTION
# [perf] `scan_available_connections` — drop the n² matrix, pre-size the result

## Summary

`scan_available_connections` (`neat-core/src/topology_ops.rs`) answered "does
this connection already exist?" from a **dense `n × n` boolean matrix**. On the
production topology (n = 1,666) that is a **2.78 MB zeroed allocation per call**
to record 21,513 synapses — a fill factor under 0.8%. It then built the result
with `Vec::new()` and no `reserve`, so the ~11 MB flat pair list grew through a
realloc-and-memcpy chain. This is a mutation-time helper, so both costs are paid
repeatedly across the population every generation.

Both wins from the issue are taken:

1. **The matrix is gone.** Existence is answered from a compressed per-`from`
   run of existing targets — an `O(n + synapses)` adjacency built once, then
   merge-walked against the candidate range `[start_to, n)`. Only edges the scan
   could ever emit are retained (`to > from`, `to >= num_inputs`, both endpoints
   in range), which drops backward, self and out-of-range synapses exactly as
   the old matrix lookup did. Scratch memory is `O(n + synapses)` instead of
   `O(n²)`.
2. **The result is pre-sized.** The exact candidate count is computed up front
   in `O(n + synapses)` — no `O(n²)` pre-pass — from the candidate span minus a
   constant-neuron prefix sum minus the distinct existing targets in range. The
   result vector is then `Vec::with_capacity`'d once at its final length.

**Contract is unchanged.** Same pairs, same order, same defensive bail-outs.
Sorted input is *not* required — each per-`from` run is sorted on build, so an
unsorted or duplicate-bearing edge list yields the same answer. Per the issue,
no `scan_available_connections_count()` / sampled variant was added; that is a
cross-repo API change for the caller side.

Closes #387.

## Evidence

This is a backend library change with no web interface, so there is no
screenshot. Evidence is benchmark and allocation measurement.

### A/B at the production anchor — n = 1,666 with 21,513 synapses

Same fixture, same release build, single call, measured under a tracking global
allocator. Both implementations returned the **identical 1,345,957 pairs**.

| Metric | Before (`n²` matrix) | After (#387) | Delta |
| --- | --- | --- | --- |
| Peak live bytes | 27,941,380 B (26.65 MB) | 10,887,048 B (10.38 MB) | **−61%** |
| Allocations | 22 | 5 | **−77%** |
| Wall clock | 4.55 ms | 1.66 ms | **−63%** |
| Result size | 10,767,656 B | 10,767,656 B | unchanged |

The 10.38 MB floor *is* the result vector (10.77 MB reported as live bytes
includes the exact-size allocation). Everything above it — the 2.78 MB matrix
and the realloc chain's transient second buffer — is gone.

### Criterion — new `topology_ops` group in `hot_paths`

`cargo bench -p neat-core --bench hot_paths -- topology_ops`, before and after
on the same machine:

| Case | Before (median) | After (median) | Change (Criterion) |
| --- | --- | --- | --- |
| `n1666_21513` | 6.5395 ms | 4.0470 ms | **−38.1%** (p = 0.00) |
| `n4127_21513` | 24.377 ms | 15.222 ms | **−37.6%** (p = 0.00) |

`n1666_21513` is the anchor named in the issue (1,666 neurons, 21,513
synapses); `n4127_21513` puts the same synapse count on the full
`production_exact` neuron count. Throughput is reported per candidate slot
(`n²`), so a reintroduced dense matrix or realloc chain shows up directly on the
next run.

### Where the memory went

```mermaid
flowchart LR
    subgraph Before["Before — O(n²) memory"]
        A1["synapses (21,513)"] --> B1["dense n × n bool matrix<br/>2.78 MB zeroed"]
        B1 --> C1["O(n²) cell scan"]
        C1 --> D1["Vec::new() → realloc chain<br/>peak 26.65 MB"]
    end
    subgraph After["After — O(n + synapses) memory"]
        A2["synapses (21,513)"] --> B2["per-from target runs<br/>(CSR adjacency, sorted)"]
        B2 --> C2["exact candidate count<br/>O(n + synapses)"]
        C2 --> D2["Vec::with_capacity(exact)<br/>peak 10.38 MB"]
        B2 --> E2["merge-walk emit<br/>(cursor never rewinds)"]
        E2 --> D2
    end
```

### Failing-first verification

The differential test was validated by deliberately perturbing the new
implementation and confirming the suite goes red:

| Perturbation | Result |
| --- | --- |
| Drop the duplicate-edge guard in the counting pass | `scan_available_connections_matches_reference_on_random_topologies` **FAILED** |
| Merge-walk cursor advances on `<=` instead of `<` | 5 of 8 `scan_available*` tests **FAILED**, including the randomised differential test |

Both perturbations were reverted before commit.

## Test Plan

New tests in the `tests` module of `neat-core/src/topology_ops.rs`, all
differential against `reference_scan_available_connections` — the pre-#387
dense-matrix implementation retained verbatim as the oracle:

- `scan_available_connections_matches_reference_on_random_topologies` —
  asserts a byte-identical `Vec<u32>` (same pairs, **same order**) across 1,344
  randomised topologies: `num_neurons` ∈ {1, 2, 3, 5, 9, 16, 31} × `num_inputs`
  ∈ {0, 1, n/2, **n**} × density ∈ {**0 (empty synapse list)**, 15, 60,
  **100 (fully connected)**} × duplicate rate ∈ {0, 30} × constant rate ∈ {0,
  25, **100 (all targets constant)**} × {sorted, shuffled}. `num_inputs = 0`
  and `num_inputs = 1` cover `from < num_inputs`.
- `scan_available_connections_matches_reference_with_out_of_range_and_duplicate_edges`
  — duplicates, self-connections, backward edges and out-of-range endpoints in
  one hostile edge list.
- `scan_available_connections_matches_reference_with_short_is_constant_buffer` —
  `is_constant` shorter than `num_neurons`.
- `scan_available_connections_num_inputs_equals_num_neurons_is_empty` —
  `num_inputs == num_neurons`.
- `scan_available_connections_unsorted_edges_match_sorted_equivalent` — the
  rewrite does not depend on the caller having sorted the edge list.

New integration test `neat-core/tests/topology_ops_allocations.rs`:

- `scan_available_connections_peak_allocation_tracks_result_size` — a tracking
  global allocator asserts peak live bytes stay within `result + 1 MiB` and the
  allocation count stays ≤ 16 at n = 1,666 / 21,513 synapses. Fails against the
  old implementation (peak 26.65 MB vs an 11.8 MB budget).

Existing defensive tests unchanged and still green:

- `scan_available_connections_mismatched_lengths_returns_empty`
- `scan_available_connections_huge_neuron_count_returns_empty` — the `n * n`
  plausibility bound is retained (it is no longer an allocation size, but it
  still rejects a neuron count whose forward-pair space could never be
  materialised)
- `scan_available_simple`, `scan_skips_constant`

New Criterion group `topology_ops` in `neat-core/benches/hot_paths.rs`, with
`neat-core/benches/README.md` updated to document it.

No existing tests were commented out, removed or modified.

## Quality gate

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D
warnings`, `cargo check`, `cargo test --workspace --lib --tests --all-features`
(all 33 test binaries green), `cargo doc -D warnings`, `cargo build --release`,
`deno check`, the Mermaid gate and codespell all pass.

**Pre-existing, unrelated gate failure.** `./quality.sh`'s bats stage is red on
a clean tree — `git stash` confirms it fails without this change. Two Issue #375
public-safety assertions (`perf sources name none of the private trainer's
internal scripts`, `perf acceptance models reference no private internal script
paths`) fire on four comments left in `tests/perf/learn_flags_wiring.ts` by
#382. CI does not run bats, so it has gone unnoticed. Out of scope of this PR;
filed as **stSoftwareAU/NEAT-AI-core#397**.

## Security self-check

- **Input validation** — the two malformed-buffer bail-outs are retained
  unchanged (mismatched `from`/`to` lengths, implausible `num_neurons`); a new
  `checked_mul` guard refuses a candidate count whose result vector could not be
  addressed, returning an empty `Vec` rather than aborting.
- **Injection surface / output encoding / auth** — not applicable; pure
  in-process computation over caller-supplied slices, no new I/O, no new
  endpoint.
- **Memory safety** — no `unsafe` added. All indexing is checked; the
  merge-walk cursor is bounded by the run end on every access, and a
  `debug_assert` pins the emitted pair count to the pre-computed capacity.
- **Secrets** — none staged; no hidden files touched.
- **Dependencies** — none added.



## Milestone
This PR is part of the **#383 Please suggest performance or memory efficiency improvements** milestone and targets the `milestone/383-please-suggest-performance-or-memory-efficienc` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms19j6g1-235b3e`<!-- vibe-worker-issue-387 -->