### PR TITLE
[gate] quality.sh bats: perf sources still name private trainer internal scripts (memory_calc.sh, worker/learn.sh) (Issue #397)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,19 @@ jobs:
           done < <(find . -name "*.sh" -not -path "./target/*" -not -path "./.git/*")
           exit "$exit_code"
 
+      # Issue #397 — the bats suite (which holds the Issue #375 public-safety
+      # assertions over tests/perf/) was enforced by the local quality.sh gate
+      # only, so a regression landed on Develop green and surfaced on a
+      # contributor's machine. Run it here so that class fails on the PR.
+      - name: Install bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+          bats --version
+
+      - name: Run bash helper tests (bats)
+        run: bats tests/scripts
+
       - name: Run codespell
         # codespell-project/actions-codespell@v2.2
         uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.24"
+version = "0.2.25"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ sequenceDiagram
 | `.github/workflows/ci.yml` | CI gate. The `rust-gates` job runs the lint (`cargo clippy -D warnings`) and compile/syntax (`cargo check --all-targets`) gates on **every push to `Develop`** (and `workflow_dispatch`); on pull requests the `quality` job — the full PR pipeline — runs the same clippy gate, so `rust-gates` is skipped there rather than compiling the workspace twice (Issue #337). |
 | `bump-deps.sh` | Cargo dep refresh + audit + native/WASM build ([Vibe Coder](#glossary-vibe-coder) hook). |
 | `.github/dependabot.yml` | Advisory-triggered security-update fast lane — raises a fix PR the moment a RustSec/OSV advisory lands, independent of the weekly bump. |
-| `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`). |
+| `tests/scripts/` | `bats` suites for shell helpers (e.g. `bump-deps.sh`), workflow contracts and published-artefact guards. Runs in `./quality.sh` **and** in the CI `scripts-and-spelling` job (Issue #397), so a regression fails on the PR rather than on a contributor's machine. |
 | `LICENSE`, `.gitleaks.toml` | Inherited from NEAT-AI `Develop`. |
 
 ## Build

--- a/docs/archive/pr-summaries/pr-summary-397.md
+++ b/docs/archive/pr-summaries/pr-summary-397.md
@@ -1,0 +1,96 @@
+## Summary
+
+`./quality.sh` was red at the bats stage on a clean tree: two assertions from the
+Issue #375 public-safety gate fired on `tests/perf/learn_flags_wiring.ts`, whose
+comments still named the private trainer's internal scripts. Reworded those four
+comments to concept level in the style #382 used elsewhere in the same file, and
+closed the CI gap that let the regression land green. Closes #397.
+
+Two changes:
+
+1. **`tests/perf/learn_flags_wiring.ts`** — four comments reworded to concept
+   level ("the shared memory-budget helper", "the learn launcher script"), so no
+   private internal script path is published. The tests themselves are unchanged;
+   only prose moved.
+2. **`.github/workflows/ci.yml`** — the `scripts-and-spelling` job now installs
+   bats and runs `bats tests/scripts`. It previously ran shellcheck, `bash -n`
+   and codespell only, so the whole bats suite — including the #375 guard — was
+   enforced by the local `quality.sh` gate alone. That is why the regression
+   survived #382 and only surfaced on a contributor's machine. The job's
+   `timeout-minutes: 15` comment already claimed "shellcheck + bats + codespell";
+   the step is now really there. No bats test compiles Rust, so the job stays
+   fast.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — local-gate only"]
+        A[PR] --> B["scripts-and-spelling:<br/>shellcheck, bash -n, codespell"] --> C["green ✅"]
+        D["contributor runs ./quality.sh"] --> E["bats fails ❌<br/>(after merge)"]
+    end
+    subgraph after["After — #397"]
+        F[PR] --> G["scripts-and-spelling:<br/>shellcheck, bash -n, <b>bats</b>, codespell"]
+        G --> H["regression fails on the PR ❌"]
+    end
+```
+
+## Evidence
+
+Backend/CLI and CI-config change — no web interface to screenshot. Evidence is
+the gate output before and after.
+
+**Before** (clean tree, `bats tests/scripts/perf_private_repo_reference.bats
+tests/scripts/private_repo_reference.bats`):
+
+```
+not ok 4 perf sources name none of the private trainer's internal scripts
+not ok 14 perf acceptance models reference no private internal script paths
+```
+
+Four lines in `tests/perf/learn_flags_wiring.ts` tripped the gate — the
+FFI/OS-headroom constant doc comment (`:31`), the two `Mirror of …` doc comments
+on `heapFloorMb` (`:57`) and `selectMaxOldSpaceSizeMb` (`:80`), and the
+`learnV8HeapFlag` doc comment (`:95`). Each named a private internal script by
+path; they are not reproduced here, since this summary is published from the same
+public repository the gate protects.
+
+**After** — all 15 assertions in both gate files pass:
+
+```
+1..15
+ok 1 all four perf acceptance-model files exist
+...
+ok 4 perf sources name none of the private trainer's internal scripts
+...
+ok 14 perf acceptance models reference no private internal script paths
+ok 15 perf acceptance models link the renamed lane (d) doc, not the old name
+```
+
+The new CI-gate tests failed first (TDD) against the unmodified workflow, then
+passed once the bats step landed:
+
+```
+not ok 2 scripts-and-spelling job installs bats
+not ok 3 scripts-and-spelling job runs the bats suite over tests/scripts
+not ok 4 the bats step is named so a failure is attributable
+not ok 5 the bats step does not swallow a failing suite
+```
+
+`actionlint` passes against the modified workflow
+(`tests/scripts/actionlint_workflow.bats::actionlint passes against the current
+workflows on disk`), and `deno test tests/perf/learn_flags_wiring_test.ts`
+reports `13 passed | 0 failed` — the reworded comments changed no behaviour.
+
+## Test Plan
+
+- **New** `tests/scripts/ci_bats_gate.bats` (5 assertions) — parses the committed
+  `ci.yml` and asserts the observable job contract: `scripts-and-spelling`
+  installs bats, runs `bats tests/scripts`, names that step so a failure is
+  attributable, and does not swallow a failing suite via `|| true` or
+  `continue-on-error`. All four substantive assertions fail against the
+  pre-change workflow.
+- **Existing, now green** `tests/scripts/perf_private_repo_reference.bats::perf
+  sources name none of the private trainer's internal scripts` and
+  `tests/scripts/private_repo_reference.bats::perf acceptance models reference no
+  private internal script paths` — the two regression assertions named in the
+  issue. No existing test was modified or removed.
+- Full `bats tests/scripts` suite green; `./quality.sh` green.

--- a/tests/perf/learn_flags_wiring.ts
+++ b/tests/perf/learn_flags_wiring.ts
@@ -28,7 +28,7 @@
 // See `docs/research/wasm64-lane-d-learn-wiring-verification.md`.
 
 /** Fixed headroom (MB) reserved for Rust FFI + OS caches before apportioning to
- * V8 — `MEMORY_FFI_OS_HEADROOM_MB` in memory_calc.sh (#1768). */
+ * V8 — the FFI/OS-headroom constant in the shared memory-budget helper. */
 export const FFI_OS_HEADROOM_MB = 1536;
 /** Share of the post-headroom budget granted to V8 (`get_max_heap_size` default). */
 export const HEAP_PERCENTAGE = 65;
@@ -54,7 +54,7 @@ export interface HostMemory {
 }
 
 /**
- * Mirror of `memory_calc.sh get_heap_floor_mb`. Hosts below 8 GB keep the global
+ * Mirror of the shared memory-budget helper's `get_heap_floor_mb`. Hosts below 8 GB keep the global
  * 1536 MB floor. The 8 GB tier uses a 3072 MB working-set floor that steps
  * **down** on a constrained host (available-aware, #3342, always on for the
  * learn/teams victim): capped at a minority share (45%) of *available* RAM but
@@ -77,7 +77,7 @@ export function heapFloorMb(host: HostMemory): number {
 }
 
 /**
- * Mirror of `memory_calc.sh get_max_heap_size`: the `--max-old-space-size` value
+ * Mirror of the shared memory-budget helper's `get_max_heap_size`: the `--max-old-space-size` value
  * (MB) the downstream trainer's learn invocation selects for a host.
  *
  *   heap = clamp((available - FFI_OS_HEADROOM) * 65%, floor(total) .. 24576)
@@ -92,7 +92,7 @@ export function selectMaxOldSpaceSizeMb(host: HostMemory): number {
   return heap;
 }
 
-/** The exact `--v8-flags` token `worker/learn.sh` injects for the learn stage. */
+/** The exact `--v8-flags` token the learn launcher script injects for the learn stage. */
 export function learnV8HeapFlag(host: HostMemory): string {
   return `--v8-flags=--max-old-space-size=${selectMaxOldSpaceSizeMb(host)}`;
 }

--- a/tests/scripts/ci_bats_gate.bats
+++ b/tests/scripts/ci_bats_gate.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# Tests for the CI bats gate (Issue #397).
+#
+# Contract under test: the `scripts-and-spelling` job in
+# .github/workflows/ci.yml must actually run `bats tests/scripts`. Before #397
+# that job ran shellcheck, `bash -n` and codespell only, so the whole bats suite
+# — including the Issue #375 public-safety assertions over `tests/perf/` — was
+# enforced by the local `quality.sh` gate alone. A regression therefore landed on
+# `Develop` green and only surfaced on a contributor's machine.
+#
+# These are "what" tests over the published workflow: they parse the committed
+# YAML and assert on the observable job contract (a step that installs bats, a
+# step that runs the suite), the same style as the other workflow tests in this
+# directory.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+require_python() {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+}
+
+# Emit every `run:` script in the scripts-and-spelling job, one per line-block.
+job_run_steps() {
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1]))
+job = data["jobs"]["scripts-and-spelling"]
+for step in job["steps"]:
+    run = step.get("run")
+    if run:
+        print(run)
+PY
+}
+
+@test "ci workflow file exists" {
+  [ -f "$WORKFLOW" ]
+}
+
+@test "scripts-and-spelling job installs bats" {
+  require_python
+  run python3 - "$WORKFLOW" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1]))
+job = data["jobs"]["scripts-and-spelling"]
+installs = [
+    line
+    for step in job["steps"]
+    for line in (step.get("run") or "").splitlines()
+    if "apt-get install" in line and "bats" in line.split()
+]
+assert installs, "no step apt-get installs bats"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "scripts-and-spelling job runs the bats suite over tests/scripts" {
+  require_python
+  run job_run_steps
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bats tests/scripts"* ]]
+}
+
+@test "the bats step is named so a failure is attributable" {
+  require_python
+  run python3 - "$WORKFLOW" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1]))
+job = data["jobs"]["scripts-and-spelling"]
+names = [
+    s.get("name", "")
+    for s in job["steps"]
+    if "bats tests/scripts" in (s.get("run") or "")
+]
+assert names, "no step runs `bats tests/scripts`"
+assert all(n.strip() for n in names), f"bats step has no name: {names!r}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "the bats step does not swallow a failing suite" {
+  # Fail loud: the runner must not be piped into `|| true` or `continue-on-error`.
+  require_python
+  run python3 - "$WORKFLOW" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1]))
+job = data["jobs"]["scripts-and-spelling"]
+found = False
+for step in job["steps"]:
+    run = step.get("run") or ""
+    if "bats tests/scripts" not in run:
+        continue
+    found = True
+    assert "|| true" not in run, "bats failure is swallowed by `|| true`"
+    assert step.get("continue-on-error") is not True, (
+        "bats step sets continue-on-error"
+    )
+assert found, "no step runs `bats tests/scripts`"
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`./quality.sh` was red at the bats stage on a clean tree: two assertions from the
Issue #375 public-safety gate fired on `tests/perf/learn_flags_wiring.ts`, whose
comments still named the private trainer's internal scripts. Reworded those four
comments to concept level in the style #382 used elsewhere in the same file, and
closed the CI gap that let the regression land green. Closes #397.

