### PR TITLE
MSE adopts the shared 8→4→1 batch skeleton (Issue #445)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,43 @@ callers, where it genuinely differs (MSE falls back through the 8-way *and*
 switch the driver's behaviour, leave that entry point out rather than growing a
 flag. `neat-core/tests/packed_record_scan.rs` pins the rule across all eight.
 
+## One batched record-scan skeleton for every loss kind (Issue #445)
+
+`batch_8way_activation!` (`neat-core/src/loss.rs`) is the single home of the
+rule that walks a packed record buffer: records are grouped **8 → 4 → 1**, each
+group's inputs are loaded into per-lane activation buffers, and the per-record
+errors accumulate into one `f64` sum. All six loss kinds — MSE included, via
+`mse_sum_batch_scattered` — invoke it with a closure carrying **only** their
+per-record reduction (`(records, target_base, act, output_start, num_outputs) ->
+f64`). Changing the grouping (a 16-lane tier, a different remainder strategy) is
+an edit **there and nowhere else**; do not re-inline the skeleton.
+
+The record-**interleaved** 8-group path (`mse_sum_batch_8way_interleaved`,
+Issue #384) is a genuinely different memory layout and stays separate — its
+`< 8` remainder still runs the same per-lane kernels, so the two are
+bit-identical.
+
+`load_record` (`neat-core/src/batch_scoring.rs`) owns the loading sub-rule:
+copy `min(record.len(), num_inputs)` values and **zero** every input slot the
+record does not cover, exactly as `CompiledNetwork::activate_into` does. Every
+per-lane loader in the batched scoring and fused loss kernels calls it, so a
+record scored in a SIMD group, in the 4-record remainder, or in the scalar tail
+sees the same inputs. `neat-core/tests/batch_record_skeleton.rs` pins the rule
+across every packed loss entry point.
+
+```mermaid
+flowchart LR
+    A["packed records"] --> B{"num_records"}
+    B -- "&ge; 8" --> C["8-record group<br/>load_record x8"]
+    B -- "4..7" --> D["4-record group<br/>load_record x4"]
+    B -- "&lt; 4" --> E["scalar tail<br/>load_record"]
+    C --> D --> E
+    C --> F["$error_fn per record"]
+    D --> F
+    E --> F
+    F --> G["f64 sum_error"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/docs/archive/pr-summaries/pr-summary-445.md
+++ b/docs/archive/pr-summaries/pr-summary-445.md
@@ -1,0 +1,105 @@
+# MSE adopts the shared 8→4→1 batch skeleton (Issue #445)
+
+## Summary
+
+MSE was the only loss kind that hand-inlined the batched record-scan skeleton —
+walk records in SIMD groups of eight, then one group of four, then a per-record
+scalar tail, loading each record's inputs into per-lane activation buffers and
+accumulating an `f64` error sum. The other five loss kinds already get that rule
+from the `batch_8way_activation!` macro, parameterised by a per-record
+`$error_fn` closure.
+
+MSE now calls the same macro. `mse_sum_batch_4way` and
+`mse_sum_batch_8way_scattered` are gone, replaced by one ~45-line
+`mse_sum_batch_scattered` that supplies only the squared-error reduction. Net
+`-511 / +105` lines. The record-**interleaved** 8-group path (Issue #384) stays
+separate, as the issue asks — it is a genuinely different memory layout, and no
+mode flag was added to merge it.
+
+The loader sub-rule that had drifted is fixed at the same time.
+`load_record` (`neat-core/src/batch_scoring.rs`) is now the single home of
+clamp-and-zero: copy `min(record.len(), num_inputs)` values and zero every input
+slot the record does not cover, exactly as `CompiledNetwork::activate_into`
+does. Every per-lane loader in the macro and in the interleaved remainder calls
+it. `load_batch_input` — whose doc comment promised zeroing its body never did —
+is deleted.
+
+Closes #445.
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot. Evidence is the
+test suite plus the pre-existing bit-identity parity guards.
+
+**Behaviour fixed.** Before this change, a packed batch whose records carried
+more input columns than the network has inputs panicked in the forward-only
+batched path (`range end index 8 out of range for slice of length 6`) while the
+single-record path silently ignored the extras. Both now agree.
+
+```
+# before (new tests against unfixed code)
+test aggregate_network_ignores_input_columns_beyond_the_network_inputs ... FAILED
+test input_columns_beyond_the_network_inputs_are_ignored ... FAILED
+test result: FAILED. 3 passed; 2 failed
+
+# after
+test result: ok. 5 passed; 0 failed
+```
+
+**Numerics unchanged.** The existing `interleaved_mse_parity` module asserts the
+scattered kernel is **bit-identical** (`f64::to_bits`) to the interleaved path
+across every record count that straddles a group boundary (8, 9, 12, 13, 15, 16,
+17, 24, 4096) for seven squash types, plus the aggregate-dispatch guard. Those
+tests pass unchanged against the macro-driven kernel, so the consolidation moved
+no bits. `./quality.sh` is green (fmt, clippy `-D warnings`, deny, full
+workspace test suite, doc build, release build).
+
+**Performance.** Not a performance change, and the benchmark harness on this
+machine cannot resolve one: every `hot_paths` network spec uses Tanh, so all
+benched MSE batches route through the *unchanged* interleaved kernel. Two
+back-to-back runs of the identical post-change binary swung from −26% to +46% on
+the same benchmark IDs, so the criterion "regressed"/"improved" verdicts in this
+range are noise, not signal.
+
+```mermaid
+flowchart LR
+    A["packed records"] --> B{"num_records"}
+    B -- "&ge; 8" --> C["8-record group<br/>load_record x8"]
+    B -- "4..7" --> D["4-record group<br/>load_record x4"]
+    B -- "&lt; 4" --> E["scalar tail<br/>load_record"]
+    C --> D --> E
+    C --> F["per-record $error_fn<br/>(MSE / MAE / CE / MAPE / MSLE / hinge)"]
+    D --> F
+    E --> F
+    F --> G["f64 sum_error"]
+```
+
+## Test Plan
+
+New `neat-core/tests/batch_record_skeleton.rs` — "what" tests driving the public
+`*_sum_batch_packed` entry points against a single-record reference built from
+`CompiledNetwork::activate`:
+
+- `grouping_does_not_change_the_batched_sum` — every loss kind, 14 record counts
+  straddling the 4- and 8-record boundaries (1, 3, 4, 5, 7, 8, 9, 11, 12, 13,
+  16, 17, 24, 33).
+- `aggregate_network_grouping_does_not_change_the_batched_sum` — the same rule
+  on a network whose `MEAN` neuron keeps it on the per-lane kernels.
+- `input_columns_beyond_the_network_inputs_are_ignored` — regression test for
+  the loader drift; fails (panics) against the unfixed code.
+- `aggregate_network_ignores_input_columns_beyond_the_network_inputs` — the same
+  regression on the scattered route; also fails against the unfixed code.
+- `uncovered_input_slots_score_as_zero` — a record covering fewer columns than
+  the network has inputs reads the uncovered slots as zero for every record, so
+  nothing leaks between groups.
+
+Existing suites re-run unchanged and green, notably
+`neat-core/src/loss.rs::interleaved_mse_parity` (bit-identity),
+`neat-core/tests/mse_squash_simd_parity.rs`,
+`neat-core/tests/mse_batch_interleaved_parity.rs`,
+`neat-core/tests/packed_record_scan.rs` and
+`neat-core/tests/aggregate_squash_tail_parity.rs`.
+
+Docs: `AGENTS.md` gains the "One batched record-scan skeleton for every loss
+kind" rule beside the #441/#443/#444 entries; the two stale
+`mse_sum_batch_4way` references in `mse_squash_simd_parity.rs` are updated.

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -269,8 +269,13 @@ pub(crate) fn neuron_activation_scalar(
 /// does not cover is zeroed so each record is scored statelessly — buffers are
 /// reused across batches, and every non-input neuron is overwritten during the
 /// forward pass, so no further reset is required.
+///
+/// The single home of the clamp-and-zero loading rule (Issue #445): every
+/// per-lane loader in the batched scoring and fused loss kernels calls this, so
+/// a record's inputs land the same way whether it was scored in a SIMD group or
+/// in the scalar tail.
 #[inline]
-fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
+pub(crate) fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
     let in_len = record.len().min(num_inputs);
     act[..in_len].copy_from_slice(&record[..in_len]);
     act[in_len..num_inputs].fill(0.0);

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -6,7 +6,7 @@
 //!
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
-use crate::batch_scoring::{SCORING_LANES, inline_squash, neuron_activation_scalar};
+use crate::batch_scoring::{SCORING_LANES, inline_squash, load_record, neuron_activation_scalar};
 use crate::network::CompiledNetwork;
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
@@ -20,6 +20,13 @@ use wasm_bindgen::prelude::*;
 ///
 /// This macro generates the neuron activation loop for 8 records in parallel,
 /// then calls a provided error calculation closure for each record.
+///
+/// The single home of the batched record-scan skeleton (Issue #445): records are
+/// grouped 8 → 4 → 1, each group's inputs are loaded through the shared
+/// [`load_record`] loader, and the per-record errors accumulate into one `f64`
+/// sum. `$error_fn` carries **only** the per-record reduction
+/// (`(records, target_base, act, output_start, num_outputs) -> f64`), so every
+/// loss kind — MSE included — shares one iteration rule.
 macro_rules! batch_8way_activation {
     ($network:expr_2021, $records:expr_2021, $values_per_record:expr_2021, $input_size:expr_2021, $num_outputs:expr_2021, $num_records:expr_2021, $error_fn:expr_2021) => {{
         let num_neurons = $network.num_neurons;
@@ -56,7 +63,7 @@ macro_rules! batch_8way_activation {
                     6 => &mut act6,
                     _ => &mut act7,
                 };
-                act[..$input_size].copy_from_slice(inputs);
+                load_record(act, inputs, num_inputs);
             }
 
             // Process each neuron for all 8 records
@@ -176,7 +183,7 @@ macro_rules! batch_8way_activation {
                         2 => &mut act2,
                         _ => &mut act3,
                     };
-                    act[..$input_size].copy_from_slice(inputs);
+                    load_record(act, inputs, num_inputs);
                 }
 
                 for (neuron_idx, neuron) in $network.neurons.iter().enumerate() {
@@ -259,7 +266,7 @@ macro_rules! batch_8way_activation {
             let inputs = &$records[base..base + $input_size];
             let target_base = base + $input_size;
 
-            act0[..$input_size].copy_from_slice(inputs);
+            load_record(&mut act0, inputs, num_inputs);
 
             for i in num_inputs..num_neurons {
                 act0[i] = 0.0;
@@ -400,9 +407,11 @@ pub fn mse_sum_batch_packed(
         );
     }
 
-    // Issue #1202 - Use batched 4-record SIMD path for forward-only networks
+    // Issue #1202 - Use batched 4-record SIMD path for forward-only networks.
+    // The shared skeleton's remainder handling is the 4-way path (Issue #445):
+    // with 4..7 records it runs one 4-record group then the scalar tail.
     if forward_only && layout.num_records >= 4 {
-        return mse_sum_batch_4way(
+        return mse_sum_batch_scattered(
             network,
             records,
             layout.values_per_record,
@@ -436,174 +445,6 @@ pub fn mse_sum_batch_packed(
     )
 }
 
-/// Issue #1202 - Batched MSE with 4-record SIMD parallelism.
-///
-/// Processes 4 records simultaneously using SIMD across records.
-/// This is an internal helper that only works for forward-only networks
-/// with standard squash functions. Falls back to single-record for edge cases.
-fn mse_sum_batch_4way(
-    network: &CompiledNetwork,
-    records: &[f32],
-    values_per_record: usize,
-    input_size: usize,
-    num_outputs: usize,
-    num_records: usize,
-) -> f64 {
-    let inv_outputs: f64 = if num_outputs > 0 {
-        1.0 / (num_outputs as f64)
-    } else {
-        return 0.0;
-    };
-
-    // Allocate 4 activation buffers
-    let num_neurons = network.num_neurons;
-    let num_inputs = network.num_inputs;
-    let mut act0: Vec<f32> = vec![0.0; num_neurons];
-    let mut act1: Vec<f32> = vec![0.0; num_neurons];
-    let mut act2: Vec<f32> = vec![0.0; num_neurons];
-    let mut act3: Vec<f32> = vec![0.0; num_neurons];
-
-    let mut sum_error: f64 = 0.0;
-    let output_start = num_neurons - num_outputs;
-
-    // Process in batches of 4
-    let full_batches = num_records / 4;
-    for batch in 0..full_batches {
-        let base_idx = batch * 4;
-
-        // Load inputs for all 4 records
-        for r in 0..4 {
-            let record_idx = base_idx + r;
-            let base = record_idx * values_per_record;
-            let inputs = &records[base..base + input_size];
-            let act = match r {
-                0 => &mut act0,
-                1 => &mut act1,
-                2 => &mut act2,
-                _ => &mut act3,
-            };
-            act[..input_size].copy_from_slice(inputs);
-        }
-
-        // Process each neuron for all 4 records
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                let val = apply_limit_range(SquashType::Identity, neuron.bias);
-                act0[actual_idx] = val;
-                act1[actual_idx] = val;
-                act2[actual_idx] = val;
-                act3[actual_idx] = val;
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                // Only use batched path for standard squash functions
-                match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
-                        // One shared activation rule (Issue #441): the scalar
-                        // helper covers every aggregate squash exactly as the
-                        // single-record reference does.
-                        for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
-                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
-                            act[actual_idx] = value;
-                        }
-                    }
-                    _ => {
-                        // Use SIMD for standard squash functions
-                        let (sum0, sum1, sum2, sum3) = weighted_sum_simd_4records(
-                            &network.synapses,
-                            &act0,
-                            &act1,
-                            &act2,
-                            &act3,
-                            start_synapse,
-                            end_synapse,
-                            neuron.bias,
-                        );
-
-                        // Vectorised squash for the hot transcendental types
-                        // (Issue #180 approximations, wired into MSE by #246);
-                        // scalar inline fallback otherwise so numerics are
-                        // unchanged for the non-vectorised squashes.
-                        let sums = [sum0, sum1, sum2, sum3];
-                        let squashed = match squash_x4(squash, sums) {
-                            Some(vec) => vec,
-                            None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
-                        };
-
-                        // Issue #245: resolve the output range once per neuron.
-                        let (low, high) = apply_get_range(squash);
-                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
-                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
-                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
-                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
-                    }
-                }
-            }
-        }
-
-        // Calculate MSE for all 4 records
-        for r in 0..4 {
-            let record_idx = base_idx + r;
-            let target_base = record_idx * values_per_record + input_size;
-            let act = match r {
-                0 => &act0,
-                1 => &act1,
-                2 => &act2,
-                _ => &act3,
-            };
-
-            let mut sq_sum: f64 = 0.0;
-            for j in 0..num_outputs {
-                let diff = (records[target_base + j] - act[output_start + j]) as f64;
-                sq_sum += diff * diff;
-            }
-            sum_error += sq_sum * inv_outputs;
-        }
-    }
-
-    // Handle remainder with single-record processing
-    let remainder_start = full_batches * 4;
-    for record_idx in remainder_start..num_records {
-        let base = record_idx * values_per_record;
-        let inputs = &records[base..base + input_size];
-        let target_base = base + input_size;
-
-        // Reuse act0 for single record
-        act0[..input_size].copy_from_slice(inputs);
-
-        // Reset non-input activations
-        for activation in act0.iter_mut().take(num_neurons).skip(num_inputs) {
-            *activation = 0.0;
-        }
-
-        // Process each neuron through the one shared activation rule
-        // (Issue #441) so the tail record matches the reference exactly.
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
-            act0[num_inputs + neuron_idx] = value;
-        }
-
-        // Calculate MSE
-        let mut sq_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_base + j] - act0[output_start + j]) as f64;
-            sq_sum += diff * diff;
-        }
-        sum_error += sq_sum * inv_outputs;
-    }
-
-    sum_error
-}
-
 /// Issue #1209 - Batched MSE with 8-record SIMD parallelism.
 ///
 /// Processes 8 records simultaneously using two SIMD vectors across records.
@@ -617,7 +458,7 @@ fn mse_sum_batch_4way(
 /// ([`mse_sum_batch_8way_interleaved`]), so each synapse reads one cache line
 /// instead of eight scattered per-lane buffers; networks containing an
 /// aggregate squash keep the exact per-lane scattered path
-/// ([`mse_sum_batch_8way_scattered`]) unchanged. Both are bit-identical to the
+/// ([`mse_sum_batch_scattered`]) unchanged. Both are bit-identical to the
 /// pre-#384 result.
 fn mse_sum_batch_8way(
     network: &CompiledNetwork,
@@ -628,7 +469,7 @@ fn mse_sum_batch_8way(
     num_records: usize,
 ) -> f64 {
     if network.has_aggregate_squash() {
-        return mse_sum_batch_8way_scattered(
+        return mse_sum_batch_scattered(
             network,
             records,
             values_per_record,
@@ -729,28 +570,13 @@ fn mse_sum_batch_8way_interleaved(
 
     if remaining >= 4 {
         let base_idx = remainder_start;
-        load_batch_input(&mut act0, records, base_idx, values_per_record, input_size);
-        load_batch_input(
-            &mut act1,
-            records,
-            base_idx + 1,
-            values_per_record,
-            input_size,
-        );
-        load_batch_input(
-            &mut act2,
-            records,
-            base_idx + 2,
-            values_per_record,
-            input_size,
-        );
-        load_batch_input(
-            &mut act3,
-            records,
-            base_idx + 3,
-            values_per_record,
-            input_size,
-        );
+        for (r, act) in [&mut act0, &mut act1, &mut act2, &mut act3]
+            .into_iter()
+            .enumerate()
+        {
+            let base = (base_idx + r) * values_per_record;
+            load_record(act, &records[base..base + input_size], num_inputs);
+        }
 
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
             let actual_idx = num_inputs + neuron_idx;
@@ -803,7 +629,7 @@ fn mse_sum_batch_8way_interleaved(
     for record_idx in final_remainder_start..num_records {
         let base = record_idx * values_per_record;
         let target_base = base + input_size;
-        act0[..input_size].copy_from_slice(&records[base..base + input_size]);
+        load_record(&mut act0, &records[base..base + input_size], num_inputs);
         for activation in act0.iter_mut().take(num_neurons).skip(num_inputs) {
             *activation = 0.0;
         }
@@ -822,25 +648,16 @@ fn mse_sum_batch_8way_interleaved(
     sum_error
 }
 
-/// Copy one record's `input_size` inputs into a per-lane activation buffer and
-/// zero the remaining non-input slots, matching the scattered 8-way loader.
-#[inline]
-fn load_batch_input(
-    act: &mut [f32],
-    records: &[f32],
-    record_idx: usize,
-    values_per_record: usize,
-    input_size: usize,
-) {
-    let base = record_idx * values_per_record;
-    act[..input_size].copy_from_slice(&records[base..base + input_size]);
-}
-
-/// Scattered per-lane fused activate + MSE (Issue #1209), retained unchanged for
-/// networks containing an aggregate squash (Issue #384). Processes 8 records via
-/// two SIMD vectors across records, falling back to 4-way for remainder < 8,
-/// then single-record for remainder < 4.
-fn mse_sum_batch_8way_scattered(
+/// Scattered per-lane fused activate + MSE (Issue #1209), used for networks
+/// containing an aggregate squash (Issue #384) and for the 4..7-record
+/// remainder of any forward-only batch.
+///
+/// Issue #445 — MSE runs the shared [`batch_8way_activation`] skeleton like
+/// every other loss kind: 8-record groups, then a 4-record group, then a scalar
+/// tail, with only the per-record squared-error reduction supplied here. The
+/// numerics are unchanged — the same kernels in the same order as the
+/// hand-inlined 8-way and 4-way copies this replaces.
+fn mse_sum_batch_scattered(
     network: &CompiledNetwork,
     records: &[f32],
     values_per_record: usize,
@@ -854,290 +671,30 @@ fn mse_sum_batch_8way_scattered(
         return 0.0;
     };
 
-    // Allocate 8 activation buffers
-    let num_neurons = network.num_neurons;
-    let num_inputs = network.num_inputs;
-    let mut act0: Vec<f32> = vec![0.0; num_neurons];
-    let mut act1: Vec<f32> = vec![0.0; num_neurons];
-    let mut act2: Vec<f32> = vec![0.0; num_neurons];
-    let mut act3: Vec<f32> = vec![0.0; num_neurons];
-    let mut act4: Vec<f32> = vec![0.0; num_neurons];
-    let mut act5: Vec<f32> = vec![0.0; num_neurons];
-    let mut act6: Vec<f32> = vec![0.0; num_neurons];
-    let mut act7: Vec<f32> = vec![0.0; num_neurons];
-
-    let mut sum_error: f64 = 0.0;
-    let output_start = num_neurons - num_outputs;
-
-    // Process in batches of 8
-    let full_batches = num_records / 8;
-    for batch in 0..full_batches {
-        let base_idx = batch * 8;
-
-        // Load inputs for all 8 records
-        for r in 0..8 {
-            let record_idx = base_idx + r;
-            let base = record_idx * values_per_record;
-            let inputs = &records[base..base + input_size];
-            let act = match r {
-                0 => &mut act0,
-                1 => &mut act1,
-                2 => &mut act2,
-                3 => &mut act3,
-                4 => &mut act4,
-                5 => &mut act5,
-                6 => &mut act6,
-                _ => &mut act7,
-            };
-            act[..input_size].copy_from_slice(inputs);
-        }
-
-        // Process each neuron for all 8 records
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                let val = apply_limit_range(SquashType::Identity, neuron.bias);
-                act0[actual_idx] = val;
-                act1[actual_idx] = val;
-                act2[actual_idx] = val;
-                act3[actual_idx] = val;
-                act4[actual_idx] = val;
-                act5[actual_idx] = val;
-                act6[actual_idx] = val;
-                act7[actual_idx] = val;
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                // Only use batched path for standard squash functions
-                match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
-                        // One shared activation rule (Issue #441): the scalar
-                        // helper covers every aggregate squash exactly as the
-                        // single-record reference does.
-                        for act in [
-                            &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
-                            &mut act6, &mut act7,
-                        ] {
-                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
-                            act[actual_idx] = value;
-                        }
-                    }
-                    _ => {
-                        // Use SIMD for standard squash functions
-                        let (sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7) =
-                            weighted_sum_simd_8records(
-                                &network.synapses,
-                                &act0,
-                                &act1,
-                                &act2,
-                                &act3,
-                                &act4,
-                                &act5,
-                                &act6,
-                                &act7,
-                                start_synapse,
-                                end_synapse,
-                                neuron.bias,
-                            );
-
-                        // Vectorised squash for the hot transcendental types
-                        // (Issue #180 approximations, wired into MSE by #246);
-                        // scalar inline fallback otherwise so numerics are
-                        // unchanged for the non-vectorised squashes.
-                        let sums = [sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7];
-                        let squashed = match squash_x8(squash, sums) {
-                            Some(vec) => vec,
-                            None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
-                        };
-
-                        // Issue #245: resolve the output range once per neuron
-                        // and clamp all 8 lanes through the bounds.
-                        let (low, high) = apply_get_range(squash);
-                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
-                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
-                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
-                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
-                        act4[actual_idx] = apply_limit_range_bounds(low, high, squashed[4]);
-                        act5[actual_idx] = apply_limit_range_bounds(low, high, squashed[5]);
-                        act6[actual_idx] = apply_limit_range_bounds(low, high, squashed[6]);
-                        act7[actual_idx] = apply_limit_range_bounds(low, high, squashed[7]);
-                    }
-                }
-            }
-        }
-
-        // Calculate MSE for all 8 records
-        for r in 0..8 {
-            let record_idx = base_idx + r;
-            let target_base = record_idx * values_per_record + input_size;
-            let act = match r {
-                0 => &act0,
-                1 => &act1,
-                2 => &act2,
-                3 => &act3,
-                4 => &act4,
-                5 => &act5,
-                6 => &act6,
-                _ => &act7,
-            };
-
-            let mut sq_sum: f64 = 0.0;
-            for j in 0..num_outputs {
-                let diff = (records[target_base + j] - act[output_start + j]) as f64;
-                sq_sum += diff * diff;
-            }
-            sum_error += sq_sum * inv_outputs;
-        }
-    }
-
-    // Handle remainder: use 4-way for 4-7 remaining records
-    let remainder_start = full_batches * 8;
-    let remaining = num_records - remainder_start;
-
-    if remaining >= 4 {
-        // Process 4 records at a time
-        let four_way_batches = remaining / 4;
-        for batch in 0..four_way_batches {
-            let base_idx = remainder_start + batch * 4;
-
-            // Load inputs for 4 records
-            for r in 0..4 {
-                let record_idx = base_idx + r;
-                let base = record_idx * values_per_record;
-                let inputs = &records[base..base + input_size];
-                let act = match r {
-                    0 => &mut act0,
-                    1 => &mut act1,
-                    2 => &mut act2,
-                    _ => &mut act3,
-                };
-                act[..input_size].copy_from_slice(inputs);
-            }
-
-            // Process each neuron for all 4 records
-            for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-                let actual_idx = num_inputs + neuron_idx;
-
-                if neuron.is_constant {
-                    let val = apply_limit_range(SquashType::Identity, neuron.bias);
-                    act0[actual_idx] = val;
-                    act1[actual_idx] = val;
-                    act2[actual_idx] = val;
-                    act3[actual_idx] = val;
-                } else {
-                    let squash = SquashType::from(neuron.squash_type);
-                    let start_synapse = neuron.start_synapse as usize;
-                    let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                    match squash {
-                        SquashType::Minimum
-                        | SquashType::Maximum
-                        | SquashType::If
-                        | SquashType::Hypotenuse
-                        | SquashType::HypotenuseV2
-                        | SquashType::Mean => {
-                            // One shared activation rule (Issue #441).
-                            for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
-                                let value =
-                                    neuron_activation_scalar(&network.synapses, act, neuron);
-                                act[actual_idx] = value;
-                            }
-                        }
-                        _ => {
-                            let (sum0, sum1, sum2, sum3) = weighted_sum_simd_4records(
-                                &network.synapses,
-                                &act0,
-                                &act1,
-                                &act2,
-                                &act3,
-                                start_synapse,
-                                end_synapse,
-                                neuron.bias,
-                            );
-
-                            // Vectorised squash for the hot transcendental
-                            // types (Issue #180 approximations, wired into MSE
-                            // by #246); scalar inline fallback otherwise.
-                            let sums = [sum0, sum1, sum2, sum3];
-                            let squashed = match squash_x4(squash, sums) {
-                                Some(vec) => vec,
-                                None => {
-                                    sums.map(|sum| inline_squash(neuron.squash_type, squash, sum))
-                                }
-                            };
-
-                            // Issue #245: resolve the range once per neuron.
-                            let (low, high) = apply_get_range(squash);
-                            act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
-                            act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
-                            act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
-                            act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
-                        }
-                    }
-                }
-            }
-
-            // Calculate MSE for 4 records
-            for r in 0..4 {
-                let record_idx = base_idx + r;
-                let target_base = record_idx * values_per_record + input_size;
-                let act = match r {
-                    0 => &act0,
-                    1 => &act1,
-                    2 => &act2,
-                    _ => &act3,
-                };
-
-                let mut sq_sum: f64 = 0.0;
-                for j in 0..num_outputs {
-                    let diff = (records[target_base + j] - act[output_start + j]) as f64;
-                    sq_sum += diff * diff;
-                }
-                sum_error += sq_sum * inv_outputs;
-            }
-        }
-    }
-
-    // Handle final remainder with single-record processing
-    let final_remainder_start = remainder_start + (remaining / 4) * 4;
-    for record_idx in final_remainder_start..num_records {
-        let base = record_idx * values_per_record;
-        let inputs = &records[base..base + input_size];
-        let target_base = base + input_size;
-
-        // Reuse act0 for single record
-        act0[..input_size].copy_from_slice(inputs);
-
-        // Reset non-input activations
-        for activation in act0.iter_mut().take(num_neurons).skip(num_inputs) {
-            *activation = 0.0;
-        }
-
-        // Process each neuron through the one shared activation rule
-        // (Issue #441) so the tail record matches the reference exactly.
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
-            act0[num_inputs + neuron_idx] = value;
-        }
-
-        // Calculate MSE
+    // MSE error calculation: mean((target - output)^2)
+    let mse_error = |records: &[f32],
+                     target_base: usize,
+                     act: &[f32],
+                     output_start: usize,
+                     num_outputs: usize|
+     -> f64 {
         let mut sq_sum: f64 = 0.0;
         for j in 0..num_outputs {
-            let diff = (records[target_base + j] - act0[output_start + j]) as f64;
+            let diff = (records[target_base + j] - act[output_start + j]) as f64;
             sq_sum += diff * diff;
         }
-        sum_error += sq_sum * inv_outputs;
-    }
+        sq_sum * inv_outputs
+    };
 
-    sum_error
+    batch_8way_activation!(
+        network,
+        records,
+        values_per_record,
+        input_size,
+        num_outputs,
+        num_records,
+        mse_error
+    )
 }
 
 /// Issue #1209 - Batched MAE with 8-record SIMD parallelism.
@@ -2051,7 +1608,7 @@ mod interleaved_mse_parity {
     //!
     //! `mse_sum_batch_8way` now dispatches standard-squash networks to
     //! [`mse_sum_batch_8way_interleaved`] and aggregate networks to the
-    //! unchanged [`mse_sum_batch_8way_scattered`]. These "what" tests assert the
+    //! unchanged [`mse_sum_batch_scattered`]. These "what" tests assert the
     //! interleaved result is **bit-identical** (`f64::to_bits`) to the scattered
     //! path it replaces across the record counts that straddle the 8-record
     //! group boundary, so a lane-transpose bug, a changed `f64` accumulation
@@ -2166,7 +1723,7 @@ mod interleaved_mse_parity {
             1,
             num_records,
         );
-        let scattered = mse_sum_batch_8way_scattered(
+        let scattered = mse_sum_batch_scattered(
             &net,
             &records,
             values_per_record,
@@ -2205,7 +1762,7 @@ mod interleaved_mse_parity {
     /// scattered kernel — never the interleaved gather (whose standard-only
     /// `squash_x8` fallback would mis-evaluate an aggregate neuron). Asserting
     /// the public `mse_sum_batch_8way` dispatcher is bit-identical to
-    /// `mse_sum_batch_8way_scattered` proves the routing, and keeps aggregate
+    /// `mse_sum_batch_scattered` proves the routing, and keeps aggregate
     /// networks bit-identical to their pre-#384 result.
     #[test]
     fn aggregate_dispatch_stays_on_scattered_path() {
@@ -2232,14 +1789,8 @@ mod interleaved_mse_parity {
                 let records = build_records(n, input_size);
                 let dispatched =
                     mse_sum_batch_8way(&net, &records, values_per_record, input_size, 1, n);
-                let scattered = mse_sum_batch_8way_scattered(
-                    &net,
-                    &records,
-                    values_per_record,
-                    input_size,
-                    1,
-                    n,
-                );
+                let scattered =
+                    mse_sum_batch_scattered(&net, &records, values_per_record, input_size, 1, n);
                 assert_eq!(
                     dispatched.to_bits(),
                     scattered.to_bits(),

--- a/neat-core/tests/batch_record_skeleton.rs
+++ b/neat-core/tests/batch_record_skeleton.rs
@@ -1,0 +1,351 @@
+//! Behavioural coverage for the batched record-scan skeleton (Issue #445).
+//!
+//! One rule says how a packed record buffer is walked and reduced by the fused
+//! loss kernels: records are grouped 8 → 4 → 1, each group's inputs are loaded
+//! into per-lane activation buffers through the shared loader, and the
+//! per-record errors accumulate into one `f64` sum. Every loss kind — MSE
+//! included — obeys it.
+//!
+//! These are "what" tests: they drive the public `*_sum_batch_packed` entry
+//! points with real networks and assert observable numbers against a
+//! single-record reference built from `CompiledNetwork::activate`. A copy of the
+//! skeleton that drifted — a loader that does not clamp the record to the
+//! network's input count, one that leaves an uncovered input slot stale, or a
+//! remainder split that drops or double-counts records — fails here no matter
+//! how the scan is implemented.
+
+use neat_core::loss::{
+    cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
+    mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
+};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+const IDENTITY: u8 = 0;
+const TANH: u8 = 7;
+const MEAN: u8 = 37;
+
+/// Every batched loss entry point shares the packed signature.
+type PackedEntry = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// A record's per-record reduction: `(targets, outputs) -> error`.
+type Reduce = fn(&[f32], &[f32]) -> f64;
+
+/// One batched loss entry point paired with its single-record reduction.
+type LossCase = (&'static str, PackedEntry, Reduce);
+
+/// Absolute tolerance for a batched sum against the single-record reference.
+/// The across-records SIMD kernels re-associate the weighted sums in `f32`, so
+/// parity is "within a small tolerance", not bit-for-bit.
+const TOL: f64 = 1e-5;
+
+fn network(
+    num_inputs: usize,
+    neurons: Vec<NeuronData>,
+    synapses: Vec<SynapseData>,
+) -> CompiledNetwork {
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Three inputs → two hidden neurons → one output, all standard squashes, so
+/// the network routes through the interleaved/standard batch kernels.
+/// `num_neurons` is 6, deliberately smaller than the widest `input_size` a test
+/// passes, so an unclamped loader writes past the activation buffer.
+fn standard_network(hidden_squash: u8) -> CompiledNetwork {
+    let num_inputs = 3;
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.37 - 0.11 * (i as f32) + 0.13 * (h as f32),
+                from_index: i as u16,
+                synapse_type: 0,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: hidden_squash,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    synapses.push(SynapseData {
+        weight: 0.61,
+        from_index: num_inputs as u16,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.44,
+        from_index: num_inputs as u16 + 1,
+        synapse_type: 0,
+    });
+    neurons.push(NeuronData {
+        bias: 0.03,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: IDENTITY,
+        is_constant: false,
+    });
+
+    network(num_inputs, neurons, synapses)
+}
+
+/// Same topology with an aggregate (`MEAN`) hidden neuron, which routes the
+/// batch through the scattered per-lane kernels instead.
+fn aggregate_network() -> CompiledNetwork {
+    standard_network(MEAN)
+}
+
+/// Packed `[inputs…, targets…]` records with distinct per-record values, so a
+/// lane mix-up or a dropped record cannot hide. Input columns beyond the
+/// network's `num_inputs` are padding the network must ignore.
+fn build_records(num_records: usize, input_size: usize, num_outputs: usize) -> Vec<f32> {
+    let values_per_record = input_size + num_outputs;
+    let mut records = vec![0.0f32; num_records * values_per_record];
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        for i in 0..input_size {
+            records[base + i] = -0.9 + 0.23 * (r as f32) - 0.17 * (i as f32);
+        }
+        for j in 0..num_outputs {
+            records[base + input_size + j] = 0.2 + 0.031 * (r as f32) + 0.05 * (j as f32);
+        }
+    }
+    records
+}
+
+/// Single-record reference: activate each record on its own (which clamps the
+/// record to the network's input count) and reduce with `reduce`.
+fn reference_sum(
+    net: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    reduce: impl Fn(&[f32], &[f32]) -> f64,
+) -> f64 {
+    let values_per_record = input_size + num_outputs;
+    let num_records = records.len() / values_per_record;
+    let mut sum = 0.0;
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        let outputs = net.activate(&records[base..base + input_size], num_outputs);
+        sum += reduce(
+            &records[base + input_size..base + values_per_record],
+            &outputs,
+        );
+    }
+    sum
+}
+
+fn mse_reduce(targets: &[f32], outputs: &[f32]) -> f64 {
+    let mut sq = 0.0;
+    for (t, o) in targets.iter().zip(outputs.iter()) {
+        let d = (*t - *o) as f64;
+        sq += d * d;
+    }
+    sq / targets.len() as f64
+}
+
+fn mae_reduce(targets: &[f32], outputs: &[f32]) -> f64 {
+    let mut abs = 0.0;
+    for (t, o) in targets.iter().zip(outputs.iter()) {
+        abs += ((*t - *o) as f64).abs();
+    }
+    abs / targets.len() as f64
+}
+
+/// Every batched loss entry point paired with its per-record reduction.
+fn loss_entries() -> Vec<LossCase> {
+    vec![
+        (
+            "mse",
+            mse_sum_batch_packed as PackedEntry,
+            mse_reduce as Reduce,
+        ),
+        ("mae", mae_sum_batch_packed as PackedEntry, mae_reduce),
+        (
+            "cross_entropy",
+            cross_entropy_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                const EPSILON: f64 = 1e-15;
+                let mut ce = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    let t = *t as f64;
+                    let o = (*o as f64).clamp(EPSILON, 1.0 - EPSILON);
+                    ce -= t * o.ln() + (1.0 - t) * (1.0 - o).ln();
+                }
+                ce / targets.len() as f64
+            },
+        ),
+        (
+            "mape",
+            mape_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                const EPSILON: f64 = 1e-15;
+                let mut mape = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    let t = (*t as f64).max(EPSILON);
+                    mape += ((*o as f64 - t) / t).abs();
+                }
+                mape / targets.len() as f64
+            },
+        ),
+        (
+            "msle",
+            msle_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                const EPSILON: f64 = 1e-15;
+                let mut msle = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    msle += (*t as f64).max(EPSILON).ln() - (*o as f64).max(EPSILON).ln();
+                }
+                msle
+            },
+        ),
+        (
+            "hinge",
+            hinge_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                let mut hinge = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    hinge += (1.0 - (*t as f64) * (*o as f64)).max(0.0);
+                }
+                hinge
+            },
+        ),
+    ]
+}
+
+/// The 8 → 4 → 1 grouping must not change the answer: for every record count
+/// that straddles a group boundary the batched sum equals the sum of the
+/// records scored one at a time.
+#[test]
+fn grouping_does_not_change_the_batched_sum() {
+    for (name, entry, reduce) in loss_entries() {
+        for &num_records in &[1usize, 3, 4, 5, 7, 8, 9, 11, 12, 13, 16, 17, 24, 33] {
+            let records = build_records(num_records, 3, 1);
+            let mut batched = standard_network(TANH);
+            let mut reference = standard_network(TANH);
+
+            let actual = entry(&mut batched, &records, 3, 1, true);
+            let expected = reference_sum(&mut reference, &records, 3, 1, reduce);
+
+            assert!(
+                (actual - expected).abs() < TOL,
+                "{name} n={num_records}: batched {actual} != single-record {expected}"
+            );
+        }
+    }
+}
+
+/// A network whose aggregate squash keeps it on the per-lane kernels obeys the
+/// same grouping rule.
+#[test]
+fn aggregate_network_grouping_does_not_change_the_batched_sum() {
+    for &num_records in &[4usize, 5, 8, 9, 12, 13, 17] {
+        let records = build_records(num_records, 3, 1);
+        let mut batched = aggregate_network();
+        let mut reference = aggregate_network();
+
+        let actual = mse_sum_batch_packed(&mut batched, &records, 3, 1, true);
+        let expected = reference_sum(&mut reference, &records, 3, 1, mse_reduce);
+
+        assert!(
+            (actual - expected).abs() < TOL,
+            "aggregate n={num_records}: batched {actual} != single-record {expected}"
+        );
+    }
+}
+
+/// Input columns beyond the network's `num_inputs` are padding: the batched
+/// loader clamps the copy exactly as `CompiledNetwork::activate` does, so the
+/// extras change nothing (and never write past the activation buffer).
+#[test]
+fn input_columns_beyond_the_network_inputs_are_ignored() {
+    // `input_size` (8) exceeds both `num_inputs` (3) and `num_neurons` (6).
+    let input_size = 8;
+    for (name, entry, reduce) in loss_entries() {
+        for &num_records in &[4usize, 5, 8, 9, 13, 17] {
+            let records = build_records(num_records, input_size, 1);
+            let mut batched = standard_network(TANH);
+            let mut reference = standard_network(TANH);
+
+            let actual = entry(&mut batched, &records, input_size, 1, true);
+            let expected = reference_sum(&mut reference, &records, input_size, 1, reduce);
+
+            assert!(
+                (actual - expected).abs() < TOL,
+                "{name} n={num_records}: padded-record batched {actual} != single-record {expected}"
+            );
+        }
+    }
+}
+
+/// The aggregate (scattered) route clamps the same way.
+#[test]
+fn aggregate_network_ignores_input_columns_beyond_the_network_inputs() {
+    let input_size = 8;
+    for &num_records in &[4usize, 8, 13] {
+        let records = build_records(num_records, input_size, 1);
+        let mut batched = aggregate_network();
+        let mut reference = aggregate_network();
+
+        let actual = mse_sum_batch_packed(&mut batched, &records, input_size, 1, true);
+        let expected = reference_sum(&mut reference, &records, input_size, 1, mse_reduce);
+
+        assert!(
+            (actual - expected).abs() < TOL,
+            "aggregate n={num_records}: padded-record batched {actual} != single-record {expected}"
+        );
+    }
+}
+
+/// A record that covers fewer columns than the network has inputs leaves the
+/// uncovered input slots reading zero for every record — no value from an
+/// earlier group leaks in.
+#[test]
+fn uncovered_input_slots_score_as_zero() {
+    // The network has 3 inputs; each record supplies only 1.
+    let input_size = 1;
+    for &num_records in &[4usize, 8, 9, 13, 17] {
+        let records = build_records(num_records, input_size, 1);
+        let mut batched = standard_network(TANH);
+        let mut reference = standard_network(TANH);
+
+        let actual = mse_sum_batch_packed(&mut batched, &records, input_size, 1, true);
+        let expected = reference_sum(&mut reference, &records, input_size, 1, mse_reduce);
+
+        assert!(
+            (actual - expected).abs() < TOL,
+            "n={num_records}: short-record batched {actual} != single-record {expected}"
+        );
+    }
+}

--- a/neat-core/tests/mse_squash_simd_parity.rs
+++ b/neat-core/tests/mse_squash_simd_parity.rs
@@ -1,5 +1,5 @@
 //! Parity guard for the SIMD squash wiring in the MSE batched loss paths
-//! (Issue #246). `mse_sum_batch_8way` / `mse_sum_batch_4way` now feed their
+//! (Issue #246). The batched MSE kernels feed their
 //! per-lane sums through the vectorised `squash_x8` / `squash_x4`
 //! approximations (shipped by #180) for the hot transcendental squashes,
 //! falling back to the scalar inline squash for every other type.
@@ -168,7 +168,8 @@ fn mse_8way_with_remainder_matches_scalar() {
     }
 }
 
-/// 5–7 records route through `mse_sum_batch_4way`, driving the 4-way SIMD block.
+/// 5–7 records fall to the shared skeleton's 4-record group, driving the 4-way
+/// SIMD block.
 #[test]
 fn mse_4way_matches_scalar_for_vectorised_squashes() {
     for squash in [


### PR DESCRIPTION
# MSE adopts the shared 8→4→1 batch skeleton (Issue #445)

## Summary

MSE was the only loss kind that hand-inlined the batched record-scan skeleton —
walk records in SIMD groups of eight, then one group of four, then a per-record
scalar tail, loading each record's inputs into per-lane activation buffers and
accumulating an `f64` error sum. The other five loss kinds already get that rule
from the `batch_8way_activation!` macro, parameterised by a per-record
`$error_fn` closure.

MSE now calls the same macro. `mse_sum_batch_4way` and
`mse_sum_batch_8way_scattered` are gone, replaced by one ~45-line
`mse_sum_batch_scattered` that supplies only the squared-error reduction. Net
`-511 / +105` lines. The record-**interleaved** 8-group path (Issue #384) stays
separate, as the issue asks — it is a genuinely different memory layout, and no
mode flag was added to merge it.

The loader sub-rule that had drifted is fixed at the same time.
`load_record` (`neat-core/src/batch_scoring.rs`) is now the single home of
clamp-and-zero: copy `min(record.len(), num_inputs)` values and zero every input
slot the record does not cover, exactly as `CompiledNetwork::activate_into`
does. Every per-lane loader in the macro and in the interleaved remainder calls
it. `load_batch_input` — whose doc comment promised zeroing its body never did —
is deleted.

Closes #445.

## Evidence

Backend/library change with no web interface, so no screenshot. Evidence is the
test suite plus the pre-existing bit-identity parity guards.

**Behaviour fixed.** Before this change, a packed batch whose records carried
more input columns than the network has inputs panicked in the forward-only
batched path (`range end index 8 out of range for slice of length 6`) while the
single-record path silently ignored the extras. Both now agree.

```
# before (new tests against unfixed code)
test aggregate_network_ignores_input_columns_beyond_the_network_inputs ... FAILED
test input_columns_beyond_the_network_inputs_are_ignored ... FAILED
test result: FAILED. 3 passed; 2 failed

# after
test result: ok. 5 passed; 0 failed
```

**Numerics unchanged.** The existing `interleaved_mse_parity` module asserts the
scattered kernel is **bit-identical** (`f64::to_bits`) to the interleaved path
across every record count that straddles a group boundary (8, 9, 12, 13, 15, 16,
17, 24, 4096) for seven squash types, plus the aggregate-dispatch guard. Those
tests pass unchanged against the macro-driven kernel, so the consolidation moved
no bits. `./quality.sh` is green (fmt, clippy `-D warnings`, deny, full
workspace test suite, doc build, release build).

**Performance.** Not a performance change, and the benchmark harness on this
machine cannot resolve one: every `hot_paths` network spec uses Tanh, so all
benched MSE batches route through the *unchanged* interleaved kernel. Two
back-to-back runs of the identical post-change binary swung from −26% to +46% on
the same benchmark IDs, so the criterion "regressed"/"improved" verdicts in this
range are noise, not signal.

```mermaid
flowchart LR
    A["packed records"] --> B{"num_records"}
    B -- "&ge; 8" --> C["8-record group<br/>load_record x8"]
    B -- "4..7" --> D["4-record group<br/>load_record x4"]
    B -- "&lt; 4" --> E["scalar tail<br/>load_record"]
    C --> D --> E
    C --> F["per-record $error_fn<br/>(MSE / MAE / CE / MAPE / MSLE / hinge)"]
    D --> F
    E --> F
    F --> G["f64 sum_error"]
```

## Test Plan

New `neat-core/tests/batch_record_skeleton.rs` — "what" tests driving the public
`*_sum_batch_packed` entry points against a single-record reference built from
`CompiledNetwork::activate`:

- `grouping_does_not_change_the_batched_sum` — every loss kind, 14 record counts
  straddling the 4- and 8-record boundaries (1, 3, 4, 5, 7, 8, 9, 11, 12, 13,
  16, 17, 24, 33).
- `aggregate_network_grouping_does_not_change_the_batched_sum` — the same rule
  on a network whose `MEAN` neuron keeps it on the per-lane kernels.
- `input_columns_beyond_the_network_inputs_are_ignored` — regression test for
  the loader drift; fails (panics) against the unfixed code.
- `aggregate_network_ignores_input_columns_beyond_the_network_inputs` — the same
  regression on the scattered route; also fails against the unfixed code.
- `uncovered_input_slots_score_as_zero` — a record covering fewer columns than
  the network has inputs reads the uncovered slots as zero for every record, so
  nothing leaks between groups.

Existing suites re-run unchanged and green, notably
`neat-core/src/loss.rs::interleaved_mse_parity` (bit-identity),
`neat-core/tests/mse_squash_simd_parity.rs`,
`neat-core/tests/mse_batch_interleaved_parity.rs`,
`neat-core/tests/packed_record_scan.rs` and
`neat-core/tests/aggregate_squash_tail_parity.rs`.

Docs: `AGENTS.md` gains the "One batched record-scan skeleton for every loss
kind" rule beside the #441/#443/#444 entries; the two stale
`mse_sum_batch_4way` references in `mse_squash_simd_parity.rs` are updated.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms94ugca-45b6ee`<!-- vibe-worker-issue-445 -->