### PR TITLE
[perf] compute_reverse_topological_order builds a Vec<Vec<u32>> adjacency (n+1 allocations per creature) (Issue #388)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.23"
+version = "0.2.24"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-388.md
+++ b/docs/archive/pr-summaries/pr-summary-388.md
@@ -1,0 +1,150 @@
+## Summary
+
+`compute_reverse_topological_order` built its inward adjacency as a
+`Vec<Vec<u32>>` — **one heap allocation per neuron** (1,666 on the production
+topology) plus the geometric regrowth of every inner `Vec` as the 21,513
+synapses were pushed — and Kahn's walk then chased a separate pointer per
+neuron, scattering the traversal across 1,666 unrelated allocations. `queue`
+and `result` were also unsized `Vec::new()`s that grew by realloc-and-copy.
+
+This replaces the per-neuron `Vec`s with a **CSR (compressed sparse row)**
+adjacency built in two passes — the same layout `PropagateInput` already uses
+for its inward lists — and pre-sizes `queue` / `result` from
+`n - input_count`. The function runs once per creature per generation to set up
+backprop ordering, so it sits on the per-generation path.
+
+The returned order is **unchanged, element for element**, and the defensive
+skip-don't-panic behaviour on malformed input (self-loops, out-of-range
+endpoints, mismatched `from`/`to` lengths, `input_count > n`, cycle tails) is
+preserved exactly — this function is reached from WASM, where a trap aborts the
+whole run.
+
+Closes #388.
+
+## Evidence
+
+### What changed
+
+```mermaid
+flowchart LR
+    subgraph before["Before — Vec&lt;Vec&lt;u32&gt;&gt;"]
+        B1["inward: Vec&lt;Vec&lt;u32&gt;&gt;"] --> B2["n heap allocations<br/>+ regrowth per push"]
+        B2 --> B3["Kahn's walk<br/>one pointer chase per neuron"]
+    end
+    subgraph after["After — CSR"]
+        A1["pass 1: count inward degree"] --> A2["prefix sum → inward_starts"]
+        A2 --> A3["pass 2: fill flat inward_indices<br/>via moving cursor"]
+        A3 --> A4["Kahn's walk<br/>one contiguous array"]
+    end
+```
+
+Neuron `v`'s inward sources are `inward_indices[inward_starts[v]..inward_starts[v + 1]]`.
+Pass 2 fills in synapse order, so each row lists its sources in exactly the
+order the per-neuron `Vec::push` produced — which is why the emitted order is
+element-identical.
+
+### Wall-clock A/B
+
+New Criterion group `reverse_topological_order` in `benches/hot_paths.rs`,
+measured **2026-07-26** on Apple M4 Pro (12 cores, 24 GB, macOS 26.5.2 arm64),
+rustc 1.97.0, Criterion 0.8.2, `--release` bench profile.
+`cargo bench -p neat-core --bench hot_paths -- reverse_topological_order --save-baseline before`
+then `--baseline before` after the change:
+
+| Shape | Before (`Vec<Vec<u32>>`) | After (CSR) | Change |
+| --- | --- | --- | --- |
+| `small_50` | 15.60 µs | 5.88 µs | −62.3% |
+| `medium_500` | 169.48 µs | 94.51 µs | −44.2% |
+| `large_5000` | 2.361 ms | 1.799 ms | −23.8% |
+| `production` | 588.97 µs | 231.09 µs | −60.8% |
+| `production_2x` | 1.372 ms | 490.28 µs | −64.3% |
+| **`production_exact`** — 1,666 non-input neurons, **21,513 synapses** | **547.19 µs** | **234.34 µs** | **−57.2%** |
+
+Criterion reported "Performance has improved" with `p = 0.00 < 0.05` on every
+shape. Full table with confidence intervals is archived in
+`neat-core/benches/BASELINE.md`.
+
+### Allocation-count A/B
+
+Counted with a counting global allocator over a single call (the harness now
+committed as `neat-core/tests/reverse_topological_allocations.rs`):
+
+| Shape | Before | After |
+| --- | --- | --- |
+| n = 128, 16 inputs | 239 | 7 |
+| production: n = 4,127 / 2,461 inputs / ~21.7 k synapses | **5,021** | **7** |
+
+**717× fewer allocations** at production shape, and the count is now
+independent of neuron count: `inward_starts`, `cursor`, `inward_indices`,
+`out_degree`, `queue`, `result`, `visited` — seven pre-sized buffers, none of
+which regrow.
+
+### Failing-first evidence
+
+- `reverse_topological_order_allocation_count_does_not_scale_with_neurons`
+  failed against the unmodified implementation:
+  `16× the neurons allocated 8174 vs 241 (delta 7933)`, and passes after.
+- The differential tests were fault-injected to prove they are the catch point
+  for a wrong-but-non-panicking order. Filling the CSR rows in reverse synapse
+  order (a valid CSR that permutes the emitted order) left every pre-existing
+  test green and failed **only** the three new differential tests:
+  `…matches_reference_on_random_dags`, `…_with_cycles`,
+  `…_on_malformed_edges`. An off-by-one in the prefix sum
+  (`inward_starts[to] += 1`) failed 7 of the 10 tests, including the existing
+  WASM-trap guards.
+
+### CLI/backend change — no UI
+
+Pure library change; there is no web interface to screenshot. Verified by the
+Rust test suite, the Criterion A/B above and the allocation harness.
+
+### Pre-existing, unrelated `quality.sh` failures
+
+`./quality.sh` fails at the bats stage on two checks that are **already red on
+a clean checkout of `Develop`** (verified with `git stash -u`):
+`perf sources name none of the private trainer's internal scripts` and
+`perf acceptance models reference no private internal script paths` — leftovers
+from the Issue #375/#376 rewording of `tests/perf/*.ts`, untouched by this PR
+and outside its scope. Note that CI does not run bats. Every other gate stage
+was run individually and is green: `cargo fmt --all`,
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
+`cargo check --workspace --all-targets --all-features`,
+`cargo test --workspace --lib --tests --all-features` (all suites `0 failed`),
+`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`,
+`cargo build --workspace --release`, `cargo bench -p neat-core --no-run --features parallel`,
+plus shellcheck, `deno check`, the Mermaid gate and codespell.
+
+## Test Plan
+
+Added in `neat-core/src/topology_ops.rs` (`#[cfg(test)]` module) — each pins the
+CSR result against a verbatim copy of the pre-change `Vec<Vec<u32>>`
+implementation kept as the differential oracle:
+
+- `reverse_topological_order_matches_reference_on_random_dags` — 200 randomised
+  DAGs (seeded PRNG, varying neuron/input counts and fan-in); asserts the order
+  is element-identical to the reference and covers every non-input neuron
+  exactly once.
+- `reverse_topological_order_matches_reference_with_cycles` — 200 randomised
+  graphs with injected back-edges; neurons left in cycles must still be
+  appended at the end in ascending index order, identically to the reference.
+- `reverse_topological_order_matches_reference_on_malformed_edges` — 200
+  randomised graphs seeded with self-loops, out-of-range `from`, out-of-range
+  `to` and duplicate edges; the CSR path must skip exactly what the reference
+  skipped and must not panic.
+- `reverse_topological_order_matches_reference_on_edge_case_shapes` — empty
+  graph, all-inputs, no-inputs, `input_count > n`, mismatched lengths,
+  self-loops only.
+
+Added in `neat-core/tests/reverse_topological_allocations.rs`:
+
+- `reverse_topological_order_allocation_count_does_not_scale_with_neurons` —
+  counting global allocator; 16× the neurons must not raise the allocation
+  count (delta < 10), and that count must stay a single-digit constant.
+
+Unchanged and still passing (the malformed-input guards from NEAT-AI #2659):
+`reverse_topological_order_oob_from_does_not_panic`,
+`reverse_topological_order_oob_to_does_not_panic`,
+`reverse_topological_order_mismatched_lengths_returns_empty`,
+`reverse_topological_order_input_count_exceeds_neurons`,
+`reverse_topological_order_simple`, `reverse_topological_order_larger`.
+No existing test was modified or removed.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -324,6 +324,42 @@ Two distinct wins stack:
   wasm path additionally pays JS↔wasm orchestration per record, so the real
   wasm32 scoring lane is no faster than this row — reinforcing the verdict.
 
+## Backprop-setup adjacency: `Vec<Vec<u32>>` → CSR (Issue #388)
+
+`compute_reverse_topological_order` built its inward adjacency as one `Vec` per
+neuron — `n + 1` heap allocations per creature plus the geometric regrowth of
+every inner `Vec` — and Kahn's walk then chased a separate pointer per neuron.
+It now builds a **CSR** triple (`inward_starts` prefix sum + flat
+`inward_indices`) in two passes, so the walk reads one contiguous array. The
+returned order is unchanged, element for element
+(`reverse_topological_order_matches_reference_on_random_dags`).
+
+**Measured 2026-07-26**, Apple M4 Pro (12 cores, 24 GB, macOS 26.5.2 arm64),
+rustc 1.97.0, Criterion 0.8.2, `--release` bench profile. New group
+`reverse_topological_order`; times are Criterion's mean `[lower, upper]`, and
+the change column is Criterion's own `--baseline` comparison median.
+
+| Shape | Before (`Vec<Vec<u32>>`) | After (CSR) | Change |
+| --- | --- | --- | --- |
+| `small_50` | 15.60 µs `[13.33, 18.37]` | 5.88 µs `[5.21, 6.63]` | −62.3% |
+| `medium_500` | 169.48 µs `[144.80, 199.02]` | 94.51 µs `[85.89, 104.21]` | −44.2% |
+| `large_5000` | 2.361 ms `[2.071, 2.682]` | 1.799 ms `[1.679, 1.928]` | −23.8% |
+| `production` | 588.97 µs `[533.27, 648.77]` | 231.09 µs `[204.74, 261.11]` | −60.8% |
+| `production_2x` | 1.372 ms `[1.211, 1.550]` | 490.28 µs `[448.27, 536.87]` | −64.3% |
+| **`production_exact`** (1,666 non-input neurons, 21,513 synapses) | **547.19 µs** `[503.07, 594.92]` | **234.34 µs** `[213.14, 257.97]` | **−57.2%** |
+
+Allocation count for one call at production shape (4,127 neurons / 2,461 inputs
+/ ~21.7 k synapses), counted with the same counting-allocator harness as
+`neat-core/tests/reverse_topological_allocations.rs`:
+
+| Shape | Before | After |
+| --- | --- | --- |
+| n = 128 | 239 | 7 |
+| production (n = 4,127) | 5,021 | **7** |
+
+The count is now independent of neuron count — asserted permanently by
+`reverse_topological_order_allocation_count_does_not_scale_with_neurons`.
+
 ## Reproducing
 
 ```bash

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -21,6 +21,7 @@ There are two bench targets:
 | `forward_pass` | `CompiledNetwork::activate` | small ~50, medium ~500, large ~5000, `production`, `production_2x` |
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` | same five shapes |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
+| `reverse_topological_order` | `compute_reverse_topological_order` over a creature's full synapse list (Issue #388) | all six shapes |
 | `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -24,6 +24,7 @@ use neat_core::simd::{
 use neat_core::squash::{SquashType, apply_squash};
 use neat_core::squash_simd::squash_x4;
 use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
+use neat_core::topology_ops::compute_reverse_topological_order;
 use neat_core::unsquash::apply_unsquash;
 
 /// Deterministic network/backprop fixtures, shared with the `bench_fixtures`
@@ -130,6 +131,34 @@ fn bench_backprop(c: &mut Criterion) {
                 };
                 let out = propagate_topological_loop(black_box(&input));
                 black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Backprop setup — `compute_reverse_topological_order` over a creature's full
+/// synapse list (Issue #388). This runs once per creature per generation to
+/// order the backprop walk, so its allocation behaviour is on the
+/// per-generation path.
+fn bench_reverse_topological_order(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reverse_topological_order");
+    for spec in &NETWORKS {
+        let data = build_backprop_data(spec, 0x1357_9BDF);
+        let from: Vec<u32> = data.synapses.iter().map(|s| s.from).collect();
+        let to: Vec<u32> = data.synapses.iter().map(|s| s.to).collect();
+        let num_neurons = spec.num_neurons as u32;
+        let num_inputs = spec.num_inputs as u32;
+        group.throughput(Throughput::Elements(from.len() as u64));
+        group.bench_function(BenchmarkId::from_parameter(spec.label), |b| {
+            b.iter(|| {
+                let order = compute_reverse_topological_order(
+                    black_box(&from),
+                    black_box(&to),
+                    black_box(num_neurons),
+                    black_box(num_inputs),
+                );
+                black_box(order);
             });
         });
     }
@@ -343,6 +372,7 @@ criterion_group!(
     bench_forward_pass,
     bench_batched_scoring,
     bench_backprop,
+    bench_reverse_topological_order,
     bench_scoring,
     bench_activation_primitives,
 );

--- a/neat-core/src/topology_ops.rs
+++ b/neat-core/src/topology_ops.rs
@@ -211,6 +211,14 @@ pub fn scan_available_connections(
 /// indices ordered with output neurons first, then hidden neurons after
 /// their downstream consumers. Input neurons are excluded. Neurons remaining
 /// in cycles are appended at the end.
+///
+/// The inward adjacency is built as a **CSR** (compressed sparse row) triple in
+/// two passes over the synapse list (Issue #388) — the same layout
+/// [`crate::PropagateInput`] uses for its inward lists. The previous
+/// `Vec<Vec<u32>>` cost one heap allocation per neuron (1,666 on the production
+/// topology) plus the geometric regrowth of every inner `Vec`; the CSR form is
+/// a fixed handful of allocations regardless of neuron count and lets the walk
+/// below read one contiguous array.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub fn compute_reverse_topological_order(
     from_indices: &[u32],
@@ -231,23 +239,56 @@ pub fn compute_reverse_topological_order(
     if input_count > n {
         return Vec::new();
     }
+    // The CSR offsets are `u32`; a synapse list longer than `u32::MAX` would
+    // overflow the prefix sum. Unreachable in practice (that is a 16 GiB edge
+    // list, and `usize` is 32-bit under WASM anyway), but bail out rather than
+    // wrap silently.
+    if from_indices.len() > u32::MAX as usize {
+        return Vec::new();
+    }
 
-    let mut out_degree = vec![0i32; n];
-    let mut inward: Vec<Vec<u32>> = vec![Vec::new(); n];
+    // A synapse survives into the adjacency when it is not a self-loop and
+    // both endpoints are inside the declared neuron count. Defensive: a
+    // pathological evolved creature can emit stale indices after a neuron
+    // rename, and panicking here traps the whole WASM run; #2659.
+    let survives = |from: usize, to: usize| from != to && from < n && to < n;
 
+    // Pass 1 — inward degree per neuron, counted one slot to the right so the
+    // prefix sum below turns the counts straight into row starts. The `n + 1`
+    // length must be representable: `usize` is 32-bit under WASM, where a
+    // `num_neurons` of `u32::MAX` would wrap it to zero and trap on the first
+    // index. Bail out the same way the other malformed inputs do.
+    let Some(starts_len) = n.checked_add(1) else {
+        return Vec::new();
+    };
+    let mut inward_starts = vec![0u32; starts_len];
+    let mut surviving = 0usize;
     for i in 0..from_indices.len() {
         let from = from_indices[i] as usize;
         let to = to_indices[i] as usize;
-
-        if from == to {
+        if !survives(from, to) {
             continue;
         }
+        inward_starts[to + 1] += 1;
+        surviving += 1;
+    }
 
-        // Defensive: skip synapses whose endpoints fall outside the
-        // declared neuron count rather than panicking. Production has
-        // observed pathological evolved creatures emitting stale indices
-        // after a neuron rename; #2659.
-        if from >= n || to >= n {
+    // Prefix sum — neuron `v`'s inward sources live in
+    // `inward_indices[inward_starts[v]..inward_starts[v + 1]]`.
+    for v in 0..n {
+        inward_starts[v + 1] += inward_starts[v];
+    }
+
+    // Pass 2 — fill the flat index array through a per-row moving cursor, in
+    // synapse order, so each row lists its sources in the same order the
+    // per-neuron `Vec` push did. Out-degree is accumulated in the same pass.
+    let mut out_degree = vec![0i32; n];
+    let mut cursor: Vec<u32> = inward_starts[..n].to_vec();
+    let mut inward_indices = vec![0u32; surviving];
+    for i in 0..from_indices.len() {
+        let from = from_indices[i] as usize;
+        let to = to_indices[i] as usize;
+        if !survives(from, to) {
             continue;
         }
 
@@ -255,17 +296,20 @@ pub fn compute_reverse_topological_order(
             out_degree[from] += 1;
         }
 
-        inward[to].push(from as u32);
+        let slot = cursor[to] as usize;
+        inward_indices[slot] = from as u32;
+        cursor[to] = slot as u32 + 1;
     }
 
-    let mut queue: Vec<usize> = Vec::new();
+    let non_inputs = n - input_count;
+    let mut queue: Vec<usize> = Vec::with_capacity(non_inputs);
     for i in input_count..n {
         if out_degree[i] == 0 {
             queue.push(i);
         }
     }
 
-    let mut result: Vec<u32> = Vec::new();
+    let mut result: Vec<u32> = Vec::with_capacity(non_inputs);
     let mut visited = vec![false; n];
     let mut head = 0;
 
@@ -279,8 +323,10 @@ pub fn compute_reverse_topological_order(
         visited[idx] = true;
         result.push(idx as u32);
 
-        for j in 0..inward[idx].len() {
-            let from = inward[idx][j] as usize;
+        let row_start = inward_starts[idx] as usize;
+        let row_end = inward_starts[idx + 1] as usize;
+        for &source in &inward_indices[row_start..row_end] {
+            let from = source as usize;
             if from == idx {
                 continue;
             }
@@ -848,6 +894,259 @@ mod tests {
         assert!(pos_of(6) < pos_of(4));
         assert!(pos_of(6) < pos_of(3));
         assert!(pos_of(7) < pos_of(5));
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_reverse_topological_order — CSR adjacency differential
+    // (Issue #388).
+    //
+    // The inward adjacency moved from a `Vec<Vec<u32>>` (one heap allocation
+    // per neuron) to a CSR triple built in two passes. The order the function
+    // returns is a contract of the backprop path, so these tests pin the CSR
+    // result to the pre-change `Vec<Vec<u32>>` reference **element for
+    // element** across randomised topologies — an off-by-one in the prefix sum
+    // or the cursor fill permutes or truncates the order and fails here.
+    // -----------------------------------------------------------------------
+
+    /// Pre-change reference: Kahn's walk over a per-neuron `Vec<Vec<u32>>`
+    /// inward adjacency. Kept verbatim (bar naming) as the differential oracle.
+    fn reference_reverse_topological_order(
+        from_indices: &[u32],
+        to_indices: &[u32],
+        num_neurons: u32,
+        num_inputs: u32,
+    ) -> Vec<u32> {
+        let n = num_neurons as usize;
+        let input_count = num_inputs as usize;
+
+        if from_indices.len() != to_indices.len() {
+            return Vec::new();
+        }
+        if input_count > n {
+            return Vec::new();
+        }
+
+        let mut out_degree = vec![0i32; n];
+        let mut inward: Vec<Vec<u32>> = vec![Vec::new(); n];
+
+        for i in 0..from_indices.len() {
+            let from = from_indices[i] as usize;
+            let to = to_indices[i] as usize;
+
+            if from == to {
+                continue;
+            }
+            if from >= n || to >= n {
+                continue;
+            }
+            if from >= input_count {
+                out_degree[from] += 1;
+            }
+            inward[to].push(from as u32);
+        }
+
+        let mut queue: Vec<usize> = Vec::new();
+        for i in input_count..n {
+            if out_degree[i] == 0 {
+                queue.push(i);
+            }
+        }
+
+        let mut result: Vec<u32> = Vec::new();
+        let mut visited = vec![false; n];
+        let mut head = 0;
+
+        while head < queue.len() {
+            let idx = queue[head];
+            head += 1;
+
+            if visited[idx] {
+                continue;
+            }
+            visited[idx] = true;
+            result.push(idx as u32);
+
+            for j in 0..inward[idx].len() {
+                let from = inward[idx][j] as usize;
+                if from == idx {
+                    continue;
+                }
+                if from < input_count {
+                    continue;
+                }
+                if visited[from] {
+                    continue;
+                }
+
+                out_degree[from] -= 1;
+                if out_degree[from] <= 0 {
+                    queue.push(from);
+                }
+            }
+        }
+
+        for i in input_count..n {
+            if !visited[i] {
+                result.push(i as u32);
+            }
+        }
+
+        result
+    }
+
+    /// Tiny SplitMix64-style PRNG so the randomised cases are reproducible
+    /// without pulling in a dependency (same shape as `benches/common`'s `Lcg`).
+    struct TestRng(u64);
+
+    impl TestRng {
+        fn next_u64(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+
+        fn below(&mut self, bound: usize) -> usize {
+            (self.next_u64() % bound as u64) as usize
+        }
+    }
+
+    /// Random feedforward DAG: every edge runs from a strictly earlier neuron
+    /// to a later non-input neuron.
+    fn random_dag(rng: &mut TestRng, n: usize, input_count: usize) -> (Vec<u32>, Vec<u32>) {
+        let mut from = Vec::new();
+        let mut to = Vec::new();
+        for target in input_count..n {
+            let fan = rng.below(6);
+            for _ in 0..fan {
+                from.push(rng.below(target) as u32);
+                to.push(target as u32);
+            }
+        }
+        (from, to)
+    }
+
+    #[test]
+    fn reverse_topological_order_matches_reference_on_random_dags() {
+        let mut rng = TestRng(0x0388_0388);
+        for case in 0..200 {
+            let input_count = 1 + rng.below(8);
+            let n = input_count + 1 + rng.below(40);
+            let (from, to) = random_dag(&mut rng, n, input_count);
+
+            let actual =
+                compute_reverse_topological_order(&from, &to, n as u32, input_count as u32);
+            let expected =
+                reference_reverse_topological_order(&from, &to, n as u32, input_count as u32);
+
+            assert_eq!(
+                actual,
+                expected,
+                "case {case}: CSR order diverged from the reference \
+                 (n={n}, inputs={input_count}, synapses={})",
+                from.len()
+            );
+            // Every non-input neuron appears exactly once in a DAG.
+            assert_eq!(
+                actual.len(),
+                n - input_count,
+                "case {case}: order truncated"
+            );
+        }
+    }
+
+    #[test]
+    fn reverse_topological_order_matches_reference_with_cycles() {
+        // Back-edges create cycles; those neurons must still be appended at the
+        // end in ascending index order, identically to the reference.
+        let mut rng = TestRng(0xC0FF_EE01);
+        for case in 0..200 {
+            let input_count = 1 + rng.below(5);
+            let n = input_count + 2 + rng.below(30);
+            let (mut from, mut to) = random_dag(&mut rng, n, input_count);
+
+            let back_edges = 1 + rng.below(4);
+            for _ in 0..back_edges {
+                let a = input_count + rng.below(n - input_count);
+                let b = input_count + rng.below(n - input_count);
+                from.push(a.max(b) as u32);
+                to.push(a.min(b) as u32);
+            }
+
+            let actual =
+                compute_reverse_topological_order(&from, &to, n as u32, input_count as u32);
+            let expected =
+                reference_reverse_topological_order(&from, &to, n as u32, input_count as u32);
+
+            assert_eq!(
+                actual, expected,
+                "case {case}: CSR order diverged from the reference on a cyclic graph"
+            );
+        }
+    }
+
+    #[test]
+    fn reverse_topological_order_matches_reference_on_malformed_edges() {
+        // Self-loops, out-of-range endpoints and duplicate edges mixed into an
+        // otherwise valid DAG: the CSR path must skip exactly what the
+        // reference skipped, and must not panic (a trap aborts the WASM run).
+        let mut rng = TestRng(0xBAD0_5EED);
+        for case in 0..200 {
+            let input_count = 1 + rng.below(5);
+            let n = input_count + 2 + rng.below(25);
+            let (mut from, mut to) = random_dag(&mut rng, n, input_count);
+
+            // Self-loop.
+            let s = input_count + rng.below(n - input_count);
+            from.push(s as u32);
+            to.push(s as u32);
+            // Out-of-range `from`.
+            from.push((n + 1 + rng.below(50)) as u32);
+            to.push((input_count + rng.below(n - input_count)) as u32);
+            // Out-of-range `to`.
+            from.push(rng.below(n) as u32);
+            to.push((n + 1 + rng.below(50)) as u32);
+            // Duplicate of an existing edge, when there is one to duplicate.
+            if !from.is_empty() {
+                let dup = rng.below(from.len());
+                let (f, t) = (from[dup], to[dup]);
+                from.push(f);
+                to.push(t);
+            }
+
+            let actual =
+                compute_reverse_topological_order(&from, &to, n as u32, input_count as u32);
+            let expected =
+                reference_reverse_topological_order(&from, &to, n as u32, input_count as u32);
+
+            assert_eq!(
+                actual, expected,
+                "case {case}: CSR order diverged from the reference on malformed edges"
+            );
+        }
+    }
+
+    #[test]
+    fn reverse_topological_order_matches_reference_on_edge_case_shapes() {
+        // Degenerate shapes the randomised generator will not reach.
+        let cases: [(&[u32], &[u32], u32, u32); 6] = [
+            (&[], &[], 0, 0),               // empty graph
+            (&[], &[], 4, 4),               // all neurons are inputs
+            (&[], &[], 4, 0),               // no inputs, no edges
+            (&[0], &[1], 2, 99),            // input_count > n
+            (&[0, 1, 2], &[2, 2], 4, 2),    // mismatched lengths
+            (&[0, 0, 0], &[0, 0, 0], 3, 1), // nothing but self-loops
+        ];
+
+        for (i, (from, to, n, inputs)) in cases.iter().enumerate() {
+            let actual = compute_reverse_topological_order(from, to, *n, *inputs);
+            let expected = reference_reverse_topological_order(from, to, *n, *inputs);
+            assert_eq!(
+                actual, expected,
+                "edge case {i} diverged from the reference"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/neat-core/tests/reverse_topological_allocations.rs
+++ b/neat-core/tests/reverse_topological_allocations.rs
@@ -1,0 +1,95 @@
+//! Allocation-count regression for `compute_reverse_topological_order`
+//! (Issue #388).
+//!
+//! The function used to build its inward adjacency as a `Vec<Vec<u32>>` — one
+//! heap allocation per neuron, plus the geometric regrowth of each inner `Vec`
+//! as synapses were pushed. It now builds a CSR (compressed sparse row)
+//! adjacency in two passes, so the allocation count is a small constant
+//! independent of the neuron count.
+//!
+//! A counting global allocator (same pattern as `scoring_allocations.rs`)
+//! records how many allocations happen inside the call. Growing the neuron
+//! count 16× must not grow the allocation count: with the old layout it would
+//! grow by thousands.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use neat_core::topology_ops::compute_reverse_topological_order;
+
+/// Global allocator forwarding to the system allocator while counting every
+/// allocation. Only the delta across two calls is observed.
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: forwarding an unchanged layout to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr`/`layout` came from `System.alloc` above.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Deterministic layered DAG: `num_inputs` inputs feeding a chain of non-input
+/// neurons, each drawing `fan_in` incoming edges from strictly earlier neurons.
+fn build_dag(num_neurons: usize, num_inputs: usize, fan_in: usize) -> (Vec<u32>, Vec<u32>) {
+    let mut from = Vec::new();
+    let mut to = Vec::new();
+    for target in num_inputs..num_neurons {
+        for k in 0..fan_in {
+            // Spread the sources deterministically over the earlier neurons.
+            let source = (target * 7 + k * 13) % target;
+            from.push(source as u32);
+            to.push(target as u32);
+        }
+    }
+    (from, to)
+}
+
+/// Allocations consumed by one `compute_reverse_topological_order` call.
+fn allocs_for(from: &[u32], to: &[u32], num_neurons: u32, num_inputs: u32) -> usize {
+    let before = ALLOC_COUNT.load(Ordering::Relaxed);
+    let order = compute_reverse_topological_order(from, to, num_neurons, num_inputs);
+    // Keep the result alive across the measurement so its allocation is counted.
+    std::hint::black_box(&order);
+    let after = ALLOC_COUNT.load(Ordering::Relaxed);
+    after - before
+}
+
+/// One test only: the allocation counter is process-global, so a second
+/// concurrently-running test in this binary would pollute the measurement.
+#[test]
+fn reverse_topological_order_allocation_count_does_not_scale_with_neurons() {
+    let (small_from, small_to) = build_dag(128, 16, 8);
+    let (large_from, large_to) = build_dag(2048, 16, 8);
+
+    let small_allocs = allocs_for(&small_from, &small_to, 128, 16);
+    let large_allocs = allocs_for(&large_from, &large_to, 2048, 16);
+
+    // The per-neuron `Vec<Vec<u32>>` layout allocated once per neuron, so the
+    // 16× larger topology allocated ~7,900 more times. The CSR layout allocates
+    // a fixed handful of buffers — inward_starts, cursor, inward_indices,
+    // out_degree, queue, result, visited — regardless of size.
+    let delta = large_allocs.saturating_sub(small_allocs);
+    assert!(
+        delta < 10,
+        "16× the neurons allocated {large_allocs} vs {small_allocs} (delta \
+         {delta}); expected a constant count — per-neuron adjacency allocation \
+         has regressed"
+    );
+
+    // …and that constant is a single-digit handful, not a per-neuron count.
+    assert!(
+        large_allocs <= 12,
+        "expected a small constant number of allocations, got {large_allocs}"
+    );
+}


### PR DESCRIPTION
## Summary

`compute_reverse_topological_order` built its inward adjacency as a
`Vec<Vec<u32>>` — **one heap allocation per neuron** (1,666 on the production
topology) plus the geometric regrowth of every inner `Vec` as the 21,513
synapses were pushed — and Kahn's walk then chased a separate pointer per
neuron, scattering the traversal across 1,666 unrelated allocations. `queue`
and `result` were also unsized `Vec::new()`s that grew by realloc-and-copy.

This replaces the per-neuron `Vec`s with a **CSR (compressed sparse row)**
adjacency built in two passes — the same layout `PropagateInput` already uses
for its inward lists — and pre-sizes `queue` / `result` from
`n - input_count`. The function runs once per creature per generation to set up
backprop ordering, so it sits on the per-generation path.

The returned order is **unchanged, element for element**, and the defensive
skip-don't-panic behaviour on malformed input (self-loops, out-of-range
endpoints, mismatched `from`/`to` lengths, `input_count > n`, cycle tails) is
preserved exactly — this function is reached from WASM, where a trap aborts the
whole run.

