### PR TITLE
One packed-record scan: eight copies become one call (Issue #444)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,25 @@ The *vectorised* `squash_x4` / `squash_x8` approximations
 (`neat-core/src/squash_simd.rs`) are a different rule and stay where they are —
 only their scalar fallback goes through `inline_squash`.
 
+## One packed-record scan for every loss entry point (Issue #444)
+
+`packed_record_scan` (`neat-core/src/loss.rs`) is the single home of the rule
+that carves a packed `[inputs…, targets…]` buffer into records: the stride is
+`input_size + num_outputs` (`packed_layout`), only whole records count, a
+record's targets start immediately after its inputs, and each record is
+activated statelessly unless the caller declares the network forward-only. All
+eight entry points — the seven `*_sum_batch_packed` kernels and `mse_mean_record`
+— call it with a closure carrying **only** their per-output reduction, so the
+per-record `1/num_outputs` factor lives in the closure (which is what keeps MSLE
+and hinge deliberately un-averaged).
+
+The driver takes a closure and **no mode flags**: SIMD dispatch stays at the
+callers, where it genuinely differs (MSE falls back through the 8-way *and*
+4-way paths; `categorical_error_sum_batch_packed` uses neither and keeps its own
+`num_outputs == 0` guard). If unifying a future entry point needs a boolean to
+switch the driver's behaviour, leave that entry point out rather than growing a
+flag. `neat-core/tests/packed_record_scan.rs` pins the rule across all eight.
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/docs/archive/pr-summaries/pr-summary-444.md
+++ b/docs/archive/pr-summaries/pr-summary-444.md
@@ -1,0 +1,113 @@
+# One packed-record scan for every loss entry point (Issue #444)
+
+## Summary
+
+The packed-record scan — the `[inputs…, targets…]` layout arithmetic plus the
+per-record reset/slice/activate driver — was copy-pasted into **eight** entry
+points in `neat-core/src/loss.rs`. Only the innermost per-output reduction
+differed, so a change to the layout rule (a buffer header, targets ahead of
+inputs, a different reset condition) needed the same edit in eight places — and
+a partial edit would still compile while silently mis-slicing records on the
+paths that were missed.
+
+This PR extracts the rule into one authoritative representation:
+
+- `packed_layout(records_len, input_size, num_outputs) -> Option<PackedLayout>`
+  — the stride (`input_size + num_outputs`) and the whole-record count, with
+  both zero guards folded into the `None` case.
+- `packed_record_scan(network, records, input_size, num_outputs, forward_only,
+  reduce)` — drives the buffer record by record and returns the sum of
+  `reduce(targets, outputs)`.
+
+Each entry point keeps its own SIMD dispatch (MSE alone falls back through the
+8-way *and* 4-way paths; `categorical_error_sum_batch_packed` uses neither and
+keeps its own `num_outputs == 0` guard) and then calls the driver with a closure
+carrying only its reduction. The per-record `1/num_outputs` factor lives inside
+each closure, which keeps MSLE and hinge deliberately un-averaged. The driver
+takes a closure and **no mode flags**. `mse_mean_record` divides the returned
+sum by `num_records` at the call site.
+
+Behaviour is unchanged — this is a de-duplication, not a semantic change.
+`AGENTS.md` gains a section stating the rule and where it lives, matching the
+existing #441 / #443 entries.
+
+Closes #444.
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Evidence is the test
+suite: `cargo test --workspace` is green (all 35 test binaries), and
+`./quality.sh` passes cleanly (fmt, clippy with `-D warnings`, deny, tests, doc,
+release build).
+
+```mermaid
+flowchart LR
+    subgraph before["Before — the rule written eight times"]
+        B1["mse_sum_batch_packed"] --> BX["stride + zero guards<br/>reset / slice / activate<br/>× 8 copies"]
+        B2["mae / cross_entropy / mape"] --> BX
+        B3["msle / hinge / categorical_error"] --> BX
+        B4["mse_mean_record"] --> BX
+    end
+    subgraph after["After — one call each"]
+        A1["mse_sum_batch_packed"] --> AD
+        A2["mae / cross_entropy / mape"] --> AD
+        A3["msle / hinge / categorical_error"] --> AD
+        A4["mse_mean_record"] --> AD
+        AD["packed_record_scan<br/>(uses packed_layout)"] --> AR["reduce(targets, outputs)<br/>— per entry point"]
+    end
+```
+
+Per-record scan, stated once:
+
+```mermaid
+flowchart TD
+    S["records buffer"] --> L{"packed_layout:<br/>stride > 0 and ≥ 1 whole record?"}
+    L -- no --> Z["0.0"]
+    L -- yes --> R{"forward_only?"}
+    R -- no --> RS["network.reset_state()"] --> A
+    R -- yes --> A["activate_into(record inputs)"]
+    A --> RD["sum += reduce(record targets, outputs)"]
+    RD --> N{"more records?"}
+    N -- yes --> R
+    N -- no --> O["sum"]
+```
+
+**Mutation check.** Before the refactor, an off-by-one target start was injected
+into a *single* copy (`mae_sum_batch_packed`); the new suite failed on it
+(`every_sum_entry_point_equals_the_sum_of_its_single_record_scans`), confirming
+the tests bite per site rather than only at the shared helper. The mutation was
+reverted before the refactor landed.
+
+**Performance.** The SIMD kernels (`*_sum_batch_8way`, `mse_sum_batch_4way` and
+the interleaved gather) are untouched — the change is confined to the scalar
+record loop, where the closure is a monomorphised `impl Fn` and indexed target
+reads became slice iteration. No benchmark numbers are claimed because this is a
+de-duplication, not a performance task.
+
+## Test Plan
+
+New: `neat-core/tests/packed_record_scan.rs` — seven "what" tests driving the
+public entry points with real networks, covering all eight sites:
+
+- `every_packed_entry_point_ignores_a_trailing_partial_record` — the stride is
+  `input_size + num_outputs` and only whole records are scanned.
+- `every_packed_entry_point_returns_zero_without_a_whole_record` — empty buffer,
+  buffer shorter than one record, and a zero-width record.
+- `every_sum_entry_point_equals_the_sum_of_its_single_record_scans` — records are
+  independent; at nine records this also pins the SIMD-batched buffer against the
+  scalar single-record path.
+- `mse_mean_record_equals_the_mean_of_its_single_record_scans` — same carve, then
+  the average.
+- `every_packed_entry_point_pairs_a_record_with_its_own_targets` — swapping two
+  records' target blocks changes the result (MSLE excluded by mathematics: its
+  reduction is `Σ(ln t) - Σ(ln o)`, invariant under that permutation).
+- `every_packed_entry_point_reads_the_target_block_of_every_record` — editing the
+  targets of any single record moves the result, including MSLE.
+- `stateless_reset_is_conditional_on_forward_only` — on a self-loop network,
+  `forward_only=false` keeps records independent, `forward_only=true` lets state
+  carry over, and `mse_mean_record` always resets.
+
+Unchanged and still green: the existing `loss.rs` unit tests, the interleaved
+MSE bit-identity guards, and `inline_squash_dispatch.rs` /
+`aggregate_squash_tail_parity.rs`, which exercise the same entry points from the
+activation side. No existing test was modified or removed.

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -277,6 +277,88 @@ macro_rules! batch_8way_activation {
     }};
 }
 
