### PR TITLE
One ISA-neutral scalar layer: 18 copies become one module (Issue #447)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,51 @@ flowchart LR
     F --> G["f64 sum_error"]
 ```
 
+## One ISA-neutral scalar layer for every weighted-sum kernel (Issue #447)
+
+`neat-core/src/simd/scalar.rs` is the single home of the rule that says what a
+weighted-sum kernel *means*: the reference scalar semantics of each kernel and
+the small-count guard in front of it — the thing every SIMD path must agree with
+bit-for-bit. It carries no intrinsics and no `cfg`, so the `wasm32` kernels in
+`simd.rs` and the x86/aarch64 kernels in `simd_native.rs` share one copy.
+
+Two layers, deliberately distinct:
+
+- **Reference kernels** (`weighted_sum`, `weighted_sum_of_squares`,
+  `weighted_sum_no_bias`, `weighted_sum_of_squares_v2`) seed their own
+  accumulator and index safely. Every target's below-threshold count
+  (`synapse_count(start, end) < SINGLE_RECORD_SIMD_MIN`) falls back to them.
+- **Seed-taking tail helpers** (`tail_sum`, `tail_sum_of_squares`,
+  `tail_sum_of_squares_v2`) take the caller's **running** accumulator, so a SIMD
+  kernel's 0..3 remainder continues the reference f32 rounding order instead of
+  starting a second sum. They cannot be replaced by the reference kernels — that
+  would reseed and break the bit-parity the tests rely on. They index with
+  `get_unchecked` under the load-time index-validation invariant above, so they
+  are `unsafe fn` with a `# Safety` contract; calling them from a
+  `#[target_feature]` fn is sound and inlinable because no vector types cross the
+  boundary.
+
+`synapse_count` is the count prologue: **saturating**, so a reversed range
+(`end < start`) counts as zero instead of underflowing. Every kernel prologue on
+both sides uses it — no raw `end - start`, no hard-coded `4`.
+
+Changing the accumulation order, the guard, or the threshold is an edit **there
+and nowhere else**; do not re-inline a scalar loop into an ISA module.
+`neat-core/tests/simd_scalar_layer.rs` pins the rule: splitting a range at any
+point and continuing through a tail helper reproduces the reference result
+exactly, and below the threshold the public kernels are bit-identical to the
+reference.
+
+```mermaid
+flowchart LR
+    W["simd.rs (wasm32)"] --> S["simd::scalar"]
+    N["simd_native.rs — x86"] --> S
+    A["simd_native.rs — NEON"] --> S
+    S --> G["synapse_count / SINGLE_RECORD_SIMD_MIN"]
+    S --> R["reference kernels"]
+    S --> T["seed-taking tail helpers"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,18 +101,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",

--- a/docs/archive/pr-summaries/pr-summary-447.md
+++ b/docs/archive/pr-summaries/pr-summary-447.md
@@ -1,0 +1,159 @@
+## Summary
+
+The ISA-neutral scalar layer of the weighted-sum kernels — the reference scalar
+loops, the seed-taking tails behind each SIMD kernel, and the count prologue
+that guards them — was duplicated between `neat-core/src/simd.rs` (wasm) and
+`neat-core/src/simd_native.rs` (x86/aarch64), and again between the two ISA
+modules inside `simd_native.rs`. The two sides had already drifted: the native
+prologues had been hardened to `end.saturating_sub(start)` with a named
+`SINGLE_RECORD_SIMD_MIN`, while the wasm prologues still computed raw
+`end - start` (an underflow/panic on `end < start`) and hard-coded the literal
+`4` four times.
+
+This extracts that layer into one `cfg`-independent module,
+`neat-core/src/simd/scalar.rs`, and points every copy at it. Eighteen scalar
+sites collapse to seven definitions with one home. **Closes #447.**
+
+The new module carries two deliberately distinct layers:
+
+- **Reference kernels** (`weighted_sum`, `weighted_sum_of_squares`,
+  `weighted_sum_no_bias`, `weighted_sum_of_squares_v2`) seed their own
+  accumulator and index safely — what every target's below-threshold count
+  falls back to.
+- **Seed-taking tail helpers** (`tail_sum`, `tail_sum_of_squares`,
+  `tail_sum_of_squares_v2`) take the caller's *running* accumulator, so a SIMD
+  kernel's 0..3 remainder continues the reference f32 rounding order instead of
+  starting a second sum. Reusing the reference kernels for tails would reseed
+  and break the bit-parity the tests and docs rely on — which is why these are
+  new helpers, not a call to the existing fallbacks. They keep `get_unchecked`
+  under the load-time index-validation invariant (`AGENTS.md` → "Unsafe & SIMD
+  invariants") and are `unsafe fn` with a `# Safety` contract naming it.
+
+`synapse_count(start, end)` is the one count prologue: **saturating**, so a
+reversed range counts as zero rather than underflowing. Every prologue on both
+sides now uses it — no raw `end - start`, no hard-coded `4`. The wasm side
+picks up the already-proven hardening as part of the same change.
+
+### Changed
+
+| File | Change |
+| --- | --- |
+| `neat-core/src/simd/scalar.rs` | **New.** The shared ISA-neutral scalar layer. |
+| `neat-core/src/simd.rs` | Declares `pub mod scalar`; four wasm small-count fallbacks and three wasm count prologues now call it. |
+| `neat-core/src/simd_native.rs` | Four scalar fallbacks and the local `SINGLE_RECORD_SIMD_MIN` deleted; six ISA tail loops (3 shapes × x86/NEON) and every count prologue now call the shared layer. |
+| `AGENTS.md` | New "One ISA-neutral scalar layer for every weighted-sum kernel (Issue #447)" section pinning the rule. |
+| `neat-core/tests/simd_scalar_layer.rs` | **New.** Pins the rule. |
+
+### Out of scope
+
+The multi-record scalar fallbacks (`weighted_sum_simd_8records_scalar`,
+`weighted_sum_simd_4records_scalar`, `weighted_sum_interleaved_8_scalar`) exist
+only on the native side — there is no wasm counterpart to drift from — so they
+stay where they are. The wasm SIMD kernels' own bounds-checked remainder loops
+are likewise left alone: routing them through the unchecked tail helpers would
+turn a wasm-side panic into undefined behaviour, which is a soundness change,
+not a de-duplication.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — 18 copies"]
+        W1["simd.rs<br/>4 prologues + 4 scalar kernels<br/>raw end - start, literal 4"]
+        X1["simd_native.rs — x86<br/>3 tail loops"]
+        A1["simd_native.rs — NEON<br/>3 tail loops"]
+        F1["simd_native.rs<br/>4 scalar kernels + SINGLE_RECORD_SIMD_MIN<br/>saturating_sub"]
+    end
+    subgraph after["After — one home"]
+        S["simd::scalar"]
+        S --> G["synapse_count (saturating)<br/>SINGLE_RECORD_SIMD_MIN"]
+        S --> R["4 reference kernels"]
+        S --> T["3 seed-taking tail helpers"]
+    end
+    before --> after
+```
+
+**Bit-parity**, not approximate agreement, is what the new tests assert: below
+the SIMD threshold every public kernel is bit-identical to the reference
+(`f32::to_bits`), and splitting a range at *any* point and continuing through a
+tail helper reproduces the reference result exactly — so a tail that reseeded or
+reordered would fail.
+
+**Correctness evidence**
+
+- `cargo test --test simd_scalar_layer` — 10 passed (new).
+- `cargo test --test simd_weighted_sums` — 23 passed (existing parity suite,
+  unchanged).
+- `./quality.sh` — green end to end (fmt, clippy `-D warnings`, `cargo deny`,
+  full workspace test run, rustdoc `-D warnings`, release build).
+- `cargo check --target wasm32-unknown-unknown` with
+  `-C target-feature=+simd128,+relaxed-simd` — clean, so the rewritten wasm
+  prologues compile on the target they serve (they are `cfg`-gated out of the
+  native test run).
+
+**Performance evidence**
+
+This is a refactor with no algorithmic change, but it moves six SIMD tail loops
+behind a function-call boundary, so codegen was verified rather than assumed:
+
+- The release assembly (`cargo rustc --release -- --emit asm`) contains **no
+  call to `tail_sum` / `tail_sum_of_squares` / `tail_sum_of_squares_v2`** — the
+  `#[inline]` helpers are fully inlined into the `#[target_feature]` kernels,
+  exactly as the previous in-body loops were. No vector types cross the
+  boundary, so the call is inlinable by construction.
+- `cargo bench --bench hot_paths -- forward_pass` was attempted and its output
+  discarded as unusable: the build host was running at load average ~14 on 12
+  cores, and re-measuring the **unchanged** baseline code against its own
+  baseline reported "+77.8% regressed". With a noise floor that wide, no
+  A/B on this host is meaningful. The inlining check above is the load-
+  independent evidence in its place.
+
+## Test Plan
+
+New — `neat-core/tests/simd_scalar_layer.rs`:
+
+- `synapse_count_measures_the_range` — the guard counts `start..end`.
+- `synapse_count_saturates_when_end_precedes_start` — regression test for the
+  drifted wasm prologue: a reversed range saturates to zero instead of
+  underflowing.
+- `reference_kernels_return_their_seed_for_a_reversed_range` — all four
+  reference kernels return bias/0.0 on `end < start`.
+- `public_kernels_survive_a_reversed_range` — the same at the public
+  `weighted_sum_*_simd` entry points.
+- `small_counts_are_bit_identical_to_the_reference_kernels` — for every count
+  below `SINGLE_RECORD_SIMD_MIN`, all four public kernels match the reference
+  bit-for-bit (`to_bits`).
+- `tail_sum_continues_the_reference_accumulation_bit_for_bit`,
+  `tail_sum_of_squares_…`, `tail_sum_of_squares_v2_…` — splitting a 9-synapse
+  range at every split point and continuing through the tail helper reproduces
+  the reference result exactly, pinning the seed-taking contract (a reseeding
+  helper fails these).
+- `tail_helpers_return_the_seed_for_an_empty_tail` — an empty tail is the
+  identity.
+- `reference_kernels_compute_the_documented_formulas` — each kernel computes its
+  documented formula on hand-checked values.
+
+Modified — `neat-core/src/simd_native.rs` unit tests: the four
+`*_matches_scalar` tests now compare against `scalar::weighted_sum*` instead of
+the deleted local fallbacks. Same assertions, same fixtures; no test was removed
+or weakened.
+
+### Security self-check
+
+- **Input validation**: the new count guard is the validation — `synapse_count`
+  saturates instead of underflowing, removing a panic (debug) / enormous-count
+  (release) path that existed in the wasm kernels.
+- **Injection surface / output encoding / authentication**: not applicable —
+  pure numeric library code, no SQL, shell, filesystem, HTTP, or rendering.
+- **Error handling**: no error paths added; nothing is swallowed. The reference
+  kernels index safely and panic loudly on a genuinely out-of-range index.
+- **Unsafe**: the three new `unsafe fn` helpers carry `# Safety` contracts
+  naming the load-time `CompiledNetwork::new` index validation, and each
+  internal `unsafe` block carries a `// SAFETY:` note. No new `unsafe` reaches
+  code that was previously bounds-checked — the helpers replace `get_unchecked`
+  loops that already had that contract.
+- **Secrets / dependencies**: none staged; no new dependency. The `Cargo.lock`
+  bump is `quality.sh`'s own `cargo upgrade`/`cargo update` step (clap
+  4.6.4 → 4.6.5, a dev-tree transitive), and `cargo deny check` passed after it.

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -15,6 +15,14 @@
 //!   on `x86_64`, **NEON** on `aarch64`; otherwise scalar (same numerics as the old fallback).
 //! - **SIMD aggregate helpers**: `weighted_sum_of_squares_simd` for Hypotenuse
 //!   and `weighted_sum_for_mean_simd` for Mean activation functions.