Closes #388.

## Evidence

### What changed

```mermaid
flowchart LR
    subgraph before["Before — Vec&lt;Vec&lt;u32&gt;&gt;"]
        B1["inward: Vec&lt;Vec&lt;u32&gt;&gt;"] --> B2["n heap allocations<br/>+ regrowth per push"]
        B2 --> B3["Kahn's walk<br/>one pointer chase per neuron"]
    end
    subgraph after["After — CSR"]
        A1["pass 1: count inward degree"] --> A2["prefix sum → inward_starts"]
        A2 --> A3["pass 2: fill flat inward_indices<br/>via moving cursor"]
        A3 --> A4["Kahn's walk<br/>one contiguous array"]
    end
```

Neuron `v`'s inward sources are `inward_indices[inward_starts[v]..inward_starts[v + 1]]`.
Pass 2 fills in synapse order, so each row lists its sources in exactly the
order the per-neuron `Vec::push` produced — which is why the emitted order is
element-identical.

### Wall-clock A/B

New Criterion group `reverse_topological_order` in `benches/hot_paths.rs`,
measured **2026-07-26** on Apple M4 Pro (12 cores, 24 GB, macOS 26.5.2 arm64),
rustc 1.97.0, Criterion 0.8.2, `--release` bench profile.
`cargo bench -p neat-core --bench hot_paths -- reverse_topological_order --save-baseline before`
then `--baseline before` after the change:

| Shape | Before (`Vec<Vec<u32>>`) | After (CSR) | Change |
| --- | --- | --- | --- |
| `small_50` | 15.60 µs | 5.88 µs | −62.3% |
| `medium_500` | 169.48 µs | 94.51 µs | −44.2% |
| `large_5000` | 2.361 ms | 1.799 ms | −23.8% |
| `production` | 588.97 µs | 231.09 µs | −60.8% |
| `production_2x` | 1.372 ms | 490.28 µs | −64.3% |
| **`production_exact`** — 1,666 non-input neurons, **21,513 synapses** | **547.19 µs** | **234.34 µs** | **−57.2%** |

Criterion reported "Performance has improved" with `p = 0.00 < 0.05` on every
shape. Full table with confidence intervals is archived in
`neat-core/benches/BASELINE.md`.

### Allocation-count A/B

Counted with a counting global allocator over a single call (the harness now
committed as `neat-core/tests/reverse_topological_allocations.rs`):

| Shape | Before | After |
| --- | --- | --- |
| n = 128, 16 inputs | 239 | 7 |
| production: n = 4,127 / 2,461 inputs / ~21.7 k synapses | **5,021** | **7** |

**717× fewer allocations** at production shape, and the count is now
independent of neuron count: `inward_starts`, `cursor`, `inward_indices`,
`out_degree`, `queue`, `result`, `visited` — seven pre-sized buffers, none of
which regrow.

