### PR TITLE
Aggregate-squash activation: one rule, called from every scalar tail (Issue #441)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,22 @@ this you **must**:
 - **Add a state-leak regression test** asserting the reused-buffer path is
   byte-identical to the fresh-allocation path across differently-sized inputs.
 
+## One activation rule for single-record work (Issue #441)
+
+`neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) is the single home
+of the rule that turns a neuron's synapse range into an activation — constants,
+the six aggregate squashes (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean),
+the standard weighted-sum fall-through, then `apply_limit_range`. **Every**
+batched kernel that drops to one record at a time (the per-lane aggregate loops
+and the scalar tails in `loss.rs`) calls it, so a record's activation never
+depends on whether it landed in a full SIMD group or in the remainder. Adding a
+squash type means editing that helper only — do not re-inline the match.
+
+`CompiledNetwork::activate` / `activate_into` deliberately keep their own copy:
+routing them through the helper measured ~30–46% slower on the `forward_pass`
+benchmark. Change the helper and those two together, and re-run
+`cargo bench --bench hot_paths -- forward_pass` if you touch them.
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/docs/archive/pr-summaries/pr-summary-441.md
+++ b/docs/archive/pr-summaries/pr-summary-441.md
@@ -1,0 +1,116 @@
+# Aggregate-squash activation: one rule, called from every scalar tail
+
+## Summary
+
+The rule that turns a neuron's inbound synapse range into an activation — the
+dispatch over `Minimum` / `Maximum` / `If` / `Hypotenuse` / `HypotenuseV2` /
+`Mean`, the standard weighted-sum fall-through, then `apply_limit_range` — was
+copy-pasted across `neat-core/src/loss.rs`, and **three of those copies had
+diverged**: they stopped at `If`, so a neuron using `Mean`, `Hypotenuse` or
+`HypotenuseV2` fell through to a plain weighted sum whenever its record landed
+in the scalar remainder instead of a full SIMD group.
+
+That was reachable in production, not theoretical: `mse_sum_batch_8way_scattered`
+is the arm selected *precisely when* `has_aggregate_squash()` is true, so the one
+path reserved for aggregate networks mis-computed its own tail records. The
+`batch_8way_activation!` tail is shared by the MAE, cross-entropy, MAPE, MSLE and
+hinge paths, and `mse_sum_batch_4way` is reached with no aggregate guard at all.
+An aggregate creature scored over nine records got the correct error for the
+first eight and a silently wrong one for the ninth.
+
+`neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) already held the
+correct rule, byte-for-byte as `CompiledNetwork::activate_into` computes it. This
+PR widens it to `pub(crate)` and calls it from every single-record site in
+`loss.rs` — the three diverged scalar tails, the four per-lane aggregate loops
+and the interleaved tail — deleting ~700 duplicated lines. Adding a seventh
+aggregate squash now means editing one match.
+
+Closes #441.
+
+### Deliberately left alone
+
+- **`CompiledNetwork::activate` / `activate_into`** keep their inlined copy.
+  Routing them through the helper was implemented and measured: `forward_pass/
+  production_exact` went from **13.4 µs → 19.3 µs (+46%)**, and still **17.4 µs
+  (+30%)** with `#[inline(always)]`. Neither copy had diverged, so the trade was
+  not worth it; the constraint is now recorded in `AGENTS.md`.
+- **`network.rs:753-926`**, the `(activation, hint_value)` trace variant — it
+  would need a mode parameter, which the issue explicitly rules out.
+
+```mermaid
+flowchart TD
+    subgraph before["Before — 8 sites, 3 diverged"]
+        B1["8-lane group<br/>6 aggregate arms"]
+        B2["4-lane group<br/>6 aggregate arms"]
+        B3["scalar tail<br/>❌ stops at If"]
+    end
+    subgraph after["After — one rule"]
+        A1["8-lane group"] --> H
+        A2["4-lane group"] --> H
+        A3["scalar tail"] --> H
+        H["neuron_activation_scalar<br/>Min · Max · If · Hyp · HypV2 · Mean<br/>+ weighted sum + limit range"]
+    end
+    before --> after
+```
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. Evidence
+is the failing-then-passing regression test plus the benchmark A/B above.
+
+**New test fails on the unfixed code** (`Hypotenuse`, tail record wrong by two
+orders of magnitude more than the SIMD tolerance):
+
+```
+mse Hypotenuse n=5: batched 2.2803990747196785 diverged from per-record
+reference 2.1519708379379026 by 0.12842823678177595 (tol 0.00001)
+mae Hypotenuse n=9: batched 5.541243314743042 diverged from per-record
+reference 5.42296490073204 by 0.11827841401100159 (tol 0.00001)
+```
+
+**After the fix:**
+
+```
+running 2 tests
+test mse_scalar_tail_matches_reference_for_every_aggregate_squash ... ok
+test shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash ... ok
+test result: ok. 2 passed; 0 failed
+```
+
+`./quality.sh` passes clean (fmt, clippy `-D warnings`, deny, full
+`cargo test --workspace`, doc build, release build).
+
+**Numerics note.** For `Hypotenuse` / `HypotenuseV2` / `Mean`, the per-lane
+aggregate loops in `loss.rs` previously used naive scalar sums; they now use the
+same SIMD sum helpers as the single-record reference. Results shift by f32
+rounding *towards* `activate` — the batch paths are now closer to the reference,
+not further. The existing bit-identity guard
+(`loss::interleaved_mse_parity`) and the `mse_squash_simd_parity` /
+`score_squash_simd_parity` suites all stay green.
+
+**Benchmark A/B** (`cargo bench --bench hot_paths`, 100 samples): batched
+scoring shows no consistent movement — `mse_sum_8records/production` 64.5 µs vs
+64.9 µs, within the ±10% run-to-run noise seen in both directions on this host.
+The changed code is only reached by aggregate networks and scalar tails, so this
+is the expected result.
+
+## Test Plan
+
+Added `neat-core/tests/aggregate_squash_tail_parity.rs`:
+
+- `mse_scalar_tail_matches_reference_for_every_aggregate_squash` — scores an
+  aggregate network through `mse_sum_batch_packed` at record counts with a
+  non-empty tail (5, 6, 7 → 4-way + tail; 9, 13 → 8-way group + tail) for all
+  six aggregate squashes, asserting the batched result matches the per-record
+  `CompiledNetwork::activate_into` reference (`forward_only = false`) within
+  1e-5.
+- `shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash` — the
+  same guard across the five loss functions sharing `batch_8way_activation!`
+  (MAE, cross-entropy, MAPE, MSLE, hinge) at counts 9 and 13.
+
+Both tests fail against the unfixed code and pass after the change. The fixture
+alternates synapse types so the `If` arm sees condition, positive and negative
+edges rather than a single branch.
+
+Existing suites unchanged and green, including the bit-identity guards that pin
+the interleaved kernel to the scattered one across the 8/4/tail boundaries.

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -152,11 +152,27 @@ fn inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
     }
 }
 