+//! - **ISA-neutral scalar layer**: the reference scalar kernels and the
+//!   small-count guard live once in [`scalar`] (Issue #447) and are shared by
+//!   the wasm and native paths.
+
+// Issue #447 - the ISA-neutral scalar layer: reference kernels, the saturating
+// count guard, and the seed-taking tail helpers, shared by the wasm kernels
+// below and the native kernels in `simd_native.rs`.
+pub mod scalar;
 
 // Native single-record/multi-record kernels live in `simd_native.rs`; only the
 // wasm32 implementations below reference `SynapseData` directly.
@@ -44,19 +52,10 @@ pub fn weighted_sum_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return bias;
-    }
-
-    // For very small counts, scalar is faster due to SIMD setup overhead
-    if count < 4 {
-        let mut sum = bias;
-        for i in start..end {
-            let synapse = &synapses[i];
-            sum += activations[synapse.from_index as usize] * synapse.weight;
-        }
-        return sum;
+    // For very small counts, scalar is faster due to SIMD setup overhead.
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum(synapses, activations, start, end, bias);
     }
 
     // Dual-accumulator approach: two independent accumulators hide FMA latency
@@ -151,19 +150,9 @@ pub fn weighted_sum_of_squares_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return 0.0;
-    }
-
-    if count < 4 {
-        let mut sum_sq = 0.0f32;
-        for i in start..end {
-            let synapse = &synapses[i];
-            let val = activations[synapse.from_index as usize] * synapse.weight;
-            sum_sq += val * val;
-        }
-        return sum_sq;
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum_of_squares(synapses, activations, start, end);
     }
 
     let mut acc = f32x4_splat(0.0);
