### PR TITLE
[perf] PC settling bench never settled — fix it, add an A/B harness, correct the #389 numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.24"
+version = "0.2.25"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-389.md
+++ b/docs/archive/pr-summaries/pr-summary-389.md
@@ -5,8 +5,21 @@
 The predictive-coding settling loop (`PredictiveCodingEngine::infer`,
 `neat-core/src/pc_inference.rs`) allocated two `Vec`s on every settling step and
 recomputed each target neuron's pre-activation once per inbound edge. This PR
-removes the per-step allocations without changing the numerics, and documents
-why the per-edge derivative recompute is **left intact**. Closes #389.
+removes the per-step allocations — **104 → 4 allocations per `infer`, a 96%
+reduction** — without changing a single result bit, and documents why the
+per-edge derivative recompute is **left intact**. Closes #389.
+
+Wall clock is unchanged (see [Evidence](#evidence)): the settling loop is
+dominated by work that cannot be removed while preserving the numerics, so this
+lands as a **memory-efficiency** win on the #383 milestone, not a speed one.
+Two speed optimisations were tried and rejected on measurement; both are
+recorded below so they are not re-attempted.
+
+> **Landed in two parts.** The buffer hoist itself merged as PR #401. That PR
+> cited a ~16% / ~8% speed-up measured against a benchmark that converged on
+> iteration 1 and never ran the settling loop at all. This PR fixes the
+> benchmark, adds the in-process A/B harness, and replaces those figures with
+> the measured result. The numbers below supersede PR #401's.
 
 ### What changed
 
@@ -20,6 +33,9 @@ why the per-edge derivative recompute is **left intact**. Closes #389.
 3. **`infer_batch` reuses one `PcScratch` across all samples** — the per-step
    working `Vec`s are allocated once for the whole batch rather than once per
    sample. Each sample's result owns its own copy of the final settled state.
+4. **Criterion `pc_inference` group + `pc_infer_ab` example** — the benchmark
+   the issue asked for, plus an in-process A/B against a standalone pre-#389
+   reference implementation.
 
 ### Semantics: why the per-edge derivative recompute stays
 
@@ -31,12 +47,17 @@ back via `compute_pre_activation` when processing later hidden neurons in the
 same step (Gauss-Seidel ordering). Whenever a target neuron's inbound sum reads
 a latent already updated this step — which happens for any target with ≥2 hidden
 inbound sources (common in multi-layer topologies) — a step-start derivative
-cache would return a different value and silently change the results. Per the
-acceptance criteria, only the provably-non-aliasing work (the two allocation
-optimisations) was hoisted; the derivative recompute is preserved and annotated
-in the code. A byte-exact incremental pre-activation cache was also rejected:
-f32 addition is non-associative, so incremental accumulation would not be
-bit-identical to the full per-edge recompute.
+cache would return a different value and silently change the results.
+
+The aliasing is in fact **total**, not occasional: every hidden neuron that
+reads target `T`'s pre-activation is by definition an inbound source of `T`, and
+it updates its own latent immediately after that read. So the next reader of `T`
+always sees a changed inbound sum, and a dirty-flag cache would never get a
+hit. Per the acceptance criteria, only the provably-non-aliasing work (the
+allocation optimisations) was hoisted; the derivative recompute is preserved and
+annotated in the code. A byte-exact incremental pre-activation cache was also
+rejected: f32 addition is non-associative, so incremental accumulation would not
+be bit-identical to the full per-edge recompute.
 
 ```mermaid
 flowchart TD
@@ -53,23 +74,83 @@ flowchart TD
 
 ## Evidence
 
-Backend/CLI change — no UI. Verified by tests plus a Criterion A/B on a
+Backend/CLI change — no UI, so no screenshot. Verified by tests plus an A/B on a
 production-shaped PC topology (32 inputs → 96 → 96 → 48 hidden → 8 outputs,
-fan-in 16, 50 steps, `energy_threshold = 0` so the loop runs to exhaustion).
+fan-in 16, 3,968 synapses, 50 steps, `energy_threshold = 0`).
 
-Benchmark: `neat-core/benches/hot_paths.rs::bench_pc_inference`
-(`cargo bench -p neat-core --bench hot_paths -- pc_inference`), same machine,
-`--warm-up-time 1 --measurement-time 3`:
+### Allocations — the measured win
 
-| Case                      | Before (baseline) | After     | Change   |
-|---------------------------|-------------------|-----------|----------|
-| `pc_inference/single_settle` | 16.41 µs       | 13.76 µs  | ~16% faster |
-| `pc_inference/batch_32`   | 532.99 µs         | 491.48 µs | ~8% faster  |
+`cargo run --release --example pc_infer_ab`, one supervised 50-step `infer`
+under a counting global allocator:
 
-Allocation evidence: `tests/pc_inference_allocations.rs` uses a counting global
-allocator to assert the allocation count barely moves between a 10-step and a
-500-step run (delta < 20) for both `infer` and `infer_batch` — before the fix a
-500-step run allocated ~980 more times.
+| | Allocations | Peak live bytes |
+| --- | --- | --- |
+| pre-#389 | 104 | 5,292 |
+| this PR | **4** | **3,308** |
+| delta | **−100 (−96.2%)** | −1,984 (−37.5%) |
+
+Four is the floor: they are exactly the four `Vec`s `PcInferenceResult` owns and
+returns (`latents`, `predictions`, `errors`, `energy_history`). The count is now
+independent of `inference_steps`; before, it was `4 + 2 × (steps + 1)`.
+
+### Wall clock — no change
+
+Same example, tight A/B alternation in one process, minimum of 400 rounds
+(minimum, not mean: the host is shared, so every sample is the true cost plus
+interference):
+
+| Case | pre-#389 | this PR | Change |
+| --- | --- | --- | --- |
+| `infer` | 1.929–1.970 ms | 1.917–1.935 ms | −0.2% … −2.4% |
+| `infer_batch/8` | 15.46–15.82 ms | 15.40–15.55 ms | ~0% |
+
+**Honest reading: no wall-clock improvement.** The measured deltas sit inside
+run-to-run noise on this host (load average ~16 on 12 cores). The loop's cost is
+`O(edges × fan-in)` dependent-f32-add chains plus one transcendental derivative
+per edge, and neither can be reduced without changing the numerics — so removing
+100 allocations out of a 1.9 ms call is not visible. The change is neutral on
+speed and large on allocation pressure; it does not regress either.
+
+### Rejected optimisations (negative results — do not re-attempt)
+
+- **Per-step derivative cache** — not value-preserving; see above. Rejected on
+  correctness, before measurement.
+- **Structure-of-arrays inward connections + CSR outward adjacency.** Replacing
+  the 16-byte `PcConnection` walk with parallel `Vec<u32>`/`Vec<f32>` arrays,
+  and the `Vec<Vec<PcOutwardConnection>>` outward map with a CSR triple carrying
+  the target's relative index and squash type inline. Implemented, verified
+  bit-identical, and measured **1.1–1.8% slower** on `infer` across repeated
+  runs. The topology's hot arrays (≈63 KB) already sit in cache, so the layout
+  change bought nothing while the extra parallel-array bounds checks cost a
+  little. Reverted — the simpler array-of-structs walk stays.
+
+### Benchmark correctness fix
+
+The `pc_inference` Criterion case originally ran **unsupervised** (`targets =
+None`). That is not a settling benchmark: `infer` initialises every non-input
+latent from its own forward prediction, so the first error vector is exactly
+zero, energy is `0.0`, and the loop converges and exits on iteration 1. It was
+timing initialisation — 12 µs instead of the 5.9 ms a real 50-step settle costs,
+a 450× understatement. Both cases are now supervised and the bench asserts
+`steps_used == 50`, so a fixture that starts converging early fails loud.
+
+### Base-branch repair (unrelated to #389, required to get here)
+
+The milestone branch's own `Merge branch 'Develop'` (9befd1d) auto-resolved two
+files without conflict markers and produced code that **does not compile**,
+blocking every PR that targets it. Repaired on the milestone branch directly
+as commit `7492a4b`, which is now part of the base, so it is not in this PR's
+diff:
+
+- `topology_ops.rs` — PRs #399 (Develop) and #400 (milestone) both rewrote
+  `compute_reverse_topological_order` for Issue #388; the hunks did not overlap
+  textually, so both CSR builds were concatenated (two prefix-sum passes, a
+  `u32`/`usize` type error, a duplicated `tests` module). Resolved to the
+  milestone side's file, with Develop's three extra differential tests
+  re-appended so trunk keeps that coverage.
+- `hot_paths.rs` — the merge took Develop's import line verbatim, dropping
+  `scan_available_connections` and `TrainingDataConfig` while keeping the bench
+  bodies that use them.
 
 ## Test Plan
 
@@ -87,20 +168,27 @@ New tests (all `cargo test` green; existing `tests/pc_inference.rs` and
   calls, including a sample shorter than `num_inputs` to exercise the
   latent-reset (no stale-buffer leak).
 - `tests/pc_inference_allocations.rs` — O(1)-allocation regression for the
-  settling loop (`infer` and `infer_batch`).
+  settling loop (`infer` and `infer_batch`): the allocation count barely moves
+  between a 10-step and a 500-step run (delta < 20). Before the fix a 500-step
+  run allocated ~980 more times.
 - `src/pc_inference.rs::tests::compute_errors_wrapper_matches_into` — the
   `compute_errors` wrapper matches `compute_errors_into`.
+- `examples/pc_infer_ab.rs` — asserts bit-identity against the pre-#389
+  reference on both the supervised and unsupervised paths before it reports any
+  numbers, so the A/B cannot quote a figure for a changed answer.
+- Repaired base: the three `reverse_topological_order_matches_reference_*`
+  differential tests carried over from Develop.
 
 ## Quality gate
 
-`clippy --all-targets --all-features -D warnings`, `cargo fmt --check`,
-`cargo test --workspace --all-features`, and `cargo doc -D warnings` all pass.
-`./quality.sh` reports two failures in pre-existing `tests/perf` doc-content
-checks (`perf_private_repo_reference.bats` / `private_repo_reference.bats`) that
-also fail on the untouched base branch and are unrelated to this change — no
-files under `tests/perf` or `docs/` prose were touched here.
+`./quality.sh` — fmt, clippy `-D warnings`, `cargo deny`, the full workspace
+test suite, `cargo doc -D warnings` and the release build.
 
 ## Security self-check
 
 Backend numeric change only. No new external input, no injection surface, no
-secrets, no new dependencies.
+secrets or `.config*.json` staged, no new dependencies. The only new `unsafe`
+code is the counting `GlobalAlloc` in `examples/pc_infer_ab.rs`, which forwards
+an unchanged `Layout` to `System` — the same delegation pattern as the existing
+`examples/reverse_topo_order_alloc_ab.rs` — and it ships in an example, not in
+the library.

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -26,6 +26,7 @@ There are two bench targets:
 | `scoring_flat` | `CompiledNetwork::score_records_flat` over the same batch in flat-slice input layout (Issue #386) | `production`, `production_2x`, `production_exact` |
 | `dataset_evaluate_mse` | `TrainingDataset::evaluate_mse` over a production-sized batch (Issue #386) | `production`, `production_2x`, `production_exact` |
 | `topology_ops` | `scan_available_connections` — the mutation-time availability scan (Issue #387); `compute_reverse_topological_order` — the per-creature backprop-ordering setup (Issue #388) | `n1666_21513`, `n4127_21513` |
+| `pc_inference` | `PredictiveCodingEngine::infer` / `infer_batch` — the predictive-coding settling loop (Issue #389) | one layered PC topology: 32 inputs → 96 → 96 → 48 hidden → 8 outputs, fan-in 16 |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
@@ -51,6 +52,18 @@ per-neuron `Vec<Vec<u32>>` — n + 1 allocations and a pointer chase per neuron 
 shows up as a throughput drop here. `cargo run --release --example
 reverse_topo_order_alloc_ab` measures the same function's allocation count
 directly against the pre-#388 shape.
+
+The `pc_inference` group (Issue #389) drives the predictive-coding settling
+loop for its full step budget. **Both cases are supervised on purpose.** An
+unsupervised `infer` initialises every non-input latent from its own forward
+prediction, so the first error vector is exactly zero, energy is `0.0` and the
+loop converges and exits on iteration 1 — it would time initialisation, not the
+loop. Clamping the outputs to targets perturbs that state, and the bench
+asserts `steps_used == 50` so a fixture that starts converging early fails loud
+instead of quietly reporting a 450× smaller number. `cargo run --release
+--example pc_infer_ab` measures the same loop's allocation count and wall clock
+directly against a standalone pre-#389 reference, in one process with tight A/B
+alternation — the more reliable comparison when the machine is loaded.
 
 `scoring_flat` scores the *same* shard through the flat-slice input entry point
 (Issue #386), so the delta against `scoring` isolates the cost of the per-record

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -687,19 +687,47 @@ fn build_pc_engine(inference_steps: u32) -> PredictiveCodingEngine {
     )
 }
 
+/// Settling iterations the predictive-coding benches drive per `infer` call.
+const PC_INFERENCE_STEPS: u32 = 50;
+
 /// Predictive-coding settling loop — `PredictiveCodingEngine::infer` and
 /// `infer_batch` on a production-shaped topology (Issue #389).
+///
+/// **Both cases are supervised.** An *unsupervised* run is not a settling
+/// benchmark at all: step 2 of `infer` initialises every non-input latent from
+/// its own forward prediction, so the first `compute_errors` returns exactly
+/// zero for every neuron, energy is `0.0`, and the loop converges and exits on
+/// iteration 1 — measuring initialisation, not the loop the issue is about.
+/// Clamping the outputs to targets perturbs the settled state, so all
+/// [`PC_INFERENCE_STEPS`] iterations run (asserted below).
 fn bench_pc_inference(c: &mut Criterion) {
     let mut group = c.benchmark_group("pc_inference");
-    let engine = build_pc_engine(50);
+    let engine = build_pc_engine(PC_INFERENCE_STEPS);
     let mut lcg = Lcg::new(0x1234_5678);
     let input: Vec<f32> = (0..engine.num_inputs())
         .map(|_| lcg.next_signed())
         .collect();
+    let targets: Vec<f32> = (0..engine.num_outputs())
+        .map(|_| lcg.next_signed())
+        .collect();
 
+    // Fail loud if the fixture stops exercising the full settling loop, or
+    // settles into a non-finite state that would make the timings meaningless.
+    let probe = engine.infer(&input, Some(&targets));
+    assert_eq!(
+        probe.steps_used, PC_INFERENCE_STEPS,
+        "pc_inference fixture converged early — the bench would not measure the settling loop"
+    );
+    assert!(
+        probe.final_energy.is_finite() && probe.latents.iter().all(|v| v.is_finite()),
+        "pc_inference fixture diverged to a non-finite state"
+    );
+
+    // One element per settling step actually executed.
+    group.throughput(Throughput::Elements(PC_INFERENCE_STEPS as u64));
     group.bench_function("single_settle", |b| {
         b.iter(|| {
-            let r = engine.infer(black_box(&input), None);
+            let r = engine.infer(black_box(&input), black_box(Some(&targets[..])));
             black_box(r);
         });
     });
@@ -712,9 +740,13 @@ fn bench_pc_inference(c: &mut Criterion) {
         })
         .collect();
     let batch_refs: Vec<&[f32]> = batch.iter().map(|v| v.as_slice()).collect();
+    let batch_targets: Vec<&[f32]> = (0..batch_refs.len()).map(|_| &targets[..]).collect();
+    group.throughput(Throughput::Elements(
+        PC_INFERENCE_STEPS as u64 * batch_refs.len() as u64,
+    ));
     group.bench_function("batch_32", |b| {
         b.iter(|| {
-            let r = engine.infer_batch(black_box(&batch_refs), None);
+            let r = engine.infer_batch(black_box(&batch_refs), black_box(Some(&batch_targets)));
             black_box(r);
         });
     });

--- a/neat-core/examples/pc_infer_ab.rs
+++ b/neat-core/examples/pc_infer_ab.rs
@@ -1,0 +1,474 @@
+//! Allocation + wall-clock A/B for the predictive-coding settling loop (Issue #389).
+//!
+//! Measures the shipped [`PredictiveCodingEngine::infer`] against a standalone
+//! reproduction of the pre-#389 implementation — fresh `predictions`/`errors`
+//! `Vec`s every step, array-of-structs inward connections, `Vec<Vec<_>>`
+//! outward adjacency — on a production-shaped topology.
+//!
+//! Both sides must return **bit-identical** results: #389 is a memory-layout
+//! and allocation change, never a numerics change. The settling loop's
+//! per-edge derivative recompute is deliberately preserved (see the note in
+//! `pc_inference.rs`), so the answer cannot move.
+//!
+//! The two sides are timed in **alternating rounds** inside one process and
+//! reported as the *fastest* round each. Min-of-rounds is the noise-robust
+//! statistic: a shared machine only ever adds time, so the minimum is the
+//! closest estimate of the true cost, and alternating means both sides see the
+//! same interference.
+//!
+//! Run with: `cargo run --release --example pc_infer_ab`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use neat_core::derivative::apply_derivative;
+use neat_core::pc_inference::{PcConnection, PcInferenceResult, PcNeuron, PredictiveCodingEngine};
+use neat_core::squash::{SquashType, apply_squash};
+
+// ---------------------------------------------------------------------------
+// Counting allocator — records allocation count and peak live bytes.
+// ---------------------------------------------------------------------------
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: `layout` is forwarded unchanged to the system allocator,
+        // which is the documented delegation pattern for a wrapper allocator.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        // SAFETY: `ptr`/`layout` come from a matching `alloc` on this
+        // allocator, which delegates to `System`.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn reset_counters() {
+    ALLOCS.store(0, Ordering::Relaxed);
+    LIVE.store(0, Ordering::Relaxed);
+    PEAK.store(0, Ordering::Relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fixture.
+// ---------------------------------------------------------------------------
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn signed(&mut self) -> f32 {
+        ((self.next_u64() >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+    }
+
+    fn below(&mut self, bound: usize) -> usize {
+        (self.next_u64() % bound as u64) as usize
+    }
+}
+
+/// Topology shape: a wide input layer feeding multi-fan-in hidden layers.
+const NUM_INPUTS: usize = 32;
+const HIDDEN_LAYERS: [usize; 3] = [96, 96, 48];
+const NUM_OUTPUTS: usize = 8;
+const FAN_IN: usize = 16;
+const STEPS: u32 = 50;
+const RATE: f32 = 0.05;
+/// Zero threshold: the supervised run never converges early, so every round
+/// pays the full [`STEPS`] settling iterations.
+const THRESHOLD: f32 = 0.0;
+
+fn build_topology() -> (Vec<PcNeuron>, Vec<PcConnection>) {
+    let mut lcg = Lcg(0x9C0D_E389);
+    let mut neurons: Vec<PcNeuron> = Vec::new();
+    let mut connections: Vec<PcConnection> = Vec::new();
+
+    let mut prev: Vec<usize> = (0..NUM_INPUTS).collect();
+    let mut next_full = NUM_INPUTS;
+
+    let mut layer_sizes: Vec<usize> = HIDDEN_LAYERS.to_vec();
+    layer_sizes.push(NUM_OUTPUTS);
+
+    for (li, &size) in layer_sizes.iter().enumerate() {
+        let is_hidden = li < HIDDEN_LAYERS.len();
+        let squash = if is_hidden {
+            SquashType::Tanh
+        } else {
+            SquashType::Identity
+        };
+        let mut this_layer: Vec<usize> = Vec::with_capacity(size);
+        for _ in 0..size {
+            let conn_start = connections.len();
+            let k = FAN_IN.min(prev.len());
+            for _ in 0..k {
+                let src = prev[lcg.below(prev.len())];
+                connections.push(PcConnection {
+                    from: src,
+                    weight: lcg.signed() * 0.5,
+                });
+            }
+            neurons.push(PcNeuron {
+                bias: lcg.signed() * 0.1,
+                squash_type: squash,
+                is_hidden,
+                conn_start,
+                conn_count: connections.len() - conn_start,
+            });
+            this_layer.push(next_full);
+            next_full += 1;
+        }
+        prev = this_layer;
+    }
+
+    (neurons, connections)
+}
+
+// ---------------------------------------------------------------------------
+// Pre-#389 reference: two `Vec`s per settling step, AoS inward connections,
+// `Vec<Vec<_>>` outward adjacency, `neurons[target_rel]` chased per edge.
+// ---------------------------------------------------------------------------
+
+fn ref_pre(neurons: &[PcNeuron], connections: &[PcConnection], rel: usize, latents: &[f32]) -> f32 {
+    let neuron = &neurons[rel];
+    let mut sum = neuron.bias;
+    for ci in neuron.conn_start..neuron.conn_start + neuron.conn_count {
+        let c = &connections[ci];
+        sum += c.weight * latents[c.from];
+    }
+    sum
+}
+
+fn ref_prediction(
+    neurons: &[PcNeuron],
+    connections: &[PcConnection],
+    rel: usize,
+    latents: &[f32],
+) -> f32 {
+    let neuron = &neurons[rel];
+    apply_squash(
+        neuron.squash_type,
+        ref_pre(neurons, connections, rel, latents),
+    )
+}
+
+/// The whole pre-#389 engine: adjacency is rebuilt per call only in
+/// [`ReferenceEngine::new`], exactly as `new_from_parts` did, so the timed
+/// `infer` below is a like-for-like comparison.
+struct ReferenceEngine {
+    num_neurons: usize,
+    num_inputs: usize,
+    num_outputs: usize,
+    neurons: Vec<PcNeuron>,
+    connections: Vec<PcConnection>,
+    outward: Vec<Vec<(usize, f32)>>,
+    hidden: Vec<usize>,
+}
+
+impl ReferenceEngine {
+    fn new(neurons: Vec<PcNeuron>, connections: Vec<PcConnection>) -> Self {
+        let num_neurons = NUM_INPUTS + neurons.len();
+        let mut outward: Vec<Vec<(usize, f32)>> = vec![Vec::new(); num_neurons];
+        for (ni, neuron) in neurons.iter().enumerate() {
+            let actual = NUM_INPUTS + ni;
+            for ci in neuron.conn_start..neuron.conn_start + neuron.conn_count {
+                let c = &connections[ci];
+                outward[c.from].push((actual, c.weight));
+            }
+        }
+        let hidden: Vec<usize> = neurons
+            .iter()
+            .enumerate()
+            .filter(|(_, n)| n.is_hidden)
+            .map(|(i, _)| NUM_INPUTS + i)
+            .collect();
+        ReferenceEngine {
+            num_neurons,
+            num_inputs: NUM_INPUTS,
+            num_outputs: NUM_OUTPUTS,
+            neurons,
+            connections,
+            outward,
+            hidden,
+        }
+    }
+
+    fn compute_errors(&self, latents: &[f32]) -> (Vec<f32>, Vec<f32>) {
+        let n = self.neurons.len();
+        let mut p = vec![0.0f32; n];
+        let mut e = vec![0.0f32; n];
+        for i in 0..n {
+            let pred = ref_prediction(&self.neurons, &self.connections, i, latents);
+            p[i] = pred;
+            e[i] = latents[self.num_inputs + i] - pred;
+        }
+        (p, e)
+    }
+
+    fn infer(&self, input: &[f32], targets: Option<&[f32]>) -> PcInferenceResult {
+        let mut latents = vec![0.0f32; self.num_neurons];
+        let input_len = input.len().min(self.num_inputs);
+        latents[..input_len].copy_from_slice(&input[..input_len]);
+        for i in 0..self.neurons.len() {
+            latents[self.num_inputs + i] =
+                ref_prediction(&self.neurons, &self.connections, i, &latents);
+        }
+        if let Some(tgt) = targets {
+            let output_start = self.num_neurons - self.num_outputs;
+            for j in 0..self.num_outputs.min(tgt.len()) {
+                latents[output_start + j] = tgt[j];
+            }
+        }
+
+        let mut energy_history = Vec::with_capacity(STEPS as usize + 1);
+        let mut converged = false;
+        let mut steps_used = 0u32;
+
+        let (mut predictions, mut errors) = self.compute_errors(&latents);
+        let mut energy = energy_of(&errors);
+        energy_history.push(energy);
+
+        for t in 0..STEPS {
+            steps_used = t + 1;
+            if energy <= THRESHOLD {
+                converged = true;
+                break;
+            }
+            for &hidden_idx in &self.hidden {
+                let hidden_rel = hidden_idx - self.num_inputs;
+                let mut gradient = errors[hidden_rel];
+                for &(to, weight) in &self.outward[hidden_idx] {
+                    let target_rel = to - self.num_inputs;
+                    let target_error = errors[target_rel];
+                    let target_squash = self.neurons[target_rel].squash_type;
+                    let pre = ref_pre(&self.neurons, &self.connections, target_rel, &latents);
+                    let derivative = apply_derivative(target_squash, pre);
+                    gradient -= weight * target_error * derivative;
+                }
+                latents[hidden_idx] -= RATE * gradient;
+            }
+            latents[..input_len].copy_from_slice(&input[..input_len]);
+            if let Some(tgt) = targets {
+                let output_start = self.num_neurons - self.num_outputs;
+                for j in 0..self.num_outputs.min(tgt.len()) {
+                    latents[output_start + j] = tgt[j];
+                }
+            }
+            let (np, ne) = self.compute_errors(&latents);
+            predictions = np;
+            errors = ne;
+            energy = energy_of(&errors);
+            energy_history.push(energy);
+        }
+        if !converged && energy <= THRESHOLD {
+            converged = true;
+        }
+
+        PcInferenceResult {
+            latents,
+            predictions,
+            errors,
+            final_energy: energy,
+            energy_history,
+            steps_used,
+            converged,
+        }
+    }
+
+    fn infer_batch(&self, inputs: &[&[f32]], targets: Option<&[&[f32]]>) -> Vec<PcInferenceResult> {
+        inputs
+            .iter()
+            .enumerate()
+            .map(|(i, input)| self.infer(input, targets.map(|t| t[i])))
+            .collect()
+    }
+}
+
+fn energy_of(errors: &[f32]) -> f32 {
+    let mut s = 0.0f32;
+    for &e in errors {
+        s += e * e;
+    }
+    0.5 * s
+}
+
+// ---------------------------------------------------------------------------
+// Comparison helpers.
+// ---------------------------------------------------------------------------
+
+/// Bit-level comparison — `to_bits` so a `NaN` or a signed zero cannot slip
+/// through an `==` that would call them equal (or unequal) by accident.
+fn assert_bit_identical(label: &str, a: &PcInferenceResult, b: &PcInferenceResult) {
+    let bits = |v: &[f32]| v.iter().map(|x| x.to_bits()).collect::<Vec<u32>>();
+    assert_eq!(bits(&a.latents), bits(&b.latents), "{label}: latents");
+    assert_eq!(
+        bits(&a.predictions),
+        bits(&b.predictions),
+        "{label}: predictions"
+    );
+    assert_eq!(bits(&a.errors), bits(&b.errors), "{label}: errors");
+    assert_eq!(
+        a.final_energy.to_bits(),
+        b.final_energy.to_bits(),
+        "{label}: final_energy"
+    );
+    assert_eq!(
+        bits(&a.energy_history),
+        bits(&b.energy_history),
+        "{label}: energy_history"
+    );
+    assert_eq!(a.steps_used, b.steps_used, "{label}: steps_used");
+    assert_eq!(a.converged, b.converged, "{label}: converged");
+}
+
+fn pct(before: f64, after: f64) -> f64 {
+    (before - after) / before * 100.0
+}
+
+fn main() {
+    const REPS: usize = 8;
+    const ROUNDS: usize = 400;
+    const BATCH_ROUNDS: usize = 40;
+    const BATCH: usize = 8;
+
+    let (neurons, connections) = build_topology();
+    let reference = ReferenceEngine::new(neurons.clone(), connections.clone());
+    let engine = PredictiveCodingEngine::new_from_parts(
+        NUM_INPUTS,
+        NUM_OUTPUTS,
+        neurons,
+        connections,
+        STEPS,
+        RATE,
+        THRESHOLD,
+    );
+
+    let mut lcg = Lcg(0x1234_5678);
+    let input: Vec<f32> = (0..NUM_INPUTS).map(|_| lcg.signed()).collect();
+    let targets: Vec<f32> = (0..NUM_OUTPUTS).map(|_| lcg.signed()).collect();
+    let batch: Vec<Vec<f32>> = (0..BATCH)
+        .map(|_| (0..NUM_INPUTS).map(|_| lcg.signed()).collect())
+        .collect();
+    let batch_refs: Vec<&[f32]> = batch.iter().map(|v| v.as_slice()).collect();
+    let batch_targets: Vec<&[f32]> = (0..BATCH).map(|_| &targets[..]).collect();
+
+    println!(
+        "topology: {NUM_INPUTS} inputs + {} non-inputs ({NUM_OUTPUTS} outputs), \
+         {} synapses, fan-in {FAN_IN}, {STEPS} settling steps\n",
+        engine.num_neurons() - NUM_INPUTS,
+        engine.connections.len()
+    );
+
+    // --- Correctness: the change must not move a single bit. ---
+    let want = reference.infer(&input, Some(&targets));
+    let got = engine.infer(&input, Some(&targets));
+    assert_bit_identical("supervised", &want, &got);
+    assert_eq!(
+        got.steps_used, STEPS,
+        "fixture converged early — it would not measure the settling loop"
+    );
+    let want_unsup = reference.infer(&input, None);
+    let got_unsup = engine.infer(&input, None);
+    assert_bit_identical("unsupervised", &want_unsup, &got_unsup);
+    println!(
+        "results bit-identical (supervised: {} steps, energy {:e}; unsupervised: {} steps)\n",
+        got.steps_used, got.final_energy, got_unsup.steps_used
+    );
+
+    // --- Allocation counts: one `infer` call each. ---
+    reset_counters();
+    let out = reference.infer(&input, Some(&targets));
+    let ref_allocs = ALLOCS.load(Ordering::Relaxed);
+    let ref_peak = PEAK.load(Ordering::Relaxed);
+    std::hint::black_box(&out);
+
+    reset_counters();
+    let out = engine.infer(&input, Some(&targets));
+    let new_allocs = ALLOCS.load(Ordering::Relaxed);
+    let new_peak = PEAK.load(Ordering::Relaxed);
+    std::hint::black_box(&out);
+
+    println!("allocations for one supervised `infer` ({STEPS} steps):");
+    println!("  pre-#389 : {ref_allocs:>5} allocations, peak {ref_peak:>7} bytes");
+    println!("  shipped  : {new_allocs:>5} allocations, peak {new_peak:>7} bytes");
+    println!(
+        "  delta    : {:>5} fewer allocations ({:.1}%)\n",
+        ref_allocs.saturating_sub(new_allocs),
+        pct(ref_allocs as f64, new_allocs as f64)
+    );
+
+    // --- Wall clock: tight A/B alternation, fastest round on each side.
+    //
+    // One call per side per round, alternating, so the two sides sit inside the
+    // same scheduling window. Reported as the minimum over ROUNDS: on a loaded
+    // machine (this harness is expected to run alongside other work) every
+    // sample is the true cost *plus* interference, so the minimum is the
+    // closest available estimate of the true cost and the mean is not. ---
+    let mut ref_best = f64::INFINITY;
+    let mut new_best = f64::INFINITY;
+    let mut ref_batch_best = f64::INFINITY;
+    let mut new_batch_best = f64::INFINITY;
+
+    // Warm up both sides so first-touch page faults land outside the timing.
+    for _ in 0..REPS {
+        std::hint::black_box(reference.infer(&input, Some(&targets)));
+        std::hint::black_box(engine.infer(&input, Some(&targets)));
+    }
+
+    for _ in 0..ROUNDS {
+        let start = Instant::now();
+        std::hint::black_box(reference.infer(&input, Some(&targets)));
+        ref_best = ref_best.min(start.elapsed().as_secs_f64());
+
+        let start = Instant::now();
+        std::hint::black_box(engine.infer(&input, Some(&targets)));
+        new_best = new_best.min(start.elapsed().as_secs_f64());
+    }
+
+    for _ in 0..BATCH_ROUNDS {
+        let start = Instant::now();
+        std::hint::black_box(reference.infer_batch(&batch_refs, Some(&batch_targets)));
+        ref_batch_best = ref_batch_best.min(start.elapsed().as_secs_f64());
+
+        let start = Instant::now();
+        std::hint::black_box(engine.infer_batch(&batch_refs, Some(&batch_targets)));
+        new_batch_best = new_batch_best.min(start.elapsed().as_secs_f64());
+    }
+
+    println!("wall clock — fastest of {ROUNDS} tightly alternated rounds:");
+    println!(
+        "  infer            pre-#389 {:>8.3} ms   shipped {:>8.3} ms   {:+.1}%",
+        ref_best * 1e3,
+        new_best * 1e3,
+        -pct(ref_best, new_best)
+    );
+    println!(
+        "  infer_batch/{BATCH}   pre-#389 {:>8.3} ms   shipped {:>8.3} ms   {:+.1}%  \
+         (fastest of {BATCH_ROUNDS})",
+        ref_batch_best * 1e3,
+        new_batch_best * 1e3,
+        -pct(ref_batch_best, new_batch_best)
+    );
+}


### PR DESCRIPTION
# [perf] PC settling loop — hoist per-step buffers, keep numerics bit-identical

## Summary

The predictive-coding settling loop (`PredictiveCodingEngine::infer`,
`neat-core/src/pc_inference.rs`) allocated two `Vec`s on every settling step and
recomputed each target neuron's pre-activation once per inbound edge. This PR
removes the per-step allocations — **104 → 4 allocations per `infer`, a 96%
reduction** — without changing a single result bit, and documents why the
per-edge derivative recompute is **left intact**. Closes #389.

Wall clock is unchanged (see [Evidence](#evidence)): the settling loop is
dominated by work that cannot be removed while preserving the numerics, so this
lands as a **memory-efficiency** win on the #383 milestone, not a speed one.
Two speed optimisations were tried and rejected on measurement; both are
recorded below so they are not re-attempted.

> **Landed in two parts.** The buffer hoist itself merged as PR #401. That PR
> cited a ~16% / ~8% speed-up measured against a benchmark that converged on
> iteration 1 and never ran the settling loop at all. This PR fixes the
> benchmark, adds the in-process A/B harness, and replaces those figures with
> the measured result. The numbers below supersede PR #401's.

### What changed

1. **`compute_errors_into(latents, predictions, errors)`** — writes prediction
   errors into caller-owned buffers. `compute_errors` is retained as a thin
   allocating wrapper (test-only, exercised by a wrapper-equivalence unit test).
2. **Hoisted working buffers** — a private `PcScratch { latents, predictions,
   errors }` is allocated once per `infer` call and reused across every settling
   step via `compute_errors_into`. The settling loop is now O(1) allocations in
   `inference_steps` instead of `2 × (steps + 1)`.
3. **`infer_batch` reuses one `PcScratch` across all samples** — the per-step
   working `Vec`s are allocated once for the whole batch rather than once per
   sample. Each sample's result owns its own copy of the final settled state.
4. **Criterion `pc_inference` group + `pc_infer_ab` example** — the benchmark
   the issue asked for, plus an in-process A/B against a standalone pre-#389
   reference implementation.

### Semantics: why the per-edge derivative recompute stays

The issue asked to precompute the squash derivative once per non-input neuron
per step. **This is not value-preserving here**, so it was not done.

The loop updates `latents[hidden_idx]` *inside* the step and reads those updates
back via `compute_pre_activation` when processing later hidden neurons in the
same step (Gauss-Seidel ordering). Whenever a target neuron's inbound sum reads
a latent already updated this step — which happens for any target with ≥2 hidden
inbound sources (common in multi-layer topologies) — a step-start derivative
cache would return a different value and silently change the results.

The aliasing is in fact **total**, not occasional: every hidden neuron that
reads target `T`'s pre-activation is by definition an inbound source of `T`, and
it updates its own latent immediately after that read. So the next reader of `T`
always sees a changed inbound sum, and a dirty-flag cache would never get a
hit. Per the acceptance criteria, only the provably-non-aliasing work (the
allocation optimisations) was hoisted; the derivative recompute is preserved and
annotated in the code. A byte-exact incremental pre-activation cache was also
rejected: f32 addition is non-associative, so incremental accumulation would not
be bit-identical to the full per-edge recompute.

```mermaid
flowchart TD
    A["infer / infer_batch"] --> B["PcScratch::for_engine<br/>(allocate once)"]
    B --> C["settle(input, targets, &mut scratch)"]
    C --> D["reset latents, clamp inputs,<br/>init from forward prediction"]
    D --> E{"for step in 0..inference_steps"}
    E -->|"energy ≤ threshold"| H["converged"]
    E -->|otherwise| F["update hidden latents<br/>(per-edge derivative recompute —<br/>Gauss-Seidel, unchanged)"]
    F --> G["compute_errors_into<br/>(reuses scratch buffers)"]
    G --> E
    H --> I["result owns final state<br/>(move for infer, clone per sample<br/>for infer_batch)"]
```

## Evidence

Backend/CLI change — no UI, so no screenshot. Verified by tests plus an A/B on a
production-shaped PC topology (32 inputs → 96 → 96 → 48 hidden → 8 outputs,
fan-in 16, 3,968 synapses, 50 steps, `energy_threshold = 0`).

### Allocations — the measured win

`cargo run --release --example pc_infer_ab`, one supervised 50-step `infer`
under a counting global allocator:

| | Allocations | Peak live bytes |
| --- | --- | --- |
| pre-#389 | 104 | 5,292 |
| this PR | **4** | **3,308** |
| delta | **−100 (−96.2%)** | −1,984 (−37.5%) |

Four is the floor: they are exactly the four `Vec`s `PcInferenceResult` owns and
returns (`latents`, `predictions`, `errors`, `energy_history`). The count is now
independent of `inference_steps`; before, it was `4 + 2 × (steps + 1)`.

### Wall clock — no change

Same example, tight A/B alternation in one process, minimum of 400 rounds
(minimum, not mean: the host is shared, so every sample is the true cost plus
interference):

| Case | pre-#389 | this PR | Change |
| --- | --- | --- | --- |
| `infer` | 1.929–1.970 ms | 1.917–1.935 ms | −0.2% … −2.4% |
| `infer_batch/8` | 15.46–15.82 ms | 15.40–15.55 ms | ~0% |

**Honest reading: no wall-clock improvement.** The measured deltas sit inside
run-to-run noise on this host (load average ~16 on 12 cores). The loop's cost is
`O(edges × fan-in)` dependent-f32-add chains plus one transcendental derivative
per edge, and neither can be reduced without changing the numerics — so removing
100 allocations out of a 1.9 ms call is not visible. The change is neutral on
speed and large on allocation pressure; it does not regress either.

### Rejected optimisations (negative results — do not re-attempt)

- **Per-step derivative cache** — not value-preserving; see above. Rejected on
  correctness, before measurement.
- **Structure-of-arrays inward connections + CSR outward adjacency.** Replacing
  the 16-byte `PcConnection` walk with parallel `Vec<u32>`/`Vec<f32>` arrays,
  and the `Vec<Vec<PcOutwardConnection>>` outward map with a CSR triple carrying
  the target's relative index and squash type inline. Implemented, verified
  bit-identical, and measured **1.1–1.8% slower** on `infer` across repeated
  runs. The topology's hot arrays (≈63 KB) already sit in cache, so the layout
  change bought nothing while the extra parallel-array bounds checks cost a
  little. Reverted — the simpler array-of-structs walk stays.

### Benchmark correctness fix

The `pc_inference` Criterion case originally ran **unsupervised** (`targets =
None`). That is not a settling benchmark: `infer` initialises every non-input
latent from its own forward prediction, so the first error vector is exactly
zero, energy is `0.0`, and the loop converges and exits on iteration 1. It was
timing initialisation — 12 µs instead of the 5.9 ms a real 50-step settle costs,
a 450× understatement. Both cases are now supervised and the bench asserts
`steps_used == 50`, so a fixture that starts converging early fails loud.

### Base-branch repair (unrelated to #389, required to get here)

The milestone branch's own `Merge branch 'Develop'` (9befd1d) auto-resolved two
files without conflict markers and produced code that **does not compile**,
blocking every PR that targets it. Repaired on the milestone branch directly
as commit `7492a4b`, which is now part of the base, so it is not in this PR's
diff:

- `topology_ops.rs` — PRs #399 (Develop) and #400 (milestone) both rewrote
  `compute_reverse_topological_order` for Issue #388; the hunks did not overlap
  textually, so both CSR builds were concatenated (two prefix-sum passes, a
  `u32`/`usize` type error, a duplicated `tests` module). Resolved to the
  milestone side's file, with Develop's three extra differential tests
  re-appended so trunk keeps that coverage.
- `hot_paths.rs` — the merge took Develop's import line verbatim, dropping
  `scan_available_connections` and `TrainingDataConfig` while keeping the bench
  bodies that use them.

## Test Plan

New tests (all `cargo test` green; existing `tests/pc_inference.rs` and
`tests/pc_learning.rs` unchanged and green):

- `tests/pc_inference.rs::infer_scratch_buffers_match_baseline` — differential
  equivalence: asserts `infer` is **bit-identical** (`latents`, `predictions`,
  `errors`, `final_energy`, `energy_history`, `steps_used`, `converged`) to a
  standalone reproduction of the pre-change algorithm, over 40 randomised
  multi-fan-in topologies × {supervised, unsupervised} × {converged-early,
  steps-exhausted}.
- `tests/pc_inference.rs::infer_batch_matches_per_sample_bit_identical` —
  `infer_batch` with a reused scratch is byte-identical to independent `infer`
  calls, including a sample shorter than `num_inputs` to exercise the
  latent-reset (no stale-buffer leak).
- `tests/pc_inference_allocations.rs` — O(1)-allocation regression for the
  settling loop (`infer` and `infer_batch`): the allocation count barely moves
  between a 10-step and a 500-step run (delta < 20). Before the fix a 500-step
  run allocated ~980 more times.
- `src/pc_inference.rs::tests::compute_errors_wrapper_matches_into` — the
  `compute_errors` wrapper matches `compute_errors_into`.
- `examples/pc_infer_ab.rs` — asserts bit-identity against the pre-#389
  reference on both the supervised and unsupervised paths before it reports any
  numbers, so the A/B cannot quote a figure for a changed answer.
- Repaired base: the three `reverse_topological_order_matches_reference_*`
  differential tests carried over from Develop.

## Quality gate

`./quality.sh` — fmt, clippy `-D warnings`, `cargo deny`, the full workspace
test suite, `cargo doc -D warnings` and the release build.

## Security self-check

Backend numeric change only. No new external input, no injection surface, no
secrets or `.config*.json` staged, no new dependencies. The only new `unsafe`
code is the counting `GlobalAlloc` in `examples/pc_infer_ab.rs`, which forwards
an unchanged `Layout` to `System` — the same delegation pattern as the existing
`examples/reverse_topo_order_alloc_ab.rs` — and it ships in an example, not in
the library.