-/// Single-record activation for one neuron, byte-for-byte identical to the body
-/// of [`CompiledNetwork::activate_into`]. Reused for constant neurons, aggregate
-/// squashes and the scalar tail so those results exactly match the reference.
+/// Single-record activation for one neuron — the shared home of the rule that
+/// turns a neuron's inbound synapse range into an activation (Issue #441).
+/// Covers constant neurons, the six aggregate squashes
+/// (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean), the standard weighted-sum
+/// fall-through and the closing range clamp, byte-for-byte as
+/// [`CompiledNetwork::activate_into`] computes them.
+///
+/// Every batched scoring kernel that has to drop to one record at a time — the
+/// per-lane aggregate loops and the scalar tails here and in [`crate::loss`] —
+/// calls this, so a record's activation does not depend on whether it landed in
+/// a full SIMD group or in the remainder.
+///
+/// `activate` / `activate_into` keep their own inlined copy: routing them
+/// through this helper measured ~30–46% slower on the `forward_pass` benchmark
+/// (Issue #441), and neither had diverged.
 #[inline]
-fn neuron_activation_scalar(synapses: &[SynapseData], act: &[f32], neuron: &NeuronData) -> f32 {
+pub(crate) fn neuron_activation_scalar(
+    synapses: &[SynapseData],
+    act: &[f32],
+    neuron: &NeuronData,
+) -> f32 {
     if neuron.is_constant {
         return apply_limit_range(SquashType::Identity, neuron.bias);
     }

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -6,13 +6,12 @@
 //!
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
-use crate::batch_scoring::SCORING_LANES;
+use crate::batch_scoring::{SCORING_LANES, neuron_activation_scalar};
 use crate::network::CompiledNetwork;
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
 use crate::squash::{SquashType, apply_squash};
 use crate::squash_simd::{squash_x4, squash_x8};
-use crate::synapse_type::SynapseType;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -86,109 +85,13 @@ macro_rules! batch_8way_activation {
                         | SquashType::Hypotenuse
                         | SquashType::HypotenuseV2
                         | SquashType::Mean => {
-                            for (r, act) in [
-                                (0, &mut act0),
-                                (1, &mut act1),
-                                (2, &mut act2),
-                                (3, &mut act3),
-                                (4, &mut act4),
-                                (5, &mut act5),
-                                (6, &mut act6),
-                                (7, &mut act7),
+                            for act in [
+                                &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
+                                &mut act6, &mut act7,
                             ] {
-                                let _ = r;
-                                let activation = match squash {
-                                    SquashType::Minimum => {
-                                        let mut min_val = f32::INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val < min_val {
-                                                min_val = val;
-                                            }
-                                        }
-                                        if min_val == f32::INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            min_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::Maximum => {
-                                        let mut max_val = f32::NEG_INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val > max_val {
-                                                max_val = val;
-                                            }
-                                        }
-                                        if max_val == f32::NEG_INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            max_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::If => {
-                                        let mut condition_sum = 0.0f32;
-                                        let mut positive_sum = 0.0f32;
-                                        let mut negative_sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            match SynapseType::from(synapse.synapse_type) {
-                                                SynapseType::Condition => condition_sum += val,
-                                                SynapseType::Negative => negative_sum += val,
-                                                SynapseType::Positive | SynapseType::Standard => {
-                                                    positive_sum += val
-                                                }
-                                            }
-                                        }
-                                        if condition_sum > 0.0 {
-                                            positive_sum + neuron.bias
-                                        } else {
-                                            negative_sum + neuron.bias
-                                        }
-                                    }
-                                    SquashType::Hypotenuse => {
-                                        let mut sum_sq = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            sum_sq += val * val;
-                                        }
-                                        sum_sq.sqrt() + neuron.bias
-                                    }
-                                    SquashType::HypotenuseV2 => {
-                                        let mut sum_sq = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val = neuron.bias
-                                                + act[synapse.from_index as usize] * synapse.weight;
-                                            sum_sq += val * val;
-                                        }
-                                        sum_sq.sqrt()
-                                    }
-                                    SquashType::Mean => {
-                                        let n = (end_synapse - start_synapse) as f32;
-                                        if n <= 0.0 {
-                                            neuron.bias
-                                        } else {
-                                            let mut sum = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                sum += act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                            }
-                                            sum / n + neuron.bias
-                                        }
-                                    }
-                                    _ => unreachable!(),
-                                };
-                                act[actual_idx] = apply_limit_range(squash, activation);
+                                let value =
+                                    neuron_activation_scalar(&$network.synapses, act, neuron);
+                                act[actual_idx] = value;
                             }
                         }
                         _ => {
@@ -306,105 +209,10 @@ macro_rules! batch_8way_activation {
                             | SquashType::Hypotenuse
                             | SquashType::HypotenuseV2
                             | SquashType::Mean => {
-                                for (r, act) in [
-                                    (0, &mut act0),
-                                    (1, &mut act1),
-                                    (2, &mut act2),
-                                    (3, &mut act3),
-                                ] {
-                                    let _ = r;
-                                    let activation = match squash {
-                                        SquashType::Minimum => {
-                                            let mut min_val = f32::INFINITY;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                if val < min_val {
-                                                    min_val = val;
-                                                }
-                                            }
-                                            if min_val == f32::INFINITY {
-                                                neuron.bias
-                                            } else {
-                                                min_val + neuron.bias
-                                            }
-                                        }
-                                        SquashType::Maximum => {
-                                            let mut max_val = f32::NEG_INFINITY;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                if val > max_val {
-                                                    max_val = val;
-                                                }
-                                            }
-                                            if max_val == f32::NEG_INFINITY {
-                                                neuron.bias
-                                            } else {
-                                                max_val + neuron.bias
-                                            }
-                                        }
-                                        SquashType::If => {
-                                            let mut condition_sum = 0.0f32;
-                                            let mut positive_sum = 0.0f32;
-                                            let mut negative_sum = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                match SynapseType::from(synapse.synapse_type) {
-                                                    SynapseType::Condition => condition_sum += val,
-                                                    SynapseType::Negative => negative_sum += val,
-                                                    SynapseType::Positive
-                                                    | SynapseType::Standard => positive_sum += val,
-                                                }
-                                            }
-                                            if condition_sum > 0.0 {
-                                                positive_sum + neuron.bias
-                                            } else {
-                                                negative_sum + neuron.bias
-                                            }
-                                        }
-                                        SquashType::Hypotenuse => {
-                                            let mut sum_sq = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                sum_sq += val * val;
-                                            }
-                                            sum_sq.sqrt() + neuron.bias
-                                        }
-                                        SquashType::HypotenuseV2 => {
-                                            let mut sum_sq = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = neuron.bias
-                                                    + act[synapse.from_index as usize]
-                                                        * synapse.weight;
-                                                sum_sq += val * val;
-                                            }
-                                            sum_sq.sqrt()
-                                        }
-                                        SquashType::Mean => {
-                                            let n = (end_synapse - start_synapse) as f32;
-                                            if n <= 0.0 {
-                                                neuron.bias
-                                            } else {
-                                                let mut sum = 0.0f32;
-                                                for synapse_idx in start_synapse..end_synapse {
-                                                    let synapse = &$network.synapses[synapse_idx];
-                                                    sum += act[synapse.from_index as usize]
-                                                        * synapse.weight;
-                                                }
-                                                sum / n + neuron.bias
-                                            }
-                                        }
-                                        _ => unreachable!(),
-                                    };
-                                    act[actual_idx] = apply_limit_range(squash, activation);
+                                for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
+                                    let value =
+                                        neuron_activation_scalar(&$network.synapses, act, neuron);
+                                    act[actual_idx] = value;
                                 }
                             }
                             _ => {
@@ -477,84 +285,8 @@ macro_rules! batch_8way_activation {
             }
 
             for (neuron_idx, neuron) in $network.neurons.iter().enumerate() {
-                let actual_idx = num_inputs + neuron_idx;
-
-                if neuron.is_constant {
-                    act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-                } else {
-                    let squash = SquashType::from(neuron.squash_type);
-                    let start_synapse = neuron.start_synapse as usize;
-                    let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                    let activation = match squash {
-                        SquashType::Minimum => {
-                            let mut min_val = f32::INFINITY;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                let val = act0[synapse.from_index as usize] * synapse.weight;
-                                if val < min_val {
-                                    min_val = val;
-                                }
-                            }
-                            if min_val == f32::INFINITY {
-                                neuron.bias
-                            } else {
-                                min_val + neuron.bias
-                            }
-                        }
-                        SquashType::Maximum => {
-                            let mut max_val = f32::NEG_INFINITY;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                let val = act0[synapse.from_index as usize] * synapse.weight;
-                                if val > max_val {
-                                    max_val = val;
-                                }
-                            }
-                            if max_val == f32::NEG_INFINITY {
-                                neuron.bias
-                            } else {
-                                max_val + neuron.bias
-                            }
-                        }
-                        SquashType::If => {
-                            let mut condition_sum = 0.0f32;
-                            let mut positive_sum = 0.0f32;
-                            let mut negative_sum = 0.0f32;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                let val = act0[synapse.from_index as usize] * synapse.weight;
-                                match SynapseType::from(synapse.synapse_type) {
-                                    SynapseType::Condition => condition_sum += val,
-                                    SynapseType::Negative => negative_sum += val,
-                                    SynapseType::Positive | SynapseType::Standard => {
-                                        positive_sum += val
-                                    }
-                                }
-                            }
-                            if condition_sum > 0.0 {
-                                positive_sum + neuron.bias
-                            } else {
-                                negative_sum + neuron.bias
-                            }
-                        }
-                        _ => {
-                            let mut sum = neuron.bias;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                sum += act0[synapse.from_index as usize] * synapse.weight;
-                            }
-                            match neuron.squash_type {
-                                0 => sum,
-                                1 => sum.max(0.0),
-                                6 => 1.0 / (1.0 + (-sum).exp()),
-                                7 => sum.tanh(),
-                                _ => apply_squash(squash, sum),
-                            }
-                        }
-                    };
-                    act0[actual_idx] = apply_limit_range(squash, activation);
-                }
+                let value = neuron_activation_scalar(&$network.synapses, &act0, neuron);
+                act0[num_inputs + neuron_idx] = value;
             }
 
             sum_error += $error_fn($records, target_base, &act0, output_start, $num_outputs);