+/// How a packed `[inputs…, targets…]` buffer is carved into records.
+///
+/// Issue #444 — the single home of the packed-record layout rule.
+struct PackedLayout {
+    /// Stride between successive records: `input_size + num_outputs`.
+    values_per_record: usize,
+    /// Whole records the buffer holds; a trailing partial record is ignored.
+    num_records: usize,
+}
+
+/// Carve a packed buffer into records, or `None` when it holds no whole record
+/// (a zero-width record, or fewer values than one full record needs).
+fn packed_layout(
+    records_len: usize,
+    input_size: usize,
+    num_outputs: usize,
+) -> Option<PackedLayout> {
+    let values_per_record = input_size + num_outputs;
+    if values_per_record == 0 {
+        return None;
+    }
+    let num_records = records_len / values_per_record;
+    if num_records == 0 {
+        return None;
+    }
+    Some(PackedLayout {
+        values_per_record,
+        num_records,
+    })
+}
+
+/// Drive a packed `[inputs…, targets…]` buffer record by record, returning the
+/// sum of `reduce(targets, outputs)` over every whole record. Returns `0.0`
+/// when the buffer holds no whole records.
+///
+/// `reduce` receives the record's target slice and the network's output slice,
+/// both `num_outputs` long. Any per-record averaging belongs inside `reduce` —
+/// MSLE and hinge deliberately do not average.
+///
+/// When `forward_only` is false the network's hidden state is cleared before
+/// each record, preserving stateless (`feedbackLoop = false`) semantics; when
+/// it is true the reset is skipped, which v4+ forward-only creatures allow.
+///
+/// Issue #444 — the single home of the per-record scan; SIMD dispatch stays at
+/// the callers, where it genuinely differs.
+fn packed_record_scan(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    forward_only: bool,
+    reduce: impl Fn(&[f32], &[f32]) -> f64,
+) -> f64 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
+        return 0.0;
+    };
+
+    // Reuse a small output buffer to avoid per-record allocation.
+    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
+    let mut sum_error: f64 = 0.0;
+
+    for record_idx in 0..layout.num_records {
+        if !forward_only {
+            // Ensure stateless behaviour for networks that may read stale activations.
+            network.reset_state();
+        }
+
+        let base = record_idx * layout.values_per_record;
+        let input_end = base + input_size;
+        let target_start = input_end;
+        // Activate into the reusable output buffer.
+        network.activate_into(&records[base..input_end], &mut outputs[..]);
+
+        sum_error += reduce(
+            &records[target_start..target_start + num_outputs],
+            &outputs[..],
+        );
+    }
+
+    sum_error
+}
+
 /// Fused activate + MSE (Mean Squared Error) calculation for batch scoring.
 ///
 /// This is a scoring fast-path designed to minimise JS/WASM boundary crossings:
@@ -301,37 +383,32 @@ pub fn mse_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
     // Falls back to 4-way for remainder handling, then single-record
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return mse_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
     // Issue #1202 - Use batched 4-record SIMD path for forward-only networks
-    if forward_only && num_records >= 4 {
+    if forward_only && layout.num_records >= 4 {
         return mse_sum_batch_4way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -341,33 +418,22 @@ pub fn mse_sum_batch_packed(
         0.0
     };
 
-    // Reuse a small output buffer to avoid per-record allocation.
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-
-    let mut sum_error: f64 = 0.0;
-    for record_idx in 0..num_records {
-        if !forward_only {
-            // Ensure stateless behaviour for networks that may read stale activations.
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-        // Activate into the reusable output buffer.
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MSE = mean((target - output)^2)
-        let mut sq_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_start + j] - outputs[j]) as f64;
-            sq_sum += diff * diff;
-        }
-        sum_error += sq_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MSE = mean((target - output)^2)
+            let mut sq_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let diff = (*t - *o) as f64;
+                sq_sum += diff * diff;
+            }
+            sq_sum * inv_outputs
+        },
+    )
 }
 
 /// Issue #1202 - Batched MSE with 4-record SIMD parallelism.
@@ -1312,24 +1378,19 @@ pub fn mae_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return mae_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -1339,31 +1400,21 @@ pub fn mae_sum_batch_packed(
         0.0
     };
 
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
-
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MAE = mean(|target - output|)
-        let mut abs_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_start + j] - outputs[j]) as f64;
-            abs_sum += diff.abs();
-        }
-        sum_error += abs_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MAE = mean(|target - output|)
+            let mut abs_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                abs_sum += ((*t - *o) as f64).abs();
+            }
+            abs_sum * inv_outputs
+        },
+    )
 }
 
 /// Fused activate + Cross Entropy calculation for batch scoring.
@@ -1388,24 +1439,19 @@ pub fn cross_entropy_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return cross_entropy_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -1416,34 +1462,25 @@ pub fn cross_entropy_sum_batch_packed(
     };
 
     const EPSILON: f64 = 1e-15;
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
 
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record Cross Entropy = -(1/n) * Σ(t * log(o) + (1-t) * log(1-o))
-        let mut ce_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = records[target_start + j] as f64;
-            let o_raw = outputs[j] as f64;
-            // Clamp to [epsilon, 1-epsilon] to prevent log(0)
-            let o = o_raw.clamp(EPSILON, 1.0 - EPSILON);
-            ce_sum -= t * o.ln() + (1.0 - t) * (1.0 - o).ln();
-        }
-        sum_error += ce_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record Cross Entropy = -(1/n) * Σ(t * log(o) + (1-t) * log(1-o))
+            let mut ce_sum: f64 = 0.0;
+            for (t, o_raw) in targets.iter().zip(outputs.iter()) {
+                let t = *t as f64;
+                // Clamp to [epsilon, 1-epsilon] to prevent log(0)
+                let o = (*o_raw as f64).clamp(EPSILON, 1.0 - EPSILON);
+                ce_sum -= t * o.ln() + (1.0 - t) * (1.0 - o).ln();
+            }
+            ce_sum * inv_outputs
+        },
+    )
 }
 
 /// Fused activate + MAPE (Mean Absolute Percentage Error) calculation for batch scoring.
@@ -1467,24 +1504,19 @@ pub fn mape_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return mape_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -1495,32 +1527,23 @@ pub fn mape_sum_batch_packed(
     };
 
     const EPSILON: f64 = 1e-15;
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
 
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MAPE = (1/n) * Σ|(output - target) / max(target, ε)|
-        let mut mape_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = (records[target_start + j] as f64).max(EPSILON);
-            let o = outputs[j] as f64;
-            mape_sum += ((o - t) / t).abs();
-        }
-        sum_error += mape_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MAPE = (1/n) * Σ|(output - target) / max(target, ε)|
+            let mut mape_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let t = (*t as f64).max(EPSILON);
+                mape_sum += ((*o as f64 - t) / t).abs();
+            }
+            mape_sum * inv_outputs
+        },
+    )
 }
 
 /// Fused activate + MSLE (Mean Squared Logarithmic Error) calculation for batch scoring.
@@ -1545,55 +1568,42 @@ pub fn msle_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return msle_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
     const EPSILON: f64 = 1e-15;
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
 
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MSLE = Σ(log(max(target, ε)) - log(max(output, ε)))
-        // Note: No averaging per record to match JS implementation
-        let mut msle_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = (records[target_start + j] as f64).max(EPSILON);
-            let o = (outputs[j] as f64).max(EPSILON);
-            msle_sum += t.ln() - o.ln();
-        }
-        sum_error += msle_sum;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MSLE = Σ(log(max(target, ε)) - log(max(output, ε)))
+            // Note: No averaging per record to match JS implementation
+            let mut msle_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let t = (*t as f64).max(EPSILON);
+                let o = (*o as f64).max(EPSILON);
+                msle_sum += t.ln() - o.ln();
+            }
+            msle_sum
+        },
+    )
 }
 
 /// Fused activate + Hinge Loss calculation for batch scoring.
