### PR TITLE
One aggregate-squash set: seven copies become one predicate (Issue #446)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,28 @@ The *vectorised* `squash_x4` / `squash_x8` approximations
 (`neat-core/src/squash_simd.rs`) are a different rule and stay where they are —
 only their scalar fallback goes through `inline_squash`.
 
+## One aggregate-squash set for dispatch and hints (Issue #446)
+
+`SquashType::is_aggregate` (`neat-core/src/squash.rs`) is the single home of the
+rule that says *which squash types are aggregates* — Minimum, Maximum, If,
+Hypotenuse, HypotenuseV2, Mean: the six that cannot be lane-vectorised and must
+take the exact single-record kernel. That one predicate drives both dispatch
+(`has_aggregate_squash`, the 8-record and 4-record group loops in
+`batch_scoring.rs`, and the same two tiers inside `batch_8way_activation!`) and
+hint semantics (`activate_and_trace` reports the activation itself as the hint;
+`apply_unsquash` prefers the caller's hint). Adding a seventh aggregate type is
+an edit **there and nowhere else** — do not restate the membership list at a
+call site, because a missed site fails **silently**: the new type would be
+routed down the lane-vectorised weighted-sum path and produce numbers that
+differ from `activate()` with no panic to flag it.
+
+`apply_unsquash` is the one site that needs the set as a *pattern* rather than a
+predicate — a guard arm would forfeit the compiler's exhaustiveness check over
+`SquashType`. It uses `aggregate_squash_patterns!()`, the `pub(crate)` macro the
+predicate itself is built from, so there is still exactly one list.
+`neat-core/tests/aggregate_squash_set.rs` pins the rule: membership, batched-vs-
+single-record parity for every squash type, and both hint semantics.
+
 ## One packed-record scan for every loss entry point (Issue #444)
 
 `packed_record_scan` (`neat-core/src/loss.rs`) is the single home of the rule

--- a/docs/archive/pr-summaries/pr-summary-446.md
+++ b/docs/archive/pr-summaries/pr-summary-446.md
@@ -1,0 +1,112 @@
+# One aggregate-squash set: seven copies become one predicate (Issue #446)
+
+## Summary
+
+The knowledge of *which squash types are aggregates* — `Minimum`, `Maximum`,
+`If`, `Hypotenuse`, `HypotenuseV2`, `Mean`: the six that cannot be
+lane-vectorised and must take the exact single-record kernel — was open-coded as
+a six-arm type list at every consumer, with no `is_aggregate` predicate anywhere
+in the crate. Adding a seventh aggregate type meant the identical one-arm edit at
+each site, and a missed site fails **silently**: the new type would be routed
+down the lane-vectorised weighted-sum path and produce numbers differing from
+`activate()`, with no panic to flag it.
+
+`SquashType::is_aggregate` (`neat-core/src/squash.rs`) is now the single home of
+that membership rule. Every site calls it instead of restating the list; local
+twists stay local (`has_aggregate_squash` keeps its own `!neuron.is_constant`
+condition, `apply_unsquash` still uses the set to pick the hint rather than to
+dispatch). Closes #446.
+
+The issue listed ten sites against an older tree; #444 and #445 have since
+folded the five `loss.rs` copies into two, so seven remained:
+
+| Site | Role |
+| --- | --- |
+| `batch_scoring.rs` `has_aggregate_squash` | dispatch: per-lane vs interleaved |
+| `batch_scoring.rs` `score_batch_per_lane` (8-group) | dispatch: scalar kernel vs SIMD lanes |
+| `batch_scoring.rs` `score_batch_per_lane` (4-group) | dispatch: scalar kernel vs SIMD lanes |
+| `loss.rs` `batch_8way_activation!` (8-lane block) | dispatch: scalar kernel vs SIMD lanes |
+| `loss.rs` `batch_8way_activation!` (4-lane block) | dispatch: scalar kernel vs SIMD lanes |
+| `network.rs` `activate_and_trace` | hint semantics: hint == activation |
+| `unsquash.rs` `apply_unsquash` | hint semantics: not invertible, prefer hint |
+
+### One list, two spellings — and why
+
+Six of the seven sites take the predicate directly (`s if s.is_aggregate()`, or a
+plain call). `apply_unsquash` is the exception: its `match` is exhaustive over
+`SquashType`, and a guard arm would forfeit the compiler's exhaustiveness check —
+a future non-aggregate squash type would then compile and fall into whatever
+catch-all replaced it. So it takes the set as a *pattern* via
+`aggregate_squash_patterns!()`, the `pub(crate)` macro that `is_aggregate` is
+itself built from. There is still exactly one list; the second spelling is a
+pattern view of the same list, not a second copy.
+
+```mermaid
+flowchart LR
+    M["aggregate_squash_patterns!()<br/>the one list"] --> P["SquashType::is_aggregate"]
+    M --> U["unsquash.rs<br/>apply_unsquash<br/>(exhaustive match)"]
+    P --> A["batch_scoring.rs<br/>has_aggregate_squash"]
+    P --> B["batch_scoring.rs<br/>8-record group"]
+    P --> C["batch_scoring.rs<br/>4-record group"]
+    P --> D["loss.rs batch_8way_activation!<br/>8-lane block"]
+    P --> E["loss.rs batch_8way_activation!<br/>4-lane block"]
+    P --> F["network.rs<br/>activate_and_trace hint"]
+```
+
+## Evidence
+
+Backend-only change to a Rust library — there is no web interface to screenshot.
+The evidence is the test suite plus a mutation check.
+
+`./quality.sh` passes cleanly (fmt, clippy with `-D warnings`, `cargo deny`,
+`cargo test --workspace`, doc build, release build):
+
+```
+✅ All quality checks passed!
+```
+
+**Mutation check — the new tests really do catch drift.** Dropping `Mean` from
+the one list produced two independent failures, which is the whole point of the
+change:
+
+1. A **compile error** at `apply_unsquash` (`error[E0004]: non-exhaustive
+   patterns: SquashType::Mean not covered`) — the pattern spelling turns a
+   dropped type into a build failure, not a silent mis-route.
+2. Keeping the macro intact but letting only `is_aggregate` drift (open-coding a
+   five-member list in the predicate) failed
+   `is_aggregate_holds_for_exactly_the_six_aggregate_squashes` and
+   `batched_scoring_matches_single_record_activation_for_every_squash_type` —
+   `Mean` records scored through the SIMD lane path diverged from `activate()`,
+   exactly the silent failure the issue describes.
+
+Both were reverted; the final tree is green.
+
+No behaviour changed: `is_aggregate` is a `const fn matches!` over the same six
+variants, so every dispatch decision and hint value is identical to before.
+
+## Test Plan
+
+New file `neat-core/tests/aggregate_squash_set.rs` — "what" tests calling real
+public entry points and asserting on observable results:
+
+- `is_aggregate_holds_for_exactly_the_six_aggregate_squashes` — every
+  `SquashType` (discriminants 0–37) agrees with the aggregate set.
+- `batched_scoring_matches_single_record_activation_for_every_squash_type` —
+  13 records (8-group + 4-group + scalar tail) through the public
+  `score_records_flat` match per-record `activate()` for all 38 squash types,
+  pinning the dispatch predicate at every batched site.
+- `traced_hint_equals_activation_for_aggregate_squashes` — `activate_and_trace`
+  reports the activation itself as the hint for each aggregate.
+- `traced_hint_is_the_pre_squash_value_for_standard_squashes` — for every
+  non-aggregate type the traced hint squashes back to the activation.
+- `unsquash_prefers_the_hint_for_every_aggregate_squash` — `apply_unsquash`
+  returns a finite hint, and falls back to the activation when the hint is NaN.
+
+Existing suites unchanged and still green, notably
+`aggregate_squash_tail_parity.rs`, `inline_squash_dispatch.rs`,
+`packed_record_scan.rs`, `batch_record_skeleton.rs` and `unsquash.rs`.
+
+Documentation: `AGENTS.md` gains a **One aggregate-squash set for dispatch and
+hints (Issue #446)** section alongside the sibling #441/#443/#444/#445 rules, and
+the `batch_scoring.rs` doc comments that spelled the six names out in prose now
+link `SquashType::is_aggregate`.

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -28,8 +28,8 @@
 //!   SIMD tolerance the batched weighted sums already introduce (Issue #230).
 //!   Every other type keeps the scalar inline branch (Identity / ReLU /
 //!   Logistic / Tanh, else `apply_squash`), so its squash stays bit-identical.
-//! - **Aggregate** squashes (Minimum, Maximum, If, Hypotenuse, HypotenuseV2,
-//!   Mean) and the **scalar tail** (`records.len() % 8` after the 4-way step)
+//! - **Aggregate** squashes ([`SquashType::is_aggregate`]) and the **scalar
+//!   tail** (`records.len() % 8` after the 4-way step)
 //!   run the exact single-record path via `neuron_activation_scalar`, so those
 //!   neurons and those records are bit-identical to the reference.
 //!
@@ -298,8 +298,8 @@ impl CompiledNetwork {
     ///   all-standard-squash production topology. Records are transposed so each
     ///   synapse gather reads one cache line.
     /// - **Per-lane fallback** ([`Self::score_batch_per_lane`]) otherwise, which
-    ///   keeps aggregate squashes (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/
-    ///   Mean) on the exact single-record kernels.
+    ///   keeps aggregate squashes ([`SquashType::is_aggregate`]) on the exact
+    ///   single-record kernels.
     ///
     /// Both group records into 8s then a 4-record group then a scalar tail, and
     /// both are bit-identical on the covered standard-squash neurons.
@@ -317,25 +317,18 @@ impl CompiledNetwork {
         }
     }
 
-    /// True when any non-constant neuron uses an aggregate squash whose exact
-    /// kernel needs a contiguous per-lane activation slice (so the interleaved
-    /// fast path does not apply). O(neurons); the scoring batch dwarfs it.
+    /// True when any non-constant neuron uses an aggregate squash
+    /// ([`SquashType::is_aggregate`], the single home of that membership rule)
+    /// whose exact kernel needs a contiguous per-lane activation slice, so the
+    /// interleaved fast path does not apply. O(neurons); the scoring batch
+    /// dwarfs it.
     ///
     /// `pub(crate)` so the fused MSE loss lane can share the same dispatch
     /// decision (Issue #384): standard-only networks route through the
     /// interleaved gather, aggregate networks stay on their exact per-lane path.
     pub(crate) fn has_aggregate_squash(&self) -> bool {
         self.neurons.iter().any(|neuron| {
-            !neuron.is_constant
-                && matches!(
-                    SquashType::from(neuron.squash_type),
-                    SquashType::Minimum
-                        | SquashType::Maximum
-                        | SquashType::If
-                        | SquashType::Hypotenuse
-                        | SquashType::HypotenuseV2
-                        | SquashType::Mean
-                )
+            !neuron.is_constant && SquashType::from(neuron.squash_type).is_aggregate()
         })
     }
 
@@ -517,12 +510,7 @@ impl CompiledNetwork {
 
                 let squash = SquashType::from(neuron.squash_type);
                 match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
+                    s if s.is_aggregate() => {
                         // Aggregate squashes stay on the exact single-record path.
                         act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
                         act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
@@ -613,12 +601,8 @@ impl CompiledNetwork {
 
                 let squash = SquashType::from(neuron.squash_type);
                 match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
+                    s if s.is_aggregate() => {
+                        // Aggregate squashes stay on the exact single-record path.
                         act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
                         act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
                         act2[actual_idx] = neuron_activation_scalar(&self.synapses, act2, neuron);

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -86,12 +86,8 @@ macro_rules! batch_8way_activation {
                     let end_synapse = start_synapse + neuron.num_synapses as usize;
 
                     match squash {
-                        SquashType::Minimum
-                        | SquashType::Maximum
-                        | SquashType::If
-                        | SquashType::Hypotenuse
-                        | SquashType::HypotenuseV2
-                        | SquashType::Mean => {
+                        // Aggregate squashes stay on the exact single-record path.
+                        s if s.is_aggregate() => {
                             for act in [
                                 &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
                                 &mut act6, &mut act7,
@@ -201,12 +197,8 @@ macro_rules! batch_8way_activation {
                         let end_synapse = start_synapse + neuron.num_synapses as usize;
 
                         match squash {
-                            SquashType::Minimum
-                            | SquashType::Maximum
-                            | SquashType::If
-                            | SquashType::Hypotenuse
-                            | SquashType::HypotenuseV2
-                            | SquashType::Mean => {
+                            // Aggregate squashes stay on the exact single-record path.
+                            s if s.is_aggregate() => {
                                 for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
                                     let value =
                                         neuron_activation_scalar(&$network.synapses, act, neuron);

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -912,14 +912,10 @@ impl CompiledNetwork {
 
                 // hintValues: for aggregate functions we expect hint==activation.
                 // For standard squashes keep the pre-squash value.
-                self.hint_values_buffer[neuron_idx] = match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => activation_limited,
-                    _ => hint_value,
+                self.hint_values_buffer[neuron_idx] = if squash.is_aggregate() {
+                    activation_limited
+                } else {
+                    hint_value
                 };
             }
         }

--- a/neat-core/src/squash.rs
+++ b/neat-core/src/squash.rs
@@ -116,6 +116,48 @@ pub enum SquashType {
     Mean = 37, // MEAN: (sum of weighted_inputs) / n + bias
 }
 
+/// The aggregate squash variants as an or-pattern — the single home of the
+/// membership list behind [`SquashType::is_aggregate`] (Issue #446).
+///
+/// Prefer `is_aggregate()`; reach for this macro only where an exhaustive
+/// `match` over `SquashType` needs the set as a *pattern* (a guard arm would
+/// forfeit the compiler's exhaustiveness check).
+macro_rules! aggregate_squash_patterns {
+    () => {
+        $crate::squash::SquashType::Minimum
+            | $crate::squash::SquashType::Maximum
+            | $crate::squash::SquashType::If
+            | $crate::squash::SquashType::Hypotenuse
+            | $crate::squash::SquashType::HypotenuseV2
+            | $crate::squash::SquashType::Mean
+    };
+}
+pub(crate) use aggregate_squash_patterns;
+
+impl SquashType {
+    /// True for the six **aggregate** squashes — `Minimum`, `Maximum`, `If`,
+    /// `Hypotenuse`, `HypotenuseV2` and `Mean` (Issue #446).
+    ///
+    /// These reduce a neuron's whole synapse range at once rather than
+    /// squashing a weighted sum, so they cannot be lane-vectorised: every
+    /// batched kernel routes them to the exact single-record kernel, and
+    /// tracing reports the activation itself as the hint. This predicate is
+    /// the single home of that membership rule — a site that restated the list
+    /// and missed a type would silently route it down the weighted-sum path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neat_core::squash::SquashType;
+    /// assert!(SquashType::Mean.is_aggregate());
+    /// assert!(!SquashType::Relu.is_aggregate());
+    /// ```
+    #[must_use]
+    pub const fn is_aggregate(self) -> bool {
+        matches!(self, aggregate_squash_patterns!())
+    }
+}
+
 impl From<u8> for SquashType {
     fn from(v: u8) -> Self {
         match v {

--- a/neat-core/src/unsquash.rs
+++ b/neat-core/src/unsquash.rs
@@ -5,7 +5,8 @@
 //! Issue #1139 - WASM Migration Phase 7.
 
 use crate::squash::{
-    GELU_COEFF, LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SQRT_2_OVER_PI, SquashType, apply_squash,
+    GELU_COEFF, LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SQRT_2_OVER_PI, SquashType,
+    aggregate_squash_patterns, apply_squash,
 };
 
 /// Apply an inverse squash (unsquash) function to a value
@@ -617,13 +618,10 @@ pub fn apply_unsquash(squash_type: SquashType, activation: f32, hint: f32) -> f3
             safe / (1.0 - safe * safe).sqrt()
         }
 
-        // Aggregate functions - return hint or activation
-        SquashType::Minimum
-        | SquashType::Maximum
-        | SquashType::If
-        | SquashType::Hypotenuse
-        | SquashType::HypotenuseV2
-        | SquashType::Mean => {
+        // Aggregate functions (see `SquashType::is_aggregate`) - not
+        // invertible, so return the hint or fall back to the activation. The
+        // pattern form keeps this match exhaustive over `SquashType`.
+        aggregate_squash_patterns!() => {
             if hint.is_finite() {
                 hint
             } else {

--- a/neat-core/tests/aggregate_squash_set.rs
+++ b/neat-core/tests/aggregate_squash_set.rs
@@ -1,0 +1,223 @@
+//! Behavioural coverage for the aggregate-squash set (Issue #446).
+//!
+//! One rule decides *which squash types are aggregates* — `Minimum`,
+//! `Maximum`, `If`, `Hypotenuse`, `HypotenuseV2` and `Mean`: the six that
+//! cannot be lane-vectorised and must take the exact single-record kernel.
+//! That one rule drives both dispatch (scalar kernel vs SIMD lane path) and
+//! hint semantics, and every consumer must agree with it — a site that
+//! disagreed would route an aggregate down the weighted-sum path and silently
+//! produce numbers that differ from `activate()`.
+//!
+//! These are "what" tests: they call [`SquashType::is_aggregate`] and the
+//! public activation, scoring and unsquash entry points and assert on the
+//! observable results, so a drifted membership list fails here regardless of
+//! how the set is spelled.
+
+use neat_core::range::apply_limit_range;
+use neat_core::squash::{SquashType, apply_squash};
+use neat_core::unsquash::apply_unsquash;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// The six aggregate squashes.
+const AGGREGATES: [SquashType; 6] = [
+    SquashType::Minimum,
+    SquashType::Maximum,
+    SquashType::If,
+    SquashType::Hypotenuse,
+    SquashType::HypotenuseV2,
+    SquashType::Mean,
+];
+
+/// Highest discriminant currently defined on `SquashType` (`Mean = 37`).
+const MAX_SQUASH_ID: u8 = 37;
+
+const INPUT_SIZE: usize = 6;
+
+/// Enough records to cover the 8-record group, the 4-record group and the
+/// scalar tail in one scoring call (8 + 4 + 1).
+const RECORD_COUNT: usize = 13;
+
+/// The batched kernels reach the same activation rule as the single-record
+/// reference, so the only permitted gap is f32 summation order inside the SIMD
+/// weighted sums.
+const TOLERANCE: f32 = 1.0e-5;
+
+/// Every `SquashType`, in discriminant order.
+fn all_squash_types() -> Vec<SquashType> {
+    (0..=MAX_SQUASH_ID).map(SquashType::from).collect()
+}
+
+/// Build a network: `INPUT_SIZE` inputs fully connected into two hidden
+/// neurons and one output neuron, every non-input neuron using `squash`.
+/// Mirrors the fixture in `aggregate_squash_tail_parity.rs`.
+fn build_network(squash: SquashType) -> CompiledNetwork {
+    let num_inputs = INPUT_SIZE;
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.27 - 0.1 * (i as f32) + 0.06 * (h as f32),
+                from_index: i as u16,
+                // Alternate the synapse type so the `If` arm sees condition,
+                // positive and negative edges rather than one branch only.
+                synapse_type: (i % 3) as u8,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    synapses.push(SynapseData {
+        weight: 0.62,
+        from_index: num_inputs as u16,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.44,
+        from_index: num_inputs as u16 + 1,
+        synapse_type: 1,
+    });
+    neurons.push(NeuronData {
+        bias: 0.015,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Flat inputs, distinct per record so a mis-routed record cannot hide.
+fn build_inputs(num_records: usize) -> Vec<f32> {
+    let mut inputs = vec![0.0f32; num_records * INPUT_SIZE];
+    for r in 0..num_records {
+        for i in 0..INPUT_SIZE {
+            inputs[r * INPUT_SIZE + i] = (((r * 7 + i * 3) as f32) * 0.013).sin() * 0.9;
+        }
+    }
+    inputs
+}
+
+#[test]
+fn is_aggregate_holds_for_exactly_the_six_aggregate_squashes() {
+    for squash in all_squash_types() {
+        let expected = AGGREGATES.contains(&squash);
+        assert_eq!(
+            squash.is_aggregate(),
+            expected,
+            "{squash:?}: is_aggregate() disagrees with the aggregate set"
+        );
+    }
+}
+
+#[test]
+fn batched_scoring_matches_single_record_activation_for_every_squash_type() {
+    let inputs = build_inputs(RECORD_COUNT);
+
+    for squash in all_squash_types() {
+        let batched = build_network(squash).score_records_flat(&inputs, INPUT_SIZE, 1);
+        assert_eq!(batched.len(), RECORD_COUNT);
+
+        let mut reference_net = build_network(squash);
+        for r in 0..RECORD_COUNT {
+            let record = &inputs[r * INPUT_SIZE..(r + 1) * INPUT_SIZE];
+            let expected = reference_net.activate(record, 1)[0];
+            let diff = (expected - batched[r]).abs();
+            assert!(
+                diff <= TOLERANCE || (expected.is_nan() && batched[r].is_nan()),
+                "{squash:?} record {r}: batched {} diverged from single-record {expected} by {diff}",
+                batched[r]
+            );
+        }
+    }
+}
+
+#[test]
+fn traced_hint_equals_activation_for_aggregate_squashes() {
+    let inputs = build_inputs(1);
+
+    for squash in AGGREGATES {
+        let mut net = build_network(squash);
+        let result = net.activate_and_trace(&inputs, 1);
+        // Layout: [outputs, non-input activations, hint values, trace data].
+        let activations = &result[1..4];
+        let hints = &result[4..7];
+        for (idx, (&activation, &hint)) in activations.iter().zip(hints).enumerate() {
+            assert_eq!(
+                hint, activation,
+                "{squash:?} neuron {idx}: aggregate hint must be the activation"
+            );
+        }
+    }
+}
+
+#[test]
+fn traced_hint_is_the_pre_squash_value_for_standard_squashes() {
+    let inputs = build_inputs(1);
+
+    for squash in all_squash_types().into_iter().filter(|s| !s.is_aggregate()) {
+        let mut net = build_network(squash);
+        let result = net.activate_and_trace(&inputs, 1);
+        let activations = &result[1..4];
+        let hints = &result[4..7];
+        for (idx, (&activation, &hint)) in activations.iter().zip(hints).enumerate() {
+            let expected = apply_limit_range(squash, apply_squash(squash, hint));
+            let diff = (expected - activation).abs();
+            assert!(
+                diff <= TOLERANCE || (expected.is_nan() && activation.is_nan()),
+                "{squash:?} neuron {idx}: hint {hint} does not squash to activation {activation} (got {expected})"
+            );
+        }
+    }
+}
+
+#[test]
+fn unsquash_prefers_the_hint_for_every_aggregate_squash() {
+    for squash in all_squash_types().into_iter().filter(|s| s.is_aggregate()) {
+        // A finite hint is the recovered pre-squash value.
+        assert_eq!(
+            apply_unsquash(squash, 0.5, 1.25),
+            1.25,
+            "{squash:?}: aggregate unsquash must return the hint"
+        );
+        // Without a usable hint it falls back to the activation.
+        assert_eq!(
+            apply_unsquash(squash, 0.5, f32::NAN),
+            0.5,
+            "{squash:?}: aggregate unsquash must fall back to the activation"
+        );
+    }
+}


### PR DESCRIPTION
# One aggregate-squash set: seven copies become one predicate (Issue #446)

## Summary

The knowledge of *which squash types are aggregates* — `Minimum`, `Maximum`,
`If`, `Hypotenuse`, `HypotenuseV2`, `Mean`: the six that cannot be
lane-vectorised and must take the exact single-record kernel — was open-coded as
a six-arm type list at every consumer, with no `is_aggregate` predicate anywhere
in the crate. Adding a seventh aggregate type meant the identical one-arm edit at
each site, and a missed site fails **silently**: the new type would be routed
down the lane-vectorised weighted-sum path and produce numbers differing from
`activate()`, with no panic to flag it.

`SquashType::is_aggregate` (`neat-core/src/squash.rs`) is now the single home of
that membership rule. Every site calls it instead of restating the list; local
twists stay local (`has_aggregate_squash` keeps its own `!neuron.is_constant`
condition, `apply_unsquash` still uses the set to pick the hint rather than to
dispatch). Closes #446.

The issue listed ten sites against an older tree; #444 and #445 have since
folded the five `loss.rs` copies into two, so seven remained:

| Site | Role |
| --- | --- |
| `batch_scoring.rs` `has_aggregate_squash` | dispatch: per-lane vs interleaved |
| `batch_scoring.rs` `score_batch_per_lane` (8-group) | dispatch: scalar kernel vs SIMD lanes |
| `batch_scoring.rs` `score_batch_per_lane` (4-group) | dispatch: scalar kernel vs SIMD lanes |
| `loss.rs` `batch_8way_activation!` (8-lane block) | dispatch: scalar kernel vs SIMD lanes |
| `loss.rs` `batch_8way_activation!` (4-lane block) | dispatch: scalar kernel vs SIMD lanes |
| `network.rs` `activate_and_trace` | hint semantics: hint == activation |
| `unsquash.rs` `apply_unsquash` | hint semantics: not invertible, prefer hint |

### One list, two spellings — and why

Six of the seven sites take the predicate directly (`s if s.is_aggregate()`, or a
plain call). `apply_unsquash` is the exception: its `match` is exhaustive over
`SquashType`, and a guard arm would forfeit the compiler's exhaustiveness check —
a future non-aggregate squash type would then compile and fall into whatever
catch-all replaced it. So it takes the set as a *pattern* via
`aggregate_squash_patterns!()`, the `pub(crate)` macro that `is_aggregate` is
itself built from. There is still exactly one list; the second spelling is a
pattern view of the same list, not a second copy.

```mermaid
flowchart LR
    M["aggregate_squash_patterns!()<br/>the one list"] --> P["SquashType::is_aggregate"]
    M --> U["unsquash.rs<br/>apply_unsquash<br/>(exhaustive match)"]
    P --> A["batch_scoring.rs<br/>has_aggregate_squash"]
    P --> B["batch_scoring.rs<br/>8-record group"]
    P --> C["batch_scoring.rs<br/>4-record group"]
    P --> D["loss.rs batch_8way_activation!<br/>8-lane block"]
    P --> E["loss.rs batch_8way_activation!<br/>4-lane block"]
    P --> F["network.rs<br/>activate_and_trace hint"]
```

## Evidence

Backend-only change to a Rust library — there is no web interface to screenshot.
The evidence is the test suite plus a mutation check.

`./quality.sh` passes cleanly (fmt, clippy with `-D warnings`, `cargo deny`,
`cargo test --workspace`, doc build, release build):

```
✅ All quality checks passed!
```

**Mutation check — the new tests really do catch drift.** Dropping `Mean` from
the one list produced two independent failures, which is the whole point of the
change:

1. A **compile error** at `apply_unsquash` (`error[E0004]: non-exhaustive
   patterns: SquashType::Mean not covered`) — the pattern spelling turns a
   dropped type into a build failure, not a silent mis-route.
2. Keeping the macro intact but letting only `is_aggregate` drift (open-coding a
   five-member list in the predicate) failed
   `is_aggregate_holds_for_exactly_the_six_aggregate_squashes` and
   `batched_scoring_matches_single_record_activation_for_every_squash_type` —
   `Mean` records scored through the SIMD lane path diverged from `activate()`,
   exactly the silent failure the issue describes.

Both were reverted; the final tree is green.

No behaviour changed: `is_aggregate` is a `const fn matches!` over the same six
variants, so every dispatch decision and hint value is identical to before.

## Test Plan

New file `neat-core/tests/aggregate_squash_set.rs` — "what" tests calling real
public entry points and asserting on observable results:

- `is_aggregate_holds_for_exactly_the_six_aggregate_squashes` — every
  `SquashType` (discriminants 0–37) agrees with the aggregate set.
- `batched_scoring_matches_single_record_activation_for_every_squash_type` —
  13 records (8-group + 4-group + scalar tail) through the public
  `score_records_flat` match per-record `activate()` for all 38 squash types,
  pinning the dispatch predicate at every batched site.
- `traced_hint_equals_activation_for_aggregate_squashes` — `activate_and_trace`
  reports the activation itself as the hint for each aggregate.
- `traced_hint_is_the_pre_squash_value_for_standard_squashes` — for every
  non-aggregate type the traced hint squashes back to the activation.
- `unsquash_prefers_the_hint_for_every_aggregate_squash` — `apply_unsquash`
  returns a finite hint, and falls back to the activation when the hint is NaN.

Existing suites unchanged and still green, notably
`aggregate_squash_tail_parity.rs`, `inline_squash_dispatch.rs`,
`packed_record_scan.rs`, `batch_record_skeleton.rs` and `unsquash.rs`.

Documentation: `AGENTS.md` gains a **One aggregate-squash set for dispatch and
hints (Issue #446)** section alongside the sibling #441/#443/#444/#445 rules, and
the `batch_scoring.rs` doc comments that spelled the six names out in prose now
link `SquashType::is_aggregate`.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms98c0hj-78586b`<!-- vibe-worker-issue-446 -->