@@ -219,18 +208,9 @@ pub fn weighted_sum_no_bias_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return 0.0;
-    }
-
-    if count < 4 {
-        let mut sum = 0.0f32;
-        for i in start..end {
-            let synapse = &synapses[i];
-            sum += activations[synapse.from_index as usize] * synapse.weight;
-        }
-        return sum;
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum_no_bias(synapses, activations, start, end);
     }
 
     let mut acc = f32x4_splat(0.0);
@@ -283,19 +263,9 @@ pub fn weighted_sum_of_squares_v2_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return 0.0;
-    }
-
-    if count < 4 {
-        let mut sum_sq = 0.0f32;
-        for i in start..end {
-            let synapse = &synapses[i];
-            let val = bias + activations[synapse.from_index as usize] * synapse.weight;
-            sum_sq += val * val;
-        }
-        return sum_sq;
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum_of_squares_v2(synapses, activations, start, end, bias);
     }
 
     let bias_vec = f32x4_splat(bias);
@@ -356,8 +326,7 @@ pub fn weighted_sum_simd_4records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32) {
-    let count = end - start;
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias);
     }
 
@@ -414,8 +383,7 @@ pub fn weighted_sum_simd_8records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
-    let count = end - start;
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias, bias, bias, bias, bias);
     }
 
