### PR TITLE
dead-code: remove get_training_state_num_neurons / get_training_state_num_synapses WASM exports (Issue #424)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,6 +94,32 @@ Each major-equivalent bump is recorded here so downstream consumers can see what
 changed without diffing the API. The generated `v<version>` GitHub release notes
 point back at this file.
 
+### `0.8.0` — `get_training_state_num_neurons` / `get_training_state_num_synapses` removed (Issue #424)
+
+The public `neat_core::get_training_state_num_neurons` and
+`neat_core::get_training_state_num_synapses` — and the WASM exports of the same
+names — are **removed**. A dead-code audit (Issue #416, from #413) found no
+caller in NEAT-AI, NEAT-AI-Discovery, NEAT-AI-scorer, NEAT-AI-Examples or
+NEAT-AI-Explore; `WasmModuleLoader.ts` never bound either export. Both accessors
+survive inside `training_state.rs` as `#[cfg(test)]` helpers, so the
+init-and-free assertions on the recorded counts are unchanged.
+
+**Migration** — track the sizes you passed to `init_training_state` yourself, or
+derive them from the state readers:
+
+```rust
+// Before (0.7.x)
+let num_synapses = get_training_state_num_synapses();
+let num_neurons = get_training_state_num_neurons();
+
+// After (0.8.0) — the caller already owns these values
+init_training_state(num_synapses, num_neurons);
+```
+
+The rest of `training_state.rs` is untouched: `init_training_state`,
+`free_training_state`, `reset_training_state`, the `read_*_state` readers and
+the `accumulate_*_persistent_*way` exports are all live.
+
 ### `0.7.0` — `apply_calculate_error_batch_4way` / `calculate_error_batch_4way` removed (Issue #423)
 
 The public `neat_core::apply_calculate_error_batch_4way` (both the `wasm32` SIMD

--- a/docs/archive/pr-summaries/pr-summary-424.md
+++ b/docs/archive/pr-summaries/pr-summary-424.md
@@ -1,0 +1,81 @@
+## Summary
+
+Removed the `get_training_state_num_neurons` and `get_training_state_num_synapses`
+WASM exports and their public re-exports, per the #416 dead-code audit. Neither
+had a `module.<name>` binding in NEAT-AI's `src/wasm/WasmModuleLoader.ts`, nor a
+caller in NEAT-AI, NEAT-AI-Discovery, NEAT-AI-scorer, NEAT-AI-Examples or
+NEAT-AI-Explore — their only references were the in-file tests. Closes #424.
+
+Route taken: the **preferred** one from the issue — both accessors are kept as
+`#[cfg(test)]` helpers in `training_state.rs` (attribute dropped, `pub` dropped,
+`lib.rs` re-export dropped), so `test_init_and_reset` keeps asserting the
+recorded `NUM_SYNAPSES` / `NUM_NEURONS` counts **unchanged**. No assertions were
+weakened or deleted.
+
+Breaking removal of two public items → **minor** bump `0.7.0` → `0.8.0`, a
+`RELEASING.md` breaking-change log entry, and a `refactor!:` Conventional-Commit
+marker. Rebased on the milestone branch after siblings #422 (`0.6.0`) and #423
+(`0.7.0`) merged, so there is no version collision.
+
+Everything else in `training_state.rs` is untouched: `init_training_state`,
+`free_training_state`, `reset_training_state`, the `read_*_state` readers and
+the `accumulate_*_persistent_*way` exports remain live.
+
+### Changes
+
+| File | Change |
+| --- | --- |
+| `neat-core/src/training_state.rs` | both accessors: `#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]` and `pub` dropped, `#[cfg(test)]` added |
+| `neat-core/src/lib.rs` | both names dropped from `pub use training_state::{...}` |
+| `Cargo.toml` / `Cargo.lock` | workspace version `0.7.0` → `0.8.0` |
+| `RELEASING.md` | `0.8.0` breaking-change log entry with migration note |
+
+## Evidence
+
+Backend/Rust-only change — no web interface to screenshot. Verified by running
+the acceptance commands locally:
+
+| Acceptance check | Result |
+| --- | --- |
+| `cargo clippy --workspace --all-targets -- -D warnings` | green (no `dead_code` warning from the `cfg(test)` gating) |
+| `cargo test --workspace` | green; `training_state::tests::test_init_and_reset` passes with its count assertions intact |
+| `cargo check -p neat-core --target wasm32-unknown-unknown` | green |
+| `wasm-pack build` (as `scripts/build-wasm-bundle.sh` runs it) | succeeds; `grep get_training_state_num_ wasm_activation.d.ts` returns nothing |
+| `./quality.sh` | `✅ All quality checks passed!` |
+| `breaking-change` signal | `refactor!:` marker + `RELEASING.md` entry + minor bump |
+
+Generated `wasm_activation.d.ts` after the change — the removed names are gone
+while the live neighbours still export:
+
+```text
+$ grep -n 'get_training_state_num_' wasm_activation.d.ts
+(no matches)
+
+$ grep -n 'free_training_state\|init_training_state\|read_synapse_state' wasm_activation.d.ts
+478:export function free_training_state(): void;
+518:export function init_training_state(num_synapses: number, num_neurons: number): void;
+640:export function read_synapse_state(index: number): Float64Array;
+```
+
+Where the two accessors moved:
+
+```mermaid
+flowchart LR
+    A["training_state.rs<br/>get_training_state_num_*"] --> B["#[cfg(test)] only"]
+    A -.removed.-> C["wasm_bindgen export<br/>wasm_activation.d.ts"]
+    A -.removed.-> D["pub use in lib.rs<br/>public Rust API"]
+    B --> E["test_init_and_reset<br/>assertions unchanged"]
+```
+
+## Test Plan
+
+No new tests — this is a removal, and the existing coverage is exactly what the
+issue asks to preserve:
+
+- `neat-core/src/training_state.rs::tests::test_init_and_reset` — unmodified.
+  Still asserts `get_training_state_num_synapses() == 4` and
+  `get_training_state_num_neurons() == 2` after `init_training_state(4, 2)`, and
+  `get_training_state_num_synapses() == 0` after `free_training_state()`. It now
+  calls the `#[cfg(test)]` helpers rather than public API.
+- `cargo test --workspace` — full suite green, no other test referenced either
+  name.

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -92,8 +92,7 @@ pub use topology_ops::{
 pub use training_state::{
     accumulate_bias_persistent_4way, accumulate_bias_persistent_8way,
     accumulate_weight_persistent_4way, accumulate_weight_persistent_8way, free_training_state,
-    get_training_state_num_neurons, get_training_state_num_synapses, init_training_state,
-    read_all_neuron_state, read_all_synapse_state, read_neuron_state, read_synapse_state,
-    reset_training_state,
+    init_training_state, read_all_neuron_state, read_all_synapse_state, read_neuron_state,
+    read_synapse_state, reset_training_state,
 };
 pub use unsquash::apply_unsquash;

--- a/neat-core/src/training_state.rs
+++ b/neat-core/src/training_state.rs
@@ -339,15 +339,21 @@ pub fn accumulate_bias_persistent_8way(
     });
 }
 
-/// Get the number of synapses in the current training state.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub fn get_training_state_num_synapses() -> usize {
+/// Number of synapses recorded in the current training state.
+///
+/// Test-only (Issue #424): no consumer bound the former WASM export, so it is
+/// no longer exported or re-exported — it survives purely so the tests can
+/// assert what `init_training_state` / `free_training_state` record.
+#[cfg(test)]
+fn get_training_state_num_synapses() -> usize {
     NUM_SYNAPSES.with(|n| *n.borrow())
 }
 
-/// Get the number of neurons in the current training state.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub fn get_training_state_num_neurons() -> usize {
+/// Number of neurons recorded in the current training state.
+///
+/// Test-only — see [`get_training_state_num_synapses`].
+#[cfg(test)]
+fn get_training_state_num_neurons() -> usize {
     NUM_NEURONS.with(|n| *n.borrow())
 }
 


### PR DESCRIPTION
## Summary

Removed the `get_training_state_num_neurons` and `get_training_state_num_synapses`
WASM exports and their public re-exports, per the #416 dead-code audit. Neither
had a `module.<name>` binding in NEAT-AI's `src/wasm/WasmModuleLoader.ts`, nor a
caller in NEAT-AI, NEAT-AI-Discovery, NEAT-AI-scorer, NEAT-AI-Examples or
NEAT-AI-Explore — their only references were the in-file tests. Closes #424.

Route taken: the **preferred** one from the issue — both accessors are kept as
`#[cfg(test)]` helpers in `training_state.rs` (attribute dropped, `pub` dropped,
`lib.rs` re-export dropped), so `test_init_and_reset` keeps asserting the
recorded `NUM_SYNAPSES` / `NUM_NEURONS` counts **unchanged**. No assertions were
weakened or deleted.

Breaking removal of two public items → **minor** bump `0.7.0` → `0.8.0`, a
`RELEASING.md` breaking-change log entry, and a `refactor!:` Conventional-Commit
marker. Rebased on the milestone branch after siblings #422 (`0.6.0`) and #423
(`0.7.0`) merged, so there is no version collision.

Everything else in `training_state.rs` is untouched: `init_training_state`,
`free_training_state`, `reset_training_state`, the `read_*_state` readers and
the `accumulate_*_persistent_*way` exports remain live.

### Changes

| File | Change |
| --- | --- |
| `neat-core/src/training_state.rs` | both accessors: `#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]` and `pub` dropped, `#[cfg(test)]` added |
| `neat-core/src/lib.rs` | both names dropped from `pub use training_state::{...}` |
| `Cargo.toml` / `Cargo.lock` | workspace version `0.7.0` → `0.8.0` |
| `RELEASING.md` | `0.8.0` breaking-change log entry with migration note |

## Evidence

Backend/Rust-only change — no web interface to screenshot. Verified by running
the acceptance commands locally:

| Acceptance check | Result |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | green (no `dead_code` warning from the `cfg(test)` gating) |
| `cargo test --workspace` | green; `training_state::tests::test_init_and_reset` passes with its count assertions intact |
| `cargo check -p neat-core --target wasm32-unknown-unknown` | green |
| `wasm-pack build` (as `scripts/build-wasm-bundle.sh` runs it) | succeeds; `grep get_training_state_num_ wasm_activation.d.ts` returns nothing |
| `./quality.sh` | `✅ All quality checks passed!` |
| `breaking-change` signal | `refactor!:` marker + `RELEASING.md` entry + minor bump |

Generated `wasm_activation.d.ts` after the change — the removed names are gone
while the live neighbours still export:

```text
$ grep -n 'get_training_state_num_' wasm_activation.d.ts
(no matches)

$ grep -n 'free_training_state\|init_training_state\|read_synapse_state' wasm_activation.d.ts
478:export function free_training_state(): void;
518:export function init_training_state(num_synapses: number, num_neurons: number): void;
640:export function read_synapse_state(index: number): Float64Array;
```

Where the two accessors moved:

```mermaid
flowchart LR
    A["training_state.rs<br/>get_training_state_num_*"] --> B["#[cfg(test)] only"]
    A -.removed.-> C["wasm_bindgen export<br/>wasm_activation.d.ts"]
    A -.removed.-> D["pub use in lib.rs<br/>public Rust API"]
    B --> E["test_init_and_reset<br/>assertions unchanged"]
```

## Test Plan

No new tests — this is a removal, and the existing coverage is exactly what the
issue asks to preserve:

- `neat-core/src/training_state.rs::tests::test_init_and_reset` — unmodified.
  Still asserts `get_training_state_num_synapses() == 4` and
  `get_training_state_num_neurons() == 2` after `init_training_state(4, 2)`, and
  `get_training_state_num_synapses() == 0` after `free_training_state()`. It now
  calls the `#[cfg(test)]` helpers rather than public API.
- `cargo test --workspace` — full suite green, no other test referenced either
  name.



## Milestone
This PR is part of the **#416 dead-code: four WASM exports have no binding in NEAT-AI's WasmModuleLoader** milestone and targets the `milestone/416-dead-code-four-wasm-exports-have-no-binding-in` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms61tghn-3b7351`<!-- vibe-worker-issue-424 -->