@@ -1618,54 +1628,38 @@ pub fn hinge_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return hinge_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
-
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record Hinge = Σmax(0, 1 - target * output)
-        // Note: No averaging per record to match JS implementation
-        let mut hinge_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = records[target_start + j] as f64;
-            let o = outputs[j] as f64;
-            hinge_sum += (1.0 - t * o).max(0.0);
-        }
-        sum_error += hinge_sum;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record Hinge = Σmax(0, 1 - target * output)
+            // Note: No averaging per record to match JS implementation
+            let mut hinge_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                hinge_sum += (1.0 - (*t as f64) * (*o as f64)).max(0.0);
+            }
+            hinge_sum
+        },
+    )
 }
 
 /// Fused activate + Categorical Error (argmax misclassification) for batch scoring.
@@ -1706,58 +1700,40 @@ pub fn categorical_error_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
-        return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 || num_outputs == 0 {
+    // A record with no outputs has no class to predict — guard before the scan,
+    // whose closure indexes the first target and output.
+    if num_outputs == 0 {
         return 0.0;
     }
 
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut misclassified: f64 = 0.0;
-
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Argmax with first-index tie-breaking — matches the TS reference
-        // (`a > b` so equal values keep the earlier index).
-        let mut target_argmax: usize = 0;
-        let mut target_best: f32 = records[target_start];
-        for j in 1..num_outputs {
-            let v = records[target_start + j];
-            if v > target_best {
-                target_best = v;
-                target_argmax = j;
+    /// Argmax with first-index tie-breaking — matches the TS reference
+    /// (`a > b` so equal values keep the earlier index).
+    fn argmax(values: &[f32]) -> usize {
+        let mut best_idx: usize = 0;
+        let mut best: f32 = values[0];
+        for (idx, v) in values.iter().enumerate().skip(1) {
+            if *v > best {
+                best = *v;
+                best_idx = idx;
             }
         }
-
-        let mut output_argmax: usize = 0;
-        let mut output_best: f32 = outputs[0];
-        for j in 1..num_outputs {
-            let v = outputs[j];
-            if v > output_best {
-                output_best = v;
-                output_argmax = j;
-            }
-        }
-
-        if target_argmax != output_argmax {
-            misclassified += 1.0;
-        }
+        best_idx
     }
 
-    misclassified
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            if argmax(targets) != argmax(outputs) {
+                1.0
+            } else {
+                0.0
+            }
+        },
+    )
 }
 
 /// Non-fused recurrent-path MSE for `forwardOnly: false` networks.
@@ -1790,14 +1766,9 @@ pub fn mse_mean_record(
     input_size: usize,
     num_outputs: usize,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     let inv_outputs: f64 = if num_outputs > 0 {
         1.0 / (num_outputs as f64)
@@ -1805,31 +1776,26 @@ pub fn mse_mean_record(
         0.0
     };
 
-    // Reuse a small output buffer to avoid per-record allocation.
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
+    // Non-fused recurrent path: `forward_only = false` clears hidden state
+    // between records so the previous record's activations cannot leak in.
+    let sum_error = packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        false,
+        |targets, outputs| {
+            // Per-record MSE = mean over outputs of (target - output)^2.
+            let mut sq_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let diff = (*t - *o) as f64;
+                sq_sum += diff * diff;
+            }
+            sq_sum * inv_outputs
+        },
+    );
 
-    for record_idx in 0..num_records {
-        // Non-fused recurrent path: clear hidden state between records so the
-        // previous record's activations cannot leak into this activation.
-        network.reset_state();
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MSE = mean over outputs of (target - output)^2.
-        let mut sq_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_start + j] - outputs[j]) as f64;
-            sq_sum += diff * diff;
-        }
-        sum_error += sq_sum * inv_outputs;
-    }
-
-    sum_error / (num_records as f64)
+    sum_error / (layout.num_records as f64)
 }
 
 #[cfg(test)]