@@ -474,7 +442,7 @@ pub fn weighted_sum_interleaved_8(
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    if end <= start {
+    if scalar::synapse_count(start, end) == 0 {
         return [bias; 8];
     }
 

--- a/neat-core/src/simd/scalar.rs
+++ b/neat-core/src/simd/scalar.rs
@@ -1,0 +1,195 @@
+//! ISA-neutral scalar layer of the weighted-sum kernels (Issue #447).
+//!
+//! This module is the single home of one rule: **the reference scalar semantics
+//! of each weighted-sum kernel, and the small-count guard in front of it** — the
+//! thing every SIMD path must agree with bit-for-bit. It carries no intrinsics
+//! and no `cfg`, so the `wasm32` kernels in [`crate::simd`] and the x86/aarch64
+//! kernels in `simd_native.rs` share one copy instead of drifting apart.
+//!
+//! Two layers, deliberately distinct:
+//!
+//! - **Reference kernels** ([`weighted_sum`], [`weighted_sum_of_squares`],
+//!   [`weighted_sum_no_bias`], [`weighted_sum_of_squares_v2`]) seed their own
+//!   accumulator and index the activation buffer safely. They are what a
+//!   below-threshold count falls back to on every target.
+//! - **Seed-taking tail helpers** ([`tail_sum`], [`tail_sum_of_squares`],
+//!   [`tail_sum_of_squares_v2`]) take the caller's *running* accumulator, so a
+//!   SIMD kernel's 0..3 remainder continues the same f32 rounding order rather
+//!   than starting a second sum. They index with `get_unchecked` under the
+//!   load-time index-validation invariant documented in `AGENTS.md`
+//!   ("Unsafe & SIMD invariants"), which is why they are `unsafe fn`.
+//!
+//! The two layers are pinned to each other by
+//! `neat-core/tests/simd_scalar_layer.rs`: splitting a range at any point and
+//! continuing through a tail helper reproduces the reference result exactly.
+
+use crate::network::SynapseData;
+
+/// SIMD setup (lane gather, horizontal reduce) only pays off once there is at
+/// least one full 4-wide chunk; below that the scalar reference kernels win.
+pub const SINGLE_RECORD_SIMD_MIN: usize = 4;
+
+/// Number of synapses in `start..end`.
+///
+/// Saturating: a reversed range (`end < start`) counts as zero rather than
+/// underflowing, so a caller that hands over a degenerate range gets the
+/// empty-range answer instead of a panic in debug or a colossal count in
+/// release.
+#[inline]
+pub fn synapse_count(start: usize, end: usize) -> usize {
+    end.saturating_sub(start)
+}
+
+/// Reference kernel: `bias + sum(activation[from] * weight)`.
+#[inline]
+pub fn weighted_sum(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> f32 {
+    let mut sum = bias;
+    for synapse in synapses.iter().take(end).skip(start) {
+        sum += activations[synapse.from_index as usize] * synapse.weight;
+    }
+    sum
+}
+
+/// Reference kernel: `sum((activation[from] * weight)^2)` (Hypotenuse).
+#[inline]
+pub fn weighted_sum_of_squares(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+) -> f32 {
+    let mut sum_sq = 0.0f32;
+    for synapse in synapses.iter().take(end).skip(start) {
+        let val = activations[synapse.from_index as usize] * synapse.weight;
+        sum_sq += val * val;
+    }
+    sum_sq
+}
+
+/// Reference kernel: `sum(activation[from] * weight)`, no bias (Mean).
+#[inline]
+pub fn weighted_sum_no_bias(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+) -> f32 {
+    let mut sum = 0.0f32;
+    for synapse in synapses.iter().take(end).skip(start) {
+        sum += activations[synapse.from_index as usize] * synapse.weight;
+    }
+    sum
+}
+
+/// Reference kernel: `sum((bias + activation[from] * weight)^2)` (HypotenuseV2).
+#[inline]
+pub fn weighted_sum_of_squares_v2(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> f32 {
+    let mut sum_sq = 0.0f32;
+    for synapse in synapses.iter().take(end).skip(start) {
+        let val = bias + activations[synapse.from_index as usize] * synapse.weight;
+        sum_sq += val * val;
+    }
+    sum_sq
+}
+
+/// Continue a running plain weighted sum over the `i..end` remainder.
+///
+/// Takes `acc` — the caller's running accumulator — so a SIMD kernel's tail
+/// keeps the reference f32 rounding order instead of starting a second sum and
+/// merging it. Seeding it with `bias` and `i == start` reproduces
+/// [`weighted_sum`] exactly.
+///
+/// # Safety
+/// `end` must be `<= synapses.len()`, and every `synapse.from_index` in
+/// `i..end` must be a valid index into `activations`. `CompiledNetwork::new`
+/// enforces the index range at load time (`NetworkError::InvalidSynapseIndex`),
+/// so callers holding a loaded network already satisfy this — see the
+/// "Unsafe & SIMD invariants" section of `AGENTS.md`.
+#[inline]
+pub unsafe fn tail_sum(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    i: usize,
+    end: usize,
+    acc: f32,
+) -> f32 {
+    let mut sum = acc;
+    let mut idx = i;
+    while idx < end {
+        // SAFETY: `idx < end <= synapses.len()`, and the caller guarantees
+        // every `from_index` in `i..end` indexes `activations` (load-time
+        // validation in `CompiledNetwork::new`).
+        let s = unsafe { synapses.get_unchecked(idx) };
+        sum += unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
+        idx += 1;
+    }
+    sum
+}
+
+/// Continue a running sum of squared weighted activations over `i..end`.
+///
+/// Seeding it with `0.0` and `i == start` reproduces
+/// [`weighted_sum_of_squares`] exactly.
+///
+/// # Safety
+/// Same contract as [`tail_sum`].
+#[inline]
+pub unsafe fn tail_sum_of_squares(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    i: usize,
+    end: usize,
+    acc: f32,
+) -> f32 {
+    let mut sum = acc;
+    let mut idx = i;
+    while idx < end {
+        // SAFETY: same as `tail_sum` — load-time index validation.
+        let s = unsafe { synapses.get_unchecked(idx) };
+        let val = unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
+        sum += val * val;
+        idx += 1;
+    }
+    sum
+}
+
+/// Continue a running sum of squared `(bias + weighted activation)` over
+/// `i..end`.
+///
+/// Seeding it with `0.0` and `i == start` reproduces
+/// [`weighted_sum_of_squares_v2`] exactly.
+///
+/// # Safety
+/// Same contract as [`tail_sum`].
+#[inline]
+pub unsafe fn tail_sum_of_squares_v2(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    i: usize,
+    end: usize,
+    acc: f32,
+    bias: f32,
+) -> f32 {
+    let mut sum = acc;
+    let mut idx = i;
+    while idx < end {
+        // SAFETY: same as `tail_sum` — load-time index validation.
+        let s = unsafe { synapses.get_unchecked(idx) };
+        let val = bias + unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
+        sum += val * val;
+        idx += 1;
+    }
+    sum
+}

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -10,8 +10,13 @@
 //! gathering 4 indexed activations per step, FMA-accumulating, then horizontally
 //! reducing — with FMA+SSE on `x86_64`, NEON on `aarch64`, and scalar elsewhere and
 //! for the 0..3 synapse tail.
+//!
+//! The ISA-neutral scalar layer — the reference kernels, the saturating count
+//! guard, and the seed-taking tail helpers — lives once in
+//! [`crate::simd::scalar`] (Issue #447) and is shared with the wasm kernels.
 
 use crate::network::SynapseData;
+use crate::simd::scalar;
 
 #[inline]
 fn weighted_sum_simd_8records_scalar(
@@ -106,7 +111,7 @@ fn weighted_sum_interleaved_8_scalar(
 
 #[cfg(target_arch = "x86_64")]
 mod x86 {
-    use super::SynapseData;
+    use super::{SynapseData, scalar};
     use core::arch::x86_64::*;
 
     /// # Safety
@@ -260,7 +265,7 @@ mod x86 {
         bias: f32,
     ) -> f32 {
         let mut acc = _mm_setzero_ps();
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -281,13 +286,10 @@ mod x86 {
         }
         let mut out = [0.0_f32; 4];
         unsafe { _mm_storeu_ps(out.as_mut_ptr(), acc) };
-        let mut sum = bias + out[0] + out[1] + out[2] + out[3];
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            sum += unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            i += 1;
-        }
-        sum
+        let sum = bias + out[0] + out[1] + out[2] + out[3];
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum`'s contract — load-time validation in `CompiledNetwork::new`.
+        unsafe { scalar::tail_sum(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -305,7 +307,7 @@ mod x86 {
         end: usize,
     ) -> f32 {
         let mut acc = _mm_setzero_ps();
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -327,14 +329,10 @@ mod x86 {
         }
         let mut out = [0.0_f32; 4];
         unsafe { _mm_storeu_ps(out.as_mut_ptr(), acc) };
-        let mut sum = out[0] + out[1] + out[2] + out[3];
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val = unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = out[0] + out[1] + out[2] + out[3];
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -354,7 +352,7 @@ mod x86 {
     ) -> f32 {
         let bias_vec = _mm_set1_ps(bias);
         let mut acc = _mm_setzero_ps();
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -376,21 +374,16 @@ mod x86 {
         }
         let mut out = [0.0_f32; 4];
         unsafe { _mm_storeu_ps(out.as_mut_ptr(), acc) };
-        let mut sum = out[0] + out[1] + out[2] + out[3];
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val =
-                bias + unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = out[0] + out[1] + out[2] + out[3];
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares_v2`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares_v2(synapses, activations, i, end, sum, bias) }
     }
 }
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64 {
-    use super::SynapseData;
+    use super::{SynapseData, scalar};
     use core::arch::aarch64::*;
 
     /// # Safety
@@ -553,7 +546,7 @@ mod aarch64 {
         let mut acc = vdupq_n_f32(0.0);
         let mut wl = [0.0_f32; 4];
         let mut al = [0.0_f32; 4];
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -575,13 +568,10 @@ mod aarch64 {
             acc = vfmaq_f32(acc, weights, acts);
             i += 4;
         }
-        let mut sum = bias + vaddvq_f32(acc);
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            sum += unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            i += 1;
-        }
-        sum
+        let sum = bias + vaddvq_f32(acc);
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum`'s contract — load-time validation in `CompiledNetwork::new`.
+        unsafe { scalar::tail_sum(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -601,7 +591,7 @@ mod aarch64 {
         let mut acc = vdupq_n_f32(0.0);
         let mut wl = [0.0_f32; 4];
         let mut al = [0.0_f32; 4];
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -624,14 +614,10 @@ mod aarch64 {
             acc = vfmaq_f32(acc, products, products);
             i += 4;
         }
-        let mut sum = vaddvq_f32(acc);
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val = unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = vaddvq_f32(acc);
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -653,7 +639,7 @@ mod aarch64 {
         let mut acc = vdupq_n_f32(0.0);
         let mut wl = [0.0_f32; 4];
         let mut al = [0.0_f32; 4];
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -676,15 +662,10 @@ mod aarch64 {
             acc = vfmaq_f32(acc, vals, vals);
             i += 4;
         }
-        let mut sum = vaddvq_f32(acc);
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val =
-                bias + unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = vaddvq_f32(acc);
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares_v2`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares_v2(synapses, activations, i, end, sum, bias) }
     }
 }
 
@@ -705,8 +686,7 @@ pub fn weighted_sum_simd_8records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
-    let count = end.saturating_sub(start);
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias, bias, bias, bias, bias);
     }
 