@@ -729,102 +461,12 @@ fn mse_sum_batch_4way(
                     | SquashType::Hypotenuse
                     | SquashType::HypotenuseV2
                     | SquashType::Mean => {
-                        // Fall back to scalar for special squash functions
-                        for (r, act) in [
-                            (0, &mut act0),
-                            (1, &mut act1),
-                            (2, &mut act2),
-                            (3, &mut act3),
-                        ] {
-                            let _ = r;
-                            let activation = match squash {
-                                SquashType::Minimum => {
-                                    let mut min_val = f32::INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val < min_val {
-                                            min_val = val;
-                                        }
-                                    }
-                                    if min_val == f32::INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        min_val + neuron.bias
-                                    }
-                                }
-                                SquashType::Maximum => {
-                                    let mut max_val = f32::NEG_INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val > max_val {
-                                            max_val = val;
-                                        }
-                                    }
-                                    if max_val == f32::NEG_INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        max_val + neuron.bias
-                                    }
-                                }
-                                SquashType::If => {
-                                    let mut condition_sum = 0.0f32;
-                                    let mut positive_sum = 0.0f32;
-                                    let mut negative_sum = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        match SynapseType::from(synapse.synapse_type) {
-                                            SynapseType::Condition => condition_sum += val,
-                                            SynapseType::Negative => negative_sum += val,
-                                            SynapseType::Positive | SynapseType::Standard => {
-                                                positive_sum += val
-                                            }
-                                        }
-                                    }
-                                    if condition_sum > 0.0 {
-                                        positive_sum + neuron.bias
-                                    } else {
-                                        negative_sum + neuron.bias
-                                    }
-                                }
-                                SquashType::Hypotenuse => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt() + neuron.bias
-                                }
-                                SquashType::HypotenuseV2 => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = neuron.bias
-                                            + act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt()
-                                }
-                                SquashType::Mean => {
-                                    let n = (end_synapse - start_synapse) as f32;
-                                    if n <= 0.0 {
-                                        neuron.bias
-                                    } else {
-                                        let mut sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            sum +=
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                        }
-                                        sum / n + neuron.bias
-                                    }
-                                }
-                                _ => unreachable!(),
-                            };
-                            act[actual_idx] = apply_limit_range(squash, activation);
+                        // One shared activation rule (Issue #441): the scalar
+                        // helper covers every aggregate squash exactly as the
+                        // single-record reference does.
+                        for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
+                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
+                            act[actual_idx] = value;
                         }
                     }
                     _ => {
@@ -907,86 +549,11 @@ fn mse_sum_batch_4way(
             *activation = 0.0;
         }
 
-        // Process each neuron
+        // Process each neuron through the one shared activation rule
+        // (Issue #441) so the tail record matches the reference exactly.
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                let activation = match squash {
-                    SquashType::Minimum => {
-                        let mut min_val = f32::INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val < min_val {
-                                min_val = val;
-                            }
-                        }
-                        if min_val == f32::INFINITY {
-                            neuron.bias
-                        } else {
-                            min_val + neuron.bias
-                        }
-                    }
-                    SquashType::Maximum => {
-                        let mut max_val = f32::NEG_INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val > max_val {
-                                max_val = val;
-                            }
-                        }
-                        if max_val == f32::NEG_INFINITY {
-                            neuron.bias
-                        } else {
-                            max_val + neuron.bias
-                        }
-                    }
-                    SquashType::If => {
-                        let mut condition_sum = 0.0f32;
-                        let mut positive_sum = 0.0f32;
-                        let mut negative_sum = 0.0f32;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            match SynapseType::from(synapse.synapse_type) {
-                                SynapseType::Condition => condition_sum += val,
-                                SynapseType::Negative => negative_sum += val,
-                                SynapseType::Positive | SynapseType::Standard => {
-                                    positive_sum += val
-                                }
-                            }
-                        }
-                        if condition_sum > 0.0 {
-                            positive_sum + neuron.bias
-                        } else {
-                            negative_sum + neuron.bias
-                        }
-                    }
-                    _ => {
-                        let mut sum = neuron.bias;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            sum += act0[synapse.from_index as usize] * synapse.weight;
-                        }
-                        match neuron.squash_type {
-                            0 => sum,
-                            1 => sum.max(0.0),
-                            6 => 1.0 / (1.0 + (-sum).exp()),
-                            7 => sum.tanh(),
-                            _ => apply_squash(squash, sum),
-                        }
-                    }
-                };
-                act0[actual_idx] = apply_limit_range(squash, activation);
-            }
+            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
+            act0[num_inputs + neuron_idx] = value;
         }
 
         // Calculate MSE
