### PR TITLE
Extract bounded_safe_zone helper from twelve SquashType arms (Issue #442)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-442.md
+++ b/docs/archive/pr-summaries/pr-summary-442.md
@@ -1,0 +1,103 @@
+# Extract the bounded safe-zone rule shared by twelve SquashType arms
+
+## Summary
+
+Twelve `SquashType` arms of `apply_safe_zone_adjustment`
+(`neat-core/src/safe_zone.rs`) each re-implemented the same ~22-line bounded
+safe-zone policy. Only the safe band `[safe_min, safe_max]` and the fade width
+differed — the guards, the `[1e-3, 1e3]` weight thresholds and the linear fade
+formula were character-for-character identical. Extracted one private helper and
+collapsed each arm to a single call. Closes #442.
+
+```rust
+#[inline(always)]
+fn bounded_safe_zone(
+    raw_input: f32, error: f32, weight: f32,
+    safe_min: f32, safe_max: f32, fade: f32,
+) -> f32
+```
+
+Each arm is now one line, e.g.
+`SquashType::Selu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0)`.
+
+The six parameters are plain numeric bounds — no mode flags and no
+`if caller == …` branching, so this is a call rather than a parameterised
+super-helper. The arms encoding genuinely different rules (`Sine`, `Cosine`,
+`Tan`, `Gaussian`, `BipolarSigmoid`, `ArcTan`, `Square`, `Cube`, `Sqrt`,
+`Logistic`, `Tanh`, `HardTanh`, and the rest) are untouched.
+
+Behaviour is unchanged. `safe_zone.rs` drops from 1010 to 630 lines.
+
+### Bounds per arm
+
+| Arm | `safe_min` | `safe_max` | `fade` |
+| --- | ---: | ---: | ---: |
+| `LeakyRelu` | -50 | 50 | 20 |
+| `Selu` | -10 | 10 | 10 |
+| `Elu` | -10 | 10 | 10 |
+| `Softsign` | -10 | 10 | 10 |
+| `Softplus` | -10 | 20 | 10 |
+| `Swish` | -10 | 10 | 10 |
+| `Mish` | -10 | 10 | 10 |
+| `Gelu` | -6 | 6 | 10 |
+| `StdInverse` | -10 | 10 | 10 |
+| `Exponential` | -10 | 30 | 10 |
+| `LogSigmoid` | -20 | 20 | 10 |
+| `Isru` | -10 | 10 | 10 |
+
+`LogSigmoid` previously spelled its fade edges as absolute `fade_min = -30.0` /
+`fade_max = 30.0` rather than `safe_min - fade` / `safe_max + fade`; those are
+the same values, so the collapse to `fade = 10.0` is exact.
+
+## Evidence
+
+This is a backend library refactor with no web interface, so there is no
+screenshot. The evidence is the behavioural test suite plus a green quality
+gate.
+
+```mermaid
+flowchart TD
+    A["apply_safe_zone_adjustment(squash, raw, error, weight)"] --> B{"raw is finite?"}
+    B -- no --> Z["0.0"]
+    B -- yes --> C{"match squash_type"}
+    C -- "12 bounded arms" --> D["bounded_safe_zone(raw, error, weight,<br/>safe_min, safe_max, fade)"]
+    C -- "other arms" --> E["arm-specific rule, still inline"]
+    D --> F{"outside band and<br/>error pushes further out?"}
+    F -- yes --> Z
+    F -- no --> G{"inside band, weight outside<br/>[1e-3, 1e3], error correcting it?"}
+    G -- yes --> Z
+    G -- no --> H{"inside band?"}
+    H -- yes --> I["1.0"]
+    H -- no --> J["linear fade to 0.0 across<br/>`fade` past the edge"]
+```
+
+Quality gate (`./quality.sh`) passes cleanly: rustfmt, clippy, `cargo deny`, the
+full workspace test suite, doc build and release build.
+
+## Test Plan
+
+Added `neat-core/tests/safe_zone_bounded.rs` — seven behavioural tests, each
+looping over all twelve arms with their `(safe_min, safe_max, fade)` bounds and
+asserting on the factor returned by the public
+`apply_safe_zone_adjustment`, not on the helper:
+
+- `inside_band_with_healthy_weight_flows_fully` — both edges and the centre
+  return `1.0` for negative, zero and positive error.
+- `outside_band_with_worsening_error_blocks_gradient` — past either edge with an
+  error pushing further out returns `0.0`.
+- `inside_band_defers_to_a_correcting_tiny_weight` — `|weight| < 1e-3` with
+  `weight * error > 0` returns `0.0`; the same weight with a non-correcting
+  error still returns `1.0`.
+- `inside_band_defers_to_a_correcting_huge_weight` — the `|weight| > 1e3`
+  mirror.
+- `beyond_band_fades_linearly_to_zero` — 25%, 50%, 75% and 100% into each fade
+  band returns exactly `0.75`, `0.5`, `0.25` and `0.0`.
+- `past_the_fade_width_no_gradient_flows` — beyond the fade width returns `0.0`.
+- `non_finite_raw_input_is_never_safe` — `NaN` and both infinities return `0.0`.
+
+These were written and run **before** the extraction, against the twelve
+existing copies, so they characterise the pre-change behaviour; they then stayed
+green afterwards. That is what verifies the refactor is behaviour-preserving —
+for a pure extraction there is no new behaviour for a failing-first test to
+describe. The existing `test_safe_zone_adjustment` in
+`neat-core/tests/integration.rs` is unchanged and still passes.

--- a/neat-core/src/safe_zone.rs
+++ b/neat-core/src/safe_zone.rs
@@ -5,6 +5,56 @@
 
 use crate::squash::SquashType;
 
+/// Gradient-flow factor for a squash whose safe band is `[safe_min, safe_max]`
+/// and which fades linearly to zero over `fade` either side of it.
+///
+/// The rule: no gradient when the raw input is already outside the band and the
+/// error pushes it further out; no gradient when the raw input is inside the
+/// band but the weight sits outside `[1e-3, 1e3]` and the error is already
+/// correcting it (let the weight recover first); full gradient inside the band;
+/// otherwise a linear fade to zero across `fade` past each edge.
+#[inline(always)]
+fn bounded_safe_zone(
+    raw_input: f32,
+    error: f32,
+    weight: f32,
+    safe_min: f32,
+    safe_max: f32,
+    fade: f32,
+) -> f32 {
+    const MIN_WEIGHT: f32 = 1e-3;
+    const MAX_WEIGHT: f32 = 1e3;
+
+    let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
+    let raw_getting_worse =
+        (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
+
+    let abs_weight = weight.abs();
+    let weight_too_small = abs_weight < MIN_WEIGHT;
+    let weight_too_large = abs_weight > MAX_WEIGHT;
+    let weight_improving =
+        (weight_too_small && weight * error > 0.0) || (weight_too_large && weight * error < 0.0);
+
+    if !in_safe_range && raw_getting_worse {
+        return 0.0;
+    }
+    if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
+        return 0.0;
+    }
+
+    if in_safe_range {
+        return 1.0;
+    }
+    if raw_input > safe_max && raw_input <= safe_max + fade {
+        return 1.0 - (raw_input - safe_max) / fade;
+    }
+    if raw_input < safe_min && raw_input >= safe_min - fade {
+        return 1.0 - (safe_min - raw_input) / fade;
+    }
+
+    0.0
+}
+
 /// Apply safe zone adjustment for a given activation function
 /// Issue #1140 - WASM Migration Phase 8: Implement safeZoneAdjustment() in Rust/WASM
 ///
@@ -81,118 +131,13 @@ pub fn apply_safe_zone_adjustment(
         }
 
         // LeakyReLU: Never fully saturates, but has weight-based logic
-        SquashType::LeakyRelu => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -50.0;
-            let safe_max = 50.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 20.0 {
-                return 1.0 - (raw_input - safe_max) / 20.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 20.0 {
-                return 1.0 - (safe_min - raw_input) / 20.0;
-            }
-
-            0.0
-        }
+        SquashType::LeakyRelu => bounded_safe_zone(raw_input, error, weight, -50.0, 50.0, 20.0),
 
         // SELU: Similar to ELU but with specific safe zones
-        SquashType::Selu => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Selu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // ELU: Similar pattern to SELU
-        SquashType::Elu => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Elu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // LOGISTIC (Sigmoid): Classic sigmoid saturation
         SquashType::Logistic => {
@@ -289,192 +234,19 @@ pub fn apply_safe_zone_adjustment(
         }
 
         // Softsign: Slow saturation
-        SquashType::Softsign => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-
-            // Soft fade near edge zones
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Softsign => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Softplus: One-sided saturation
-        SquashType::Softplus => {
-            let safe_min = -10.0;
-            let safe_max = 20.0;
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improves = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_raw && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improves {
-                return 0.0;
-            }
-
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Softplus => bounded_safe_zone(raw_input, error, weight, -10.0, 20.0, 10.0),
 
         // Swish: Similar to tanh in behaviour
-        SquashType::Swish => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Swish => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Mish: Similar to Swish
-        SquashType::Mish => {
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-            let raw_worsening =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_raw && raw_worsening {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Mish => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // GELU: Similar to ReLU but smoother
-        SquashType::Gelu => {
-            let safe_min = -6.0;
-            let safe_max = 6.0;
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improves = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_raw && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improves {
-                return 0.0;
-            }
-
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Gelu => bounded_safe_zone(raw_input, error, weight, -6.0, 6.0, 10.0),
 
         // SINE: Periodic, always varying
         SquashType::Sine => {
@@ -803,168 +575,16 @@ pub fn apply_safe_zone_adjustment(
         }
 
         // StdInverse: Sensitive around zero
-        SquashType::StdInverse => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::StdInverse => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Exponential: Grows rapidly
-        SquashType::Exponential => {
-            // Safe zone for Exponential raw input
-            let safe_min = -10.0;
-            let safe_max = 30.0;
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-
-            // Check if pushing raw input would make it worse
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            // Safe weight bounds
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-
-            // Is weight improvement in direction of error?
-            let weight_improves = (weight_too_small && weight * error > 0.0)
-                || // growing small weight
-                (weight_too_large && weight * error < 0.0); // shrinking big weight
-
-            // Fallback to weight adjustment
-            if !in_safe_raw && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improves {
-                return 0.0;
-            }
-
-            // Default logic (fade outside the soft safe zone)
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Exponential => bounded_safe_zone(raw_input, error, weight, -10.0, 30.0, 10.0),
 
         // LogSigmoid: Flattens sharply for large negative inputs
-        SquashType::LogSigmoid => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -20.0;
-            let safe_max = 20.0;
-            let fade_min = -30.0;
-            let fade_max = 30.0;
-
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            // Prefer not to propagate if the raw input is very bad and the weight would help
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-
-            // Soft fade zones
-            if raw_input > safe_max && raw_input <= fade_max {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= fade_min {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::LogSigmoid => bounded_safe_zone(raw_input, error, weight, -20.0, 20.0, 10.0),
 
         // ISRU: Saturates at large |x|
-        SquashType::Isru => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Isru => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Aggregate functions - not differentiable, always return 0
         SquashType::Minimum | SquashType::Maximum | SquashType::If => 0.0,

--- a/neat-core/tests/safe_zone_bounded.rs
+++ b/neat-core/tests/safe_zone_bounded.rs
@@ -1,0 +1,136 @@
+//! Behavioural coverage for the bounded safe-zone rule shared by twelve
+//! `SquashType` arms of `apply_safe_zone_adjustment` (Issue #442).
+//!
+//! Each arm below differs only in its safe band `[safe_min, safe_max]` and the
+//! fade width either side of it. These tests assert the observable factor
+//! returned for every branch of that rule, so the shared policy stays pinned
+//! regardless of how the arms are implemented.
+
+use neat_core::{SquashType, apply_safe_zone_adjustment};
+
+/// `(squash, safe_min, safe_max, fade)` for every arm using the bounded rule.
+const BOUNDED_ARMS: &[(SquashType, f32, f32, f32)] = &[
+    (SquashType::LeakyRelu, -50.0, 50.0, 20.0),
+    (SquashType::Selu, -10.0, 10.0, 10.0),
+    (SquashType::Elu, -10.0, 10.0, 10.0),
+    (SquashType::Softsign, -10.0, 10.0, 10.0),
+    (SquashType::Softplus, -10.0, 20.0, 10.0),
+    (SquashType::Swish, -10.0, 10.0, 10.0),
+    (SquashType::Mish, -10.0, 10.0, 10.0),
+    (SquashType::Gelu, -6.0, 6.0, 10.0),
+    (SquashType::StdInverse, -10.0, 10.0, 10.0),
+    (SquashType::Exponential, -10.0, 30.0, 10.0),
+    (SquashType::LogSigmoid, -20.0, 20.0, 10.0),
+    (SquashType::Isru, -10.0, 10.0, 10.0),
+];
+
+/// A weight comfortably inside the `[1e-3, 1e3]` guard band.
+const HEALTHY_WEIGHT: f32 = 1.0;
+
+fn assert_close(actual: f32, expected: f32, what: &str) {
+    assert!(
+        (actual - expected).abs() < 1e-5,
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn inside_band_with_healthy_weight_flows_fully() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        let centre = (safe_min + safe_max) / 2.0;
+        for raw in [safe_min, centre, safe_max] {
+            for error in [-1.0, 0.0, 1.0] {
+                let factor = apply_safe_zone_adjustment(squash, raw, error, HEALTHY_WEIGHT);
+                assert_close(factor, 1.0, &format!("{squash:?} raw={raw} error={error}"));
+            }
+        }
+    }
+}
+
+#[test]
+fn outside_band_with_worsening_error_blocks_gradient() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        // Below the band and the error pushes it further down.
+        let below = apply_safe_zone_adjustment(squash, safe_min - 1.0, -1.0, HEALTHY_WEIGHT);
+        assert_close(below, 0.0, &format!("{squash:?} below band, worsening"));
+
+        // Above the band and the error pushes it further up.
+        let above = apply_safe_zone_adjustment(squash, safe_max + 1.0, 1.0, HEALTHY_WEIGHT);
+        assert_close(above, 0.0, &format!("{squash:?} above band, worsening"));
+    }
+}
+
+#[test]
+fn inside_band_defers_to_a_correcting_tiny_weight() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        let centre = (safe_min + safe_max) / 2.0;
+        // |weight| < 1e-3 and weight * error > 0 -- let the weight grow first.
+        let factor = apply_safe_zone_adjustment(squash, centre, 1.0, 1e-4);
+        assert_close(factor, 0.0, &format!("{squash:?} tiny weight correcting"));
+
+        // Same tiny weight but the error is not correcting it -- gradient flows.
+        let factor = apply_safe_zone_adjustment(squash, centre, -1.0, 1e-4);
+        assert_close(
+            factor,
+            1.0,
+            &format!("{squash:?} tiny weight not correcting"),
+        );
+    }
+}
+
+#[test]
+fn inside_band_defers_to_a_correcting_huge_weight() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        let centre = (safe_min + safe_max) / 2.0;
+        // |weight| > 1e3 and weight * error < 0 -- let the weight shrink first.
+        let factor = apply_safe_zone_adjustment(squash, centre, -1.0, 1e4);
+        assert_close(factor, 0.0, &format!("{squash:?} huge weight correcting"));
+
+        let factor = apply_safe_zone_adjustment(squash, centre, 1.0, 1e4);
+        assert_close(
+            factor,
+            1.0,
+            &format!("{squash:?} huge weight not correcting"),
+        );
+    }
+}
+
+#[test]
+fn beyond_band_fades_linearly_to_zero() {
+    for &(squash, safe_min, safe_max, fade) in BOUNDED_ARMS {
+        for fraction in [0.25_f32, 0.5, 0.75, 1.0] {
+            let expected = 1.0 - fraction;
+
+            // Upper fade: error must not be worsening (error <= 0).
+            let raw = safe_max + fade * fraction;
+            let factor = apply_safe_zone_adjustment(squash, raw, -1.0, HEALTHY_WEIGHT);
+            assert_close(factor, expected, &format!("{squash:?} upper fade at {raw}"));
+
+            // Lower fade: error must not be worsening (error >= 0).
+            let raw = safe_min - fade * fraction;
+            let factor = apply_safe_zone_adjustment(squash, raw, 1.0, HEALTHY_WEIGHT);
+            assert_close(factor, expected, &format!("{squash:?} lower fade at {raw}"));
+        }
+    }
+}
+
+#[test]
+fn past_the_fade_width_no_gradient_flows() {
+    for &(squash, safe_min, safe_max, fade) in BOUNDED_ARMS {
+        let above = apply_safe_zone_adjustment(squash, safe_max + fade + 1.0, -1.0, HEALTHY_WEIGHT);
+        assert_close(above, 0.0, &format!("{squash:?} past upper fade"));
+
+        let below = apply_safe_zone_adjustment(squash, safe_min - fade - 1.0, 1.0, HEALTHY_WEIGHT);
+        assert_close(below, 0.0, &format!("{squash:?} past lower fade"));
+    }
+}
+
+#[test]
+fn non_finite_raw_input_is_never_safe() {
+    for &(squash, ..) in BOUNDED_ARMS {
+        for raw in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let factor = apply_safe_zone_adjustment(squash, raw, 1.0, HEALTHY_WEIGHT);
+            assert_close(factor, 0.0, &format!("{squash:?} raw={raw}"));
+        }
+    }
+}


### PR DESCRIPTION
# Extract the bounded safe-zone rule shared by twelve SquashType arms

## Summary

Twelve `SquashType` arms of `apply_safe_zone_adjustment`
(`neat-core/src/safe_zone.rs`) each re-implemented the same ~22-line bounded
safe-zone policy. Only the safe band `[safe_min, safe_max]` and the fade width
differed — the guards, the `[1e-3, 1e3]` weight thresholds and the linear fade
formula were character-for-character identical. Extracted one private helper and
collapsed each arm to a single call. Closes #442.

```rust
#[inline(always)]
fn bounded_safe_zone(
    raw_input: f32, error: f32, weight: f32,
    safe_min: f32, safe_max: f32, fade: f32,
) -> f32
```

Each arm is now one line, e.g.
`SquashType::Selu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0)`.

The six parameters are plain numeric bounds — no mode flags and no
`if caller == …` branching, so this is a call rather than a parameterised
super-helper. The arms encoding genuinely different rules (`Sine`, `Cosine`,
`Tan`, `Gaussian`, `BipolarSigmoid`, `ArcTan`, `Square`, `Cube`, `Sqrt`,
`Logistic`, `Tanh`, `HardTanh`, and the rest) are untouched.

Behaviour is unchanged. `safe_zone.rs` drops from 1010 to 630 lines.

### Bounds per arm

| Arm | `safe_min` | `safe_max` | `fade` |
| --- | ---: | ---: | ---: |
| `LeakyRelu` | -50 | 50 | 20 |
| `Selu` | -10 | 10 | 10 |
| `Elu` | -10 | 10 | 10 |
| `Softsign` | -10 | 10 | 10 |
| `Softplus` | -10 | 20 | 10 |
| `Swish` | -10 | 10 | 10 |
| `Mish` | -10 | 10 | 10 |
| `Gelu` | -6 | 6 | 10 |
| `StdInverse` | -10 | 10 | 10 |
| `Exponential` | -10 | 30 | 10 |
| `LogSigmoid` | -20 | 20 | 10 |
| `Isru` | -10 | 10 | 10 |

`LogSigmoid` previously spelled its fade edges as absolute `fade_min = -30.0` /
`fade_max = 30.0` rather than `safe_min - fade` / `safe_max + fade`; those are
the same values, so the collapse to `fade = 10.0` is exact.

## Evidence

This is a backend library refactor with no web interface, so there is no
screenshot. The evidence is the behavioural test suite plus a green quality
gate.

```mermaid
flowchart TD
    A["apply_safe_zone_adjustment(squash, raw, error, weight)"] --> B{"raw is finite?"}
    B -- no --> Z["0.0"]
    B -- yes --> C{"match squash_type"}
    C -- "12 bounded arms" --> D["bounded_safe_zone(raw, error, weight,<br/>safe_min, safe_max, fade)"]
    C -- "other arms" --> E["arm-specific rule, still inline"]
    D --> F{"outside band and<br/>error pushes further out?"}
    F -- yes --> Z
    F -- no --> G{"inside band, weight outside<br/>[1e-3, 1e3], error correcting it?"}
    G -- yes --> Z
    G -- no --> H{"inside band?"}
    H -- yes --> I["1.0"]
    H -- no --> J["linear fade to 0.0 across<br/>`fade` past the edge"]
```

Quality gate (`./quality.sh`) passes cleanly: rustfmt, clippy, `cargo deny`, the
full workspace test suite, doc build and release build.

## Test Plan

Added `neat-core/tests/safe_zone_bounded.rs` — seven behavioural tests, each
looping over all twelve arms with their `(safe_min, safe_max, fade)` bounds and
asserting on the factor returned by the public
`apply_safe_zone_adjustment`, not on the helper:

- `inside_band_with_healthy_weight_flows_fully` — both edges and the centre
  return `1.0` for negative, zero and positive error.
- `outside_band_with_worsening_error_blocks_gradient` — past either edge with an
  error pushing further out returns `0.0`.
- `inside_band_defers_to_a_correcting_tiny_weight` — `|weight| < 1e-3` with
  `weight * error > 0` returns `0.0`; the same weight with a non-correcting
  error still returns `1.0`.
- `inside_band_defers_to_a_correcting_huge_weight` — the `|weight| > 1e3`
  mirror.
- `beyond_band_fades_linearly_to_zero` — 25%, 50%, 75% and 100% into each fade
  band returns exactly `0.75`, `0.5`, `0.25` and `0.0`.
- `past_the_fade_width_no_gradient_flows` — beyond the fade width returns `0.0`.
- `non_finite_raw_input_is_never_safe` — `NaN` and both infinities return `0.0`.

These were written and run **before** the extraction, against the twelve
existing copies, so they characterise the pre-change behaviour; they then stayed
green afterwards. That is what verifies the refactor is behaviour-preserving —
for a pure extraction there is no new behaviour for a failing-first test to
describe. The existing `test_safe_zone_adjustment` in
`neat-core/tests/integration.rs` is unchanged and still passes.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms8xoiqo-aef26d`<!-- vibe-worker-issue-442 -->