@@ -755,7 +735,7 @@ pub fn weighted_sum_interleaved_8(
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    if end <= start {
+    if scalar::synapse_count(start, end) == 0 {
         return [bias; 8];
     }
 
@@ -799,8 +779,7 @@ pub fn weighted_sum_simd_4records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32) {
-    let count = end.saturating_sub(start);
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias);
     }
 
@@ -844,73 +823,8 @@ pub fn weighted_sum_simd_4records(
 // fall back to the scalar loop elsewhere and for the 0..3 synapse tail.
 // ============================================================================
 
-/// Scalar fallback: bias + sum(activation[from] * weight).
-#[inline]
-fn weighted_sum_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-    bias: f32,
-) -> f32 {
-    let mut sum = bias;
-    for synapse in synapses.iter().take(end).skip(start) {
-        sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
-    sum
-}
-
-/// Scalar fallback: sum((activation[from] * weight)^2).
-#[inline]
-fn weighted_sum_of_squares_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-) -> f32 {
-    let mut sum_sq = 0.0f32;
-    for synapse in synapses.iter().take(end).skip(start) {
-        let val = activations[synapse.from_index as usize] * synapse.weight;
-        sum_sq += val * val;
-    }
-    sum_sq
-}
-
-/// Scalar fallback: sum(activation[from] * weight), no bias.
-#[inline]
-fn weighted_sum_no_bias_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-) -> f32 {
-    let mut sum = 0.0f32;
-    for synapse in synapses.iter().take(end).skip(start) {
-        sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
-    sum
-}
-
-/// Scalar fallback: sum((bias + activation[from] * weight)^2).
-#[inline]
-fn weighted_sum_of_squares_v2_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-    bias: f32,
-) -> f32 {
-    let mut sum_sq = 0.0f32;
-    for synapse in synapses.iter().take(end).skip(start) {
-        let val = bias + activations[synapse.from_index as usize] * synapse.weight;
-        sum_sq += val * val;
-    }
-    sum_sq
-}
-
-// SIMD setup (lane gather, horizontal reduce) only pays off once there is at
-// least one full 4-wide chunk; below that the scalar loop wins.
-const SINGLE_RECORD_SIMD_MIN: usize = 4;
+// The scalar fallbacks and the `SINGLE_RECORD_SIMD_MIN` threshold live in
+// `crate::simd::scalar` (Issue #447), shared with the wasm kernels.
 
 /// Single-record weighted sum: `bias + sum(activation[from] * weight)`.
 ///
@@ -930,7 +844,7 @@ pub fn weighted_sum_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -952,7 +866,7 @@ pub fn weighted_sum_simd(
             }
         }
     }
-    weighted_sum_scalar(synapses, activations, start, end, bias)
+    scalar::weighted_sum(synapses, activations, start, end, bias)
 }
 
 /// Single-record sum of squared weighted activations (Hypotenuse): `sum((a*w)^2)`.
@@ -966,7 +880,7 @@ pub fn weighted_sum_of_squares_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -988,7 +902,7 @@ pub fn weighted_sum_of_squares_simd(
             }
         }
     }
-    weighted_sum_of_squares_scalar(synapses, activations, start, end)
+    scalar::weighted_sum_of_squares(synapses, activations, start, end)
 }
 
 /// Single-record weighted sum without bias (Mean): `sum(activation[from] * weight)`.
@@ -1002,7 +916,7 @@ pub fn weighted_sum_no_bias_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -1022,7 +936,7 @@ pub fn weighted_sum_no_bias_simd(
             }
         }
     }
-    weighted_sum_no_bias_scalar(synapses, activations, start, end)
+    scalar::weighted_sum_no_bias(synapses, activations, start, end)
 }
 
 /// Single-record sum of squared (bias + weighted activation) (HypotenuseV2):
@@ -1038,7 +952,7 @@ pub fn weighted_sum_of_squares_v2_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -1066,7 +980,7 @@ pub fn weighted_sum_of_squares_v2_simd(
             }
         }
     }
-    weighted_sum_of_squares_v2_scalar(synapses, activations, start, end, bias)
+    scalar::weighted_sum_of_squares_v2(synapses, activations, start, end, bias)
 }
 
 #[cfg(test)]
@@ -1149,7 +1063,7 @@ mod tests {
     #[test]
     fn weighted_sum_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_scalar(&syn, &acts, 0, 6, 0.25);
+        let s = scalar::weighted_sum(&syn, &acts, 0, 6, 0.25);
         let n = weighted_sum_simd(&syn, &acts, 0, 6, 0.25);
         close(n, s);
     }