### Failing-first evidence

- `reverse_topological_order_allocation_count_does_not_scale_with_neurons`
  failed against the unmodified implementation:
  `16× the neurons allocated 8174 vs 241 (delta 7933)`, and passes after.
- The differential tests were fault-injected to prove they are the catch point
  for a wrong-but-non-panicking order. Filling the CSR rows in reverse synapse
  order (a valid CSR that permutes the emitted order) left every pre-existing
  test green and failed **only** the three new differential tests:
  `…matches_reference_on_random_dags`, `…_with_cycles`,
  `…_on_malformed_edges`. An off-by-one in the prefix sum
  (`inward_starts[to] += 1`) failed 7 of the 10 tests, including the existing
  WASM-trap guards.

### CLI/backend change — no UI

Pure library change; there is no web interface to screenshot. Verified by the
Rust test suite, the Criterion A/B above and the allocation harness.

### Pre-existing, unrelated `quality.sh` failures

`./quality.sh` fails at the bats stage on two checks that are **already red on
a clean checkout of `Develop`** (verified with `git stash -u`):
`perf sources name none of the private trainer's internal scripts` and
`perf acceptance models reference no private internal script paths` — leftovers
from the Issue #375/#376 rewording of `tests/perf/*.ts`, untouched by this PR
and outside its scope. Note that CI does not run bats. Every other gate stage
was run individually and is green: `cargo fmt --all`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`cargo check --workspace --all-targets --all-features`,
`cargo test --workspace --lib --tests --all-features` (all suites `0 failed`),
`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`,
`cargo build --workspace --release`, `cargo bench -p neat-core --no-run --features parallel`,
plus shellcheck, `deno check`, the Mermaid gate and codespell.

