### PR TITLE
dead-code: remove apply_limit_range_f64 and its test-only caller (Issue #427)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-427.md
+++ b/docs/archive/pr-summaries/pr-summary-427.md
@@ -1,0 +1,55 @@
+# Remove dead `apply_limit_range_f64` (Issue #427)
+
+## Summary
+
+Deleted `apply_limit_range_f64` from `neat-core/src/range.rs` and its only
+caller, the integration test `test_limit_range_f64_clamping`. The function had
+no caller outside that test, was absent from `lib.rs`'s curated re-exports, and
+had no `#[wasm_bindgen]` wrapper — so removing it is not a public-surface
+change. Its `#[allow(dead_code)]` suppressed nothing (`dead_code` does not fire
+on `pub` items in a reachable `pub mod` of a library crate) and only obscured
+that the function was unused. Sub-issue of #417. Closes #427.
+
+`F32_LARGE` stays — it is still used throughout `apply_get_range`.
+
+## Evidence
+
+Backend-only change with no web interface, so no screenshot applies. Evidence is
+the acceptance-criteria checks and the green quality gate:
+
+- `grep -rn '\bapply_limit_range_f64\b' neat-core/src neat-core/tests neat-core/benches`
+  → no hits.
+- No `#[allow(dead_code)]` remains in `neat-core/src/range.rs`.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p neat-core` → clean, no
+  `unresolved link` warning. The removed doc comment was the only one naming the
+  f64 helper; the surviving `apply_limit_range` / `apply_limit_range_bounds`
+  docs never linked to it, so no dangling intra-doc link was left behind.
+- `./quality.sh` → fmt, clippy `-D warnings`, deny, full test run, doc build and
+  release build all pass.
+
+### Coverage dependency
+
+The issue flagged that `test_limit_range_f64_clamping` was the only test
+asserting an *unbounded* activation's infinity clamps to a finite `±F32_LARGE`.
+The sibling sub-issue #425 has already landed on the milestone branch, adding
+`test_limit_range_unbounded_infinity_clamping` on the f32 path — it asserts
+`is_finite()` and the `±1e30` magnitude for `Identity`, `Cube`, `LeakyRelu`,
+`Tan`, `BentIdentity`, `Complement` and `StdInverse`. That coverage is strictly
+broader than the single `Identity` assertion being deleted here, so no coverage
+is lost and no inline replacement was needed.
+
+```mermaid
+flowchart LR
+    A["#425 (merged): f32 unbounded<br/>infinity clamp test"] --> B["coverage safe"]
+    B --> C["#427: delete apply_limit_range_f64<br/>+ test_limit_range_f64_clamping"]
+```
+
+## Test Plan
+
+- Removed `neat-core/tests/range.rs::test_limit_range_f64_clamping` (the deleted
+  function's only caller) and dropped `apply_limit_range_f64` from the `use` on
+  line 3. No other test was modified.
+- Retained `test_limit_range_clamping` and `test_limit_range_unbounded_infinity_clamping`,
+  which together cover the equivalent bounded and unbounded clamp behaviour on
+  the f32 path that remains in use.
+- Full workspace suite re-run green via `./quality.sh`.

--- a/neat-core/src/range.rs
+++ b/neat-core/src/range.rs
@@ -143,29 +143,3 @@ pub fn apply_limit_range(squash_type: SquashType, value: f32) -> f32 {
     let (low, high) = apply_get_range(squash_type);
     apply_limit_range_bounds(low, high, value)
 }
-
-/// Clamp an `f64` value to the valid output range of `squash_type`.
-///
-/// `NaN` maps to `0.0`. Infinities are clamped to the activation's finite
-/// bounds, themselves capped at `±F32_LARGE` so the result never overflows
-/// back to infinity. The `f32` counterpart is [`apply_limit_range`].
-#[allow(dead_code)]
-#[inline(always)]
-pub fn apply_limit_range_f64(squash_type: SquashType, value: f64) -> f64 {
-    if value.is_nan() {
-        return 0.0;
-    }
-
-    let (low_f32, high_f32) = apply_get_range(squash_type);
-    let low = low_f32 as f64;
-    let high = high_f32 as f64;
-
-    if value == f64::INFINITY {
-        return high.min(F32_LARGE as f64);
-    }
-    if value == f64::NEG_INFINITY {
-        return low.max(-(F32_LARGE as f64));
-    }
-
-    value.max(low).min(high)
-}

--- a/neat-core/tests/range.rs
+++ b/neat-core/tests/range.rs
@@ -1,6 +1,6 @@
 //! Range validation tests (moved from `src/range.rs`).
 
-use neat_core::range::{apply_limit_range_bounds, apply_limit_range_f64};
+use neat_core::range::apply_limit_range_bounds;
 use neat_core::{SquashType, apply_get_range, apply_limit_range, apply_validate_range};
 
 /// Every squash type, so the hoisted-bounds helper can be checked against the
@@ -285,39 +285,6 @@ fn test_limit_range_unbounded_infinity_clamping() {
             "{squash:?} -inf should clamp to a large negative"
         );
     }
-}
-
-#[test]
-fn test_limit_range_f64_clamping() {
-    // Values within range pass through unchanged.
-    assert_eq!(apply_limit_range_f64(SquashType::Logistic, 0.5), 0.5);
-    assert_eq!(apply_limit_range_f64(SquashType::Tanh, 0.0), 0.0);
-
-    // Out-of-range values are clamped to the activation bounds.
-    assert_eq!(apply_limit_range_f64(SquashType::Logistic, -0.5), 0.0);
-    assert_eq!(apply_limit_range_f64(SquashType::Logistic, 1.5), 1.0);
-    assert_eq!(apply_limit_range_f64(SquashType::Relu6, 10.0), 6.0);
-
-    // NaN maps to 0.
-    assert_eq!(apply_limit_range_f64(SquashType::Logistic, f64::NAN), 0.0);
-
-    // Bounded ranges clamp infinities to the finite bounds.
-    assert_eq!(
-        apply_limit_range_f64(SquashType::Logistic, f64::INFINITY),
-        1.0
-    );
-    assert_eq!(
-        apply_limit_range_f64(SquashType::Logistic, f64::NEG_INFINITY),
-        0.0
-    );
-
-    // Unbounded ranges clamp infinities to ±F32_LARGE (no overflow to inf).
-    let hi = apply_limit_range_f64(SquashType::Identity, f64::INFINITY);
-    assert!(hi.is_finite(), "Identity +inf should be finite");
-    assert!(hi > 1e30, "Identity +inf should clamp to a large positive");
-    let lo = apply_limit_range_f64(SquashType::Identity, f64::NEG_INFINITY);
-    assert!(lo.is_finite(), "Identity -inf should be finite");
-    assert!(lo < -1e30, "Identity -inf should clamp to a large negative");
 }
 
 #[test]


### PR DESCRIPTION
# Remove dead `apply_limit_range_f64` (Issue #427)

## Summary

Deleted `apply_limit_range_f64` from `neat-core/src/range.rs` and its only
caller, the integration test `test_limit_range_f64_clamping`. The function had
no caller outside that test, was absent from `lib.rs`'s curated re-exports, and
had no `#[wasm_bindgen]` wrapper — so removing it is not a public-surface
change. Its `#[allow(dead_code)]` suppressed nothing (`dead_code` does not fire
on `pub` items in a reachable `pub mod` of a library crate) and only obscured
that the function was unused. Sub-issue of #417. Closes #427.

`F32_LARGE` stays — it is still used throughout `apply_get_range`.

## Evidence

Backend-only change with no web interface, so no screenshot applies. Evidence is
the acceptance-criteria checks and the green quality gate:

- `grep -rn '\bapply_limit_range_f64\b' neat-core/src neat-core/tests neat-core/benches`
  → no hits.
- No `#[allow(dead_code)]` remains in `neat-core/src/range.rs`.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p neat-core` → clean, no
  `unresolved link` warning. The removed doc comment was the only one naming the
  f64 helper; the surviving `apply_limit_range` / `apply_limit_range_bounds`
  docs never linked to it, so no dangling intra-doc link was left behind.
- `./quality.sh` → fmt, clippy `-D warnings`, deny, full test run, doc build and
  release build all pass.

### Coverage dependency

The issue flagged that `test_limit_range_f64_clamping` was the only test
asserting an *unbounded* activation's infinity clamps to a finite `±F32_LARGE`.
The sibling sub-issue #425 has already landed on the milestone branch, adding
`test_limit_range_unbounded_infinity_clamping` on the f32 path — it asserts
`is_finite()` and the `±1e30` magnitude for `Identity`, `Cube`, `LeakyRelu`,
`Tan`, `BentIdentity`, `Complement` and `StdInverse`. That coverage is strictly
broader than the single `Identity` assertion being deleted here, so no coverage
is lost and no inline replacement was needed.

```mermaid
flowchart LR
    A["#425 (merged): f32 unbounded<br/>infinity clamp test"] --> B["coverage safe"]
    B --> C["#427: delete apply_limit_range_f64<br/>+ test_limit_range_f64_clamping"]
```

## Test Plan

- Removed `neat-core/tests/range.rs::test_limit_range_f64_clamping` (the deleted
  function's only caller) and dropped `apply_limit_range_f64` from the `use` on
  line 3. No other test was modified.
- Retained `test_limit_range_clamping` and `test_limit_range_unbounded_infinity_clamping`,
  which together cover the equivalent bounded and unbounded clamp behaviour on
  the f32 path that remains in use.
- Full workspace suite re-run green via `./quality.sh`.



## Milestone
This PR is part of the **#417 dead-code: f64 helpers apply_squash_f64 / apply_limit_range_f64 carry a stale #[allow(dead_code)] and have no production caller** milestone and targets the `milestone/417-dead-code-f64-helpers-apply-squash-f64-apply-l` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms67i2nc-113fd7`<!-- vibe-worker-issue-427 -->