@@ -1157,7 +1071,7 @@ mod tests {
     #[test]
     fn weighted_sum_no_bias_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_no_bias_scalar(&syn, &acts, 0, 6);
+        let s = scalar::weighted_sum_no_bias(&syn, &acts, 0, 6);
         let n = weighted_sum_no_bias_simd(&syn, &acts, 0, 6);
         close(n, s);
     }
@@ -1165,7 +1079,7 @@ mod tests {
     #[test]
     fn weighted_sum_of_squares_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_of_squares_scalar(&syn, &acts, 0, 6);
+        let s = scalar::weighted_sum_of_squares(&syn, &acts, 0, 6);
         let n = weighted_sum_of_squares_simd(&syn, &acts, 0, 6);
         close(n, s);
     }
@@ -1173,7 +1087,7 @@ mod tests {
     #[test]
     fn weighted_sum_of_squares_v2_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_of_squares_v2_scalar(&syn, &acts, 0, 6, -0.5);
+        let s = scalar::weighted_sum_of_squares_v2(&syn, &acts, 0, 6, -0.5);
         let n = weighted_sum_of_squares_v2_simd(&syn, &acts, 0, 6, -0.5);
         close(n, s);
     }

--- a/neat-core/tests/simd_scalar_layer.rs
+++ b/neat-core/tests/simd_scalar_layer.rs
@@ -1,0 +1,240 @@
+//! Pins the ISA-neutral scalar layer shared by the wasm (`simd.rs`) and native
+//! (`simd_native.rs`) weighted-sum kernels (Issue #447).
+//!
+//! The rule under test: `neat_core::simd::scalar` is the single home of the
+//! reference scalar semantics of each weighted-sum kernel and of the
+//! small-count guard in front of it. Every SIMD path must agree with it
+//! bit-for-bit below the SIMD threshold, the guard must saturate rather than
+//! underflow on a reversed range, and the seed-taking tail helpers must
+//! continue the reference accumulation without reseeding.
+
+use neat_core::network::SynapseData;
+use neat_core::simd::scalar;
+use neat_core::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd,
+};
+
+fn synapse(from_index: u16, weight: f32) -> SynapseData {
+    SynapseData {
+        weight,
+        from_index,
+        synapse_type: 0,
+    }
+}
+
+/// Nine synapses: enough for two full 4-wide SIMD chunks plus a scalar tail,
+/// with values chosen so re-ordering the f32 additions is observable.
+fn fixture() -> (Vec<SynapseData>, Vec<f32>) {
+    let synapses = vec![
+        synapse(0, 0.5),
+        synapse(2, -1.5),
+        synapse(1, 2.0),
+        synapse(3, 0.25),
+        synapse(4, -0.75),
+        synapse(2, 1.25),
+        synapse(0, 1e-7),
+        synapse(4, 3.5),
+        synapse(1, -0.125),
+    ];
+    let activations = vec![1.0_f32, 2.0, -3.0, 0.5, 4.0];
+    (synapses, activations)
+}
+
+// ---- The small-count guard -------------------------------------------------
+
+#[test]
+fn synapse_count_measures_the_range() {
+    assert_eq!(scalar::synapse_count(2, 7), 5);
+    assert_eq!(scalar::synapse_count(0, 0), 0);
+}
+
+#[test]
+fn synapse_count_saturates_when_end_precedes_start() {
+    assert_eq!(
+        scalar::synapse_count(9, 4),
+        0,
+        "a reversed range must saturate to zero, not underflow"
+    );
+    assert_eq!(scalar::synapse_count(1, 0), 0);
+}
+
+#[test]
+fn reference_kernels_return_their_seed_for_a_reversed_range() {
+    let (synapses, activations) = fixture();
+    assert_eq!(
+        scalar::weighted_sum(&synapses, &activations, 9, 4, 0.25),
+        0.25
+    );
+    assert_eq!(
+        scalar::weighted_sum_of_squares(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_no_bias(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_of_squares_v2(&synapses, &activations, 9, 4, 0.25),
+        0.0
+    );
+}
+
+#[test]
+fn public_kernels_survive_a_reversed_range() {
+    let (synapses, activations) = fixture();
+    assert_eq!(weighted_sum_simd(&synapses, &activations, 9, 4, 0.25), 0.25);
+    assert_eq!(
+        weighted_sum_of_squares_simd(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        weighted_sum_no_bias_simd(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        weighted_sum_of_squares_v2_simd(&synapses, &activations, 9, 4, 0.25),
+        0.0
+    );
+}
+
+/// Below the SIMD threshold the public kernels *are* the reference scalar
+/// kernels — bit-for-bit, not merely approximately.
+#[test]
+fn small_counts_are_bit_identical_to_the_reference_kernels() {
+    let (synapses, activations) = fixture();
+    for count in 0..scalar::SINGLE_RECORD_SIMD_MIN {
+        let end = count;
+        assert_eq!(
+            weighted_sum_simd(&synapses, &activations, 0, end, 0.25).to_bits(),
+            scalar::weighted_sum(&synapses, &activations, 0, end, 0.25).to_bits(),
+            "weighted_sum_simd drifted from the reference at count {count}"
+        );
+        assert_eq!(
+            weighted_sum_of_squares_simd(&synapses, &activations, 0, end).to_bits(),
+            scalar::weighted_sum_of_squares(&synapses, &activations, 0, end).to_bits(),
+            "weighted_sum_of_squares_simd drifted from the reference at count {count}"
+        );
+        assert_eq!(
+            weighted_sum_no_bias_simd(&synapses, &activations, 0, end).to_bits(),
+            scalar::weighted_sum_no_bias(&synapses, &activations, 0, end).to_bits(),
+            "weighted_sum_no_bias_simd drifted from the reference at count {count}"
+        );
+        assert_eq!(
+            weighted_sum_of_squares_v2_simd(&synapses, &activations, 0, end, -0.5).to_bits(),
+            scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, end, -0.5).to_bits(),
+            "weighted_sum_of_squares_v2_simd drifted from the reference at count {count}"
+        );
+    }
+}
+
+// ---- The seed-taking tail helpers ------------------------------------------
+//
+// A tail helper must continue the caller's running accumulator, never reseed
+// it: splitting a range anywhere has to reproduce the reference result exactly.
+
+#[test]
+fn tail_sum_continues_the_reference_accumulation_bit_for_bit() {
+    let (synapses, activations) = fixture();
+    let reference = scalar::weighted_sum(&synapses, &activations, 0, synapses.len(), 0.25);
+    for split in 0..=synapses.len() {
+        let head = scalar::weighted_sum(&synapses, &activations, 0, split, 0.25);
+        // SAFETY: every `from_index` in the fixture is < activations.len() and
+        // `end == synapses.len()`, satisfying the helper's index contract.
+        let full =
+            unsafe { scalar::tail_sum(&synapses, &activations, split, synapses.len(), head) };
+        assert_eq!(
+            full.to_bits(),
+            reference.to_bits(),
+            "tail_sum reseeded or reordered at split {split}"
+        );
+    }
+}
+
+#[test]
+fn tail_sum_of_squares_continues_the_reference_accumulation_bit_for_bit() {
+    let (synapses, activations) = fixture();
+    let reference = scalar::weighted_sum_of_squares(&synapses, &activations, 0, synapses.len());
+    for split in 0..=synapses.len() {
+        let head = scalar::weighted_sum_of_squares(&synapses, &activations, 0, split);
+        // SAFETY: as above — the fixture satisfies the index contract.
+        let full = unsafe {
+            scalar::tail_sum_of_squares(&synapses, &activations, split, synapses.len(), head)
+        };
+        assert_eq!(
+            full.to_bits(),
+            reference.to_bits(),
+            "tail_sum_of_squares reseeded or reordered at split {split}"
+        );
+    }
+}
+
+#[test]
+fn tail_sum_of_squares_v2_continues_the_reference_accumulation_bit_for_bit() {
+    let (synapses, activations) = fixture();
+    let bias = -0.5_f32;
+    let reference =
+        scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, synapses.len(), bias);
+    for split in 0..=synapses.len() {
+        let head = scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, split, bias);
+        // SAFETY: as above — the fixture satisfies the index contract.
+        let full = unsafe {
+            scalar::tail_sum_of_squares_v2(
+                &synapses,
+                &activations,
+                split,
+                synapses.len(),
+                head,
+                bias,
+            )
+        };
+        assert_eq!(
+            full.to_bits(),
+            reference.to_bits(),
+            "tail_sum_of_squares_v2 reseeded or reordered at split {split}"
+        );
+    }
+}
+
+#[test]
+fn tail_helpers_return_the_seed_for_an_empty_tail() {
+    let (synapses, activations) = fixture();
+    // SAFETY: an empty tail reads nothing.
+    unsafe {
+        assert_eq!(scalar::tail_sum(&synapses, &activations, 4, 4, 1.5), 1.5);
+        assert_eq!(
+            scalar::tail_sum_of_squares(&synapses, &activations, 4, 4, 1.5),
+            1.5
+        );
+        assert_eq!(
+            scalar::tail_sum_of_squares_v2(&synapses, &activations, 4, 4, 1.5, -0.5),
+            1.5
+        );
+    }
+}
+
+// ---- The reference kernels themselves --------------------------------------
+
+#[test]
+fn reference_kernels_compute_the_documented_formulas() {
+    let synapses = vec![synapse(1, 0.5), synapse(0, -2.0)];
+    let activations = vec![3.0_f32, 4.0];
+    // a*w = 4.0*0.5 = 2.0 and 3.0*-2.0 = -6.0
+    assert_eq!(
+        scalar::weighted_sum(&synapses, &activations, 0, 2, 1.0),
+        1.0 + 2.0 - 6.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_no_bias(&synapses, &activations, 0, 2),
+        2.0 - 6.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_of_squares(&synapses, &activations, 0, 2),
+        4.0 + 36.0
+    );
+    // (bias + a*w)^2 with bias = 1.0 → 3.0^2 + (-5.0)^2
+    assert_eq!(
+        scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, 2, 1.0),
+        9.0 + 25.0
+    );
+}


