### PR TITLE
One chunk-walk scaffold for the wasm weighted-sum kernels (Issue #448)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,51 @@ flowchart LR
     S --> T["seed-taking tail helpers"]
 ```
 
+## One chunk-walk scaffold for the wasm weighted-sum kernels (Issue #448)
+
+The scaffold helpers at the top of `neat-core/src/simd.rs` — `gather4`,
+`gather4_products`, `reduce4` — are the single home of the rule that says *how a
+`wasm32` kernel walks a synapse span*: chunk into fours, gather weights and
+activations into `f32x4` lanes, fold, reduce the lanes, then finish the 0..3
+remainder from the **running** accumulator through the `scalar::tail_*` helpers
+(Issue #447). All four single-record kernels — `weighted_sum_simd`,
+`weighted_sum_of_squares_simd`, `weighted_sum_no_bias_simd`,
+`weighted_sum_of_squares_v2_simd` — call them, so a change to the walk lands on
+every kernel at once. It previously did not: the Issue #1197 dual-accumulator
+rework reached `weighted_sum_simd` alone and the doc on
+`weighted_sum_no_bias_simd` claimed otherwise for four releases.
+
+Two constraints on anyone editing the scaffold:
+
+- **Every helper touching `v128`/`f32x4_*` must repeat
+  `#[target_feature(enable = "simd128", enable = "relaxed-simd")]`** — without it
+  the intrinsics do not compile and the vector arguments do not inline into the
+  caller.
+- **The fold stays in each kernel.** These are calls, not a parameterised
+  super-helper: plain FMA, square-the-product, and square-the-biased-product are
+  genuinely different folds, and unifying them would need a mode flag. If a
+  future kernel only fits behind a flag, leave it out of the scaffold instead.
+
+The dual-accumulator form (two chains, chunks of eight) is still on
+`weighted_sum_simd` only, and the docs now say so; promoting the other three is
+a fold-level edit on top of the shared walk.
+
+`neat-core/tests/simd_chunk_walk_scaffold.rs` pins the rule: every kernel
+reproduces its `simd::scalar` reference from **any** offset (not just
+`start == 0`), the remainder continues the span rather than restarting it, and a
+reversed span yields the kernel's seed.
+
+```mermaid
+flowchart LR
+    K1["weighted_sum_simd"] --> G["gather4 / gather4_products"]
+    K2["weighted_sum_of_squares_simd"] --> G
+    K3["weighted_sum_no_bias_simd"] --> G
+    K4["weighted_sum_of_squares_v2_simd"] --> G
+    G --> F["fold — stays in each kernel"]
+    F --> R["reduce4"]
+    R --> T["scalar::tail_* — seed-taking remainder"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/docs/archive/pr-summaries/pr-summary-448.md
+++ b/docs/archive/pr-summaries/pr-summary-448.md
@@ -1,0 +1,96 @@
+# One chunk-walk scaffold for the wasm weighted-sum kernels (Issue #448)
+
+## Summary
+
+The four single-record `wasm32` kernels in `neat-core/src/simd.rs` each carried
+their own copy of the same chunk-loop scaffolding — 4-wide lane gather, lane
+reduce, and the 0..3 scalar remainder — around different folds. The cost was
+already paid: the Issue #1197 dual-accumulator rework landed on
+`weighted_sum_simd` only, and `weighted_sum_no_bias_simd`'s doc claimed it
+"Shares the dual-accumulator approach with `weighted_sum_simd`" when its body
+ran a single accumulator.
+
+This extracts the scaffold into three helpers — `gather4`, `gather4_products`,
+`reduce4` — and routes every kernel's remainder through the seed-taking
+`scalar::tail_*` helpers that Issue #447 already made the single home of that
+rule, replacing four re-inlined scalar loops. The fold stays in each kernel, as
+the issue requires: these are calls, not a parameterised super-helper, because
+unifying plain-FMA, square-the-product and square-the-biased-product would need
+a mode flag. Both stale doc claims are corrected — `weighted_sum_of_squares_simd`
+also claimed dual accumulators — and `AGENTS.md` gains the rule so the next
+scaffold improvement cannot land on one copy again.
+
+Behaviour is unchanged: the refactor is numerically bit-identical (evidence
+below). Applying the dual-accumulator form to the other three kernels is
+deliberately **not** in this PR — that is a performance change, and this repo
+requires before/after benchmark evidence for those. With the walk shared it is
+now a fold-level edit on top of one scaffold.
+
+Closes #448.
+
+```mermaid
+flowchart LR
+    K1["weighted_sum_simd"] --> G["gather4 / gather4_products"]
+    K2["weighted_sum_of_squares_simd"] --> G
+    K3["weighted_sum_no_bias_simd"] --> G
+    K4["weighted_sum_of_squares_v2_simd"] --> G
+    G --> F["fold — stays in each kernel"]
+    F --> R["reduce4"]
+    R --> T["scalar::tail_* — seed-taking remainder"]
+```
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. The
+changed code is `wasm32`-only, which the native test suite cannot execute, so it
+was verified by **running the refactored kernels on a real wasm runtime**
+(`wasm32-wasip1` under Node's WASI, `-C target-feature=+simd128,+relaxed-simd`):
+
+- All three new parity checks pass when compiled to wasm and executed:
+
+  ```
+  every_kernel_matches_its_reference_from_any_offset: ok
+  the_remainder_continues_the_span_rather_than_restarting_it: ok
+  an_empty_or_reversed_span_is_the_kernel_seed: ok
+  ```
+
+- **Bit-identical to the pre-refactor kernels.** The same wasm probe was run
+  against `simd.rs` before and after the change, dumping the raw `f32` bit
+  patterns of all four kernels over every `(start, count)` span for
+  `start` 0..11 and `count` 0..40 — 492 spans, 1968 results:
+
+  ```
+  diff before.txt after.txt   # no differences
+  BIT-IDENTICAL across 492 spans
+  ```
+
+  `gather4_products` uses `f32x4_mul`, a plain IEEE-754 lane multiply rather
+  than a relaxed operation, so replacing the hand-packed
+  `f32x4(a0*w0, …)` gathers cannot shift a result; the `scalar::tail_*` helpers
+  continue the running accumulator in the same order the inline loops did.
+
+- `cargo clippy --target wasm32-unknown-unknown` with `-D warnings` is clean
+  (the wasm path is not covered by `quality.sh` or the PR CI lane — it builds
+  only on push to `Develop` via `wasm-bundle.yml`).
+- `./quality.sh` passes: fmt, clippy, deny, doc, and the full native test suite.
+
+## Test Plan
+
+Added `neat-core/tests/simd_chunk_walk_scaffold.rs` (3 tests) — the file that
+pins the rule, in the style of `simd_scalar_layer.rs`:
+
+- `every_kernel_matches_its_reference_from_any_offset` — sweeps all four kernels
+  over starts 0..9 × counts 0..24 against the `simd::scalar` reference kernels.
+  The **offset** sweep is the new coverage: `simd_weighted_sums.rs` sweeps counts
+  from `start == 0` only, which would not catch a scaffold that derives its
+  chunk base from the chunk index alone.
+- `the_remainder_continues_the_span_rather_than_restarting_it` — a span of 8+3
+  equals the 8-span plus the three trailing synapses' contribution, pinning the
+  seed-taking tail rather than a second sum merged in.
+- `an_empty_or_reversed_span_is_the_kernel_seed` — empty and reversed ranges
+  return each kernel's seed (`bias` / `0.0`), carrying the Issue #447 saturating
+  count guard through the refactor.
+
+No existing tests were removed or modified. `simd_weighted_sums.rs` (23 tests)
+and `simd_scalar_layer.rs` (8 tests) continue to pass unchanged and remain the
+regression net for kernel semantics.

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -5,8 +5,10 @@
 //!
 //! ## Optimisation strategies
 //!
-//! - **Dual accumulator**: Uses two independent SIMD accumulators to hide FMA latency
-//!   by allowing out-of-order execution of independent multiply-add chains.
+//! - **Dual accumulator**: [`weighted_sum_simd`] uses two independent SIMD
+//!   accumulators to hide FMA latency by allowing out-of-order execution of
+//!   independent multiply-add chains. The other three single-record kernels run
+//!   a single accumulator in chunks of four.
 //! - **FMA (fused multiply-add)**: Uses `f32x4_relaxed_madd` from relaxed-simd to
 //!   perform multiply and add in a single instruction with better precision.
 //! - **Multi-record batching**: Processes the same neuron across 4 or 8 input records
@@ -18,6 +20,9 @@
 //! - **ISA-neutral scalar layer**: the reference scalar kernels and the
 //!   small-count guard live once in [`scalar`] (Issue #447) and are shared by
 //!   the wasm and native paths.
+//! - **Shared chunk-walk scaffold**: the wasm kernels gather, reduce and finish
+//!   their remainder through one set of helpers (Issue #448) so an improvement
+//!   to the walk cannot land on one kernel only.
 
 // Issue #447 - the ISA-neutral scalar layer: reference kernels, the saturating
 // count guard, and the seed-taking tail helpers, shared by the wasm kernels
@@ -33,7 +38,82 @@ use crate::network::SynapseData;
 // SIMD intrinsics for vectorised synapse weight summation
 // Issue #1197 - Added f32x4_relaxed_madd for FMA optimisation
 #[cfg(target_arch = "wasm32")]
-use core::arch::wasm32::{f32x4, f32x4_add, f32x4_extract_lane, f32x4_relaxed_madd, f32x4_splat};
+use core::arch::wasm32::{
+    f32x4, f32x4_add, f32x4_extract_lane, f32x4_mul, f32x4_relaxed_madd, f32x4_splat, v128,
+};
+
+// ============================================================================
+// Chunk-walk scaffold (Issue #448)
+//
+// One home for *how* a wasm kernel walks a synapse span: gather four synapses
+// into `f32x4` lanes, reduce the lanes back to a scalar, then finish the 0..3
+// remainder through the seed-taking tail helpers in [`scalar`]. Every
+// single-record kernel below calls these, so an improvement to the walk cannot
+// land on one copy only — which is exactly how the Issue #1197 dual-accumulator
+// rework came to sit on `weighted_sum_simd` alone.
+//
+// The *fold* deliberately stays in each kernel: these are calls, not a
+// parameterised super-helper. Unifying the four folds would need a mode flag,
+// and a flag is what makes a shared helper drift back apart.
+//
+// Every helper here touches `v128`/`f32x4_*`, so each repeats the
+// `#[target_feature]` attributes — without them the intrinsics do not compile
+// and the vector arguments do not inline into the caller.
+//
+// Index precondition (Issue #207): the 0..3 remainder runs through the
+// `scalar::tail_*` helpers, which index `activations` with `get_unchecked`, so
+// every `from_index` in `start..end` must be a valid index into `activations`.
+// `CompiledNetwork::new` enforces exactly that at load time
+// (`NetworkError::InvalidSynapseIndex`), which is why the native kernels have
+// always carried this contract — the wasm kernels now share it rather than
+// re-inlining a checked copy of the same loop.
+// ============================================================================
+
+/// Gather the four synapses at `base..base + 4` into `(weights, activations)`
+/// lanes.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn gather4(synapses: &[SynapseData], activations: &[f32], base: usize) -> (v128, v128) {
+    let s0 = &synapses[base];
+    let s1 = &synapses[base + 1];
+    let s2 = &synapses[base + 2];
+    let s3 = &synapses[base + 3];
+
+    (
+        f32x4(s0.weight, s1.weight, s2.weight, s3.weight),
+        f32x4(
+            activations[s0.from_index as usize],
+            activations[s1.from_index as usize],
+            activations[s2.from_index as usize],
+            activations[s3.from_index as usize],
+        ),
+    )
+}
+
+/// Lane-wise `activation[from] * weight` for the four synapses at
+/// `base..base + 4`.
+///
+/// Bit-identical to computing each product scalar-wise and packing the lanes:
+/// `f32x4_mul` is a plain IEEE-754 multiply per lane, not a relaxed operation.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn gather4_products(synapses: &[SynapseData], activations: &[f32], base: usize) -> v128 {
+    let (weights, acts) = gather4(synapses, activations, base);
+    f32x4_mul(weights, acts)
+}
+
+/// Horizontal sum of the four lanes, in lane order.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn reduce4(acc: v128) -> f32 {
+    f32x4_extract_lane::<0>(acc)
+        + f32x4_extract_lane::<1>(acc)
+        + f32x4_extract_lane::<2>(acc)
+        + f32x4_extract_lane::<3>(acc)
+}
 
 /// Issue #1178 - SIMD-optimised weighted sum for standard activations
 /// Issue #1197 - Uses FMA (fused multiply-add) via relaxed-simd for better performance