Two changes:

1. **`tests/perf/learn_flags_wiring.ts`** — four comments reworded to concept
   level ("the shared memory-budget helper", "the learn launcher script"), so no
   private internal script path is published. The tests themselves are unchanged;
   only prose moved.
2. **`.github/workflows/ci.yml`** — the `scripts-and-spelling` job now installs
   bats and runs `bats tests/scripts`. It previously ran shellcheck, `bash -n`
   and codespell only, so the whole bats suite — including the #375 guard — was
   enforced by the local `quality.sh` gate alone. That is why the regression
   survived #382 and only surfaced on a contributor's machine. The job's
   `timeout-minutes: 15` comment already claimed "shellcheck + bats + codespell";
   the step is now really there. No bats test compiles Rust, so the job stays
   fast.

```mermaid
flowchart LR
    subgraph before["Before — local-gate only"]
        A[PR] --> B["scripts-and-spelling:<br/>shellcheck, bash -n, codespell"] --> C["green ✅"]
        D["contributor runs ./quality.sh"] --> E["bats fails ❌<br/>(after merge)"]
    end
    subgraph after["After — #397"]
        F[PR] --> G["scripts-and-spelling:<br/>shellcheck, bash -n, <b>bats</b>, codespell"]
        G --> H["regression fails on the PR ❌"]
    end
```