## Test Plan

Added in `neat-core/src/topology_ops.rs` (`#[cfg(test)]` module) — each pins the
CSR result against a verbatim copy of the pre-change `Vec<Vec<u32>>`
implementation kept as the differential oracle:

- `reverse_topological_order_matches_reference_on_random_dags` — 200 randomised
  DAGs (seeded PRNG, varying neuron/input counts and fan-in); asserts the order
  is element-identical to the reference and covers every non-input neuron
  exactly once.
- `reverse_topological_order_matches_reference_with_cycles` — 200 randomised
  graphs with injected back-edges; neurons left in cycles must still be
  appended at the end in ascending index order, identically to the reference.
- `reverse_topological_order_matches_reference_on_malformed_edges` — 200
  randomised graphs seeded with self-loops, out-of-range `from`, out-of-range
  `to` and duplicate edges; the CSR path must skip exactly what the reference
  skipped and must not panic.
- `reverse_topological_order_matches_reference_on_edge_case_shapes` — empty
  graph, all-inputs, no-inputs, `input_count > n`, mismatched lengths,
  self-loops only.

Added in `neat-core/tests/reverse_topological_allocations.rs`:

- `reverse_topological_order_allocation_count_does_not_scale_with_neurons` —
  counting global allocator; 16× the neurons must not raise the allocation
  count (delta < 10), and that count must stay a single-digit constant.

Unchanged and still passing (the malformed-input guards from NEAT-AI #2659):
`reverse_topological_order_oob_from_does_not_panic`,
`reverse_topological_order_oob_to_does_not_panic`,
`reverse_topological_order_mismatched_lengths_returns_empty`,
`reverse_topological_order_input_count_exceeds_neurons`,
`reverse_topological_order_simple`, `reverse_topological_order_larger`.
No existing test was modified or removed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms19j6g1-235b3e`<!-- vibe-worker-issue-388 -->