@@ -1205,25 +772,8 @@ fn mse_sum_batch_8way_interleaved(
             *activation = 0.0;
         }
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-            if neuron.is_constant {
-                act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-                continue;
-            }
-            let squash = SquashType::from(neuron.squash_type);
-            let start_synapse = neuron.start_synapse as usize;
-            let end_synapse = start_synapse + neuron.num_synapses as usize;
-            let mut sum = neuron.bias;
-            for synapse in network
-                .synapses
-                .iter()
-                .take(end_synapse)
-                .skip(start_synapse)
-            {
-                sum += act0[synapse.from_index as usize] * synapse.weight;
-            }
-            let activation = inline_squash_scalar(neuron.squash_type, squash, sum);
-            act0[actual_idx] = apply_limit_range(squash, activation);
+            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
+            act0[num_inputs + neuron_idx] = value;
         }
         let mut sq_sum: f64 = 0.0;
         for j in 0..num_outputs {
@@ -1346,106 +896,15 @@ fn mse_sum_batch_8way_scattered(
                     | SquashType::Hypotenuse
                     | SquashType::HypotenuseV2
                     | SquashType::Mean => {
-                        // Fall back to scalar for special squash functions
-                        for (r, act) in [
-                            (0, &mut act0),
-                            (1, &mut act1),
-                            (2, &mut act2),
-                            (3, &mut act3),
-                            (4, &mut act4),
-                            (5, &mut act5),
-                            (6, &mut act6),
-                            (7, &mut act7),
+                        // One shared activation rule (Issue #441): the scalar
+                        // helper covers every aggregate squash exactly as the
+                        // single-record reference does.
+                        for act in [
+                            &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
+                            &mut act6, &mut act7,
                         ] {
-                            let _ = r;
-                            let activation = match squash {
-                                SquashType::Minimum => {
-                                    let mut min_val = f32::INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val < min_val {
-                                            min_val = val;
-                                        }
-                                    }
-                                    if min_val == f32::INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        min_val + neuron.bias
-                                    }
-                                }
-                                SquashType::Maximum => {
-                                    let mut max_val = f32::NEG_INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val > max_val {
-                                            max_val = val;
-                                        }
-                                    }
-                                    if max_val == f32::NEG_INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        max_val + neuron.bias
-                                    }
-                                }
-                                SquashType::If => {
-                                    let mut condition_sum = 0.0f32;
-                                    let mut positive_sum = 0.0f32;
-                                    let mut negative_sum = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        match SynapseType::from(synapse.synapse_type) {
-                                            SynapseType::Condition => condition_sum += val,
-                                            SynapseType::Negative => negative_sum += val,
-                                            SynapseType::Positive | SynapseType::Standard => {
-                                                positive_sum += val
-                                            }
-                                        }
-                                    }
-                                    if condition_sum > 0.0 {
-                                        positive_sum + neuron.bias
-                                    } else {
-                                        negative_sum + neuron.bias
-                                    }
-                                }
-                                SquashType::Hypotenuse => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt() + neuron.bias
-                                }
-                                SquashType::HypotenuseV2 => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = neuron.bias
-                                            + act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt()
-                                }
-                                SquashType::Mean => {
-                                    let n = (end_synapse - start_synapse) as f32;
-                                    if n <= 0.0 {
-                                        neuron.bias
-                                    } else {
-                                        let mut sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            sum +=
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                        }
-                                        sum / n + neuron.bias
-                                    }
-                                }
-                                _ => unreachable!(),
-                            };
-                            act[actual_idx] = apply_limit_range(squash, activation);
+                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
+                            act[actual_idx] = value;
                         }
                     }
                     _ => {
@@ -1573,71 +1032,11 @@ fn mse_sum_batch_8way_scattered(
                         | SquashType::Hypotenuse
                         | SquashType::HypotenuseV2
                         | SquashType::Mean => {
-                            for (r, act) in [
-                                (0, &mut act0),
-                                (1, &mut act1),
-                                (2, &mut act2),
-                                (3, &mut act3),
-                            ] {
-                                let _ = r;
-                                let activation = match squash {
-                                    SquashType::Minimum => {
-                                        let mut min_val = f32::INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val < min_val {
-                                                min_val = val;
-                                            }
-                                        }
-                                        if min_val == f32::INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            min_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::Maximum => {
-                                        let mut max_val = f32::NEG_INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val > max_val {
-                                                max_val = val;
-                                            }
-                                        }
-                                        if max_val == f32::NEG_INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            max_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::If => {
-                                        let mut condition_sum = 0.0f32;
-                                        let mut positive_sum = 0.0f32;
-                                        let mut negative_sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            match SynapseType::from(synapse.synapse_type) {
-                                                SynapseType::Condition => condition_sum += val,
-                                                SynapseType::Negative => negative_sum += val,
-                                                SynapseType::Positive | SynapseType::Standard => {
-                                                    positive_sum += val
-                                                }
-                                            }
-                                        }
-                                        if condition_sum > 0.0 {
-                                            positive_sum + neuron.bias
-                                        } else {
-                                            negative_sum + neuron.bias
-                                        }
-                                    }
-                                    _ => unreachable!(),
-                                };
-                                act[actual_idx] = apply_limit_range(squash, activation);
+                            // One shared activation rule (Issue #441).
+                            for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
+                                let value =
+                                    neuron_activation_scalar(&network.synapses, act, neuron);
+                                act[actual_idx] = value;
                             }
                         }
                         _ => {
@@ -1719,86 +1118,11 @@ fn mse_sum_batch_8way_scattered(
             *activation = 0.0;
         }
 
-        // Process each neuron
+        // Process each neuron through the one shared activation rule
+        // (Issue #441) so the tail record matches the reference exactly.
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                let activation = match squash {
-                    SquashType::Minimum => {
-                        let mut min_val = f32::INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val < min_val {
-                                min_val = val;
-                            }
-                        }
-                        if min_val == f32::INFINITY {
-                            neuron.bias
-                        } else {
-                            min_val + neuron.bias
-                        }
-                    }
-                    SquashType::Maximum => {
-                        let mut max_val = f32::NEG_INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val > max_val {
-                                max_val = val;
-                            }
-                        }
-                        if max_val == f32::NEG_INFINITY {
-                            neuron.bias
-                        } else {
-                            max_val + neuron.bias
-                        }
-                    }
-                    SquashType::If => {
-                        let mut condition_sum = 0.0f32;
-                        let mut positive_sum = 0.0f32;
-                        let mut negative_sum = 0.0f32;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            match SynapseType::from(synapse.synapse_type) {
-                                SynapseType::Condition => condition_sum += val,
-                                SynapseType::Negative => negative_sum += val,
-                                SynapseType::Positive | SynapseType::Standard => {
-                                    positive_sum += val
-                                }
-                            }
-                        }
-                        if condition_sum > 0.0 {
-                            positive_sum + neuron.bias
-                        } else {
-                            negative_sum + neuron.bias
-                        }
-                    }
-                    _ => {
-                        let mut sum = neuron.bias;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            sum += act0[synapse.from_index as usize] * synapse.weight;
-                        }
-                        match neuron.squash_type {
-                            0 => sum,
-                            1 => sum.max(0.0),
-                            6 => 1.0 / (1.0 + (-sum).exp()),
-                            7 => sum.tanh(),
-                            _ => apply_squash(squash, sum),
-                        }
-                    }
-                };
-                act0[actual_idx] = apply_limit_range(squash, activation);
-            }
+            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
+            act0[num_inputs + neuron_idx] = value;
         }
 
         // Calculate MSE