## Evidence

Backend/CLI and CI-config change — no web interface to screenshot. Evidence is
the gate output before and after.

**Before** (clean tree, `bats tests/scripts/perf_private_repo_reference.bats
tests/scripts/private_repo_reference.bats`):

```
not ok 4 perf sources name none of the private trainer's internal scripts
not ok 14 perf acceptance models reference no private internal script paths
```

Four lines in `tests/perf/learn_flags_wiring.ts` tripped the gate — the
FFI/OS-headroom constant doc comment (`:31`), the two `Mirror of …` doc comments
on `heapFloorMb` (`:57`) and `selectMaxOldSpaceSizeMb` (`:80`), and the
`learnV8HeapFlag` doc comment (`:95`). Each named a private internal script by
path; they are not reproduced here, since this summary is published from the same
public repository the gate protects.

**After** — all 15 assertions in both gate files pass:

```
1..15
ok 1 all four perf acceptance-model files exist
...
ok 4 perf sources name none of the private trainer's internal scripts
...
ok 14 perf acceptance models reference no private internal script paths
ok 15 perf acceptance models link the renamed lane (d) doc, not the old name
```

The new CI-gate tests failed first (TDD) against the unmodified workflow, then
passed once the bats step landed:

```
not ok 2 scripts-and-spelling job installs bats
not ok 3 scripts-and-spelling job runs the bats suite over tests/scripts
not ok 4 the bats step is named so a failure is attributable
not ok 5 the bats step does not swallow a failing suite
```

`actionlint` passes against the modified workflow
(`tests/scripts/actionlint_workflow.bats::actionlint passes against the current
workflows on disk`), and `deno test tests/perf/learn_flags_wiring_test.ts`
reports `13 passed | 0 failed` — the reworded comments changed no behaviour.

## Test Plan

- **New** `tests/scripts/ci_bats_gate.bats` (5 assertions) — parses the committed
  `ci.yml` and asserts the observable job contract: `scripts-and-spelling`
  installs bats, runs `bats tests/scripts`, names that step so a failure is
  attributable, and does not swallow a failing suite via `|| true` or
  `continue-on-error`. All four substantive assertions fail against the
  pre-change workflow.
- **Existing, now green** `tests/scripts/perf_private_repo_reference.bats::perf
  sources name none of the private trainer's internal scripts` and
  `tests/scripts/private_repo_reference.bats::perf acceptance models reference no
  private internal script paths` — the two regression assertions named in the
  issue. No existing test was modified or removed.
- Full `bats tests/scripts` suite green; `./quality.sh` green.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms1rloj7-02fe8f`<!-- vibe-worker-issue-397 -->