### PR TITLE
Migrate remaining callers to the flat scoring entry points and deprecate score_records / score_records_parallel (Issue #408)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.2.27"
+version = "0.2.28"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ Basic validity only — it is not a style or lint gate, and it requires
 
 | Feature | Default | Effect |
 |---------|---------|--------|
-| `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
+| `parallel` | off | Native-only data-parallel record scoring via `rayon` (Issue #179). Adds `CompiledNetwork::score_records_parallel_flat`, which chunks records across the rayon pool. Off by default, so the default build and the `wasm32` build pull in **no** `rayon` symbols and keep their single-thread path. |
 
 Scoring a production-size dataset pushes many records through one [creature](#glossary-creature) — an
-embarrassingly parallel workload *across records*. Both `score_records` and
-`score_records_parallel` drive the forward pass through the **8-record batched
-SIMD path** (Issue #230): records are grouped into 8s (then a 4-record group,
+embarrassingly parallel workload *across records*. Both `score_records_flat`
+and `score_records_parallel_flat` drive the forward pass through the **8-record
+batched SIMD path** (Issue #230): records are grouped into 8s (then a 4-record group,
 then a scalar tail) and forwarded through `weighted_sum_simd_8records` /
 `weighted_sum_simd_4records`, loading each synapse weight once and applying it
 across the lanes. On the gather-bound production topology this cut single-core
@@ -125,7 +125,8 @@ With the `parallel` feature the throughput additionally scales with core count.
 On the exact committed production topology the native lane beats the wasm32 lane
 **1.78×** per core (NEON + FMA vs `simd128` + relaxed-madd) and **4.75×** at 12
 cores versus a single-threaded wasm32 creature — so where the native `rust_scorer`
-is built, production per-creature scoring should use `score_records_parallel`.
+is built, production per-creature scoring should use
+`score_records_parallel_flat`.
 See the native-vs-wasm32 decision, numbers, and the generation-end idle-core
 "win zone" in [`neat-core/benches/BASELINE.md`](neat-core/benches/BASELINE.md)
 (Issue #288).
@@ -137,11 +138,11 @@ bit-for-bit. Output order always matches input order.
 
 ```rust
 // Off-feature / wasm: transparently runs sequentially (still batched SIMD).
-let outputs = net.score_records(&records, num_outputs);
+let outputs = net.score_records_flat(&inputs, stride, num_outputs);
 
 // With `--features parallel` on native: batches scored across the rayon pool,
 // same results, in input order.
-let outputs = net.score_records_parallel(&records, num_outputs);
+let outputs = net.score_records_parallel_flat(&inputs, stride, num_outputs);
 ```
 
 ### Flat record input (Issue #386)
@@ -165,9 +166,12 @@ net.score_records_flat_into(&inputs, stride, num_outputs, &mut out);
 let outputs = net.score_records_parallel_flat(&inputs, stride, num_outputs);
 ```
 
-The `&[Vec<f32>]` entry points remain and drive the identical kernel, so the two
-layouts are **bit-identical** — asserted across the 8-record group boundary and
-both dispatch arms by
+The per-record `&[Vec<f32>]` entry points (`score_records`,
+`score_records_parallel`) are **deprecated** since `0.2.28` (Issue #408) and
+scheduled for removal (Issue #409); every in-repo caller now uses the flat ones.
+They still drive the identical kernel, so the two layouts are
+**bit-identical** — asserted across the 8-record group boundary and both
+dispatch arms by
 [`tests/flat_record_scoring_parity.rs`](neat-core/tests/flat_record_scoring_parity.rs).
 A malformed batch (zero `stride`, or a buffer that is not a whole number of
 records) **panics** rather than silently mis-slicing every record.
@@ -175,8 +179,8 @@ records) **panics** rather than silently mis-slicing every record.
 ```mermaid
 flowchart LR
     R[records] --> S{parallel feature?}
-    S -- off / wasm32 --> Q[score_records<br/>sequential, batched SIMD]
-    S -- on, native --> P[score_records_parallel<br/>rayon chunks]
+    S -- off / wasm32 --> Q[score_records_flat<br/>sequential, batched SIMD]
+    S -- on, native --> P[score_records_parallel_flat<br/>rayon chunks]
     P --> W1[worker 1<br/>own lane scratch]
     P --> Wn[worker N<br/>own lane scratch]
     subgraph B[batched forward per chunk]

--- a/docs/archive/pr-summaries/pr-summary-408.md
+++ b/docs/archive/pr-summaries/pr-summary-408.md
@@ -1,0 +1,143 @@
+# Migrate remaining callers to the flat scoring entry points, deprecate the per-record ones
+
+## Summary
+
+Phase 2 of the flat-slice migration started by #386: every remaining in-repo
+caller of the per-record `&[Vec<f32>]` scoring API now uses the flat entry
+points, and the old wrappers are marked `#[deprecated]`. Warning-only by design
+— nothing is deleted, so no consumer can break. Removal is tracked separately by
+Issue #409 and deliberately does **not** land here. Closes #408.
+
+What changed:
+
+1. **Deprecation** — `CompiledNetwork::score_records` and **both** `cfg` arms of
+   `CompiledNetwork::score_records_parallel` carry
+   `#[deprecated(since = "0.2.28", note = "use score_records_flat / score_records_parallel_flat (Issue #386)")]`.
+   The sequential fallback arm now drives the shared `score_batch_alloc` helper
+   directly instead of calling `score_records`, so it needs no
+   `allow(deprecated)` of its own.
+2. **Callers migrated** to `score_records_flat` / `score_records_parallel_flat`,
+   with each fixture flattened into the contiguous `record * stride` layout at
+   construction time (outside any measured or timed region):
+
+   | File | Sites |
+   |---|---|
+   | `neat-core/benches/hot_paths.rs` | `scoring` group |
+   | `neat-core/benches/parallel_scoring.rs` | `score_in_pool` (missed by the issue's ground-truth table) |
+   | `neat-core/tests/parallel_scoring.rs` | 11 sites (missed by the issue's ground-truth table) |
+   | `neat-core/tests/bench_fixtures.rs` | production-batch smoke test |
+   | `neat-core/tests/score_squash_simd_parity.rs` | `assert_parity` |
+   | `neat-core/tests/interleaved_scoring_parity.rs` | 3 sites |
+   | `neat-core/tests/scoring_allocations.rs` | 2 sites |
+
+3. **Parity test kept on both APIs** — `flat_record_scoring_parity.rs` exists
+   precisely to compare the two layouts, so its three oracle call sites carry
+   `#[allow(deprecated)]` with a comment naming the deletion issue (#409). These
+   are the only `allow(deprecated)` sites in the tree.
+4. **Version + docs** — workspace version `0.2.27 → 0.2.28` (patch: deprecation
+   is non-breaking under `RELEASING.md`), and the deprecation is noted in the
+   `parallel_scoring` module docs and `README.md`. There is no `CHANGELOG.md` in
+   this repo — the `v<version>` GitHub release cut by `release.yml` is the
+   release note, so the version bump plus the README/module-doc note is how the
+   project normally records this.
+
+### Bench-group note
+
+`hot_paths` carried two groups measuring the same shard: `scoring` (per-record
+input) and `scoring_flat` (flat input), added by #386 as a deliberate A/B of the
+two input layouts. With the per-record entry point deprecated there is no second
+layout left to compare against, so migrating `scoring` would have made the two
+groups byte-for-byte identical. The long-running `scoring/production/*` baseline
+series in `benches/BASELINE.md` is kept and now drives `score_records_flat`; the
+redundant `scoring_flat` group is retired. `benches/README.md` and the group's
+doc comment both say so.
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. The
+evidence is the compiler: CI builds with `RUSTFLAGS="-D warnings"`, which turns
+`deprecated` into a hard error, so a missed caller fails the build rather than
+sliding through. `./quality.sh` is green, including
+`cargo clippy --workspace --all-targets --all-features -- -D warnings` and the
+same lint run under the **default** feature set (which is what compiles the
+`cfg(not(parallel))` fallback arm).
+
+```
+🔧 Running linter...
+    Finished `dev` profile
+✅ Running type checks...
+🧪 Running tests...
+📖 Building documentation...
+🏗️ Building release...
+✅ All quality checks passed!
+```
+
+Migrated suites, all green and with unchanged expected values:
+
+```
+test result: ok. 15 passed  (bench_fixtures)
+test result: ok.  8 passed  (flat_record_scoring_parity)
+test result: ok.  3 passed  (interleaved_scoring_parity)
+test result: ok.  9 passed  (parallel_scoring)
+test result: ok.  3 passed  (score_squash_simd_parity)
+test result: ok.  1 passed  (scoring_allocations)
+```
+
+Sequential phasing agreed by the parent issue, and where this PR sits:
+
+```mermaid
+flowchart LR
+    A["#386 — add flat entry points<br/>score_records_flat / _parallel_flat"] --> B
+    B["#408 — migrate callers<br/>+ #deprecated (this PR)"] --> C
+    C["#409 — delete wrappers<br/>+ RecordBatch::PerRecord"]
+    B -.->|"warning-only,<br/>no consumer can break"| B
+```
+
+Call-site shape after the migration:
+
+```mermaid
+flowchart TD
+    F["fixture: Vec&lt;Vec&lt;f32&gt;&gt;"] --> FL["flatten at construction<br/>(outside timed / measured region)"]
+    FL --> I["inputs: &amp;[f32], stride"]
+    I --> S{"parallel feature?"}
+    S -- "off / wasm32" --> Q["score_records_flat"]
+    S -- "on, native" --> P["score_records_parallel_flat"]
+    Q --> K["score_batch_into<br/>(shared kernel, pub(crate) — not deprecated)"]
+    P --> K
+    K --> O["flat outputs, input order"]
+    D["score_records /<br/>score_records_parallel<br/>#deprecated"] -.->|"only caller left:<br/>flat_record_scoring_parity.rs"| K
+```
+
+## Test Plan
+
+No new behaviour is introduced, so no new tests: this is a call-site change and
+the existing parity/allocation suites are the regression guard. Every expected
+value and tolerance in the migrated files is unchanged — only the entry point
+and the input layout differ.
+
+Modified tests (all still asserting on observable outcomes, "what" not "how"):
+
+- `neat-core/tests/parallel_scoring.rs` — all 9 tests now score through
+  `score_records_flat` / `score_records_parallel_flat`; the independent
+  per-record `activate` reference is untouched, as are `TOL`, the tail-boundary
+  counts `[0,1,2,3,4,5,7,8,9,12,15,16,17,24,31,33]`, and the bit-identity
+  assertion between the sequential and parallel paths. `score_records_matches_reference`
+  is renamed `sequential_scoring_matches_reference` — it no longer names a
+  deprecated function, and the assertion is unchanged.
+- `neat-core/tests/interleaved_scoring_parity.rs` — both dispatch arms
+  (interleaved fast path, aggregate per-lane fallback) and the exact
+  single-record bit-identity case, across counts `[1,7,8,9,16,17]`, `TOL` 2e-3.
+- `neat-core/tests/score_squash_simd_parity.rs` — `assert_parity` scores the
+  flattened batch; the scalar `activate` reference and `TOL` 1e-3 are unchanged.
+- `neat-core/tests/scoring_allocations.rs` — the counting-allocator regression
+  now measures `score_records_flat`. Records are flattened in
+  `build_flat_records` *before* the measured window, so the flattening cost is
+  not counted; the `delta < 50` assertion is unchanged and still fails loudly if
+  per-record output allocation returns.
+- `neat-core/tests/bench_fixtures.rs` —
+  `score_records_on_production_batch_yields_finite_ordered_outputs` scores the
+  flat buffer; the flat-length and finiteness assertions are unchanged.
+- `neat-core/tests/flat_record_scoring_parity.rs` — **unchanged assertions**;
+  only `#[allow(deprecated)]` plus comments naming #409 were added. This suite
+  is what proves the deprecated and flat paths remain bit-identical, so it is
+  also the regression guard for the migration itself.

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -22,18 +22,20 @@ There are two bench targets:
 | `batched_scoring` | `activate_and_trace_batch_4way`, 8-record `mse_sum_batch_packed` (all shapes), production-sized `mse_sum_batch_packed` (`mse_sum_production`, Issue #384) | 8-record: same five shapes; `mse_sum_production`: `production`, `production_2x`, `production_exact` |
 | `backprop` | one `propagate_topological_loop` step | same five shapes |
 | `reverse_topological_order` | `compute_reverse_topological_order` over a creature's full synapse list (Issue #388) | all six shapes |
-| `scoring` | `CompiledNetwork::score_records` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
-| `scoring_flat` | `CompiledNetwork::score_records_flat` over the same batch in flat-slice input layout (Issue #386) | `production`, `production_2x`, `production_exact` |
+| `scoring` | `CompiledNetwork::score_records_flat` over a production-sized record batch | `production`, `production_2x`, `production_exact` |
 | `dataset_evaluate_mse` | `TrainingDataset::evaluate_mse` over a production-sized batch (Issue #386) | `production`, `production_2x`, `production_exact` |
 | `topology_ops` | `scan_available_connections` — the mutation-time availability scan (Issue #387); `compute_reverse_topological_order` — the per-creature backprop-ordering setup (Issue #388) | `n1666_21513`, `n4127_21513` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
 
 The `scoring` group (Issue #228) pushes a full production-sized record batch
-through one creature via `score_records`, so `hot_paths` reports single-core
-scoring throughput at production record volume alongside the parallel harness.
-It covers only the gather-bound `production` shapes and is reachable with the
-`production` filter (`--bench hot_paths -- production`).
+through one creature via `score_records_flat`, so `hot_paths` reports
+single-core scoring throughput at production record volume alongside the
+parallel harness. It covers only the gather-bound `production` shapes and is
+reachable with the `production` filter (`--bench hot_paths -- production`).
+Issue #408 retired the separate `scoring_flat` A/B group: with the per-record
+entry point deprecated there is no second input layout left to compare against,
+so `scoring` now *is* the flat measurement.
 
 The `topology_ops` group (Issue #387) covers the mutation-time helpers, which
 are not per-record hot paths but are paid repeatedly across the population every
@@ -52,9 +54,7 @@ shows up as a throughput drop here. `cargo run --release --example
 reverse_topo_order_alloc_ab` measures the same function's allocation count
 directly against the pre-#388 shape.
 
-`scoring_flat` scores the *same* shard through the flat-slice input entry point
-(Issue #386), so the delta against `scoring` isolates the cost of the per-record
-`Vec` header indirection. `dataset_evaluate_mse` measures the WASM
+`dataset_evaluate_mse` measures the WASM
 dataset-offload evaluation call (Issue #298) end to end at the same record
 volume — bounds check, forward pass and MSE accumulation.
 

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -200,47 +200,20 @@ fn bench_reverse_topological_order(c: &mut Criterion) {
 }
 
 /// Scoring throughput — a full production-shaped record batch pushed through
-/// one creature via `score_records` (Issue #228). Sized to
+/// one creature via `score_records_flat` (Issue #228, #386). Sized to
 /// [`PRODUCTION_SCORING_RECORDS`] so the single-core scoring figure in
 /// `hot_paths` is measured at production record volume, matching the
 /// `parallel_scoring` harness. Only the production shapes are gather-bound in
 /// the way real scoring is, so this group covers just `production` /
 /// `production_2x` and is reachable via `--bench hot_paths -- production`.
+///
+/// The records are flattened into the contiguous `record * stride` layout at
+/// fixture-construction time, outside the timed loop. Issue #408 retired the
+/// separate `scoring_flat` A/B group: with the per-record entry point
+/// deprecated there is no second input layout left to compare against, so
+/// `scoring` now *is* the flat measurement.
 fn bench_scoring(c: &mut Criterion) {
     let mut group = c.benchmark_group("scoring");
-    for spec in NETWORKS
-        .iter()
-        .filter(|s| s.label.starts_with("production"))
-    {
-        let net = build_network(spec, 0x5EED);
-        let records = build_records(net.num_inputs(), PRODUCTION_SCORING_RECORDS);
-        let num_outputs = spec.num_outputs;
-        group.throughput(Throughput::Elements(PRODUCTION_SCORING_RECORDS as u64));
-        group.bench_with_input(
-            BenchmarkId::from_parameter(spec.label),
-            &records,
-            |b, records| {
-                b.iter(|| {
-                    let out = net.score_records(black_box(records), black_box(num_outputs));
-                    black_box(out);
-                });
-            },
-        );
-    }
-    group.finish();
-}
-
-/// Flat-slice record **input** scoring — `score_records_flat` over the same
-/// production shard the `scoring` group scores as `&[Vec<f32>]` (Issue #386).
-///
-/// Same kernel, same records, same output layout; only the input layout differs,
-/// so the delta against `scoring` is the cost of the per-record `Vec` header
-/// pointer-chase on each lane load. The one-heap-allocation-per-record the
-/// `&[Vec<f32>]` signature forces on the *caller* is not measured here (both
-/// fixtures are built outside the timed loop) — it is pure additional saving for
-/// callers that already hold a contiguous buffer.
-fn bench_scoring_flat(c: &mut Criterion) {
-    let mut group = c.benchmark_group("scoring_flat");
     for spec in NETWORKS
         .iter()
         .filter(|s| s.label.starts_with("production"))
@@ -728,7 +701,6 @@ criterion_group!(
     bench_backprop,
     bench_reverse_topological_order,
     bench_scoring,
-    bench_scoring_flat,
     bench_dataset_evaluate_mse,
     bench_activation_primitives,
     bench_topology_ops,

--- a/neat-core/benches/parallel_scoring.rs
+++ b/neat-core/benches/parallel_scoring.rs
@@ -37,12 +37,13 @@ mod bench {
             .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
     }
 
-    /// Score `records` inside a rayon pool of exactly `threads` workers, so the
-    /// 1-core and all-core measurements share one code path and differ only in
-    /// pool size.
+    /// Score a flat `record * stride` input buffer (Issue #386) inside a rayon
+    /// pool of exactly `threads` workers, so the 1-core and all-core
+    /// measurements share one code path and differ only in pool size.
     fn score_in_pool(
         net: &CompiledNetwork,
-        records: &[Vec<f32>],
+        inputs: &[f32],
+        stride: usize,
         num_outputs: usize,
         threads: usize,
     ) -> Vec<f32> {
@@ -50,7 +51,7 @@ mod bench {
             .num_threads(threads)
             .build()
             .expect("failed to build rayon pool");
-        pool.install(|| net.score_records_parallel(records, num_outputs))
+        pool.install(|| net.score_records_parallel_flat(inputs, stride, num_outputs))
     }
 
     pub fn bench_parallel_scoring(c: &mut Criterion) {
@@ -61,21 +62,35 @@ mod bench {
         for label in ["production", "production_2x", "production_exact"] {
             let s = spec(label);
             let net = build_network(s, 0x5EED);
-            let records = build_records(net.num_inputs(), NUM_RECORDS);
+            let stride = net.num_inputs();
+            // Flattened at fixture-construction time, outside the timed loop.
+            let inputs: Vec<f32> = build_records(stride, NUM_RECORDS)
+                .into_iter()
+                .flatten()
+                .collect();
             let num_outputs = s.num_outputs;
 
             let mut group = c.benchmark_group(format!("score_records/{label}"));
             group.throughput(Throughput::Elements(NUM_RECORDS as u64));
 
             group.bench_function("1_core", |b| {
-                b.iter(|| black_box(score_in_pool(&net, black_box(&records), num_outputs, 1)))
+                b.iter(|| {
+                    black_box(score_in_pool(
+                        &net,
+                        black_box(&inputs),
+                        stride,
+                        num_outputs,
+                        1,
+                    ))
+                })
             });
 
             group.bench_function(format!("{all_cores}_cores"), |b| {
                 b.iter(|| {
                     black_box(score_in_pool(
                         &net,
-                        black_box(&records),
+                        black_box(&inputs),
+                        stride,
                         num_outputs,
                         all_cores,
                     ))

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -52,8 +52,13 @@
 //! matching flat layout: record `i`'s inputs are
 //! `inputs[i * stride .. i * stride + stride]`. Callers that already hold a
 //! contiguous buffer skip the one-heap-allocation-per-record marshalling the
-//! `&[Vec<f32>]` signatures force. The `&[Vec<f32>]` entry points remain, and
-//! both layouts feed the identical kernel, so their results are bit-identical.
+//! `&[Vec<f32>]` signatures force. Both layouts feed the identical kernel, so
+//! their results are bit-identical.
+//!
+//! The per-record `&[Vec<f32>]` entry points ([`CompiledNetwork::score_records`]
+//! and [`CompiledNetwork::score_records_parallel`]) are **deprecated** since
+//! `0.2.28` (Issue #408) — every in-repo caller now uses the flat entry points.
+//! They still compile and behave identically; removal is tracked by Issue #409.
 
 use crate::batch_scoring::{BatchScratch, RecordBatch};
 use crate::network::CompiledNetwork;
@@ -84,6 +89,17 @@ impl CompiledNetwork {
     /// This is the fallback used when the `parallel` feature is off or when
     /// building for `wasm32`, and the reference path the parallel results must
     /// match exactly.
+    ///
+    /// # Deprecated
+    ///
+    /// Superseded by [`CompiledNetwork::score_records_flat`] (Issue #386), which
+    /// takes the same records as one contiguous buffer and so avoids the
+    /// one-heap-allocation-per-record marshalling this signature forces on the
+    /// caller. Removal is tracked by Issue #409.
+    #[deprecated(
+        since = "0.2.28",
+        note = "use score_records_flat / score_records_parallel_flat (Issue #386)"
+    )]
     pub fn score_records(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         self.score_batch_alloc(RecordBatch::PerRecord(records), num_outputs)
     }
@@ -170,6 +186,15 @@ impl CompiledNetwork {
     /// the sequential path regardless of thread count.
     ///
     /// Available with the `parallel` feature on native targets.
+    ///
+    /// # Deprecated
+    ///
+    /// Superseded by [`CompiledNetwork::score_records_parallel_flat`] (Issue
+    /// #386). Removal is tracked by Issue #409.
+    #[deprecated(
+        since = "0.2.28",
+        note = "use score_records_flat / score_records_parallel_flat (Issue #386)"
+    )]
     #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
     pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
         use rayon::prelude::*;
@@ -195,9 +220,20 @@ impl CompiledNetwork {
     /// the `parallel` feature is disabled or building for `wasm32` (where
     /// `rayon` is unavailable). Same signature and identical results to the
     /// feature-on path — just single-threaded.
+    ///
+    /// # Deprecated
+    ///
+    /// Superseded by [`CompiledNetwork::score_records_parallel_flat`] (Issue
+    /// #386). Removal is tracked by Issue #409.
+    #[deprecated(
+        since = "0.2.28",
+        note = "use score_records_flat / score_records_parallel_flat (Issue #386)"
+    )]
     #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
     pub fn score_records_parallel(&self, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
-        self.score_records(records, num_outputs)
+        // Drives the shared sequential implementation directly rather than the
+        // deprecated `score_records`, so the fallback needs no `allow(deprecated)`.
+        self.score_batch_alloc(RecordBatch::PerRecord(records), num_outputs)
     }
 
     /// Flat-input counterpart of [`CompiledNetwork::score_records_parallel`]

--- a/neat-core/tests/bench_fixtures.rs
+++ b/neat-core/tests/bench_fixtures.rs
@@ -322,9 +322,12 @@ fn score_records_on_production_batch_yields_finite_ordered_outputs() {
     // exercising the exact fixture path the scoring benches time.
     let records = build_records(net.num_inputs(), 96);
 
-    // `score_records` returns a flat `[record * num_outputs]` buffer (Issue #229),
-    // so assert on the flat length and finiteness rather than per-record rows.
-    let out = net.score_records(&records, prod.num_outputs);
+    // `score_records_flat` takes the batch as one contiguous buffer (Issue #386)
+    // and returns a flat `[record * num_outputs]` buffer (Issue #229), so assert
+    // on the flat length and finiteness rather than per-record rows.
+    let stride = net.num_inputs();
+    let inputs: Vec<f32> = records.iter().flat_map(|r| r.iter().copied()).collect();
+    let out = net.score_records_flat(&inputs, stride, prod.num_outputs);
     assert_eq!(out.len(), records.len() * prod.num_outputs);
     assert!(
         out.iter().all(|v| v.is_finite()),

--- a/neat-core/tests/flat_record_scoring_parity.rs
+++ b/neat-core/tests/flat_record_scoring_parity.rs
@@ -12,6 +12,12 @@
 //! shard, and both dispatch arms are covered — the record-interleaved fast path
 //! (all-standard squash) and the aggregate-squash per-lane fallback. A stride
 //! or offset slip shows up as wrong lane values at the 7/9/12 remainder counts.
+//!
+//! This file is the **one** place still calling the deprecated per-record
+//! entry points (Issue #408): comparing the two APIs is precisely its job, so
+//! the deprecation is silenced with `#[allow(deprecated)]` on the three call
+//! sites below. Converting the oracle to an independent reference belongs to
+//! the deletion issue, stSoftwareAU/NEAT-AI-core#409.
 
 use neat_core::squash::SquashType;
 use neat_core::{CompiledNetwork, NeuronData, SynapseData};
@@ -125,6 +131,8 @@ fn spec(label: &str) -> &'static NetSpec {
 }
 
 /// Assert the two entry points agree bit-for-bit across every boundary count.
+// Deliberate per-record oracle — see the module comment and Issue #409.
+#[allow(deprecated)]
 fn assert_flat_matches_per_record(net: &CompiledNetwork, width: usize, num_outputs: usize) {
     for &count in &COUNTS {
         let recs = records(width, count);
@@ -158,6 +166,8 @@ fn flat_input_matches_per_record_on_the_aggregate_squash_arm() {
 }
 
 #[test]
+// Deliberate per-record oracle — see the module comment and Issue #409.
+#[allow(deprecated)]
 fn flat_input_matches_per_record_at_production_shard_width() {
     let s = spec("production");
     let net = build_network(s, 0x5EED);
@@ -171,6 +181,8 @@ fn flat_input_matches_per_record_at_production_shard_width() {
 }
 
 #[test]
+// Deliberate per-record oracle — see the module comment and Issue #409.
+#[allow(deprecated)]
 fn flat_input_zero_fills_a_stride_narrower_than_the_network() {
     // A record shorter than the network's input arity is zero-filled, exactly as
     // the per-record path does for a short `Vec`.

--- a/neat-core/tests/interleaved_scoring_parity.rs
+++ b/neat-core/tests/interleaved_scoring_parity.rs
@@ -4,8 +4,8 @@
 //! layout (fast path, taken when the network has no aggregate-squash neurons)
 //! and the original per-lane layout (fallback, taken when it does). These are
 //! "what" tests: they build real forward networks, score batches through the
-//! public `score_records` entry point, and assert the flat output matches the
-//! scalar single-record `activate` reference — so a lane transposition, a
+//! public `score_records_flat` entry point, and assert the flat output matches
+//! the scalar single-record `activate` reference — so a lane transposition, a
 //! dropped tail record, or a wrong dispatch would surface as a parity break.
 //!
 //! Record counts straddle the 8-record group boundary (1, 7, 8, 9, 16, 17) so
@@ -97,6 +97,12 @@ fn records(num_inputs: usize, count: usize) -> Vec<Vec<f32>> {
         .collect()
 }
 
+/// Pack per-record vectors into the flat `record * stride` layout the scoring
+/// entry point takes (Issue #386).
+fn flatten(recs: &[Vec<f32>]) -> Vec<f32> {
+    recs.iter().flat_map(|r| r.iter().copied()).collect()
+}
+
 /// Reference outputs from the scalar single-record `activate` path.
 fn reference(net: &CompiledNetwork, recs: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
     let mut scratch = net.clone();
@@ -119,7 +125,7 @@ fn interleaved_fast_path_matches_reference_across_boundaries() {
     let net = build_network(num_inputs, SquashType::Tanh);
     for &count in &COUNTS {
         let recs = records(num_inputs, count);
-        let got = net.score_records(&recs, 1);
+        let got = net.score_records_flat(&flatten(&recs), num_inputs, 1);
         let want = reference(&net, &recs, 1);
         assert_eq!(got.len(), want.len(), "count {count}: length mismatch");
         for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
@@ -137,7 +143,10 @@ fn interleaved_single_record_is_bit_identical_to_activate() {
     let num_inputs = 12;
     let net = build_network(num_inputs, SquashType::Tanh);
     let recs = records(num_inputs, 1);
-    assert_eq!(net.score_records(&recs, 1), reference(&net, &recs, 1));
+    assert_eq!(
+        net.score_records_flat(&flatten(&recs), num_inputs, 1),
+        reference(&net, &recs, 1)
+    );
 }
 
 #[test]
@@ -148,7 +157,7 @@ fn aggregate_fallback_path_matches_reference_across_boundaries() {
     let net = build_network(num_inputs, SquashType::Maximum);
     for &count in &COUNTS {
         let recs = records(num_inputs, count);
-        let got = net.score_records(&recs, 1);
+        let got = net.score_records_flat(&flatten(&recs), num_inputs, 1);
         let want = reference(&net, &recs, 1);
         assert_eq!(got, want, "count {count}: aggregate fallback must be exact");
     }

--- a/neat-core/tests/parallel_scoring.rs
+++ b/neat-core/tests/parallel_scoring.rs
@@ -2,7 +2,8 @@
 //!
 //! These assert on observable outcomes — the returned output vectors — rather
 //! than on threading mechanics. They run in both feature modes: with the
-//! `parallel` feature off, `score_records_parallel` is the sequential fallback;
+//! `parallel` feature off, `score_records_parallel_flat` is the sequential
+//! fallback;
 //! with `--features parallel` (as `quality.sh` runs via `--all-features`), the
 //! same assertions exercise the rayon path.
 //!
@@ -69,10 +70,16 @@ fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
         .collect()
 }
 
+/// Pack per-record vectors into the flat `record * stride` layout the scoring
+/// entry points take (Issue #386).
+fn flatten(recs: &[Vec<f32>]) -> Vec<f32> {
+    recs.iter().flat_map(|r| r.iter().copied()).collect()
+}
+
 /// Independent sequential reference: a fresh scratch clone scored one record at
 /// a time via per-record `activate` (which still allocates its own output
 /// `Vec`), flattened to the flat `[record * num_outputs]` layout the scoring
-/// path now returns. Deliberately does not call `score_records`, so the parity
+/// path now returns. Deliberately does not call the scoring path, so the parity
 /// assertion does not assume the two share an implementation.
 fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
     let mut scratch = net.clone();
@@ -89,7 +96,8 @@ fn parallel_scoring_matches_sequential_on_production_fixture() {
     let records = build_records(&net, 257); // not a multiple of any core count
 
     let expected = reference(&net, &records, s.num_outputs);
-    let actual = net.score_records_parallel(&records, s.num_outputs);
+    let actual =
+        net.score_records_parallel_flat(&flatten(&records), net.num_inputs(), s.num_outputs);
 
     assert_eq!(actual.len(), records.len() * s.num_outputs);
     assert_close(&actual, &expected, "production fixture");
@@ -103,23 +111,24 @@ fn parallel_scoring_matches_sequential_across_shapes() {
         let records = build_records(&net, 128);
 
         let expected = reference(&net, &records, s.num_outputs);
-        let actual = net.score_records_parallel(&records, s.num_outputs);
+        let actual =
+            net.score_records_parallel_flat(&flatten(&records), net.num_inputs(), s.num_outputs);
 
         assert_close(&actual, &expected, &format!("shape {label}"));
     }
 }
 
 #[test]
-fn score_records_matches_reference() {
+fn sequential_scoring_matches_reference() {
     let s = spec("medium_500");
     let net = build_network(s, 0x1357);
     let records = build_records(&net, 64);
 
     let expected = reference(&net, &records, s.num_outputs);
     assert_close(
-        &net.score_records(&records, s.num_outputs),
+        &net.score_records_flat(&flatten(&records), net.num_inputs(), s.num_outputs),
         &expected,
-        "score_records medium_500",
+        "score_records_flat medium_500",
     );
 }
 
@@ -132,7 +141,8 @@ fn output_order_is_preserved() {
     // Each record is distinct, so a re-ordered result would not match the
     // index-aligned reference within tolerance (a swap is an O(1) error).
     let expected = reference(&net, &records, s.num_outputs);
-    let actual = net.score_records_parallel(&records, s.num_outputs);
+    let actual =
+        net.score_records_parallel_flat(&flatten(&records), net.num_inputs(), s.num_outputs);
     for (i, (a, e)) in actual
         .chunks_exact(s.num_outputs)
         .zip(expected.chunks_exact(s.num_outputs))
@@ -148,7 +158,7 @@ fn each_output_has_num_outputs_elements() {
     let net = build_network(s, 0x99);
     let records = build_records(&net, 16);
 
-    let out = net.score_records_parallel(&records, s.num_outputs);
+    let out = net.score_records_parallel_flat(&flatten(&records), net.num_inputs(), s.num_outputs);
     // Flat buffer: 16 records each contributing exactly num_outputs elements.
     assert_eq!(out.len(), 16 * s.num_outputs);
     assert_eq!(out.chunks_exact(s.num_outputs).count(), 16);
@@ -159,10 +169,16 @@ fn each_output_has_num_outputs_elements() {
 fn empty_records_yields_empty_output() {
     let s = spec("small_50");
     let net = build_network(s, 0x7);
-    let empty: Vec<Vec<f32>> = Vec::new();
+    let stride = net.num_inputs();
 
-    assert!(net.score_records_parallel(&empty, s.num_outputs).is_empty());
-    assert!(net.score_records(&empty, s.num_outputs).is_empty());
+    assert!(
+        net.score_records_parallel_flat(&[], stride, s.num_outputs)
+            .is_empty()
+    );
+    assert!(
+        net.score_records_flat(&[], stride, s.num_outputs)
+            .is_empty()
+    );
 }
 
 #[test]
@@ -173,7 +189,7 @@ fn single_record_matches_direct_activate() {
 
     let mut scratch = net.clone();
     let direct = scratch.activate(&record, s.num_outputs);
-    let via_parallel = net.score_records_parallel(std::slice::from_ref(&record), s.num_outputs);
+    let via_parallel = net.score_records_parallel_flat(&record, net.num_inputs(), s.num_outputs);
 
     // Single record: it runs the scalar tail, which is the exact single-record
     // path — so the flat buffer is bit-for-bit that record's outputs.
@@ -193,8 +209,9 @@ fn tail_boundary_record_counts_match_reference() {
         let records = build_records(&net, count);
         let expected = reference(&net, &records, s.num_outputs);
 
-        let seq = net.score_records(&records, s.num_outputs);
-        let par = net.score_records_parallel(&records, s.num_outputs);
+        let flat = flatten(&records);
+        let seq = net.score_records_flat(&flat, net.num_inputs(), s.num_outputs);
+        let par = net.score_records_parallel_flat(&flat, net.num_inputs(), s.num_outputs);
 
         assert_eq!(
             seq.len(),
@@ -206,11 +223,15 @@ fn tail_boundary_record_counts_match_reference() {
             count * s.num_outputs,
             "par length for count {count}"
         );
-        assert_close(&seq, &expected, &format!("score_records count {count}"));
+        assert_close(
+            &seq,
+            &expected,
+            &format!("score_records_flat count {count}"),
+        );
         assert_close(
             &par,
             &expected,
-            &format!("score_records_parallel count {count}"),
+            &format!("score_records_parallel_flat count {count}"),
         );
     }
 }
@@ -228,8 +249,9 @@ fn sequential_and_parallel_are_bit_identical() {
         let net = build_network(s, 0x5AFE_5EED);
         for &count in &[7usize, 8, 9, 65, 130, 257] {
             let records = build_records(&net, count);
-            let seq = net.score_records(&records, s.num_outputs);
-            let par = net.score_records_parallel(&records, s.num_outputs);
+            let flat = flatten(&records);
+            let seq = net.score_records_flat(&flat, net.num_inputs(), s.num_outputs);
+            let par = net.score_records_parallel_flat(&flat, net.num_inputs(), s.num_outputs);
             assert_eq!(
                 seq, par,
                 "seq vs parallel diverged for {label} count {count}"

--- a/neat-core/tests/score_squash_simd_parity.rs
+++ b/neat-core/tests/score_squash_simd_parity.rs
@@ -6,8 +6,8 @@
 //! inline squash for every other type.
 //!
 //! These are "what" tests: they build a real forward network, score a batch of
-//! distinct records through the public `score_records` entry point, and assert
-//! the result matches the scalar single-record `activate` reference within the
+//! distinct records through the public `score_records_flat` entry point, and
+//! assert the result matches the scalar `activate` reference within the
 //! documented SIMD tolerance. Distinct per-record inputs mean a lane
 //! transposition in the wiring would break the parity, so the tests double as a
 //! regression guard for the batching itself.
@@ -100,7 +100,7 @@ fn build_records(num_records: usize, num_inputs: usize) -> Vec<Vec<f32>> {
 
 /// Scalar single-record reference: score each record via `activate` (the scalar
 /// forward pass) and flatten to the `[record * num_outputs]` layout that
-/// `score_records` returns. Deliberately independent of `score_records`.
+/// `score_records_flat` returns. Deliberately independent of the scoring path.
 fn reference(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> Vec<f32> {
     let mut scratch = net.clone();
     records
@@ -121,8 +121,11 @@ fn assert_parity(squash: SquashType, num_records: usize) {
     let net = build_network(num_inputs, squash);
     let records = build_records(num_records, num_inputs);
 
+    // Flat input layout (Issue #386): record `i` occupies
+    // `flat[i * num_inputs .. (i + 1) * num_inputs]`.
+    let flat: Vec<f32> = records.iter().flat_map(|r| r.iter().copied()).collect();
     let expected = reference(&net, &records, num_outputs);
-    let actual = net.score_records(&records, num_outputs);
+    let actual = net.score_records_flat(&flat, num_inputs, num_outputs);
 
     assert_eq!(
         actual.len(),

--- a/neat-core/tests/scoring_allocations.rs
+++ b/neat-core/tests/scoring_allocations.rs
@@ -1,6 +1,6 @@
 //! Allocation-count regression for the record-scoring hot path (Issue #229, #230).
 //!
-//! `score_records` drives every record through the batched SIMD forward pass
+//! `score_records_flat` drives every record through the batched SIMD forward pass
 //! ([`CompiledNetwork::score_batch_into`], Issue #230), writing into one
 //! pre-sized flat buffer instead of allocating a fresh output `Vec` per record
 //! via `activate`'s `to_vec()`. This test proves the batch performs **no
@@ -53,17 +53,19 @@ fn spec(label: &str) -> &'static NetSpec {
         .unwrap_or_else(|| panic!("no NetSpec labelled {label}"))
 }
 
-fn build_records(net: &CompiledNetwork, count: usize) -> Vec<Vec<f32>> {
+/// Build `count` records already packed into the flat `record * stride` layout
+/// (Issue #386), so the flattening cost sits outside the measured region.
+fn build_flat_records(net: &CompiledNetwork, count: usize) -> Vec<f32> {
     (0..count)
-        .map(|i| build_inputs(net.num_inputs(), 0xA110_0000 + i as u64))
+        .flat_map(|i| build_inputs(net.num_inputs(), 0xA110_0000 + i as u64))
         .collect()
 }
 
-/// Allocation count consumed by scoring `records` (records/network built
+/// Allocation count consumed by scoring `inputs` (records/network built
 /// beforehand so only the scoring call is measured).
-fn allocs_for(net: &CompiledNetwork, records: &[Vec<f32>], num_outputs: usize) -> usize {
+fn allocs_for(net: &CompiledNetwork, inputs: &[f32], num_outputs: usize) -> usize {
     let before = ALLOC_COUNT.load(Ordering::Relaxed);
-    let out = net.score_records(records, num_outputs);
+    let out = net.score_records_flat(inputs, net.num_inputs(), num_outputs);
     // Keep the result alive across the measurement so its allocation is counted.
     std::hint::black_box(&out);
     let after = ALLOC_COUNT.load(Ordering::Relaxed);
@@ -75,11 +77,11 @@ fn score_records_has_no_per_record_output_allocation() {
     let s = spec("production");
     let net = build_network(s, 0x000A_110C);
 
-    let small = build_records(&net, 100);
-    let large = build_records(&net, 1000);
+    let small = build_flat_records(&net, 100);
+    let large = build_flat_records(&net, 1000);
 
     // Warm up any one-off lazy initialisation so it is not counted below.
-    std::hint::black_box(net.score_records(&small, s.num_outputs));
+    std::hint::black_box(net.score_records_flat(&small, net.num_inputs(), s.num_outputs));
 
     let small_allocs = allocs_for(&net, &small, s.num_outputs);
     let large_allocs = allocs_for(&net, &large, s.num_outputs);


### PR DESCRIPTION
# Migrate remaining callers to the flat scoring entry points, deprecate the per-record ones

## Summary

Phase 2 of the flat-slice migration started by #386: every remaining in-repo
caller of the per-record `&[Vec<f32>]` scoring API now uses the flat entry
points, and the old wrappers are marked `#[deprecated]`. Warning-only by design
— nothing is deleted, so no consumer can break. Removal is tracked separately by
Issue #409 and deliberately does **not** land here. Closes #408.

What changed:

1. **Deprecation** — `CompiledNetwork::score_records` and **both** `cfg` arms of
   `CompiledNetwork::score_records_parallel` carry
   `#[deprecated(since = "0.2.28", note = "use score_records_flat / score_records_parallel_flat (Issue #386)")]`.
   The sequential fallback arm now drives the shared `score_batch_alloc` helper
   directly instead of calling `score_records`, so it needs no
   `allow(deprecated)` of its own.
2. **Callers migrated** to `score_records_flat` / `score_records_parallel_flat`,
   with each fixture flattened into the contiguous `record * stride` layout at
   construction time (outside any measured or timed region):

   | File | Sites |
   |---|---|
   | `neat-core/benches/hot_paths.rs` | `scoring` group |
   | `neat-core/benches/parallel_scoring.rs` | `score_in_pool` (missed by the issue's ground-truth table) |
   | `neat-core/tests/parallel_scoring.rs` | 11 sites (missed by the issue's ground-truth table) |
   | `neat-core/tests/bench_fixtures.rs` | production-batch smoke test |
   | `neat-core/tests/score_squash_simd_parity.rs` | `assert_parity` |
   | `neat-core/tests/interleaved_scoring_parity.rs` | 3 sites |
   | `neat-core/tests/scoring_allocations.rs` | 2 sites |

3. **Parity test kept on both APIs** — `flat_record_scoring_parity.rs` exists
   precisely to compare the two layouts, so its three oracle call sites carry
   `#[allow(deprecated)]` with a comment naming the deletion issue (#409). These
   are the only `allow(deprecated)` sites in the tree.
4. **Version + docs** — workspace version `0.2.27 → 0.2.28` (patch: deprecation
   is non-breaking under `RELEASING.md`), and the deprecation is noted in the
   `parallel_scoring` module docs and `README.md`. There is no `CHANGELOG.md` in
   this repo — the `v<version>` GitHub release cut by `release.yml` is the
   release note, so the version bump plus the README/module-doc note is how the
   project normally records this.

### Bench-group note

`hot_paths` carried two groups measuring the same shard: `scoring` (per-record
input) and `scoring_flat` (flat input), added by #386 as a deliberate A/B of the
two input layouts. With the per-record entry point deprecated there is no second
layout left to compare against, so migrating `scoring` would have made the two
groups byte-for-byte identical. The long-running `scoring/production/*` baseline
series in `benches/BASELINE.md` is kept and now drives `score_records_flat`; the
redundant `scoring_flat` group is retired. `benches/README.md` and the group's
doc comment both say so.

## Evidence

Backend/library change with no web interface, so no screenshot applies. The
evidence is the compiler: CI builds with `RUSTFLAGS="-D warnings"`, which turns
`deprecated` into a hard error, so a missed caller fails the build rather than
sliding through. `./quality.sh` is green, including
`cargo clippy --workspace --all-targets --all-features -- -D warnings` and the
same lint run under the **default** feature set (which is what compiles the
`cfg(not(parallel))` fallback arm).

```
🔧 Running linter...
    Finished `dev` profile
✅ Running type checks...
🧪 Running tests...
📖 Building documentation...
🏗️ Building release...
✅ All quality checks passed!
```

Migrated suites, all green and with unchanged expected values:

```
test result: ok. 15 passed  (bench_fixtures)
test result: ok.  8 passed  (flat_record_scoring_parity)
test result: ok.  3 passed  (interleaved_scoring_parity)
test result: ok.  9 passed  (parallel_scoring)
test result: ok.  3 passed  (score_squash_simd_parity)
test result: ok.  1 passed  (scoring_allocations)
```

Sequential phasing agreed by the parent issue, and where this PR sits:

```mermaid
flowchart LR
    A["#386 — add flat entry points<br/>score_records_flat / _parallel_flat"] --> B
    B["#408 — migrate callers<br/>+ #deprecated (this PR)"] --> C
    C["#409 — delete wrappers<br/>+ RecordBatch::PerRecord"]
    B -.->|"warning-only,<br/>no consumer can break"| B
```

Call-site shape after the migration:

```mermaid
flowchart TD
    F["fixture: Vec&lt;Vec&lt;f32&gt;&gt;"] --> FL["flatten at construction<br/>(outside timed / measured region)"]
    FL --> I["inputs: &amp;[f32], stride"]
    I --> S{"parallel feature?"}
    S -- "off / wasm32" --> Q["score_records_flat"]
    S -- "on, native" --> P["score_records_parallel_flat"]
    Q --> K["score_batch_into<br/>(shared kernel, pub(crate) — not deprecated)"]
    P --> K
    K --> O["flat outputs, input order"]
    D["score_records /<br/>score_records_parallel<br/>#deprecated"] -.->|"only caller left:<br/>flat_record_scoring_parity.rs"| K
```

## Test Plan

No new behaviour is introduced, so no new tests: this is a call-site change and
the existing parity/allocation suites are the regression guard. Every expected
value and tolerance in the migrated files is unchanged — only the entry point
and the input layout differ.

Modified tests (all still asserting on observable outcomes, "what" not "how"):

- `neat-core/tests/parallel_scoring.rs` — all 9 tests now score through
  `score_records_flat` / `score_records_parallel_flat`; the independent
  per-record `activate` reference is untouched, as are `TOL`, the tail-boundary
  counts `[0,1,2,3,4,5,7,8,9,12,15,16,17,24,31,33]`, and the bit-identity
  assertion between the sequential and parallel paths. `score_records_matches_reference`
  is renamed `sequential_scoring_matches_reference` — it no longer names a
  deprecated function, and the assertion is unchanged.
- `neat-core/tests/interleaved_scoring_parity.rs` — both dispatch arms
  (interleaved fast path, aggregate per-lane fallback) and the exact
  single-record bit-identity case, across counts `[1,7,8,9,16,17]`, `TOL` 2e-3.
- `neat-core/tests/score_squash_simd_parity.rs` — `assert_parity` scores the
  flattened batch; the scalar `activate` reference and `TOL` 1e-3 are unchanged.
- `neat-core/tests/scoring_allocations.rs` — the counting-allocator regression
  now measures `score_records_flat`. Records are flattened in
  `build_flat_records` *before* the measured window, so the flattening cost is
  not counted; the `delta < 50` assertion is unchanged and still fails loudly if
  per-record output allocation returns.
- `neat-core/tests/bench_fixtures.rs` —
  `score_records_on_production_batch_yields_finite_ordered_outputs` scores the
  flat buffer; the flat-length and finiteness assertions are unchanged.
- `neat-core/tests/flat_record_scoring_parity.rs` — **unchanged assertions**;
  only `#[allow(deprecated)]` plus comments naming #409 were added. This suite
  is what proves the deprecated and flat paths remain bit-identical, so it is
  also the regression guard for the migration itself.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms33pjlc-3b8187`<!-- vibe-worker-issue-408 -->