--- a/neat-core/tests/packed_record_scan.rs
+++ b/neat-core/tests/packed_record_scan.rs
@@ -1,0 +1,437 @@
+//! Behavioural coverage for the packed-record scan rule (Issue #444).
+//!
+//! One rule says how a packed `[inputs…, targets…]` buffer is carved into
+//! records: the record stride is `input_size + num_outputs`, only whole records
+//! count, a record's targets start immediately after its inputs, and each
+//! record is activated statelessly unless the caller declares the network
+//! forward-only. Every packed loss entry point in `neat_core::loss` obeys it.
+//!
+//! These are "what" tests: they drive the public entry points with real
+//! networks and assert observable numbers — a buffer's result equals the sum of
+//! its records' individual results, a trailing partial record contributes
+//! nothing, and targets are read from the slice that follows the inputs. A copy
+//! of the arithmetic that drifted — a different stride, an off-by-one target
+//! start, a dropped `reset_state()` — fails here no matter how the scan is
+//! implemented.
+
+use neat_core::loss::{
+    categorical_error_sum_batch_packed, cross_entropy_sum_batch_packed, hinge_sum_batch_packed,
+    mae_sum_batch_packed, mape_sum_batch_packed, mse_mean_record, mse_sum_batch_packed,
+    msle_sum_batch_packed,
+};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Identity squash — keeps every fixture's activation exact, so a mismatch is a
+/// carve bug rather than an approximation.
+const IDENTITY: u8 = 0;
+
+/// Two inputs feeding two independent output neurons, no hidden state:
+///   `out0 =  0.5*in0 - 0.3*in1 + 0.10`
+///   `out1 = -0.2*in0 + 0.7*in1 + 0.05`
+fn linear_network() -> CompiledNetwork {
+    let synapses = vec![
+        SynapseData {
+            weight: 0.5,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: -0.3,
+            from_index: 1,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: -0.2,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 0.7,
+            from_index: 1,
+            synapse_type: 0,
+        },
+    ];
+    let neurons = vec![
+        NeuronData {
+            bias: 0.10,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: IDENTITY,
+            is_constant: false,
+        },
+        NeuronData {
+            bias: 0.05,
+            start_synapse: 2,
+            num_synapses: 2,
+            squash_type: IDENTITY,
+            is_constant: false,
+        },
+    ];
+    network(4, 2, neurons, synapses)
+}
+
+/// One input into a single output neuron that also reads **its own** previous
+/// activation, so the record loop's `reset_state()` is observable: with the
+/// reset each record sees `out = in`, without it `out = in + 0.5 * previous`.
+fn self_loop_network() -> CompiledNetwork {
+    let synapses = vec![
+        SynapseData {
+            weight: 1.0,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 0.5,
+            from_index: 1,
+            synapse_type: 0,
+        },
+    ];
+    let neurons = vec![NeuronData {
+        bias: 0.0,
+        start_synapse: 0,
+        num_synapses: 2,
+        squash_type: IDENTITY,
+        is_constant: false,
+    }];
+    network(2, 1, neurons, synapses)
+}
+
+fn network(
+    num_neurons: usize,
+    num_inputs: usize,
+    neurons: Vec<NeuronData>,
+    synapses: Vec<SynapseData>,
+) -> CompiledNetwork {
+    let num_non_inputs = neurons.len();
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+type PackedEntry = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// `mse_mean_record` always resets, so it takes no `forward_only` flag; the
+/// wrapper lets it join the table for the layout rules it shares.
+fn mse_mean_record_entry(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    _forward_only: bool,
+) -> f64 {
+    mse_mean_record(network, records, input_size, num_outputs)
+}
+
+/// The seven entry points that return a **sum** over records.
+const SUM_ENTRIES: [(&str, PackedEntry); 7] = [
+    ("mse", mse_sum_batch_packed),
+    ("mae", mae_sum_batch_packed),
+    ("cross_entropy", cross_entropy_sum_batch_packed),
+    ("mape", mape_sum_batch_packed),
+    ("msle", msle_sum_batch_packed),
+    ("hinge", hinge_sum_batch_packed),
+    ("categorical_error", categorical_error_sum_batch_packed),
+];
+
+/// Every entry point carving a packed buffer — the seven sums plus the mean.
+const ALL_ENTRIES: [(&str, PackedEntry); 8] = [
+    ("mse", mse_sum_batch_packed),
+    ("mae", mae_sum_batch_packed),
+    ("cross_entropy", cross_entropy_sum_batch_packed),
+    ("mape", mape_sum_batch_packed),
+    ("msle", msle_sum_batch_packed),
+    ("hinge", hinge_sum_batch_packed),
+    ("categorical_error", categorical_error_sum_batch_packed),
+    ("mse_mean_record", mse_mean_record_entry),
+];
+
+const INPUT_SIZE: usize = 2;
+const NUM_OUTPUTS: usize = 2;
+
+/// Packed `[in0, in1, t0, t1]` records with distinct, strictly positive targets
+/// — positive keeps MAPE and MSLE away from their epsilon clamps, distinct
+/// makes a record mix-up visible.
+fn packed_records(num_records: usize) -> Vec<f32> {
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+    let mut records = vec![0.0f32; num_records * values_per_record];
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        let f = r as f32;
+        records[base] = 0.9 - 0.11 * f;
+        records[base + 1] = 0.2 + 0.07 * f;
+        records[base + 2] = 0.3 + 0.05 * f;
+        records[base + 3] = 0.8 - 0.04 * f;
+    }
+    records
+}
+
+fn assert_close(actual: f64, expected: f64, what: &str) {
+    let tolerance = 1e-6 * expected.abs().max(1.0);
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
+/// The record stride is `input_size + num_outputs` and only whole records are
+/// scanned, so trailing bytes that cannot complete a record are invisible.
+#[test]
+fn every_packed_entry_point_ignores_a_trailing_partial_record() {
+    for (name, entry) in ALL_ENTRIES {
+        for forward_only in [true, false] {
+            let whole = packed_records(9);
+            for extra in 1..(INPUT_SIZE + NUM_OUTPUTS) {
+                let mut ragged = whole.clone();
+                ragged.extend(std::iter::repeat_n(0.42f32, extra));
+
+                let mut net = linear_network();
+                let want = entry(&mut net, &whole, INPUT_SIZE, NUM_OUTPUTS, forward_only);
+                let mut net = linear_network();
+                let got = entry(&mut net, &ragged, INPUT_SIZE, NUM_OUTPUTS, forward_only);
+
+                assert_close(
+                    got,
+                    want,
+                    &format!("{name} (forward_only={forward_only}) with {extra} trailing values"),
+                );
+            }
+        }
+    }
+}
+
+/// A buffer holding no whole record — empty, short, or a zero-width record —
+/// has no error to report.
+#[test]
+fn every_packed_entry_point_returns_zero_without_a_whole_record() {
+    let empty: Vec<f32> = Vec::new();
+    let short = vec![0.5f32; INPUT_SIZE + NUM_OUTPUTS - 1];
+    let non_empty = packed_records(3);
+
+    for (name, entry) in ALL_ENTRIES {
+        for forward_only in [true, false] {
+            let mut net = linear_network();
+            assert_eq!(
+                entry(&mut net, &empty, INPUT_SIZE, NUM_OUTPUTS, forward_only),
+                0.0,
+                "{name}: empty buffer"
+            );
+            assert_eq!(
+                entry(&mut net, &short, INPUT_SIZE, NUM_OUTPUTS, forward_only),
+                0.0,
+                "{name}: buffer shorter than one record"
+            );
+            // Zero stride: no record can be carved out of any buffer.
+            assert_eq!(
+                entry(&mut net, &non_empty, 0, 0, forward_only),
+                0.0,
+                "{name}: zero-width record"
+            );
+        }
+    }
+}
+
+/// Records are independent: scanning a buffer of N records gives the same total
+/// as scanning each record on its own. This pins the stride, the per-record
+/// target start and the stateless activation protocol together — and, at nine
+/// records, that the SIMD-batched buffer agrees with the scalar single-record
+/// path.
+#[test]
+fn every_sum_entry_point_equals_the_sum_of_its_single_record_scans() {
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+    for (name, entry) in SUM_ENTRIES {
+        for forward_only in [true, false] {
+            for num_records in [1usize, 3, 4, 8, 9] {
+                let records = packed_records(num_records);
+
+                let mut net = linear_network();
+                let whole = entry(&mut net, &records, INPUT_SIZE, NUM_OUTPUTS, forward_only);
+
+                let mut per_record = 0.0f64;
+                for r in 0..num_records {
+                    let base = r * values_per_record;
+                    let mut net = linear_network();
+                    per_record += entry(
+                        &mut net,
+                        &records[base..base + values_per_record],
+                        INPUT_SIZE,
+                        NUM_OUTPUTS,
+                        forward_only,
+                    );
+                }
+
+                assert_close(
+                    whole,
+                    per_record,
+                    &format!("{name} (forward_only={forward_only}, {num_records} records)"),
+                );
+            }
+        }
+    }
+}
+
+/// `mse_mean_record` carves the same records and then averages them.
+#[test]
+fn mse_mean_record_equals_the_mean_of_its_single_record_scans() {
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+    for num_records in [1usize, 3, 9] {
+        let records = packed_records(num_records);
+
+        let mut net = linear_network();
+        let whole = mse_mean_record(&mut net, &records, INPUT_SIZE, NUM_OUTPUTS);
+
+        let mut per_record = 0.0f64;
+        for r in 0..num_records {
+            let base = r * values_per_record;
+            let mut net = linear_network();
+            per_record += mse_mean_record(
+                &mut net,
+                &records[base..base + values_per_record],
+                INPUT_SIZE,
+                NUM_OUTPUTS,
+            );
+        }
+
+        assert_close(
+            whole,
+            per_record / num_records as f64,
+            &format!("mse_mean_record over {num_records} records"),
+        );
+    }
+}
+
+/// A record's targets are the values packed *after* its own inputs. Swapping
+/// the two records' target blocks pairs each input with the other record's
+/// targets, which must change the total — an entry point reading targets from a
+/// fixed offset, or from the wrong record, would not notice.
+///
+/// MSLE is excluded by mathematics, not by exemption: its per-record reduction
+/// is `Σ(ln t) - Σ(ln o)`, so permuting whole target blocks across records
+/// cannot change its total. The next test covers MSLE's target reads.
+#[test]
+fn every_packed_entry_point_pairs_a_record_with_its_own_targets() {
+    #[rustfmt::skip]
+    let paired: Vec<f32> = vec![
+        0.9, 0.1, /* targets */ 0.2, 0.9,
+        0.1, 0.8, /* targets */ 0.8, 0.3,
+    ];
+    #[rustfmt::skip]
+    let swapped: Vec<f32> = vec![
+        0.9, 0.1, /* targets */ 0.8, 0.3,
+        0.1, 0.8, /* targets */ 0.2, 0.9,
+    ];
+
+    for (name, entry) in ALL_ENTRIES {
+        if name == "msle" {
+            continue;
+        }
+        let mut net = linear_network();
+        let as_packed = entry(&mut net, &paired, INPUT_SIZE, NUM_OUTPUTS, true);
+        let mut net = linear_network();
+        let as_swapped = entry(&mut net, &swapped, INPUT_SIZE, NUM_OUTPUTS, true);
+
+        assert!(
+            (as_packed - as_swapped).abs() > 1e-6,
+            "{name}: swapping the records' target blocks left the result unchanged \
+             ({as_packed} vs {as_swapped}) — targets are not being read per record"
+        );
+    }
+}
+
+/// Every record's target block is read from that record's own offset: editing
+/// the targets of *any* single record — first, middle or last — must move the
+/// result. An entry point that read targets from one fixed offset, or that
+/// mis-strided past a record, would leave at least one edit invisible.
+#[test]
+fn every_packed_entry_point_reads_the_target_block_of_every_record() {
+    const NUM_RECORDS: usize = 3;
+    // Inputs chosen so the network's output argmax is 1 for every record; the
+    // edited target block below flips the target argmax, which `categorical_error`
+    // needs in order to notice at all.
+    let mut base: Vec<f32> = Vec::new();
+    for r in 0..NUM_RECORDS {
+        let f = r as f32;
+        base.extend([0.1 + 0.05 * f, 0.9 - 0.05 * f, 0.2, 0.9]);
+    }
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+
+    for (name, entry) in ALL_ENTRIES {
+        let mut net = linear_network();
+        let unedited = entry(&mut net, &base, INPUT_SIZE, NUM_OUTPUTS, true);
+
+        for r in 0..NUM_RECORDS {
+            let mut edited = base.clone();
+            let target_start = r * values_per_record + INPUT_SIZE;
+            edited[target_start] = 0.95;
+            edited[target_start + 1] = 0.1;
+
+            let mut net = linear_network();
+            let got = entry(&mut net, &edited, INPUT_SIZE, NUM_OUTPUTS, true);
+            assert!(
+                (got - unedited).abs() > 1e-6,
+                "{name}: editing record {r}'s target block left the result unchanged \
+                 ({got} vs {unedited})"
+            );
+        }
+    }
+}
+
+/// The per-record `reset_state()` is conditional on `forward_only`: with
+/// `forward_only=false` a stateful network is driven statelessly (records stay
+/// independent), and with `forward_only=true` the reset is skipped, so the
+/// previous record's activation carries over.
+#[test]
+fn stateless_reset_is_conditional_on_forward_only() {
+    // Single-output records `[in, target]` on the self-loop network.
+    let records: Vec<f32> = vec![0.6, 0.2, 0.5, 0.3, 0.4, 0.1];
+    let num_records = 3;
+
+    let mut net = self_loop_network();
+    let stateless = mse_sum_batch_packed(&mut net, &records, 1, 1, false);
+
+    let mut independent = 0.0f64;
+    for r in 0..num_records {
+        let mut net = self_loop_network();
+        independent += mse_sum_batch_packed(&mut net, &records[r * 2..r * 2 + 2], 1, 1, false);
+    }
+    assert_close(
+        stateless,
+        independent,
+        "forward_only=false must reset between records",
+    );
+
+    let mut net = self_loop_network();
+    let stateful = mse_sum_batch_packed(&mut net, &records, 1, 1, true);
+    assert!(
+        (stateful - stateless).abs() > 1e-6,
+        "forward_only=true must skip the reset, leaving the self-loop's state to \
+         carry over (got {stateful}, stateless {stateless})"
+    );
+
+    // `mse_mean_record` has no flag — it always resets.
+    let mut net = self_loop_network();
+    let mean = mse_mean_record(&mut net, &records, 1, 1);
+    assert_close(
+        mean,
+        independent / num_records as f64,
+        "mse_mean_record must reset between records",
+    );
+}


### PR DESCRIPTION
# One packed-record scan for every loss entry point (Issue #444)

## Summary

The packed-record scan — the `[inputs…, targets…]` layout arithmetic plus the
per-record reset/slice/activate driver — was copy-pasted into **eight** entry
points in `neat-core/src/loss.rs`. Only the innermost per-output reduction
differed, so a change to the layout rule (a buffer header, targets ahead of
inputs, a different reset condition) needed the same edit in eight places — and
a partial edit would still compile while silently mis-slicing records on the
paths that were missed.

This PR extracts the rule into one authoritative representation:

- `packed_layout(records_len, input_size, num_outputs) -> Option<PackedLayout>`
  — the stride (`input_size + num_outputs`) and the whole-record count, with
  both zero guards folded into the `None` case.
- `packed_record_scan(network, records, input_size, num_outputs, forward_only,
  reduce)` — drives the buffer record by record and returns the sum of
  `reduce(targets, outputs)`.

Each entry point keeps its own SIMD dispatch (MSE alone falls back through the
8-way *and* 4-way paths; `categorical_error_sum_batch_packed` uses neither and
keeps its own `num_outputs == 0` guard) and then calls the driver with a closure
carrying only its reduction. The per-record `1/num_outputs` factor lives inside
each closure, which keeps MSLE and hinge deliberately un-averaged. The driver
takes a closure and **no mode flags**. `mse_mean_record` divides the returned
sum by `num_records` at the call site.

Behaviour is unchanged — this is a de-duplication, not a semantic change.
`AGENTS.md` gains a section stating the rule and where it lives, matching the
existing #441 / #443 entries.

Closes #444.

## Evidence

Backend/library change with no web interface to screenshot. Evidence is the test
suite: `cargo test --workspace` is green (all 35 test binaries), and
`./quality.sh` passes cleanly (fmt, clippy with `-D warnings`, deny, tests, doc,
release build).

```mermaid
flowchart LR
    subgraph before["Before — the rule written eight times"]
        B1["mse_sum_batch_packed"] --> BX["stride + zero guards<br/>reset / slice / activate<br/>× 8 copies"]
        B2["mae / cross_entropy / mape"] --> BX
        B3["msle / hinge / categorical_error"] --> BX
        B4["mse_mean_record"] --> BX
    end
    subgraph after["After — one call each"]
        A1["mse_sum_batch_packed"] --> AD
        A2["mae / cross_entropy / mape"] --> AD
        A3["msle / hinge / categorical_error"] --> AD
        A4["mse_mean_record"] --> AD
        AD["packed_record_scan<br/>(uses packed_layout)"] --> AR["reduce(targets, outputs)<br/>— per entry point"]
    end
```

Per-record scan, stated once:

```mermaid
flowchart TD
    S["records buffer"] --> L{"packed_layout:<br/>stride > 0 and ≥ 1 whole record?"}
    L -- no --> Z["0.0"]
    L -- yes --> R{"forward_only?"}
    R -- no --> RS["network.reset_state()"] --> A
    R -- yes --> A["activate_into(record inputs)"]
    A --> RD["sum += reduce(record targets, outputs)"]
    RD --> N{"more records?"}
    N -- yes --> R
    N -- no --> O["sum"]
```

**Mutation check.** Before the refactor, an off-by-one target start was injected
into a *single* copy (`mae_sum_batch_packed`); the new suite failed on it
(`every_sum_entry_point_equals_the_sum_of_its_single_record_scans`), confirming
the tests bite per site rather than only at the shared helper. The mutation was
reverted before the refactor landed.

**Performance.** The SIMD kernels (`*_sum_batch_8way`, `mse_sum_batch_4way` and
the interleaved gather) are untouched — the change is confined to the scalar
record loop, where the closure is a monomorphised `impl Fn` and indexed target
reads became slice iteration. No benchmark numbers are claimed because this is a
de-duplication, not a performance task.

## Test Plan

New: `neat-core/tests/packed_record_scan.rs` — seven "what" tests driving the
public entry points with real networks, covering all eight sites:

- `every_packed_entry_point_ignores_a_trailing_partial_record` — the stride is
  `input_size + num_outputs` and only whole records are scanned.
- `every_packed_entry_point_returns_zero_without_a_whole_record` — empty buffer,
  buffer shorter than one record, and a zero-width record.
- `every_sum_entry_point_equals_the_sum_of_its_single_record_scans` — records are
  independent; at nine records this also pins the SIMD-batched buffer against the
  scalar single-record path.
- `mse_mean_record_equals_the_mean_of_its_single_record_scans` — same carve, then
  the average.
- `every_packed_entry_point_pairs_a_record_with_its_own_targets` — swapping two
  records' target blocks changes the result (MSLE excluded by mathematics: its
  reduction is `Σ(ln t) - Σ(ln o)`, invariant under that permutation).
- `every_packed_entry_point_reads_the_target_block_of_every_record` — editing the
  targets of any single record moves the result, including MSLE.
- `stateless_reset_is_conditional_on_forward_only` — on a self-loop network,
  `forward_only=false` keeps records independent, `forward_only=true` lets state
  carry over, and `mse_mean_record` always resets.

Unchanged and still green: the existing `loss.rs` unit tests, the interleaved
MSE bit-identity guards, and `inline_squash_dispatch.rs` /
`aggregate_squash_tail_parity.rs`, which exercise the same entry points from the
activation side. No existing test was modified or removed.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms90tmz0-e34398`<!-- vibe-worker-issue-444 -->