### PR DESCRIPTION
## Summary

The ISA-neutral scalar layer of the weighted-sum kernels — the reference scalar
loops, the seed-taking tails behind each SIMD kernel, and the count prologue
that guards them — was duplicated between `neat-core/src/simd.rs` (wasm) and
`neat-core/src/simd_native.rs` (x86/aarch64), and again between the two ISA
modules inside `simd_native.rs`. The two sides had already drifted: the native
prologues had been hardened to `end.saturating_sub(start)` with a named
`SINGLE_RECORD_SIMD_MIN`, while the wasm prologues still computed raw
`end - start` (an underflow/panic on `end < start`) and hard-coded the literal
`4` four times.

This extracts that layer into one `cfg`-independent module,
`neat-core/src/simd/scalar.rs`, and points every copy at it. Eighteen scalar
sites collapse to seven definitions with one home. **Closes #447.**

The new module carries two deliberately distinct layers:

- **Reference kernels** (`weighted_sum`, `weighted_sum_of_squares`,
  `weighted_sum_no_bias`, `weighted_sum_of_squares_v2`) seed their own
  accumulator and index safely — what every target's below-threshold count
  falls back to.
- **Seed-taking tail helpers** (`tail_sum`, `tail_sum_of_squares`,
  `tail_sum_of_squares_v2`) take the caller's *running* accumulator, so a SIMD
  kernel's 0..3 remainder continues the reference f32 rounding order instead of
  starting a second sum. Reusing the reference kernels for tails would reseed
  and break the bit-parity the tests and docs rely on — which is why these are
  new helpers, not a call to the existing fallbacks. They keep `get_unchecked`
  under the load-time index-validation invariant (`AGENTS.md` → "Unsafe & SIMD
  invariants") and are `unsafe fn` with a `# Safety` contract naming it.

`synapse_count(start, end)` is the one count prologue: **saturating**, so a
reversed range counts as zero rather than underflowing. Every prologue on both
sides now uses it — no raw `end - start`, no hard-coded `4`. The wasm side
picks up the already-proven hardening as part of the same change.

### Changed

| File | Change |
| --- | --- |
| `neat-core/src/simd/scalar.rs` | **New.** The shared ISA-neutral scalar layer. |
| `neat-core/src/simd.rs` | Declares `pub mod scalar`; four wasm small-count fallbacks and three wasm count prologues now call it. |
| `neat-core/src/simd_native.rs` | Four scalar fallbacks and the local `SINGLE_RECORD_SIMD_MIN` deleted; six ISA tail loops (3 shapes × x86/NEON) and every count prologue now call the shared layer. |
| `AGENTS.md` | New "One ISA-neutral scalar layer for every weighted-sum kernel (Issue #447)" section pinning the rule. |
| `neat-core/tests/simd_scalar_layer.rs` | **New.** Pins the rule. |

### Out of scope

The multi-record scalar fallbacks (`weighted_sum_simd_8records_scalar`,
`weighted_sum_simd_4records_scalar`, `weighted_sum_interleaved_8_scalar`) exist
only on the native side — there is no wasm counterpart to drift from — so they
stay where they are. The wasm SIMD kernels' own bounds-checked remainder loops
are likewise left alone: routing them through the unchecked tail helpers would
turn a wasm-side panic into undefined behaviour, which is a soundness change,
not a de-duplication.

## Evidence

Backend/library change — no web interface to screenshot.

```mermaid
flowchart LR
    subgraph before["Before — 18 copies"]
        W1["simd.rs<br/>4 prologues + 4 scalar kernels<br/>raw end - start, literal 4"]
        X1["simd_native.rs — x86<br/>3 tail loops"]
        A1["simd_native.rs — NEON<br/>3 tail loops"]
        F1["simd_native.rs<br/>4 scalar kernels + SINGLE_RECORD_SIMD_MIN<br/>saturating_sub"]
    end
    subgraph after["After — one home"]
        S["simd::scalar"]
        S --> G["synapse_count (saturating)<br/>SINGLE_RECORD_SIMD_MIN"]
        S --> R["4 reference kernels"]
        S --> T["3 seed-taking tail helpers"]
    end
    before --> after
```

**Bit-parity**, not approximate agreement, is what the new tests assert: below
the SIMD threshold every public kernel is bit-identical to the reference
(`f32::to_bits`), and splitting a range at *any* point and continuing through a
tail helper reproduces the reference result exactly — so a tail that reseeded or
reordered would fail.

**Correctness evidence**

- `cargo test --test simd_scalar_layer` — 10 passed (new).
- `cargo test --test simd_weighted_sums` — 23 passed (existing parity suite,
  unchanged).
- `./quality.sh` — green end to end (fmt, clippy `-D warnings`, `cargo deny`,
  full workspace test run, rustdoc `-D warnings`, release build).
- `cargo check --target wasm32-unknown-unknown` with
  `-C target-feature=+simd128,+relaxed-simd` — clean, so the rewritten wasm
  prologues compile on the target they serve (they are `cfg`-gated out of the
  native test run).

**Performance evidence**

This is a refactor with no algorithmic change, but it moves six SIMD tail loops
behind a function-call boundary, so codegen was verified rather than assumed:

- The release assembly (`cargo rustc --release -- --emit asm`) contains **no
  call to `tail_sum` / `tail_sum_of_squares` / `tail_sum_of_squares_v2`** — the
  `#[inline]` helpers are fully inlined into the `#[target_feature]` kernels,
  exactly as the previous in-body loops were. No vector types cross the
  boundary, so the call is inlinable by construction.
- `cargo bench --bench hot_paths -- forward_pass` was attempted and its output
  discarded as unusable: the build host was running at load average ~14 on 12
  cores, and re-measuring the **unchanged** baseline code against its own
  baseline reported "+77.8% regressed". With a noise floor that wide, no
  A/B on this host is meaningful. The inlining check above is the load-
  independent evidence in its place.

## Test Plan

New — `neat-core/tests/simd_scalar_layer.rs`:

- `synapse_count_measures_the_range` — the guard counts `start..end`.
- `synapse_count_saturates_when_end_precedes_start` — regression test for the
  drifted wasm prologue: a reversed range saturates to zero instead of
  underflowing.
- `reference_kernels_return_their_seed_for_a_reversed_range` — all four
  reference kernels return bias/0.0 on `end < start`.
- `public_kernels_survive_a_reversed_range` — the same at the public
  `weighted_sum_*_simd` entry points.
- `small_counts_are_bit_identical_to_the_reference_kernels` — for every count
  below `SINGLE_RECORD_SIMD_MIN`, all four public kernels match the reference
  bit-for-bit (`to_bits`).
- `tail_sum_continues_the_reference_accumulation_bit_for_bit`,
  `tail_sum_of_squares_…`, `tail_sum_of_squares_v2_…` — splitting a 9-synapse
  range at every split point and continuing through the tail helper reproduces
  the reference result exactly, pinning the seed-taking contract (a reseeding
  helper fails these).
- `tail_helpers_return_the_seed_for_an_empty_tail` — an empty tail is the
  identity.
- `reference_kernels_compute_the_documented_formulas` — each kernel computes its
  documented formula on hand-checked values.

Modified — `neat-core/src/simd_native.rs` unit tests: the four
`*_matches_scalar` tests now compare against `scalar::weighted_sum*` instead of
the deleted local fallbacks. Same assertions, same fixtures; no test was removed
or weakened.

### Security self-check

- **Input validation**: the new count guard is the validation — `synapse_count`
  saturates instead of underflowing, removing a panic (debug) / enormous-count
  (release) path that existed in the wasm kernels.
- **Injection surface / output encoding / authentication**: not applicable —
  pure numeric library code, no SQL, shell, filesystem, HTTP, or rendering.
- **Error handling**: no error paths added; nothing is swallowed. The reference
  kernels index safely and panic loudly on a genuinely out-of-range index.
- **Unsafe**: the three new `unsafe fn` helpers carry `# Safety` contracts
  naming the load-time `CompiledNetwork::new` index validation, and each
  internal `unsafe` block carries a `// SAFETY:` note. No new `unsafe` reaches
  code that was previously bounds-checked — the helpers replace `get_unchecked`
  loops that already had that contract.
- **Secrets / dependencies**: none staged; no new dependency. The `Cargo.lock`
  bump is `quality.sh`'s own `cargo upgrade`/`cargo update` step (clap
  4.6.4 → 4.6.5, a dev-tree transitive), and `cargo deny check` passed after it.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms99y572-d6b18b`<!-- vibe-worker-issue-447 -->