@@ -41,6 +121,15 @@ use core::arch::wasm32::{f32x4, f32x4_add, f32x4_extract_lane, f32x4_relaxed_mad
 /// Uses a dual-accumulator approach: processes 8 synapses per iteration with two
 /// independent f32x4 accumulators to hide FMA latency via instruction-level
 /// parallelism. Falls back to 4-wide for counts 4..7 and scalar for < 4.
+///
+/// Walks the span through the shared chunk-walk scaffold ([`gather4`],
+/// [`reduce4`], the seed-taking tail in [`scalar`]) — Issue #448.
+///
+/// Issue #207 - the 0..3 tail delegates to a `get_unchecked` helper, so every
+/// `synapse.from_index` in `start..end` must be a valid index into
+/// `activations`. `CompiledNetwork::new` enforces this at load time
+/// (`NetworkError::InvalidSynapseIndex`), so callers holding a loaded network
+/// already satisfy the precondition.
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -70,76 +159,42 @@ pub fn weighted_sum_simd(
 
     for _ in 0..chunks_of_8 {
         // First group of 4 -> acc0
-        let s0 = &synapses[i];
-        let s1 = &synapses[i + 1];
-        let s2 = &synapses[i + 2];
-        let s3 = &synapses[i + 3];
-        let weights0 = f32x4(s0.weight, s1.weight, s2.weight, s3.weight);
-        let acts0 = f32x4(
-            activations[s0.from_index as usize],
-            activations[s1.from_index as usize],
-            activations[s2.from_index as usize],
-            activations[s3.from_index as usize],
-        );
+        let (weights0, acts0) = gather4(synapses, activations, i);
         acc0 = f32x4_relaxed_madd(weights0, acts0, acc0);
 
         // Second group of 4 -> acc1 (independent chain)
-        let s4 = &synapses[i + 4];
-        let s5 = &synapses[i + 5];
-        let s6 = &synapses[i + 6];
-        let s7 = &synapses[i + 7];
-        let weights1 = f32x4(s4.weight, s5.weight, s6.weight, s7.weight);
-        let acts1 = f32x4(
-            activations[s4.from_index as usize],
-            activations[s5.from_index as usize],
-            activations[s6.from_index as usize],
-            activations[s7.from_index as usize],
-        );
+        let (weights1, acts1) = gather4(synapses, activations, i + 4);
         acc1 = f32x4_relaxed_madd(weights1, acts1, acc1);
 
         i += 8;
     }
 
     // Handle remaining chunk of 4 if present
-    let remaining = end - i;
-    if remaining >= 4 {
-        let s0 = &synapses[i];
-        let s1 = &synapses[i + 1];
-        let s2 = &synapses[i + 2];
-        let s3 = &synapses[i + 3];
-        let weights = f32x4(s0.weight, s1.weight, s2.weight, s3.weight);
-        let acts = f32x4(
-            activations[s0.from_index as usize],
-            activations[s1.from_index as usize],
-            activations[s2.from_index as usize],
-            activations[s3.from_index as usize],
-        );
+    if scalar::synapse_count(i, end) >= 4 {
+        let (weights, acts) = gather4(synapses, activations, i);
         acc0 = f32x4_relaxed_madd(weights, acts, acc0);
         i += 4;
     }
 
-    // Merge accumulators
-    let merged = f32x4_add(acc0, acc1);
+    // Merge accumulators, then reduce the lanes
+    scalar_sum += reduce4(f32x4_add(acc0, acc1));
 
-    // Horizontal sum of merged SIMD accumulator
-    scalar_sum += f32x4_extract_lane::<0>(merged)
-        + f32x4_extract_lane::<1>(merged)
-        + f32x4_extract_lane::<2>(merged)
-        + f32x4_extract_lane::<3>(merged);
-
-    // Handle scalar remainder (0-3 synapses)
-    for idx in i..end {
-        let synapse = &synapses[idx];
-        scalar_sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
-
-    scalar_sum
+    // SAFETY: `end <= synapses.len()` (the caller's range indexes the chunk
+    // loop above), and every `from_index` in `i..end` indexes `activations` —
+    // load-time validation in `CompiledNetwork::new` (`AGENTS.md`,
+    // "Unsafe & SIMD invariants") is `tail_sum`'s stated precondition.
+    unsafe { scalar::tail_sum(synapses, activations, i, end, scalar_sum) }
 }
 
 /// Issue #1178 - SIMD-optimised sum of squared weighted activations for Hypotenuse.
 ///
-/// Computes sum((activation[from] * weight)^2) using SIMD with dual accumulators.
+/// Computes sum((activation[from] * weight)^2) using SIMD.
 /// Used by the Hypotenuse squash function: sqrt(sum_sq) + bias.
+///
+/// Shares the chunk-walk scaffold ([`gather4_products`], [`reduce4`], the
+/// seed-taking tail) with the other single-record kernels, and runs a single
+/// accumulator over chunks of four. Same index precondition as
+/// [`weighted_sum_simd`].
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -156,48 +211,32 @@ pub fn weighted_sum_of_squares_simd(
     }
 
     let mut acc = f32x4_splat(0.0);
-    let mut scalar_sum = 0.0f32;
     let chunks = count / 4;
 
     for chunk in 0..chunks {
-        let base = start + chunk * 4;
-        let s0 = &synapses[base];
-        let s1 = &synapses[base + 1];
-        let s2 = &synapses[base + 2];
-        let s3 = &synapses[base + 3];
-
-        // Compute weighted activations
-        let products = f32x4(
-            activations[s0.from_index as usize] * s0.weight,
-            activations[s1.from_index as usize] * s1.weight,
-            activations[s2.from_index as usize] * s2.weight,
-            activations[s3.from_index as usize] * s3.weight,
-        );
-
         // Square and accumulate: acc += products * products
+        let products = gather4_products(synapses, activations, start + chunk * 4);
         acc = f32x4_relaxed_madd(products, products, acc);
     }
 
-    scalar_sum += f32x4_extract_lane::<0>(acc)
-        + f32x4_extract_lane::<1>(acc)
-        + f32x4_extract_lane::<2>(acc)
-        + f32x4_extract_lane::<3>(acc);
-
+    let scalar_sum = reduce4(acc);
     let remainder_start = start + chunks * 4;
-    for i in remainder_start..end {
-        let synapse = &synapses[i];
-        let val = activations[synapse.from_index as usize] * synapse.weight;
-        scalar_sum += val * val;
-    }
 
-    scalar_sum
+    // SAFETY: same contract as `weighted_sum_simd`'s tail — load-time index
+    // validation in `CompiledNetwork::new`.
+    unsafe { scalar::tail_sum_of_squares(synapses, activations, remainder_start, end, scalar_sum) }
 }
 
 /// Issue #1178 - SIMD-optimised weighted sum for Mean activation.
 ///
 /// Computes the plain weighted sum (without bias) using SIMD, intended for
-/// the Mean squash: sum / n + bias. Shares the dual-accumulator approach
-/// with `weighted_sum_simd` but omits the bias to keep the division clean.
+/// the Mean squash: sum / n + bias. Omits the bias to keep the division clean.
+///
+/// Shares the chunk-walk scaffold ([`gather4`], [`reduce4`], the seed-taking
+/// tail) with the other single-record kernels, but runs a **single**
+/// accumulator over chunks of four — the Issue #1197 dual-accumulator form is
+/// on [`weighted_sum_simd`] only. Same index precondition as
+/// [`weighted_sum_simd`].
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -214,44 +253,30 @@ pub fn weighted_sum_no_bias_simd(
     }
 
     let mut acc = f32x4_splat(0.0);
-    let mut scalar_sum = 0.0f32;
     let chunks = count / 4;
 
     for chunk in 0..chunks {
-        let base = start + chunk * 4;
-        let s0 = &synapses[base];
-        let s1 = &synapses[base + 1];
-        let s2 = &synapses[base + 2];
-        let s3 = &synapses[base + 3];
-
-        let weights = f32x4(s0.weight, s1.weight, s2.weight, s3.weight);
-        let acts = f32x4(
-            activations[s0.from_index as usize],
-            activations[s1.from_index as usize],
-            activations[s2.from_index as usize],
-            activations[s3.from_index as usize],
-        );
+        let (weights, acts) = gather4(synapses, activations, start + chunk * 4);
         acc = f32x4_relaxed_madd(weights, acts, acc);
     }
 
-    scalar_sum += f32x4_extract_lane::<0>(acc)
-        + f32x4_extract_lane::<1>(acc)
-        + f32x4_extract_lane::<2>(acc)
-        + f32x4_extract_lane::<3>(acc);
-
+    let scalar_sum = reduce4(acc);
     let remainder_start = start + chunks * 4;
-    for i in remainder_start..end {
-        let synapse = &synapses[i];
-        scalar_sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
 
-    scalar_sum
+    // SAFETY: same contract as `weighted_sum_simd`'s tail — load-time index
+    // validation in `CompiledNetwork::new`.
+    unsafe { scalar::tail_sum(synapses, activations, remainder_start, end, scalar_sum) }
 }
 
 /// Issue #1178 - SIMD-optimised sum of squared (bias + weighted activation) for HypotenuseV2.
 ///
 /// Computes sum((bias + activation[from] * weight)^2) using SIMD.
 /// Used by the HypotenuseV2 squash function: sqrt(sum_sq).
+///
+/// Shares the chunk-walk scaffold ([`gather4_products`], [`reduce4`], the
+/// seed-taking tail) with the other single-record kernels, and runs a single
+/// accumulator over chunks of four. Same index precondition as
+/// [`weighted_sum_simd`].
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -270,42 +295,30 @@ pub fn weighted_sum_of_squares_v2_simd(
 
     let bias_vec = f32x4_splat(bias);
     let mut acc = f32x4_splat(0.0);
-    let mut scalar_sum = 0.0f32;
     let chunks = count / 4;
 
     for chunk in 0..chunks {
-        let base = start + chunk * 4;
-        let s0 = &synapses[base];
-        let s1 = &synapses[base + 1];
-        let s2 = &synapses[base + 2];
-        let s3 = &synapses[base + 3];
-
-        // Compute bias + activation * weight
-        let weighted = f32x4(
-            activations[s0.from_index as usize] * s0.weight,
-            activations[s1.from_index as usize] * s1.weight,
-            activations[s2.from_index as usize] * s2.weight,
-            activations[s3.from_index as usize] * s3.weight,
-        );
+        // Compute bias + activation * weight, then square and accumulate
+        let weighted = gather4_products(synapses, activations, start + chunk * 4);
         let vals = f32x4_add(bias_vec, weighted);
-
-        // Square and accumulate: acc += vals * vals
         acc = f32x4_relaxed_madd(vals, vals, acc);
     }
 
-    scalar_sum += f32x4_extract_lane::<0>(acc)
-        + f32x4_extract_lane::<1>(acc)
-        + f32x4_extract_lane::<2>(acc)
-        + f32x4_extract_lane::<3>(acc);
-
+    let scalar_sum = reduce4(acc);
     let remainder_start = start + chunks * 4;
-    for i in remainder_start..end {
-        let synapse = &synapses[i];
-        let val = bias + activations[synapse.from_index as usize] * synapse.weight;
-        scalar_sum += val * val;
-    }
 
-    scalar_sum
+    // SAFETY: same contract as `weighted_sum_simd`'s tail — load-time index
+    // validation in `CompiledNetwork::new`.
+    unsafe {
+        scalar::tail_sum_of_squares_v2(
+            synapses,
+            activations,
+            remainder_start,
+            end,
+            scalar_sum,
+            bias,
+        )
+    }
 }
 
 /// Issue #1202 - SIMD-optimised weighted sum for 4 records simultaneously.

--- a/neat-core/tests/simd_chunk_walk_scaffold.rs
+++ b/neat-core/tests/simd_chunk_walk_scaffold.rs
@@ -1,0 +1,147 @@
+//! Chunk-walk scaffold parity (Issue #448).
+//!
+//! The four single-record weighted-sum kernels share one walk over a synapse
+//! span: gather four synapses into lanes, fold, reduce the lanes, then finish
+//! the 0..3 remainder from the running accumulator. This file pins the
+//! observable consequence of that walk — **every** kernel reproduces its
+//! reference scalar result at **every** offset and count, not just at
+//! `start == 0`.
+//!
+//! `simd_weighted_sums.rs` sweeps counts from `start == 0`; the offset sweep
+//! here is what catches a scaffold that computes its chunk base from the chunk
+//! index alone, because then the first gather silently reads from the wrong
+//! synapse whenever `start > 0`.
+//!
+//! References come from `neat_core::simd::scalar` (Issue #447), the single home
+//! of what each kernel means, so this test cannot drift from the semantics it
+//! is checking.
+
+use neat_core::network::SynapseData;
+use neat_core::simd::scalar;
+use neat_core::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd,
+};
+
+/// Widest span the sweep builds: two dual-accumulator chunks of eight, a
+/// trailing chunk of four, and a 1..3 scalar remainder, from any offset.
+const MAX_SPAN: usize = 24;
+
+/// Fan-in wide enough to exercise repeated `from_index` gathers without the
+/// activation buffer dominating the arithmetic.
+const NUM_INPUTS: usize = 11;
+
+fn fixture() -> (Vec<SynapseData>, Vec<f32>) {
+    let synapses = (0..MAX_SPAN + 10)
+        .map(|i| SynapseData {
+            weight: ((i as f32) * 0.37).cos() * 1.5,
+            from_index: (i % NUM_INPUTS) as u16,
+            synapse_type: 0,
+        })
+        .collect();
+    let activations = (0..NUM_INPUTS)
+        .map(|i| ((i as f32) * 0.61).sin() - 0.25)
+        .collect();
+    (synapses, activations)
+}
+
+/// f32 accumulation over a span drifts from the reference by a few ULP once the
+/// SIMD path fuses multiply-adds, so compare relative to the magnitude.
+fn assert_close(got: f32, want: f32, what: &str) {
+    let tol = 1e-4 * (1.0 + want.abs());
+    assert!(
+        (got - want).abs() <= tol,
+        "{what}: got {got}, want {want} (tol {tol})"
+    );
+}
+
+#[test]
+fn every_kernel_matches_its_reference_from_any_offset() {
+    let (synapses, activations) = fixture();
+    let bias = -0.45f32;
+
+    for start in 0..10usize {
+        for count in 0..=MAX_SPAN {
+            let end = start + count;
+            let at = format!("start={start} count={count}");
+
+            assert_close(
+                weighted_sum_simd(&synapses, &activations, start, end, bias),
+                scalar::weighted_sum(&synapses, &activations, start, end, bias),
+                &format!("weighted_sum_simd {at}"),
+            );
+            assert_close(
+                weighted_sum_no_bias_simd(&synapses, &activations, start, end),
+                scalar::weighted_sum_no_bias(&synapses, &activations, start, end),
+                &format!("weighted_sum_no_bias_simd {at}"),
+            );
+            assert_close(
+                weighted_sum_of_squares_simd(&synapses, &activations, start, end),
+                scalar::weighted_sum_of_squares(&synapses, &activations, start, end),
+                &format!("weighted_sum_of_squares_simd {at}"),
+            );
+            assert_close(
+                weighted_sum_of_squares_v2_simd(&synapses, &activations, start, end, bias),
+                scalar::weighted_sum_of_squares_v2(&synapses, &activations, start, end, bias),
+                &format!("weighted_sum_of_squares_v2_simd {at}"),
+            );
+        }
+    }
+}
+
+#[test]
+fn the_remainder_continues_the_span_rather_than_restarting_it() {
+    // A span of 8 + 3 and a span of 8 + 0 must differ by exactly the three
+    // trailing synapses' contribution: the tail continues the running
+    // accumulator, it does not start a second sum that is merged in.
+    let (synapses, activations) = fixture();
+    let bias = 0.8f32;
+    let start = 3usize;
+
+    let body_only = weighted_sum_no_bias_simd(&synapses, &activations, start, start + 8);
+    let with_tail = weighted_sum_no_bias_simd(&synapses, &activations, start, start + 11);
+    let tail_contribution =
+        scalar::weighted_sum_no_bias(&synapses, &activations, start + 8, start + 11);
+    assert_close(
+        with_tail,
+        body_only + tail_contribution,
+        "no_bias tail continues the span",
+    );
+
+    let body_only = weighted_sum_simd(&synapses, &activations, start, start + 8, bias);
+    let with_tail = weighted_sum_simd(&synapses, &activations, start, start + 11, bias);
+    let tail_contribution =
+        scalar::weighted_sum_no_bias(&synapses, &activations, start + 8, start + 11);
+    assert_close(
+        with_tail,
+        body_only + tail_contribution,
+        "weighted_sum tail continues the span",
+    );
+}
+
+#[test]
+fn an_empty_or_reversed_span_is_the_kernel_seed() {
+    let (synapses, activations) = fixture();
+    let bias = 1.25f32;
+
+    // Reversed ranges saturate to a zero count (Issue #447), so each kernel
+    // returns its seed rather than walking a colossal span.
+    for (start, end) in [(5usize, 5usize), (9, 2)] {
+        assert_eq!(
+            weighted_sum_simd(&synapses, &activations, start, end, bias),
+            bias
+        );
+        assert_eq!(
+            weighted_sum_no_bias_simd(&synapses, &activations, start, end),
+            0.0
+        );
+        assert_eq!(
+            weighted_sum_of_squares_simd(&synapses, &activations, start, end),
+            0.0
+        );
+        assert_eq!(
+            weighted_sum_of_squares_v2_simd(&synapses, &activations, start, end, bias),
+            0.0
+        );
+    }
+}


### PR DESCRIPTION
# One chunk-walk scaffold for the wasm weighted-sum kernels (Issue #448)

## Summary

The four single-record `wasm32` kernels in `neat-core/src/simd.rs` each carried
their own copy of the same chunk-loop scaffolding — 4-wide lane gather, lane
reduce, and the 0..3 scalar remainder — around different folds. The cost was
already paid: the Issue #1197 dual-accumulator rework landed on
`weighted_sum_simd` only, and `weighted_sum_no_bias_simd`'s doc claimed it
"Shares the dual-accumulator approach with `weighted_sum_simd`" when its body
ran a single accumulator.

This extracts the scaffold into three helpers — `gather4`, `gather4_products`,
`reduce4` — and routes every kernel's remainder through the seed-taking
`scalar::tail_*` helpers that Issue #447 already made the single home of that
rule, replacing four re-inlined scalar loops. The fold stays in each kernel, as
the issue requires: these are calls, not a parameterised super-helper, because
unifying plain-FMA, square-the-product and square-the-biased-product would need
a mode flag. Both stale doc claims are corrected — `weighted_sum_of_squares_simd`
also claimed dual accumulators — and `AGENTS.md` gains the rule so the next
scaffold improvement cannot land on one copy again.

Behaviour is unchanged: the refactor is numerically bit-identical (evidence
below). Applying the dual-accumulator form to the other three kernels is
deliberately **not** in this PR — that is a performance change, and this repo
requires before/after benchmark evidence for those. With the walk shared it is
now a fold-level edit on top of one scaffold.

Closes #448.

```mermaid
flowchart LR
    K1["weighted_sum_simd"] --> G["gather4 / gather4_products"]
    K2["weighted_sum_of_squares_simd"] --> G
    K3["weighted_sum_no_bias_simd"] --> G
    K4["weighted_sum_of_squares_v2_simd"] --> G
    G --> F["fold — stays in each kernel"]
    F --> R["reduce4"]
    R --> T["scalar::tail_* — seed-taking remainder"]
```

## Evidence

Backend/library change with no web interface, so no screenshot applies. The
changed code is `wasm32`-only, which the native test suite cannot execute, so it
was verified by **running the refactored kernels on a real wasm runtime**
(`wasm32-wasip1` under Node's WASI, `-C target-feature=+simd128,+relaxed-simd`):

- All three new parity checks pass when compiled to wasm and executed:

  ```
  every_kernel_matches_its_reference_from_any_offset: ok
  the_remainder_continues_the_span_rather_than_restarting_it: ok
  an_empty_or_reversed_span_is_the_kernel_seed: ok
  ```

- **Bit-identical to the pre-refactor kernels.** The same wasm probe was run
  against `simd.rs` before and after the change, dumping the raw `f32` bit
  patterns of all four kernels over every `(start, count)` span for
  `start` 0..11 and `count` 0..40 — 492 spans, 1968 results:

  ```
  diff before.txt after.txt   # no differences
  BIT-IDENTICAL across 492 spans
  ```

  `gather4_products` uses `f32x4_mul`, a plain IEEE-754 lane multiply rather
  than a relaxed operation, so replacing the hand-packed
  `f32x4(a0*w0, …)` gathers cannot shift a result; the `scalar::tail_*` helpers
  continue the running accumulator in the same order the inline loops did.

- `cargo clippy --target wasm32-unknown-unknown` with `-D warnings` is clean
  (the wasm path is not covered by `quality.sh` or the PR CI lane — it builds
  only on push to `Develop` via `wasm-bundle.yml`).
- `./quality.sh` passes: fmt, clippy, deny, doc, and the full native test suite.

## Test Plan

Added `neat-core/tests/simd_chunk_walk_scaffold.rs` (3 tests) — the file that
pins the rule, in the style of `simd_scalar_layer.rs`:

- `every_kernel_matches_its_reference_from_any_offset` — sweeps all four kernels
  over starts 0..9 × counts 0..24 against the `simd::scalar` reference kernels.
  The **offset** sweep is the new coverage: `simd_weighted_sums.rs` sweeps counts
  from `start == 0` only, which would not catch a scaffold that derives its
  chunk base from the chunk index alone.
- `the_remainder_continues_the_span_rather_than_restarting_it` — a span of 8+3
  equals the 8-span plus the three trailing synapses' contribution, pinning the
  seed-taking tail rather than a second sum merged in.
- `an_empty_or_reversed_span_is_the_kernel_seed` — empty and reversed ranges
  return each kernel's seed (`bias` / `0.0`), carrying the Issue #447 saturating
  count guard through the refactor.

No existing tests were removed or modified. `simd_weighted_sums.rs` (23 tests)
and `simd_scalar_layer.rs` (8 tests) continue to pass unchanged and remain the
regression net for kernel semantics.



## Milestone
This PR is part of the **Duplicate Knowledge** milestone and targets the `milestone/duplicate-knowledge` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms99y572-d6b18b`<!-- vibe-worker-issue-448 -->