### PR TITLE
test: cover the unbounded-range infinity clamp on the f32 apply_limit_range path (Issue #425)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-425.md
+++ b/docs/archive/pr-summaries/pr-summary-425.md
@@ -1,0 +1,56 @@
+# PR Summary — Issue #425
+
+## Summary
+
+`test_limit_range_f64_clamping` was the only test asserting that the
+**unbounded** activation ranges clamp `±inf` to a finite `±F32_LARGE`. Sibling
+work under #417 deletes `apply_limit_range_f64` and that test, which would
+silently drop the assertion.
+
+This PR adds `test_limit_range_unbounded_infinity_clamping` to
+`neat-core/tests/range.rs`, asserting the same behaviour through the production
+`apply_limit_range` (f32) path for all seven `(-F32_LARGE, F32_LARGE)`
+activations: `Identity`, `Cube`, `LeakyRelu`, `Tan`, `BentIdentity`,
+`Complement`, `StdInverse`.
+
+Test-only — no change to `neat-core/src/`. Closes #425.
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. The
+evidence is the test run.
+
+The new assertions pass against the **current, unmodified** implementation, as
+the acceptance criteria require:
+
+```
+running 10 tests
+test test_limit_range_clamping ... ok
+test test_limit_range_f64_clamping ... ok
+test test_limit_range_unbounded_infinity_clamping ... ok
+...
+test result: ok. 10 passed; 0 failed
+```
+
+`./quality.sh` (fmt, clippy `-D warnings`, deny, workspace tests, doc, release
+build) finished with `✅ All quality checks passed!`.
+
+Coverage handover across the two milestone PRs:
+
+```mermaid
+flowchart LR
+    A["test_limit_range_f64_clamping<br/>(only ±inf → finite guard)"] --> B["this PR: add<br/>test_limit_range_unbounded_infinity_clamping<br/>(f32 apply_limit_range)"]
+    B --> C["#417 sibling: delete<br/>apply_limit_range_f64 + its test"]
+    C --> D["guard preserved on the<br/>production f32 path"]
+```
+
+## Test Plan
+
+- Added `neat-core/tests/range.rs::test_limit_range_unbounded_infinity_clamping`
+  — for each unbounded activation, asserts `apply_limit_range(s, f32::INFINITY)`
+  is finite and `> 1e30`, and `apply_limit_range(s, f32::NEG_INFINITY)` is
+  finite and `< -1e30`.
+- No existing tests were modified or removed.
+- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets
+  --all-features -- -D warnings`, and the workspace test suite are green via
+  `./quality.sh`.

--- a/neat-core/tests/range.rs
+++ b/neat-core/tests/range.rs
@@ -260,6 +260,34 @@ fn test_limit_range_clamping() {
 }
 
 #[test]
+fn test_limit_range_unbounded_infinity_clamping() {
+    // Unbounded ranges clamp infinities to ±F32_LARGE (no overflow to inf).
+    for squash in [
+        SquashType::Identity,
+        SquashType::Cube,
+        SquashType::LeakyRelu,
+        SquashType::Tan,
+        SquashType::BentIdentity,
+        SquashType::Complement,
+        SquashType::StdInverse,
+    ] {
+        let hi = apply_limit_range(squash, f32::INFINITY);
+        assert!(hi.is_finite(), "{squash:?} +inf should be finite");
+        assert!(
+            hi > 1e30,
+            "{squash:?} +inf should clamp to a large positive"
+        );
+
+        let lo = apply_limit_range(squash, f32::NEG_INFINITY);
+        assert!(lo.is_finite(), "{squash:?} -inf should be finite");
+        assert!(
+            lo < -1e30,
+            "{squash:?} -inf should clamp to a large negative"
+        );
+    }
+}
+
+#[test]
 fn test_limit_range_f64_clamping() {
     // Values within range pass through unchanged.
     assert_eq!(apply_limit_range_f64(SquashType::Logistic, 0.5), 0.5);


### PR DESCRIPTION
# PR Summary — Issue #425

## Summary

`test_limit_range_f64_clamping` was the only test asserting that the
**unbounded** activation ranges clamp `±inf` to a finite `±F32_LARGE`. Sibling
work under #417 deletes `apply_limit_range_f64` and that test, which would
silently drop the assertion.

This PR adds `test_limit_range_unbounded_infinity_clamping` to
`neat-core/tests/range.rs`, asserting the same behaviour through the production
`apply_limit_range` (f32) path for all seven `(-F32_LARGE, F32_LARGE)`
activations: `Identity`, `Cube`, `LeakyRelu`, `Tan`, `BentIdentity`,
`Complement`, `StdInverse`.

Test-only — no change to `neat-core/src/`. Closes #425.

## Evidence

Backend/library change with no web interface, so no screenshot applies. The
evidence is the test run.

The new assertions pass against the **current, unmodified** implementation, as
the acceptance criteria require:

```
running 10 tests
test test_limit_range_clamping ... ok
test test_limit_range_f64_clamping ... ok
test test_limit_range_unbounded_infinity_clamping ... ok
...
test result: ok. 10 passed; 0 failed
```

`./quality.sh` (fmt, clippy `-D warnings`, deny, workspace tests, doc, release
build) finished with `✅ All quality checks passed!`.

Coverage handover across the two milestone PRs:

```mermaid
flowchart LR
    A["test_limit_range_f64_clamping<br/>(only ±inf → finite guard)"] --> B["this PR: add<br/>test_limit_range_unbounded_infinity_clamping<br/>(f32 apply_limit_range)"]
    B --> C["#417 sibling: delete<br/>apply_limit_range_f64 + its test"]
    C --> D["guard preserved on the<br/>production f32 path"]
```

## Test Plan

- Added `neat-core/tests/range.rs::test_limit_range_unbounded_infinity_clamping`
  — for each unbounded activation, asserts `apply_limit_range(s, f32::INFINITY)`
  is finite and `> 1e30`, and `apply_limit_range(s, f32::NEG_INFINITY)` is
  finite and `< -1e30`.
- No existing tests were modified or removed.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets
  --all-features -- -D warnings`, and the workspace test suite are green via
  `./quality.sh`.



## Milestone
This PR is part of the **#417 dead-code: f64 helpers apply_squash_f64 / apply_limit_range_f64 carry a stale #[allow(dead_code)] and have no production caller** milestone and targets the `milestone/417-dead-code-f64-helpers-apply-squash-f64-apply-l` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms659rw5-c3eb57`<!-- vibe-worker-issue-425 -->