--- a/neat-core/tests/aggregate_squash_tail_parity.rs
+++ b/neat-core/tests/aggregate_squash_tail_parity.rs
@@ -1,0 +1,189 @@
+//! Parity guard for the **scalar tails** of the fused batch-loss kernels on
+//! aggregate-squash networks (Issue #441).
+//!
+//! The batched loss kernels group records into 8s, then a 4-record group, then
+//! a single-record scalar tail. Every group size must compute a neuron's
+//! activation by the same rule as the single-record reference
+//! ([`CompiledNetwork::activate_into`], reached with `forward_only = false`),
+//! including the aggregate squashes — `Minimum`, `Maximum`, `If`,
+//! `Hypotenuse`, `HypotenuseV2` and `Mean` — which are not a weighted sum.
+//!
+//! These are "what" tests: they score a real aggregate-squash network through
+//! the public packed entry points at record counts that leave a non-empty tail
+//! (5/6/7 → 4-way + tail, 9/13 → 8-way group + tail) and assert the batched
+//! error matches the per-record reference. A tail that falls through to a plain
+//! weighted sum shifts the tail record's output by orders of magnitude, so the
+//! tight tolerance below fails loudly.
+
+use neat_core::loss::{
+    cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
+    mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
+};
+use neat_core::squash::SquashType;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Every aggregate squash the activation rule dispatches on.
+const AGGREGATES: [SquashType; 6] = [
+    SquashType::Minimum,
+    SquashType::Maximum,
+    SquashType::If,
+    SquashType::Hypotenuse,
+    SquashType::HypotenuseV2,
+    SquashType::Mean,
+];
+
+/// Record counts with a non-empty scalar tail: 5/6/7 exercise the 4-way group
+/// plus tail, 9 and 13 the 8-way group plus (4-way plus) tail.
+const TAIL_COUNTS: [usize; 5] = [5, 6, 7, 9, 13];
+
+const INPUT_SIZE: usize = 6;
+
+/// The batched kernels reach the same activation rule as the reference, so the
+/// only permitted gap is f32 summation order inside the SIMD weighted sums.
+const TOLERANCE: f64 = 1.0e-5;
+
+/// Build a forward-only network: `num_inputs` inputs fully connected into two
+/// hidden neurons and one output neuron, every non-input neuron using `squash`.
+/// Mirrors the fixture in `mse_batch_interleaved_parity.rs`.
+fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.27 - 0.1 * (i as f32) + 0.06 * (h as f32),
+                from_index: i as u16,
+                // Alternate the synapse type so the `If` arm sees condition,
+                // positive and negative edges rather than one branch only.
+                synapse_type: (i % 3) as u8,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    let hidden0 = num_inputs as u16;
+    let hidden1 = num_inputs as u16 + 1;
+    synapses.push(SynapseData {
+        weight: 0.62,
+        from_index: hidden0,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.44,
+        from_index: hidden1,
+        synapse_type: 1,
+    });
+    neurons.push(NeuronData {
+        bias: 0.015,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Packed `[inputs..., target]` records, distinct per record so a tail-record
+/// mix-up cannot hide. Targets stay in `(0, 1)` so cross-entropy, MAPE and MSLE
+/// are all well defined on the same fixture.
+fn build_records(num_records: usize, input_size: usize) -> Vec<f32> {
+    let values_per_record = input_size + 1;
+    let mut records = vec![0.0f32; num_records * values_per_record];
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        for i in 0..input_size {
+            records[base + i] = (((r * 7 + i * 3) as f32) * 0.013).sin() * 0.9;
+        }
+        records[base + input_size] = 0.5 + (((r * 5 + 1) as f32) * 0.011).cos() * 0.25;
+    }
+    records
+}
+
+type PackedLoss = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// Score `num_records` through `loss` on the batched (`forward_only = true`)
+/// and the per-record reference (`forward_only = false`) paths and assert they
+/// agree. The reference activates each record on its own through
+/// `CompiledNetwork::activate_into`.
+fn assert_tail_matches_reference(
+    name: &str,
+    loss: PackedLoss,
+    squash: SquashType,
+    num_records: usize,
+) {
+    let mut batched_net = build_network(INPUT_SIZE, squash);
+    let mut reference_net = build_network(INPUT_SIZE, squash);
+    let records = build_records(num_records, INPUT_SIZE);
+
+    let batched = loss(&mut batched_net, &records, INPUT_SIZE, 1, true);
+    let reference = loss(&mut reference_net, &records, INPUT_SIZE, 1, false);
+
+    let diff = (reference - batched).abs();
+    assert!(
+        diff <= TOLERANCE,
+        "{name} {squash:?} n={num_records}: batched {batched} diverged from per-record reference {reference} by {diff} (tol {TOLERANCE})"
+    );
+}
+
+#[test]
+fn mse_scalar_tail_matches_reference_for_every_aggregate_squash() {
+    for squash in AGGREGATES {
+        for &n in &TAIL_COUNTS {
+            assert_tail_matches_reference("mse", mse_sum_batch_packed, squash, n);
+        }
+    }
+}
+
+#[test]
+fn shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash() {
+    // MAE, cross-entropy, MAPE, MSLE and hinge all share the 8-way activation
+    // macro, so they share one scalar tail. Counts 9 and 13 leave that tail
+    // non-empty; the 8-way path needs at least 8 records.
+    let losses: [(&str, PackedLoss); 5] = [
+        ("mae", mae_sum_batch_packed),
+        ("cross_entropy", cross_entropy_sum_batch_packed),
+        ("mape", mape_sum_batch_packed),
+        ("msle", msle_sum_batch_packed),
+        ("hinge", hinge_sum_batch_packed),
+    ];
+    for (name, loss) in losses {
+        for squash in AGGREGATES {
+            for &n in &[9usize, 13] {
+                assert_tail_matches_reference(name, loss, squash, n);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Aggregate-squash activation: one rule, called from every scalar tail

## Summary

The rule that turns a neuron's inbound synapse range into an activation — the
dispatch over `Minimum` / `Maximum` / `If` / `Hypotenuse` / `HypotenuseV2` /
`Mean`, the standard weighted-sum fall-through, then `apply_limit_range` — was
copy-pasted across `neat-core/src/loss.rs`, and **three of those copies had
diverged**: they stopped at `If`, so a neuron using `Mean`, `Hypotenuse` or
`HypotenuseV2` fell through to a plain weighted sum whenever its record landed
in the scalar remainder instead of a full SIMD group.

That was reachable in production, not theoretical: `mse_sum_batch_8way_scattered`
is the arm selected *precisely when* `has_aggregate_squash()` is true, so the one
path reserved for aggregate networks mis-computed its own tail records. The
`batch_8way_activation!` tail is shared by the MAE, cross-entropy, MAPE, MSLE and
hinge paths, and `mse_sum_batch_4way` is reached with no aggregate guard at all.
An aggregate creature scored over nine records got the correct error for the
first eight and a silently wrong one for the ninth.

`neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) already held the
correct rule, byte-for-byte as `CompiledNetwork::activate_into` computes it. This
PR widens it to `pub(crate)` and calls it from every single-record site in
`loss.rs` — the three diverged scalar tails, the four per-lane aggregate loops
and the interleaved tail — deleting ~700 duplicated lines. Adding a seventh
aggregate squash now means editing one match.

Closes #441.

### Deliberately left alone

- **`CompiledNetwork::activate` / `activate_into`** keep their inlined copy.
  Routing them through the helper was implemented and measured: `forward_pass/
  production_exact` went from **13.4 µs → 19.3 µs (+46%)**, and still **17.4 µs
  (+30%)** with `#[inline(always)]`. Neither copy had diverged, so the trade was
  not worth it; the constraint is now recorded in `AGENTS.md`.
- **`network.rs:753-926`**, the `(activation, hint_value)` trace variant — it
  would need a mode parameter, which the issue explicitly rules out.

```mermaid
flowchart TD
    subgraph before["Before — 8 sites, 3 diverged"]
        B1["8-lane group<br/>6 aggregate arms"]
        B2["4-lane group<br/>6 aggregate arms"]
        B3["scalar tail<br/>❌ stops at If"]
    end
    subgraph after["After — one rule"]
        A1["8-lane group"] --> H
        A2["4-lane group"] --> H
        A3["scalar tail"] --> H
        H["neuron_activation_scalar<br/>Min · Max · If · Hyp · HypV2 · Mean<br/>+ weighted sum + limit range"]
    end
    before --> after
```

## Evidence

Backend/library change with no web interface, so no screenshot applies. Evidence
is the failing-then-passing regression test plus the benchmark A/B above.

**New test fails on the unfixed code** (`Hypotenuse`, tail record wrong by two
orders of magnitude more than the SIMD tolerance):

```
mse Hypotenuse n=5: batched 2.2803990747196785 diverged from per-record
reference 2.1519708379379026 by 0.12842823678177595 (tol 0.00001)
mae Hypotenuse n=9: batched 5.541243314743042 diverged from per-record
reference 5.42296490073204 by 0.11827841401100159 (tol 0.00001)
```

**After the fix:**

```
running 2 tests
test mse_scalar_tail_matches_reference_for_every_aggregate_squash ... ok
test shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash ... ok
test result: ok. 2 passed; 0 failed
```

`./quality.sh` passes clean (fmt, clippy `-D warnings`, deny, full
`cargo test --workspace`, doc build, release build).

**Numerics note.** For `Hypotenuse` / `HypotenuseV2` / `Mean`, the per-lane
aggregate loops in `loss.rs` previously used naive scalar sums; they now use the
same SIMD sum helpers as the single-record reference. Results shift by f32
rounding *towards* `activate` — the batch paths are now closer to the reference,
not further. The existing bit-identity guard
(`loss::interleaved_mse_parity`) and the `mse_squash_simd_parity` /
`score_squash_simd_parity` suites all stay green.

**Benchmark A/B** (`cargo bench --bench hot_paths`, 100 samples): batched
scoring shows no consistent movement — `mse_sum_8records/production` 64.5 µs vs
64.9 µs, within the ±10% run-to-run noise seen in both directions on this host.
The changed code is only reached by aggregate networks and scalar tails, so this
is the expected result.

## Test Plan

Added `neat-core/tests/aggregate_squash_tail_parity.rs`:

- `mse_scalar_tail_matches_reference_for_every_aggregate_squash` — scores an
  aggregate network through `mse_sum_batch_packed` at record counts with a
  non-empty tail (5, 6, 7 → 4-way + tail; 9, 13 → 8-way group + tail) for all
  six aggregate squashes, asserting the batched result matches the per-record
  `CompiledNetwork::activate_into` reference (`forward_only = false`) within
  1e-5.
- `shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash` — the
  same guard across the five loss functions sharing `batch_8way_activation!`
  (MAE, cross-entropy, MAPE, MSLE, hinge) at counts 9 and 13.

Both tests fail against the unfixed code and pass after the change. The fixture
alternates synapse types so the `If` arm sees condition, positive and negative
edges rather than a single branch.

Existing suites unchanged and green, including the bit-identity guards that pin
the interleaved kernel to the scattered one across the 8/4/tail boundaries.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms8y13nu-a9d535`<!-- vibe-worker-issue-441 -->