### PR TITLE
Milestone: Duplicate Knowledge

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,6 +26,9 @@ env:
   # semgrep/semgrep:1.170.1 — `:latest` as of 2026-07. Refresh with
   # `docker buildx imagetools inspect semgrep/semgrep:latest`.
   SEMGREP_IMAGE: semgrep/semgrep@sha256:98c2572fced2474539fd27cab3207ebd8e95e4e7aab4c3b381fdc5e2641d9941
+  # PR #468 — fallback path when Docker Hub itself is unreachable. Must track
+  # the version the digest above pins, so both paths scan with the same semgrep.
+  SEMGREP_VERSION: 1.170.1
 
 jobs:
   semgrep:
@@ -44,13 +47,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pull semgrep image
+      # PR #468 — retries alone cannot survive a Docker Hub outage: all five
+      # attempts hit `Get "https://registry-1.docker.io/v2/": context deadline
+      # exceeded` and the job failed without semgrep ever running. Docker Hub is
+      # a single point of failure for this gate, so fall back to the PyPI
+      # release (different infrastructure) at the same version. The container
+      # remains the primary, digest-pinned path; the fallback is version-pinned
+      # and only reachable once the pinned image is provably unavailable.
+      - name: Obtain semgrep
+        id: obtain
         run: |
           set -euo pipefail
           attempts=5
           for attempt in $(seq 1 "$attempts"); do
             if docker pull "$SEMGREP_IMAGE"; then
               echo "Pulled $SEMGREP_IMAGE on attempt $attempt."
+              echo "mode=docker" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$attempt" -lt "$attempts" ]; then
@@ -59,18 +71,28 @@ jobs:
               sleep "$backoff"
             fi
           done
-          # Fail loud — never let an unpullable scanner image look like a pass.
-          echo "::error::Could not pull $SEMGREP_IMAGE after $attempts attempts; the registry is unreachable, so no SAST scan ran."
-          exit 1
+          echo "::warning::Could not pull $SEMGREP_IMAGE after $attempts attempts; falling back to semgrep $SEMGREP_VERSION from PyPI."
+          # Fail loud — if neither source yields a scanner, the job fails rather
+          # than reporting a pass for a scan that never ran.
+          if ! pipx install "semgrep==${SEMGREP_VERSION}"; then
+            echo "::error::Neither the pinned container nor PyPI provided semgrep, so no SAST scan ran."
+            exit 1
+          fi
+          echo "mode=pypi" >> "$GITHUB_OUTPUT"
 
       - name: Semgrep scan
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_MODE: ${{ steps.obtain.outputs.mode }}
         run: |
           set -euo pipefail
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE:/src" \
-            -w /src \
-            -e SEMGREP_APP_TOKEN \
-            "$SEMGREP_IMAGE" \
-            sh -c 'git config --global --add safe.directory /src && semgrep ci --config p/default'
+          if [ "$SEMGREP_MODE" = "docker" ]; then
+            docker run --rm \
+              -v "$GITHUB_WORKSPACE:/src" \
+              -w /src \
+              -e SEMGREP_APP_TOKEN \
+              "$SEMGREP_IMAGE" \
+              sh -c 'git config --global --add safe.directory /src && semgrep ci --config p/default'
+          else
+            semgrep ci --config p/default
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,28 @@ The *vectorised* `squash_x4` / `squash_x8` approximations
 (`neat-core/src/squash_simd.rs`) are a different rule and stay where they are —
 only their scalar fallback goes through `inline_squash`.
 
+## One aggregate-squash set for dispatch and hints (Issue #446)
+
+`SquashType::is_aggregate` (`neat-core/src/squash.rs`) is the single home of the
+rule that says *which squash types are aggregates* — Minimum, Maximum, If,
+Hypotenuse, HypotenuseV2, Mean: the six that cannot be lane-vectorised and must
+take the exact single-record kernel. That one predicate drives both dispatch
+(`has_aggregate_squash`, the 8-record and 4-record group loops in
+`batch_scoring.rs`, and the same two tiers inside `batch_8way_activation!`) and
+hint semantics (`activate_and_trace` reports the activation itself as the hint;
+`apply_unsquash` prefers the caller's hint). Adding a seventh aggregate type is
+an edit **there and nowhere else** — do not restate the membership list at a
+call site, because a missed site fails **silently**: the new type would be
+routed down the lane-vectorised weighted-sum path and produce numbers that
+differ from `activate()` with no panic to flag it.
+
+`apply_unsquash` is the one site that needs the set as a *pattern* rather than a
+predicate — a guard arm would forfeit the compiler's exhaustiveness check over
+`SquashType`. It uses `aggregate_squash_patterns!()`, the `pub(crate)` macro the
+predicate itself is built from, so there is still exactly one list.
+`neat-core/tests/aggregate_squash_set.rs` pins the rule: membership, batched-vs-
+single-record parity for every squash type, and both hint semantics.
+
 ## One packed-record scan for every loss entry point (Issue #444)
 
 `packed_record_scan` (`neat-core/src/loss.rs`) is the single home of the rule

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,51 @@ flowchart LR
     F --> G["f64 sum_error"]
 ```
 
+## One ISA-neutral scalar layer for every weighted-sum kernel (Issue #447)
+
+`neat-core/src/simd/scalar.rs` is the single home of the rule that says what a
+weighted-sum kernel *means*: the reference scalar semantics of each kernel and
+the small-count guard in front of it — the thing every SIMD path must agree with
+bit-for-bit. It carries no intrinsics and no `cfg`, so the `wasm32` kernels in
+`simd.rs` and the x86/aarch64 kernels in `simd_native.rs` share one copy.
+
+Two layers, deliberately distinct:
+
+- **Reference kernels** (`weighted_sum`, `weighted_sum_of_squares`,
+  `weighted_sum_no_bias`, `weighted_sum_of_squares_v2`) seed their own
+  accumulator and index safely. Every target's below-threshold count
+  (`synapse_count(start, end) < SINGLE_RECORD_SIMD_MIN`) falls back to them.
+- **Seed-taking tail helpers** (`tail_sum`, `tail_sum_of_squares`,
+  `tail_sum_of_squares_v2`) take the caller's **running** accumulator, so a SIMD
+  kernel's 0..3 remainder continues the reference f32 rounding order instead of
+  starting a second sum. They cannot be replaced by the reference kernels — that
+  would reseed and break the bit-parity the tests rely on. They index with
+  `get_unchecked` under the load-time index-validation invariant above, so they
+  are `unsafe fn` with a `# Safety` contract; calling them from a
+  `#[target_feature]` fn is sound and inlinable because no vector types cross the
+  boundary.
+
+`synapse_count` is the count prologue: **saturating**, so a reversed range
+(`end < start`) counts as zero instead of underflowing. Every kernel prologue on
+both sides uses it — no raw `end - start`, no hard-coded `4`.
+
+Changing the accumulation order, the guard, or the threshold is an edit **there
+and nowhere else**; do not re-inline a scalar loop into an ISA module.
+`neat-core/tests/simd_scalar_layer.rs` pins the rule: splitting a range at any
+point and continuing through a tail helper reproduces the reference result
+exactly, and below the threshold the public kernels are bit-identical to the
+reference.
+
+```mermaid
+flowchart LR
+    W["simd.rs (wasm32)"] --> S["simd::scalar"]
+    N["simd_native.rs — x86"] --> S
+    A["simd_native.rs — NEON"] --> S
+    S --> G["synapse_count / SINGLE_RECORD_SIMD_MIN"]
+    S --> R["reference kernels"]
+    S --> T["seed-taking tail helpers"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,43 @@ callers, where it genuinely differs (MSE falls back through the 8-way *and*
 switch the driver's behaviour, leave that entry point out rather than growing a
 flag. `neat-core/tests/packed_record_scan.rs` pins the rule across all eight.
 
+## One batched record-scan skeleton for every loss kind (Issue #445)
+
+`batch_8way_activation!` (`neat-core/src/loss.rs`) is the single home of the
+rule that walks a packed record buffer: records are grouped **8 → 4 → 1**, each
+group's inputs are loaded into per-lane activation buffers, and the per-record
+errors accumulate into one `f64` sum. All six loss kinds — MSE included, via
+`mse_sum_batch_scattered` — invoke it with a closure carrying **only** their
+per-record reduction (`(records, target_base, act, output_start, num_outputs) ->
+f64`). Changing the grouping (a 16-lane tier, a different remainder strategy) is
+an edit **there and nowhere else**; do not re-inline the skeleton.
+
+The record-**interleaved** 8-group path (`mse_sum_batch_8way_interleaved`,
+Issue #384) is a genuinely different memory layout and stays separate — its
+`< 8` remainder still runs the same per-lane kernels, so the two are
+bit-identical.
+
+`load_record` (`neat-core/src/batch_scoring.rs`) owns the loading sub-rule:
+copy `min(record.len(), num_inputs)` values and **zero** every input slot the
+record does not cover, exactly as `CompiledNetwork::activate_into` does. Every
+per-lane loader in the batched scoring and fused loss kernels calls it, so a
+record scored in a SIMD group, in the 4-record remainder, or in the scalar tail
+sees the same inputs. `neat-core/tests/batch_record_skeleton.rs` pins the rule
+across every packed loss entry point.
+
+```mermaid
+flowchart LR
+    A["packed records"] --> B{"num_records"}
+    B -- "&ge; 8" --> C["8-record group<br/>load_record x8"]
+    B -- "4..7" --> D["4-record group<br/>load_record x4"]
+    B -- "&lt; 4" --> E["scalar tail<br/>load_record"]
+    C --> D --> E
+    C --> F["$error_fn per record"]
+    D --> F
+    E --> F
+    F --> G["f64 sum_error"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,24 @@ routing them through the helper measured ~30–46% slower on the `forward_pass`
 benchmark. Change the helper and those two together, and re-run
 `cargo bench --bench hot_paths -- forward_pass` if you touch them.
 
+## One hot-squash dispatch for standard neurons (Issue #443)
+
+`inline_squash` (`neat-core/src/batch_scoring.rs`) is the single home of the
+*other* half of that rule: which squash types are hot enough to branch inline
+(`0` Identity, `1` ReLU, `6` Logistic, `7` Tanh) and the exact scalar formula
+each uses, with everything else deferring to `apply_squash`. Every site that
+squashes a standard weighted sum calls it — the three single-record forward
+passes in `network.rs`, the 4-way traced batch, and the scalar `None`-fallback
+branch of every batched loss and scoring kernel — so the SIMD-batched and
+scalar-tail paths agree bit-for-bit. Promoting a fifth type to the inline set,
+or reformulating one of the four, is an edit **there and nowhere else**; do not
+re-inline the match. `neat-core/tests/inline_squash_dispatch.rs` pins the rule
+across every public activation path.
+
+The *vectorised* `squash_x4` / `squash_x8` approximations
+(`neat-core/src/squash_simd.rs`) are a different rule and stay where they are —
+only their scalar fallback goes through `inline_squash`.
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,22 @@ this you **must**:
 - **Add a state-leak regression test** asserting the reused-buffer path is
   byte-identical to the fresh-allocation path across differently-sized inputs.
 
+## One activation rule for single-record work (Issue #441)
+
+`neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) is the single home
+of the rule that turns a neuron's synapse range into an activation — constants,
+the six aggregate squashes (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean),
+the standard weighted-sum fall-through, then `apply_limit_range`. **Every**
+batched kernel that drops to one record at a time (the per-lane aggregate loops
+and the scalar tails in `loss.rs`) calls it, so a record's activation never
+depends on whether it landed in a full SIMD group or in the remainder. Adding a
+squash type means editing that helper only — do not re-inline the match.
+
+`CompiledNetwork::activate` / `activate_into` deliberately keep their own copy:
+routing them through the helper measured ~30–46% slower on the `forward_pass`
+benchmark. Change the helper and those two together, and re-run
+`cargo bench --bench hot_paths -- forward_pass` if you touch them.
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,25 @@ The *vectorised* `squash_x4` / `squash_x8` approximations
 (`neat-core/src/squash_simd.rs`) are a different rule and stay where they are —
 only their scalar fallback goes through `inline_squash`.
 
+## One packed-record scan for every loss entry point (Issue #444)
+
+`packed_record_scan` (`neat-core/src/loss.rs`) is the single home of the rule
+that carves a packed `[inputs…, targets…]` buffer into records: the stride is
+`input_size + num_outputs` (`packed_layout`), only whole records count, a
+record's targets start immediately after its inputs, and each record is
+activated statelessly unless the caller declares the network forward-only. All
+eight entry points — the seven `*_sum_batch_packed` kernels and `mse_mean_record`
+— call it with a closure carrying **only** their per-output reduction, so the
+per-record `1/num_outputs` factor lives in the closure (which is what keeps MSLE
+and hinge deliberately un-averaged).
+
+The driver takes a closure and **no mode flags**: SIMD dispatch stays at the
+callers, where it genuinely differs (MSE falls back through the 8-way *and*
+4-way paths; `categorical_error_sum_batch_packed` uses neither and keeps its own
+`num_outputs == 0` guard). If unifying a future entry point needs a boolean to
+switch the driver's behaviour, leave that entry point out rather than growing a
+flag. `neat-core/tests/packed_record_scan.rs` pins the rule across all eight.
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,51 @@ flowchart LR
     S --> T["seed-taking tail helpers"]
 ```
 
+## One chunk-walk scaffold for the wasm weighted-sum kernels (Issue #448)
+
+The scaffold helpers at the top of `neat-core/src/simd.rs` — `gather4`,
+`gather4_products`, `reduce4` — are the single home of the rule that says *how a
+`wasm32` kernel walks a synapse span*: chunk into fours, gather weights and
+activations into `f32x4` lanes, fold, reduce the lanes, then finish the 0..3
+remainder from the **running** accumulator through the `scalar::tail_*` helpers
+(Issue #447). All four single-record kernels — `weighted_sum_simd`,
+`weighted_sum_of_squares_simd`, `weighted_sum_no_bias_simd`,
+`weighted_sum_of_squares_v2_simd` — call them, so a change to the walk lands on
+every kernel at once. It previously did not: the Issue #1197 dual-accumulator
+rework reached `weighted_sum_simd` alone and the doc on
+`weighted_sum_no_bias_simd` claimed otherwise for four releases.
+
+Two constraints on anyone editing the scaffold:
+
+- **Every helper touching `v128`/`f32x4_*` must repeat
+  `#[target_feature(enable = "simd128", enable = "relaxed-simd")]`** — without it
+  the intrinsics do not compile and the vector arguments do not inline into the
+  caller.
+- **The fold stays in each kernel.** These are calls, not a parameterised
+  super-helper: plain FMA, square-the-product, and square-the-biased-product are
+  genuinely different folds, and unifying them would need a mode flag. If a
+  future kernel only fits behind a flag, leave it out of the scaffold instead.
+
+The dual-accumulator form (two chains, chunks of eight) is still on
+`weighted_sum_simd` only, and the docs now say so; promoting the other three is
+a fold-level edit on top of the shared walk.
+
+`neat-core/tests/simd_chunk_walk_scaffold.rs` pins the rule: every kernel
+reproduces its `simd::scalar` reference from **any** offset (not just
+`start == 0`), the remainder continues the span rather than restarting it, and a
+reversed span yields the kernel's seed.
+
+```mermaid
+flowchart LR
+    K1["weighted_sum_simd"] --> G["gather4 / gather4_products"]
+    K2["weighted_sum_of_squares_simd"] --> G
+    K3["weighted_sum_no_bias_simd"] --> G
+    K4["weighted_sum_of_squares_v2_simd"] --> G
+    G --> F["fold — stays in each kernel"]
+    F --> R["reduce4"]
+    R --> T["scalar::tail_* — seed-taking remainder"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,18 +101,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-441.md
+++ b/docs/archive/pr-summaries/pr-summary-441.md
@@ -1,0 +1,116 @@
+# Aggregate-squash activation: one rule, called from every scalar tail
+
+## Summary
+
+The rule that turns a neuron's inbound synapse range into an activation — the
+dispatch over `Minimum` / `Maximum` / `If` / `Hypotenuse` / `HypotenuseV2` /
+`Mean`, the standard weighted-sum fall-through, then `apply_limit_range` — was
+copy-pasted across `neat-core/src/loss.rs`, and **three of those copies had
+diverged**: they stopped at `If`, so a neuron using `Mean`, `Hypotenuse` or
+`HypotenuseV2` fell through to a plain weighted sum whenever its record landed
+in the scalar remainder instead of a full SIMD group.
+
+That was reachable in production, not theoretical: `mse_sum_batch_8way_scattered`
+is the arm selected *precisely when* `has_aggregate_squash()` is true, so the one
+path reserved for aggregate networks mis-computed its own tail records. The
+`batch_8way_activation!` tail is shared by the MAE, cross-entropy, MAPE, MSLE and
+hinge paths, and `mse_sum_batch_4way` is reached with no aggregate guard at all.
+An aggregate creature scored over nine records got the correct error for the
+first eight and a silently wrong one for the ninth.
+
+`neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) already held the
+correct rule, byte-for-byte as `CompiledNetwork::activate_into` computes it. This
+PR widens it to `pub(crate)` and calls it from every single-record site in
+`loss.rs` — the three diverged scalar tails, the four per-lane aggregate loops
+and the interleaved tail — deleting ~700 duplicated lines. Adding a seventh
+aggregate squash now means editing one match.
+
+Closes #441.
+
+### Deliberately left alone
+
+- **`CompiledNetwork::activate` / `activate_into`** keep their inlined copy.
+  Routing them through the helper was implemented and measured: `forward_pass/
+  production_exact` went from **13.4 µs → 19.3 µs (+46%)**, and still **17.4 µs
+  (+30%)** with `#[inline(always)]`. Neither copy had diverged, so the trade was
+  not worth it; the constraint is now recorded in `AGENTS.md`.
+- **`network.rs:753-926`**, the `(activation, hint_value)` trace variant — it
+  would need a mode parameter, which the issue explicitly rules out.
+
+```mermaid
+flowchart TD
+    subgraph before["Before — 8 sites, 3 diverged"]
+        B1["8-lane group<br/>6 aggregate arms"]
+        B2["4-lane group<br/>6 aggregate arms"]
+        B3["scalar tail<br/>❌ stops at If"]
+    end
+    subgraph after["After — one rule"]
+        A1["8-lane group"] --> H
+        A2["4-lane group"] --> H
+        A3["scalar tail"] --> H
+        H["neuron_activation_scalar<br/>Min · Max · If · Hyp · HypV2 · Mean<br/>+ weighted sum + limit range"]
+    end
+    before --> after
+```
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. Evidence
+is the failing-then-passing regression test plus the benchmark A/B above.
+
+**New test fails on the unfixed code** (`Hypotenuse`, tail record wrong by two
+orders of magnitude more than the SIMD tolerance):
+
+```
+mse Hypotenuse n=5: batched 2.2803990747196785 diverged from per-record
+reference 2.1519708379379026 by 0.12842823678177595 (tol 0.00001)
+mae Hypotenuse n=9: batched 5.541243314743042 diverged from per-record
+reference 5.42296490073204 by 0.11827841401100159 (tol 0.00001)
+```
+
+**After the fix:**
+
+```
+running 2 tests
+test mse_scalar_tail_matches_reference_for_every_aggregate_squash ... ok
+test shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash ... ok
+test result: ok. 2 passed; 0 failed
+```
+
+`./quality.sh` passes clean (fmt, clippy `-D warnings`, deny, full
+`cargo test --workspace`, doc build, release build).
+
+**Numerics note.** For `Hypotenuse` / `HypotenuseV2` / `Mean`, the per-lane
+aggregate loops in `loss.rs` previously used naive scalar sums; they now use the
+same SIMD sum helpers as the single-record reference. Results shift by f32
+rounding *towards* `activate` — the batch paths are now closer to the reference,
+not further. The existing bit-identity guard
+(`loss::interleaved_mse_parity`) and the `mse_squash_simd_parity` /
+`score_squash_simd_parity` suites all stay green.
+
+**Benchmark A/B** (`cargo bench --bench hot_paths`, 100 samples): batched
+scoring shows no consistent movement — `mse_sum_8records/production` 64.5 µs vs
+64.9 µs, within the ±10% run-to-run noise seen in both directions on this host.
+The changed code is only reached by aggregate networks and scalar tails, so this
+is the expected result.
+
+## Test Plan
+
+Added `neat-core/tests/aggregate_squash_tail_parity.rs`:
+
+- `mse_scalar_tail_matches_reference_for_every_aggregate_squash` — scores an
+  aggregate network through `mse_sum_batch_packed` at record counts with a
+  non-empty tail (5, 6, 7 → 4-way + tail; 9, 13 → 8-way group + tail) for all
+  six aggregate squashes, asserting the batched result matches the per-record
+  `CompiledNetwork::activate_into` reference (`forward_only = false`) within
+  1e-5.
+- `shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash` — the
+  same guard across the five loss functions sharing `batch_8way_activation!`
+  (MAE, cross-entropy, MAPE, MSLE, hinge) at counts 9 and 13.
+
+Both tests fail against the unfixed code and pass after the change. The fixture
+alternates synapse types so the `If` arm sees condition, positive and negative
+edges rather than a single branch.
+
+Existing suites unchanged and green, including the bit-identity guards that pin
+the interleaved kernel to the scattered one across the 8/4/tail boundaries.

--- a/docs/archive/pr-summaries/pr-summary-442.md
+++ b/docs/archive/pr-summaries/pr-summary-442.md
@@ -1,0 +1,103 @@
+# Extract the bounded safe-zone rule shared by twelve SquashType arms
+
+## Summary
+
+Twelve `SquashType` arms of `apply_safe_zone_adjustment`
+(`neat-core/src/safe_zone.rs`) each re-implemented the same ~22-line bounded
+safe-zone policy. Only the safe band `[safe_min, safe_max]` and the fade width
+differed — the guards, the `[1e-3, 1e3]` weight thresholds and the linear fade
+formula were character-for-character identical. Extracted one private helper and
+collapsed each arm to a single call. Closes #442.
+
+```rust
+#[inline(always)]
+fn bounded_safe_zone(
+    raw_input: f32, error: f32, weight: f32,
+    safe_min: f32, safe_max: f32, fade: f32,
+) -> f32
+```
+
+Each arm is now one line, e.g.
+`SquashType::Selu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0)`.
+
+The six parameters are plain numeric bounds — no mode flags and no
+`if caller == …` branching, so this is a call rather than a parameterised
+super-helper. The arms encoding genuinely different rules (`Sine`, `Cosine`,
+`Tan`, `Gaussian`, `BipolarSigmoid`, `ArcTan`, `Square`, `Cube`, `Sqrt`,
+`Logistic`, `Tanh`, `HardTanh`, and the rest) are untouched.
+
+Behaviour is unchanged. `safe_zone.rs` drops from 1010 to 630 lines.
+
+### Bounds per arm
+
+| Arm | `safe_min` | `safe_max` | `fade` |
+| --- | ---: | ---: | ---: |
+| `LeakyRelu` | -50 | 50 | 20 |
+| `Selu` | -10 | 10 | 10 |
+| `Elu` | -10 | 10 | 10 |
+| `Softsign` | -10 | 10 | 10 |
+| `Softplus` | -10 | 20 | 10 |
+| `Swish` | -10 | 10 | 10 |
+| `Mish` | -10 | 10 | 10 |
+| `Gelu` | -6 | 6 | 10 |
+| `StdInverse` | -10 | 10 | 10 |
+| `Exponential` | -10 | 30 | 10 |
+| `LogSigmoid` | -20 | 20 | 10 |
+| `Isru` | -10 | 10 | 10 |
+
+`LogSigmoid` previously spelled its fade edges as absolute `fade_min = -30.0` /
+`fade_max = 30.0` rather than `safe_min - fade` / `safe_max + fade`; those are
+the same values, so the collapse to `fade = 10.0` is exact.
+
+## Evidence
+
+This is a backend library refactor with no web interface, so there is no
+screenshot. The evidence is the behavioural test suite plus a green quality
+gate.
+
+```mermaid
+flowchart TD
+    A["apply_safe_zone_adjustment(squash, raw, error, weight)"] --> B{"raw is finite?"}
+    B -- no --> Z["0.0"]
+    B -- yes --> C{"match squash_type"}
+    C -- "12 bounded arms" --> D["bounded_safe_zone(raw, error, weight,<br/>safe_min, safe_max, fade)"]
+    C -- "other arms" --> E["arm-specific rule, still inline"]
+    D --> F{"outside band and<br/>error pushes further out?"}
+    F -- yes --> Z
+    F -- no --> G{"inside band, weight outside<br/>[1e-3, 1e3], error correcting it?"}
+    G -- yes --> Z
+    G -- no --> H{"inside band?"}
+    H -- yes --> I["1.0"]
+    H -- no --> J["linear fade to 0.0 across<br/>`fade` past the edge"]
+```
+
+Quality gate (`./quality.sh`) passes cleanly: rustfmt, clippy, `cargo deny`, the
+full workspace test suite, doc build and release build.
+
+## Test Plan
+
+Added `neat-core/tests/safe_zone_bounded.rs` — seven behavioural tests, each
+looping over all twelve arms with their `(safe_min, safe_max, fade)` bounds and
+asserting on the factor returned by the public
+`apply_safe_zone_adjustment`, not on the helper:
+
+- `inside_band_with_healthy_weight_flows_fully` — both edges and the centre
+  return `1.0` for negative, zero and positive error.
+- `outside_band_with_worsening_error_blocks_gradient` — past either edge with an
+  error pushing further out returns `0.0`.
+- `inside_band_defers_to_a_correcting_tiny_weight` — `|weight| < 1e-3` with
+  `weight * error > 0` returns `0.0`; the same weight with a non-correcting
+  error still returns `1.0`.
+- `inside_band_defers_to_a_correcting_huge_weight` — the `|weight| > 1e3`
+  mirror.
+- `beyond_band_fades_linearly_to_zero` — 25%, 50%, 75% and 100% into each fade
+  band returns exactly `0.75`, `0.5`, `0.25` and `0.0`.
+- `past_the_fade_width_no_gradient_flows` — beyond the fade width returns `0.0`.
+- `non_finite_raw_input_is_never_safe` — `NaN` and both infinities return `0.0`.
+
+These were written and run **before** the extraction, against the twelve
+existing copies, so they characterise the pre-change behaviour; they then stayed
+green afterwards. That is what verifies the refactor is behaviour-preserving —
+for a pure extraction there is no new behaviour for a failing-first test to
+describe. The existing `test_safe_zone_adjustment` in
+`neat-core/tests/integration.rs` is unchanged and still passes.

--- a/docs/archive/pr-summaries/pr-summary-443.md
+++ b/docs/archive/pr-summaries/pr-summary-443.md
@@ -1,0 +1,113 @@
+# One hot-squash dispatch: eleven copies become one call (Issue #443)
+
+## Summary
+
+The rule *"inline the four hot squash types, defer everything else to
+`apply_squash`"* was written out at **eleven** sites — three private helpers
+that already encoded it, plus eight longhand `match` copies. `inline_squash`
+(`neat-core/src/batch_scoring.rs`) is promoted to `pub(crate)` as the single
+home; `inline_squash_scalar` (`loss.rs`) and
+`CompiledNetwork::apply_inline_squash` (`network.rs`) are deleted in its favour,
+and every longhand match becomes one call. Behaviour is unchanged. Closes #443.
+
+The issue listed fourteen sites against older line numbers; three of those had
+already been absorbed by the #441 aggregate-activation work, leaving eleven at
+the time of this change.
+
+### Sites collapsed
+
+| File | Was | Now |
+| --- | --- | --- |
+| `batch_scoring.rs` | `fn inline_squash` (private) | `pub(crate) fn inline_squash` — the single home |
+| `loss.rs` | `fn inline_squash_scalar` | deleted |
+| `network.rs` | `CompiledNetwork::apply_inline_squash` | deleted |
+| `loss.rs` × 5 | inline `apply_squash_inline` closures in the 8-way macro, its 4-way remainder, `mse_sum_batch_4way`, and both loops of `mse_sum_batch_8way_scattered` | `inline_squash(...)` |
+| `network.rs` × 3 | inline matches in `activate`, `activate_into`, `activate_and_trace` | `inline_squash(...)` |
+
+The vectorised `squash_x4` / `squash_x8` approximations are a different rule and
+stay where they are — only their scalar `None`-fallback branch now calls the
+shared helper.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — 11 copies of one rule"]
+        A1["network.rs activate / activate_into /<br/>activate_and_trace (3 matches)"]
+        A2["network.rs apply_inline_squash"]
+        A3["loss.rs 5 inline closures"]
+        A4["loss.rs inline_squash_scalar"]
+        A5["batch_scoring.rs inline_squash"]
+    end
+    subgraph after["After — one home"]
+        B["batch_scoring::inline_squash<br/>(pub(crate))"]
+    end
+    before --> after
+```
+
+## Evidence
+
+Backend-only change — no web interface to screenshot.
+
+**Mutation sweep (the real evidence).** Before merging the copies, each of the
+eleven sites was mutated one at a time (`1 => sum.max(0.0)` →
+`1 => sum.max(0.1)`) and `inline_squash_dispatch.rs` re-run. Every mutation was
+caught, proving the new test actually reaches all eleven former copies rather
+than merely compiling:
+
+```
+loss.rs:125  -> FAILED   loss.rs:795   -> FAILED
+loss.rs:239  -> FAILED   network.rs:502  -> FAILED
+loss.rs:496  -> FAILED   network.rs:667  -> FAILED
+loss.rs:939  -> FAILED   network.rs:914  -> FAILED
+loss.rs:1064 -> FAILED   network.rs:1270 -> FAILED
+batch_scoring.rs:148 -> FAILED
+```
+
+Two of the copies were initially *not* reached (the 4-record remainder inside
+the 8-way macro, and the scattered MSE kernel); the test was tightened —
+alternating input signs so every group straddles zero, and a mixed
+aggregate/standard network to route MSE onto the scattered path — until all
+eleven failed under mutation. After the merge, the same mutation applied to the
+single `inline_squash` fails four of the six tests.
+
+**No performance regression.** `network.rs`'s `activate` is a hot path, so
+`cargo bench --bench hot_paths -- forward_pass` was run before and after:
+
+| Fixture | Before | After | Criterion verdict |
+| --- | --- | --- | --- |
+| `production` | 20.559 µs | 21.468 µs | no change (p = 0.93) |
+| `production_2x` | 42.270 µs | 41.397 µs | no change (p = 0.69) |
+| `production_exact` | 19.856 µs | 21.924 µs | no change (p = 0.06) |
+
+`inline_squash` is `#[inline]` and within the same crate, so the call compiles
+to what the longhand match compiled to. (This is a duplication fix, not a
+performance task — the numbers are here to show nothing was lost.)
+
+**Quality gate.** `./quality.sh < /dev/null` passes: fmt, clippy under
+`-D warnings`, `cargo deny`, full workspace tests, docs, release build.
+
+## Test Plan
+
+Added `neat-core/tests/inline_squash_dispatch.rs` — six "what" tests asserting
+observable activations, not implementation:
+
+- `activate_squashes_every_standard_type_like_apply_squash` — all 32 standard
+  squash types × 6 probe sums, bit-exact against
+  `apply_limit_range(squash, apply_squash(squash, sum))`.
+- `activate_into_squashes_every_standard_type_like_apply_squash` — same, via
+  `activate_into`.
+- `activate_and_trace_squashes_every_standard_type_like_apply_squash` — same,
+  via `activate_and_trace`.
+- `traced_4way_batch_squashes_every_standard_type_like_apply_squash` — the 4-way
+  traced batch, within `SQUASH_SIMD_MAX_ABS_ERR` for the vectorised types.
+- `batched_loss_fallback_squash_matches_the_scalar_reference` — all six packed
+  loss entry points (`mse`, `mae`, `cross_entropy`, `mape`, `msle`, `hinge`) ×
+  six non-vectorised squash types × record counts 4 / 8 / 13, batched vs the
+  single-record reference.
+- `scattered_mse_fallback_squash_matches_the_scalar_reference` — a mixed
+  aggregate + standard network, which routes MSE onto the scattered 8-way kernel
+  that carried two of the copies.
+
+No existing tests were modified or removed. `AGENTS.md` gains a
+"One hot-squash dispatch for standard neurons" section beside the existing
+"One activation rule" note, so the convention is stated where the next agent
+will read it.

--- a/docs/archive/pr-summaries/pr-summary-444.md
+++ b/docs/archive/pr-summaries/pr-summary-444.md
@@ -1,0 +1,113 @@
+# One packed-record scan for every loss entry point (Issue #444)
+
+## Summary
+
+The packed-record scan — the `[inputs…, targets…]` layout arithmetic plus the
+per-record reset/slice/activate driver — was copy-pasted into **eight** entry
+points in `neat-core/src/loss.rs`. Only the innermost per-output reduction
+differed, so a change to the layout rule (a buffer header, targets ahead of
+inputs, a different reset condition) needed the same edit in eight places — and
+a partial edit would still compile while silently mis-slicing records on the
+paths that were missed.
+
+This PR extracts the rule into one authoritative representation:
+
+- `packed_layout(records_len, input_size, num_outputs) -> Option<PackedLayout>`
+  — the stride (`input_size + num_outputs`) and the whole-record count, with
+  both zero guards folded into the `None` case.
+- `packed_record_scan(network, records, input_size, num_outputs, forward_only,
+  reduce)` — drives the buffer record by record and returns the sum of
+  `reduce(targets, outputs)`.
+
+Each entry point keeps its own SIMD dispatch (MSE alone falls back through the
+8-way *and* 4-way paths; `categorical_error_sum_batch_packed` uses neither and
+keeps its own `num_outputs == 0` guard) and then calls the driver with a closure
+carrying only its reduction. The per-record `1/num_outputs` factor lives inside
+each closure, which keeps MSLE and hinge deliberately un-averaged. The driver
+takes a closure and **no mode flags**. `mse_mean_record` divides the returned
+sum by `num_records` at the call site.
+
+Behaviour is unchanged — this is a de-duplication, not a semantic change.
+`AGENTS.md` gains a section stating the rule and where it lives, matching the
+existing #441 / #443 entries.
+
+Closes #444.
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Evidence is the test
+suite: `cargo test --workspace` is green (all 35 test binaries), and
+`./quality.sh` passes cleanly (fmt, clippy with `-D warnings`, deny, tests, doc,
+release build).
+
+```mermaid
+flowchart LR
+    subgraph before["Before — the rule written eight times"]
+        B1["mse_sum_batch_packed"] --> BX["stride + zero guards<br/>reset / slice / activate<br/>× 8 copies"]
+        B2["mae / cross_entropy / mape"] --> BX
+        B3["msle / hinge / categorical_error"] --> BX
+        B4["mse_mean_record"] --> BX
+    end
+    subgraph after["After — one call each"]
+        A1["mse_sum_batch_packed"] --> AD
+        A2["mae / cross_entropy / mape"] --> AD
+        A3["msle / hinge / categorical_error"] --> AD
+        A4["mse_mean_record"] --> AD
+        AD["packed_record_scan<br/>(uses packed_layout)"] --> AR["reduce(targets, outputs)<br/>— per entry point"]
+    end
+```
+
+Per-record scan, stated once:
+
+```mermaid
+flowchart TD
+    S["records buffer"] --> L{"packed_layout:<br/>stride > 0 and ≥ 1 whole record?"}
+    L -- no --> Z["0.0"]
+    L -- yes --> R{"forward_only?"}
+    R -- no --> RS["network.reset_state()"] --> A
+    R -- yes --> A["activate_into(record inputs)"]
+    A --> RD["sum += reduce(record targets, outputs)"]
+    RD --> N{"more records?"}
+    N -- yes --> R
+    N -- no --> O["sum"]
+```
+
+**Mutation check.** Before the refactor, an off-by-one target start was injected
+into a *single* copy (`mae_sum_batch_packed`); the new suite failed on it
+(`every_sum_entry_point_equals_the_sum_of_its_single_record_scans`), confirming
+the tests bite per site rather than only at the shared helper. The mutation was
+reverted before the refactor landed.
+
+**Performance.** The SIMD kernels (`*_sum_batch_8way`, `mse_sum_batch_4way` and
+the interleaved gather) are untouched — the change is confined to the scalar
+record loop, where the closure is a monomorphised `impl Fn` and indexed target
+reads became slice iteration. No benchmark numbers are claimed because this is a
+de-duplication, not a performance task.
+
+## Test Plan
+
+New: `neat-core/tests/packed_record_scan.rs` — seven "what" tests driving the
+public entry points with real networks, covering all eight sites:
+
+- `every_packed_entry_point_ignores_a_trailing_partial_record` — the stride is
+  `input_size + num_outputs` and only whole records are scanned.
+- `every_packed_entry_point_returns_zero_without_a_whole_record` — empty buffer,
+  buffer shorter than one record, and a zero-width record.
+- `every_sum_entry_point_equals_the_sum_of_its_single_record_scans` — records are
+  independent; at nine records this also pins the SIMD-batched buffer against the
+  scalar single-record path.
+- `mse_mean_record_equals_the_mean_of_its_single_record_scans` — same carve, then
+  the average.
+- `every_packed_entry_point_pairs_a_record_with_its_own_targets` — swapping two
+  records' target blocks changes the result (MSLE excluded by mathematics: its
+  reduction is `Σ(ln t) - Σ(ln o)`, invariant under that permutation).
+- `every_packed_entry_point_reads_the_target_block_of_every_record` — editing the
+  targets of any single record moves the result, including MSLE.
+- `stateless_reset_is_conditional_on_forward_only` — on a self-loop network,
+  `forward_only=false` keeps records independent, `forward_only=true` lets state
+  carry over, and `mse_mean_record` always resets.
+
+Unchanged and still green: the existing `loss.rs` unit tests, the interleaved
+MSE bit-identity guards, and `inline_squash_dispatch.rs` /
+`aggregate_squash_tail_parity.rs`, which exercise the same entry points from the
+activation side. No existing test was modified or removed.

--- a/docs/archive/pr-summaries/pr-summary-445.md
+++ b/docs/archive/pr-summaries/pr-summary-445.md
@@ -1,0 +1,105 @@
+# MSE adopts the shared 8→4→1 batch skeleton (Issue #445)
+
+## Summary
+
+MSE was the only loss kind that hand-inlined the batched record-scan skeleton —
+walk records in SIMD groups of eight, then one group of four, then a per-record
+scalar tail, loading each record's inputs into per-lane activation buffers and
+accumulating an `f64` error sum. The other five loss kinds already get that rule
+from the `batch_8way_activation!` macro, parameterised by a per-record
+`$error_fn` closure.
+
+MSE now calls the same macro. `mse_sum_batch_4way` and
+`mse_sum_batch_8way_scattered` are gone, replaced by one ~45-line
+`mse_sum_batch_scattered` that supplies only the squared-error reduction. Net
+`-511 / +105` lines. The record-**interleaved** 8-group path (Issue #384) stays
+separate, as the issue asks — it is a genuinely different memory layout, and no
+mode flag was added to merge it.
+
+The loader sub-rule that had drifted is fixed at the same time.
+`load_record` (`neat-core/src/batch_scoring.rs`) is now the single home of
+clamp-and-zero: copy `min(record.len(), num_inputs)` values and zero every input
+slot the record does not cover, exactly as `CompiledNetwork::activate_into`
+does. Every per-lane loader in the macro and in the interleaved remainder calls
+it. `load_batch_input` — whose doc comment promised zeroing its body never did —
+is deleted.
+
+Closes #445.
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot. Evidence is the
+test suite plus the pre-existing bit-identity parity guards.
+
+**Behaviour fixed.** Before this change, a packed batch whose records carried
+more input columns than the network has inputs panicked in the forward-only
+batched path (`range end index 8 out of range for slice of length 6`) while the
+single-record path silently ignored the extras. Both now agree.
+
+```
+# before (new tests against unfixed code)
+test aggregate_network_ignores_input_columns_beyond_the_network_inputs ... FAILED
+test input_columns_beyond_the_network_inputs_are_ignored ... FAILED
+test result: FAILED. 3 passed; 2 failed
+
+# after
+test result: ok. 5 passed; 0 failed
+```
+
+**Numerics unchanged.** The existing `interleaved_mse_parity` module asserts the
+scattered kernel is **bit-identical** (`f64::to_bits`) to the interleaved path
+across every record count that straddles a group boundary (8, 9, 12, 13, 15, 16,
+17, 24, 4096) for seven squash types, plus the aggregate-dispatch guard. Those
+tests pass unchanged against the macro-driven kernel, so the consolidation moved
+no bits. `./quality.sh` is green (fmt, clippy `-D warnings`, deny, full
+workspace test suite, doc build, release build).
+
+**Performance.** Not a performance change, and the benchmark harness on this
+machine cannot resolve one: every `hot_paths` network spec uses Tanh, so all
+benched MSE batches route through the *unchanged* interleaved kernel. Two
+back-to-back runs of the identical post-change binary swung from −26% to +46% on
+the same benchmark IDs, so the criterion "regressed"/"improved" verdicts in this
+range are noise, not signal.
+
+```mermaid
+flowchart LR
+    A["packed records"] --> B{"num_records"}
+    B -- "&ge; 8" --> C["8-record group<br/>load_record x8"]
+    B -- "4..7" --> D["4-record group<br/>load_record x4"]
+    B -- "&lt; 4" --> E["scalar tail<br/>load_record"]
+    C --> D --> E
+    C --> F["per-record $error_fn<br/>(MSE / MAE / CE / MAPE / MSLE / hinge)"]
+    D --> F
+    E --> F
+    F --> G["f64 sum_error"]
+```
+
+## Test Plan
+
+New `neat-core/tests/batch_record_skeleton.rs` — "what" tests driving the public
+`*_sum_batch_packed` entry points against a single-record reference built from
+`CompiledNetwork::activate`:
+
+- `grouping_does_not_change_the_batched_sum` — every loss kind, 14 record counts
+  straddling the 4- and 8-record boundaries (1, 3, 4, 5, 7, 8, 9, 11, 12, 13,
+  16, 17, 24, 33).
+- `aggregate_network_grouping_does_not_change_the_batched_sum` — the same rule
+  on a network whose `MEAN` neuron keeps it on the per-lane kernels.
+- `input_columns_beyond_the_network_inputs_are_ignored` — regression test for
+  the loader drift; fails (panics) against the unfixed code.
+- `aggregate_network_ignores_input_columns_beyond_the_network_inputs` — the same
+  regression on the scattered route; also fails against the unfixed code.
+- `uncovered_input_slots_score_as_zero` — a record covering fewer columns than
+  the network has inputs reads the uncovered slots as zero for every record, so
+  nothing leaks between groups.
+
+Existing suites re-run unchanged and green, notably
+`neat-core/src/loss.rs::interleaved_mse_parity` (bit-identity),
+`neat-core/tests/mse_squash_simd_parity.rs`,
+`neat-core/tests/mse_batch_interleaved_parity.rs`,
+`neat-core/tests/packed_record_scan.rs` and
+`neat-core/tests/aggregate_squash_tail_parity.rs`.
+
+Docs: `AGENTS.md` gains the "One batched record-scan skeleton for every loss
+kind" rule beside the #441/#443/#444 entries; the two stale
+`mse_sum_batch_4way` references in `mse_squash_simd_parity.rs` are updated.

--- a/docs/archive/pr-summaries/pr-summary-446.md
+++ b/docs/archive/pr-summaries/pr-summary-446.md
@@ -1,0 +1,112 @@
+# One aggregate-squash set: seven copies become one predicate (Issue #446)
+
+## Summary
+
+The knowledge of *which squash types are aggregates* — `Minimum`, `Maximum`,
+`If`, `Hypotenuse`, `HypotenuseV2`, `Mean`: the six that cannot be
+lane-vectorised and must take the exact single-record kernel — was open-coded as
+a six-arm type list at every consumer, with no `is_aggregate` predicate anywhere
+in the crate. Adding a seventh aggregate type meant the identical one-arm edit at
+each site, and a missed site fails **silently**: the new type would be routed
+down the lane-vectorised weighted-sum path and produce numbers differing from
+`activate()`, with no panic to flag it.
+
+`SquashType::is_aggregate` (`neat-core/src/squash.rs`) is now the single home of
+that membership rule. Every site calls it instead of restating the list; local
+twists stay local (`has_aggregate_squash` keeps its own `!neuron.is_constant`
+condition, `apply_unsquash` still uses the set to pick the hint rather than to
+dispatch). Closes #446.
+
+The issue listed ten sites against an older tree; #444 and #445 have since
+folded the five `loss.rs` copies into two, so seven remained:
+
+| Site | Role |
+| --- | --- |
+| `batch_scoring.rs` `has_aggregate_squash` | dispatch: per-lane vs interleaved |
+| `batch_scoring.rs` `score_batch_per_lane` (8-group) | dispatch: scalar kernel vs SIMD lanes |
+| `batch_scoring.rs` `score_batch_per_lane` (4-group) | dispatch: scalar kernel vs SIMD lanes |
+| `loss.rs` `batch_8way_activation!` (8-lane block) | dispatch: scalar kernel vs SIMD lanes |
+| `loss.rs` `batch_8way_activation!` (4-lane block) | dispatch: scalar kernel vs SIMD lanes |
+| `network.rs` `activate_and_trace` | hint semantics: hint == activation |
+| `unsquash.rs` `apply_unsquash` | hint semantics: not invertible, prefer hint |
+
+### One list, two spellings — and why
+
+Six of the seven sites take the predicate directly (`s if s.is_aggregate()`, or a
+plain call). `apply_unsquash` is the exception: its `match` is exhaustive over
+`SquashType`, and a guard arm would forfeit the compiler's exhaustiveness check —
+a future non-aggregate squash type would then compile and fall into whatever
+catch-all replaced it. So it takes the set as a *pattern* via
+`aggregate_squash_patterns!()`, the `pub(crate)` macro that `is_aggregate` is
+itself built from. There is still exactly one list; the second spelling is a
+pattern view of the same list, not a second copy.
+
+```mermaid
+flowchart LR
+    M["aggregate_squash_patterns!()<br/>the one list"] --> P["SquashType::is_aggregate"]
+    M --> U["unsquash.rs<br/>apply_unsquash<br/>(exhaustive match)"]
+    P --> A["batch_scoring.rs<br/>has_aggregate_squash"]
+    P --> B["batch_scoring.rs<br/>8-record group"]
+    P --> C["batch_scoring.rs<br/>4-record group"]
+    P --> D["loss.rs batch_8way_activation!<br/>8-lane block"]
+    P --> E["loss.rs batch_8way_activation!<br/>4-lane block"]
+    P --> F["network.rs<br/>activate_and_trace hint"]
+```
+
+## Evidence
+
+Backend-only change to a Rust library — there is no web interface to screenshot.
+The evidence is the test suite plus a mutation check.
+
+`./quality.sh` passes cleanly (fmt, clippy with `-D warnings`, `cargo deny`,
+`cargo test --workspace`, doc build, release build):
+
+```
+✅ All quality checks passed!
+```
+
+**Mutation check — the new tests really do catch drift.** Dropping `Mean` from
+the one list produced two independent failures, which is the whole point of the
+change:
+
+1. A **compile error** at `apply_unsquash` (`error[E0004]: non-exhaustive
+   patterns: SquashType::Mean not covered`) — the pattern spelling turns a
+   dropped type into a build failure, not a silent mis-route.
+2. Keeping the macro intact but letting only `is_aggregate` drift (open-coding a
+   five-member list in the predicate) failed
+   `is_aggregate_holds_for_exactly_the_six_aggregate_squashes` and
+   `batched_scoring_matches_single_record_activation_for_every_squash_type` —
+   `Mean` records scored through the SIMD lane path diverged from `activate()`,
+   exactly the silent failure the issue describes.
+
+Both were reverted; the final tree is green.
+
+No behaviour changed: `is_aggregate` is a `const fn matches!` over the same six
+variants, so every dispatch decision and hint value is identical to before.
+
+## Test Plan
+
+New file `neat-core/tests/aggregate_squash_set.rs` — "what" tests calling real
+public entry points and asserting on observable results:
+
+- `is_aggregate_holds_for_exactly_the_six_aggregate_squashes` — every
+  `SquashType` (discriminants 0–37) agrees with the aggregate set.
+- `batched_scoring_matches_single_record_activation_for_every_squash_type` —
+  13 records (8-group + 4-group + scalar tail) through the public
+  `score_records_flat` match per-record `activate()` for all 38 squash types,
+  pinning the dispatch predicate at every batched site.
+- `traced_hint_equals_activation_for_aggregate_squashes` — `activate_and_trace`
+  reports the activation itself as the hint for each aggregate.
+- `traced_hint_is_the_pre_squash_value_for_standard_squashes` — for every
+  non-aggregate type the traced hint squashes back to the activation.
+- `unsquash_prefers_the_hint_for_every_aggregate_squash` — `apply_unsquash`
+  returns a finite hint, and falls back to the activation when the hint is NaN.
+
+Existing suites unchanged and still green, notably
+`aggregate_squash_tail_parity.rs`, `inline_squash_dispatch.rs`,
+`packed_record_scan.rs`, `batch_record_skeleton.rs` and `unsquash.rs`.
+
+Documentation: `AGENTS.md` gains a **One aggregate-squash set for dispatch and
+hints (Issue #446)** section alongside the sibling #441/#443/#444/#445 rules, and
+the `batch_scoring.rs` doc comments that spelled the six names out in prose now
+link `SquashType::is_aggregate`.

--- a/docs/archive/pr-summaries/pr-summary-447.md
+++ b/docs/archive/pr-summaries/pr-summary-447.md
@@ -1,0 +1,159 @@
+## Summary
+
+The ISA-neutral scalar layer of the weighted-sum kernels — the reference scalar
+loops, the seed-taking tails behind each SIMD kernel, and the count prologue
+that guards them — was duplicated between `neat-core/src/simd.rs` (wasm) and
+`neat-core/src/simd_native.rs` (x86/aarch64), and again between the two ISA
+modules inside `simd_native.rs`. The two sides had already drifted: the native
+prologues had been hardened to `end.saturating_sub(start)` with a named
+`SINGLE_RECORD_SIMD_MIN`, while the wasm prologues still computed raw
+`end - start` (an underflow/panic on `end < start`) and hard-coded the literal
+`4` four times.
+
+This extracts that layer into one `cfg`-independent module,
+`neat-core/src/simd/scalar.rs`, and points every copy at it. Eighteen scalar
+sites collapse to seven definitions with one home. **Closes #447.**
+
+The new module carries two deliberately distinct layers:
+
+- **Reference kernels** (`weighted_sum`, `weighted_sum_of_squares`,
+  `weighted_sum_no_bias`, `weighted_sum_of_squares_v2`) seed their own
+  accumulator and index safely — what every target's below-threshold count
+  falls back to.
+- **Seed-taking tail helpers** (`tail_sum`, `tail_sum_of_squares`,
+  `tail_sum_of_squares_v2`) take the caller's *running* accumulator, so a SIMD
+  kernel's 0..3 remainder continues the reference f32 rounding order instead of
+  starting a second sum. Reusing the reference kernels for tails would reseed
+  and break the bit-parity the tests and docs rely on — which is why these are
+  new helpers, not a call to the existing fallbacks. They keep `get_unchecked`
+  under the load-time index-validation invariant (`AGENTS.md` → "Unsafe & SIMD
+  invariants") and are `unsafe fn` with a `# Safety` contract naming it.
+
+`synapse_count(start, end)` is the one count prologue: **saturating**, so a
+reversed range counts as zero rather than underflowing. Every prologue on both
+sides now uses it — no raw `end - start`, no hard-coded `4`. The wasm side
+picks up the already-proven hardening as part of the same change.
+
+### Changed
+
+| File | Change |
+| --- | --- |
+| `neat-core/src/simd/scalar.rs` | **New.** The shared ISA-neutral scalar layer. |
+| `neat-core/src/simd.rs` | Declares `pub mod scalar`; four wasm small-count fallbacks and three wasm count prologues now call it. |
+| `neat-core/src/simd_native.rs` | Four scalar fallbacks and the local `SINGLE_RECORD_SIMD_MIN` deleted; six ISA tail loops (3 shapes × x86/NEON) and every count prologue now call the shared layer. |
+| `AGENTS.md` | New "One ISA-neutral scalar layer for every weighted-sum kernel (Issue #447)" section pinning the rule. |
+| `neat-core/tests/simd_scalar_layer.rs` | **New.** Pins the rule. |
+
+### Out of scope
+
+The multi-record scalar fallbacks (`weighted_sum_simd_8records_scalar`,
+`weighted_sum_simd_4records_scalar`, `weighted_sum_interleaved_8_scalar`) exist
+only on the native side — there is no wasm counterpart to drift from — so they
+stay where they are. The wasm SIMD kernels' own bounds-checked remainder loops
+are likewise left alone: routing them through the unchecked tail helpers would
+turn a wasm-side panic into undefined behaviour, which is a soundness change,
+not a de-duplication.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — 18 copies"]
+        W1["simd.rs<br/>4 prologues + 4 scalar kernels<br/>raw end - start, literal 4"]
+        X1["simd_native.rs — x86<br/>3 tail loops"]
+        A1["simd_native.rs — NEON<br/>3 tail loops"]
+        F1["simd_native.rs<br/>4 scalar kernels + SINGLE_RECORD_SIMD_MIN<br/>saturating_sub"]
+    end
+    subgraph after["After — one home"]
+        S["simd::scalar"]
+        S --> G["synapse_count (saturating)<br/>SINGLE_RECORD_SIMD_MIN"]
+        S --> R["4 reference kernels"]
+        S --> T["3 seed-taking tail helpers"]
+    end
+    before --> after
+```
+
+**Bit-parity**, not approximate agreement, is what the new tests assert: below
+the SIMD threshold every public kernel is bit-identical to the reference
+(`f32::to_bits`), and splitting a range at *any* point and continuing through a
+tail helper reproduces the reference result exactly — so a tail that reseeded or
+reordered would fail.
+
+**Correctness evidence**
+
+- `cargo test --test simd_scalar_layer` — 10 passed (new).
+- `cargo test --test simd_weighted_sums` — 23 passed (existing parity suite,
+  unchanged).
+- `./quality.sh` — green end to end (fmt, clippy `-D warnings`, `cargo deny`,
+  full workspace test run, rustdoc `-D warnings`, release build).
+- `cargo check --target wasm32-unknown-unknown` with
+  `-C target-feature=+simd128,+relaxed-simd` — clean, so the rewritten wasm
+  prologues compile on the target they serve (they are `cfg`-gated out of the
+  native test run).
+
+**Performance evidence**
+
+This is a refactor with no algorithmic change, but it moves six SIMD tail loops
+behind a function-call boundary, so codegen was verified rather than assumed:
+
+- The release assembly (`cargo rustc --release -- --emit asm`) contains **no
+  call to `tail_sum` / `tail_sum_of_squares` / `tail_sum_of_squares_v2`** — the
+  `#[inline]` helpers are fully inlined into the `#[target_feature]` kernels,
+  exactly as the previous in-body loops were. No vector types cross the
+  boundary, so the call is inlinable by construction.
+- `cargo bench --bench hot_paths -- forward_pass` was attempted and its output
+  discarded as unusable: the build host was running at load average ~14 on 12
+  cores, and re-measuring the **unchanged** baseline code against its own
+  baseline reported "+77.8% regressed". With a noise floor that wide, no
+  A/B on this host is meaningful. The inlining check above is the load-
+  independent evidence in its place.
+
+## Test Plan
+
+New — `neat-core/tests/simd_scalar_layer.rs`:
+
+- `synapse_count_measures_the_range` — the guard counts `start..end`.
+- `synapse_count_saturates_when_end_precedes_start` — regression test for the
+  drifted wasm prologue: a reversed range saturates to zero instead of
+  underflowing.
+- `reference_kernels_return_their_seed_for_a_reversed_range` — all four
+  reference kernels return bias/0.0 on `end < start`.
+- `public_kernels_survive_a_reversed_range` — the same at the public
+  `weighted_sum_*_simd` entry points.
+- `small_counts_are_bit_identical_to_the_reference_kernels` — for every count
+  below `SINGLE_RECORD_SIMD_MIN`, all four public kernels match the reference
+  bit-for-bit (`to_bits`).
+- `tail_sum_continues_the_reference_accumulation_bit_for_bit`,
+  `tail_sum_of_squares_…`, `tail_sum_of_squares_v2_…` — splitting a 9-synapse
+  range at every split point and continuing through the tail helper reproduces
+  the reference result exactly, pinning the seed-taking contract (a reseeding
+  helper fails these).
+- `tail_helpers_return_the_seed_for_an_empty_tail` — an empty tail is the
+  identity.
+- `reference_kernels_compute_the_documented_formulas` — each kernel computes its
+  documented formula on hand-checked values.
+
+Modified — `neat-core/src/simd_native.rs` unit tests: the four
+`*_matches_scalar` tests now compare against `scalar::weighted_sum*` instead of
+the deleted local fallbacks. Same assertions, same fixtures; no test was removed
+or weakened.
+
+### Security self-check
+
+- **Input validation**: the new count guard is the validation — `synapse_count`
+  saturates instead of underflowing, removing a panic (debug) / enormous-count
+  (release) path that existed in the wasm kernels.
+- **Injection surface / output encoding / authentication**: not applicable —
+  pure numeric library code, no SQL, shell, filesystem, HTTP, or rendering.
+- **Error handling**: no error paths added; nothing is swallowed. The reference
+  kernels index safely and panic loudly on a genuinely out-of-range index.
+- **Unsafe**: the three new `unsafe fn` helpers carry `# Safety` contracts
+  naming the load-time `CompiledNetwork::new` index validation, and each
+  internal `unsafe` block carries a `// SAFETY:` note. No new `unsafe` reaches
+  code that was previously bounds-checked — the helpers replace `get_unchecked`
+  loops that already had that contract.
+- **Secrets / dependencies**: none staged; no new dependency. The `Cargo.lock`
+  bump is `quality.sh`'s own `cargo upgrade`/`cargo update` step (clap
+  4.6.4 → 4.6.5, a dev-tree transitive), and `cargo deny check` passed after it.

--- a/docs/archive/pr-summaries/pr-summary-448.md
+++ b/docs/archive/pr-summaries/pr-summary-448.md
@@ -1,0 +1,96 @@
+# One chunk-walk scaffold for the wasm weighted-sum kernels (Issue #448)
+
+## Summary
+
+The four single-record `wasm32` kernels in `neat-core/src/simd.rs` each carried
+their own copy of the same chunk-loop scaffolding — 4-wide lane gather, lane
+reduce, and the 0..3 scalar remainder — around different folds. The cost was
+already paid: the Issue #1197 dual-accumulator rework landed on
+`weighted_sum_simd` only, and `weighted_sum_no_bias_simd`'s doc claimed it
+"Shares the dual-accumulator approach with `weighted_sum_simd`" when its body
+ran a single accumulator.
+
+This extracts the scaffold into three helpers — `gather4`, `gather4_products`,
+`reduce4` — and routes every kernel's remainder through the seed-taking
+`scalar::tail_*` helpers that Issue #447 already made the single home of that
+rule, replacing four re-inlined scalar loops. The fold stays in each kernel, as
+the issue requires: these are calls, not a parameterised super-helper, because
+unifying plain-FMA, square-the-product and square-the-biased-product would need
+a mode flag. Both stale doc claims are corrected — `weighted_sum_of_squares_simd`
+also claimed dual accumulators — and `AGENTS.md` gains the rule so the next
+scaffold improvement cannot land on one copy again.
+
+Behaviour is unchanged: the refactor is numerically bit-identical (evidence
+below). Applying the dual-accumulator form to the other three kernels is
+deliberately **not** in this PR — that is a performance change, and this repo
+requires before/after benchmark evidence for those. With the walk shared it is
+now a fold-level edit on top of one scaffold.
+
+Closes #448.
+
+```mermaid
+flowchart LR
+    K1["weighted_sum_simd"] --> G["gather4 / gather4_products"]
+    K2["weighted_sum_of_squares_simd"] --> G
+    K3["weighted_sum_no_bias_simd"] --> G
+    K4["weighted_sum_of_squares_v2_simd"] --> G
+    G --> F["fold — stays in each kernel"]
+    F --> R["reduce4"]
+    R --> T["scalar::tail_* — seed-taking remainder"]
+```
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. The
+changed code is `wasm32`-only, which the native test suite cannot execute, so it
+was verified by **running the refactored kernels on a real wasm runtime**
+(`wasm32-wasip1` under Node's WASI, `-C target-feature=+simd128,+relaxed-simd`):
+
+- All three new parity checks pass when compiled to wasm and executed:
+
+  ```
+  every_kernel_matches_its_reference_from_any_offset: ok
+  the_remainder_continues_the_span_rather_than_restarting_it: ok
+  an_empty_or_reversed_span_is_the_kernel_seed: ok
+  ```
+
+- **Bit-identical to the pre-refactor kernels.** The same wasm probe was run
+  against `simd.rs` before and after the change, dumping the raw `f32` bit
+  patterns of all four kernels over every `(start, count)` span for
+  `start` 0..11 and `count` 0..40 — 492 spans, 1968 results:
+
+  ```
+  diff before.txt after.txt   # no differences
+  BIT-IDENTICAL across 492 spans
+  ```
+
+  `gather4_products` uses `f32x4_mul`, a plain IEEE-754 lane multiply rather
+  than a relaxed operation, so replacing the hand-packed
+  `f32x4(a0*w0, …)` gathers cannot shift a result; the `scalar::tail_*` helpers
+  continue the running accumulator in the same order the inline loops did.
+
+- `cargo clippy --target wasm32-unknown-unknown` with `-D warnings` is clean
+  (the wasm path is not covered by `quality.sh` or the PR CI lane — it builds
+  only on push to `Develop` via `wasm-bundle.yml`).
+- `./quality.sh` passes: fmt, clippy, deny, doc, and the full native test suite.
+
+## Test Plan
+
+Added `neat-core/tests/simd_chunk_walk_scaffold.rs` (3 tests) — the file that
+pins the rule, in the style of `simd_scalar_layer.rs`:
+
+- `every_kernel_matches_its_reference_from_any_offset` — sweeps all four kernels
+  over starts 0..9 × counts 0..24 against the `simd::scalar` reference kernels.
+  The **offset** sweep is the new coverage: `simd_weighted_sums.rs` sweeps counts
+  from `start == 0` only, which would not catch a scaffold that derives its
+  chunk base from the chunk index alone.
+- `the_remainder_continues_the_span_rather_than_restarting_it` — a span of 8+3
+  equals the 8-span plus the three trailing synapses' contribution, pinning the
+  seed-taking tail rather than a second sum merged in.
+- `an_empty_or_reversed_span_is_the_kernel_seed` — empty and reversed ranges
+  return each kernel's seed (`bias` / `0.0`), carrying the Issue #447 saturating
+  count guard through the refactor.
+
+No existing tests were removed or modified. `simd_weighted_sums.rs` (23 tests)
+and `simd_scalar_layer.rs` (8 tests) continue to pass unchanged and remain the
+regression net for kernel semantics.

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -152,11 +152,27 @@ fn inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
     }
 }
 
-/// Single-record activation for one neuron, byte-for-byte identical to the body
-/// of [`CompiledNetwork::activate_into`]. Reused for constant neurons, aggregate
-/// squashes and the scalar tail so those results exactly match the reference.
+/// Single-record activation for one neuron — the shared home of the rule that
+/// turns a neuron's inbound synapse range into an activation (Issue #441).
+/// Covers constant neurons, the six aggregate squashes
+/// (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/Mean), the standard weighted-sum
+/// fall-through and the closing range clamp, byte-for-byte as
+/// [`CompiledNetwork::activate_into`] computes them.
+///
+/// Every batched scoring kernel that has to drop to one record at a time — the
+/// per-lane aggregate loops and the scalar tails here and in [`crate::loss`] —
+/// calls this, so a record's activation does not depend on whether it landed in
+/// a full SIMD group or in the remainder.
+///
+/// `activate` / `activate_into` keep their own inlined copy: routing them
+/// through this helper measured ~30–46% slower on the `forward_pass` benchmark
+/// (Issue #441), and neither had diverged.
 #[inline]
-fn neuron_activation_scalar(synapses: &[SynapseData], act: &[f32], neuron: &NeuronData) -> f32 {
+pub(crate) fn neuron_activation_scalar(
+    synapses: &[SynapseData],
+    act: &[f32],
+    neuron: &NeuronData,
+) -> f32 {
     if neuron.is_constant {
         return apply_limit_range(SquashType::Identity, neuron.bias);
     }

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -139,10 +139,20 @@ impl BatchScratch {
     }
 }
 
-/// Inline squash matching [`CompiledNetwork::activate_into`] exactly: the four
-/// hot types are branched directly, everything else defers to [`apply_squash`].
+/// The single home of the hot-squash dispatch rule (Issue #443): which squash
+/// types are hot enough to branch inline, and the exact scalar formula each of
+/// them uses. The four hot types are branched directly; everything else defers
+/// to [`apply_squash`].
+///
+/// **Every** site that squashes a standard weighted sum calls this — the
+/// single-record forward passes ([`CompiledNetwork::activate`] /
+/// `activate_into` / `activate_and_trace`), the 4-way traced batch, and the
+/// scalar `None`-fallback branch of every batched loss and scoring kernel — so
+/// the SIMD-batched and scalar-tail paths agree bit-for-bit. Promoting a fifth
+/// type to the inline set, or reformulating one of the four, is an edit here
+/// and nowhere else.
 #[inline]
-fn inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
+pub(crate) fn inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
     match squash_type {
         0 => sum,                        // IDENTITY
         1 => sum.max(0.0),               // ReLU

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -28,8 +28,8 @@
 //!   SIMD tolerance the batched weighted sums already introduce (Issue #230).
 //!   Every other type keeps the scalar inline branch (Identity / ReLU /
 //!   Logistic / Tanh, else `apply_squash`), so its squash stays bit-identical.
-//! - **Aggregate** squashes (Minimum, Maximum, If, Hypotenuse, HypotenuseV2,
-//!   Mean) and the **scalar tail** (`records.len() % 8` after the 4-way step)
+//! - **Aggregate** squashes ([`SquashType::is_aggregate`]) and the **scalar
+//!   tail** (`records.len() % 8` after the 4-way step)
 //!   run the exact single-record path via `neuron_activation_scalar`, so those
 //!   neurons and those records are bit-identical to the reference.
 //!
@@ -298,8 +298,8 @@ impl CompiledNetwork {
     ///   all-standard-squash production topology. Records are transposed so each
     ///   synapse gather reads one cache line.
     /// - **Per-lane fallback** ([`Self::score_batch_per_lane`]) otherwise, which
-    ///   keeps aggregate squashes (Minimum/Maximum/If/Hypotenuse/HypotenuseV2/
-    ///   Mean) on the exact single-record kernels.
+    ///   keeps aggregate squashes ([`SquashType::is_aggregate`]) on the exact
+    ///   single-record kernels.
     ///
     /// Both group records into 8s then a 4-record group then a scalar tail, and
     /// both are bit-identical on the covered standard-squash neurons.
@@ -317,25 +317,18 @@ impl CompiledNetwork {
         }
     }
 
-    /// True when any non-constant neuron uses an aggregate squash whose exact
-    /// kernel needs a contiguous per-lane activation slice (so the interleaved
-    /// fast path does not apply). O(neurons); the scoring batch dwarfs it.
+    /// True when any non-constant neuron uses an aggregate squash
+    /// ([`SquashType::is_aggregate`], the single home of that membership rule)
+    /// whose exact kernel needs a contiguous per-lane activation slice, so the
+    /// interleaved fast path does not apply. O(neurons); the scoring batch
+    /// dwarfs it.
     ///
     /// `pub(crate)` so the fused MSE loss lane can share the same dispatch
     /// decision (Issue #384): standard-only networks route through the
     /// interleaved gather, aggregate networks stay on their exact per-lane path.
     pub(crate) fn has_aggregate_squash(&self) -> bool {
         self.neurons.iter().any(|neuron| {
-            !neuron.is_constant
-                && matches!(
-                    SquashType::from(neuron.squash_type),
-                    SquashType::Minimum
-                        | SquashType::Maximum
-                        | SquashType::If
-                        | SquashType::Hypotenuse
-                        | SquashType::HypotenuseV2
-                        | SquashType::Mean
-                )
+            !neuron.is_constant && SquashType::from(neuron.squash_type).is_aggregate()
         })
     }
 
@@ -517,12 +510,7 @@ impl CompiledNetwork {
 
                 let squash = SquashType::from(neuron.squash_type);
                 match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
+                    s if s.is_aggregate() => {
                         // Aggregate squashes stay on the exact single-record path.
                         act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
                         act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
@@ -613,12 +601,8 @@ impl CompiledNetwork {
 
                 let squash = SquashType::from(neuron.squash_type);
                 match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
+                    s if s.is_aggregate() => {
+                        // Aggregate squashes stay on the exact single-record path.
                         act0[actual_idx] = neuron_activation_scalar(&self.synapses, act0, neuron);
                         act1[actual_idx] = neuron_activation_scalar(&self.synapses, act1, neuron);
                         act2[actual_idx] = neuron_activation_scalar(&self.synapses, act2, neuron);

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -269,8 +269,13 @@ pub(crate) fn neuron_activation_scalar(
 /// does not cover is zeroed so each record is scored statelessly — buffers are
 /// reused across batches, and every non-input neuron is overwritten during the
 /// forward pass, so no further reset is required.
+///
+/// The single home of the clamp-and-zero loading rule (Issue #445): every
+/// per-lane loader in the batched scoring and fused loss kernels calls this, so
+/// a record's inputs land the same way whether it was scored in a SIMD group or
+/// in the scalar tail.
 #[inline]
-fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
+pub(crate) fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
     let in_len = record.len().min(num_inputs);
     act[..in_len].copy_from_slice(&record[..in_len]);
     act[in_len..num_inputs].fill(0.0);

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -86,12 +86,8 @@ macro_rules! batch_8way_activation {
                     let end_synapse = start_synapse + neuron.num_synapses as usize;
 
                     match squash {
-                        SquashType::Minimum
-                        | SquashType::Maximum
-                        | SquashType::If
-                        | SquashType::Hypotenuse
-                        | SquashType::HypotenuseV2
-                        | SquashType::Mean => {
+                        // Aggregate squashes stay on the exact single-record path.
+                        s if s.is_aggregate() => {
                             for act in [
                                 &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
                                 &mut act6, &mut act7,
@@ -201,12 +197,8 @@ macro_rules! batch_8way_activation {
                         let end_synapse = start_synapse + neuron.num_synapses as usize;
 
                         match squash {
-                            SquashType::Minimum
-                            | SquashType::Maximum
-                            | SquashType::If
-                            | SquashType::Hypotenuse
-                            | SquashType::HypotenuseV2
-                            | SquashType::Mean => {
+                            // Aggregate squashes stay on the exact single-record path.
+                            s if s.is_aggregate() => {
                                 for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
                                     let value =
                                         neuron_activation_scalar(&$network.synapses, act, neuron);

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -277,6 +277,88 @@ macro_rules! batch_8way_activation {
     }};
 }
 
+/// How a packed `[inputs…, targets…]` buffer is carved into records.
+///
+/// Issue #444 — the single home of the packed-record layout rule.
+struct PackedLayout {
+    /// Stride between successive records: `input_size + num_outputs`.
+    values_per_record: usize,
+    /// Whole records the buffer holds; a trailing partial record is ignored.
+    num_records: usize,
+}
+
+/// Carve a packed buffer into records, or `None` when it holds no whole record
+/// (a zero-width record, or fewer values than one full record needs).
+fn packed_layout(
+    records_len: usize,
+    input_size: usize,
+    num_outputs: usize,
+) -> Option<PackedLayout> {
+    let values_per_record = input_size + num_outputs;
+    if values_per_record == 0 {
+        return None;
+    }
+    let num_records = records_len / values_per_record;
+    if num_records == 0 {
+        return None;
+    }
+    Some(PackedLayout {
+        values_per_record,
+        num_records,
+    })
+}
+
+/// Drive a packed `[inputs…, targets…]` buffer record by record, returning the
+/// sum of `reduce(targets, outputs)` over every whole record. Returns `0.0`
+/// when the buffer holds no whole records.
+///
+/// `reduce` receives the record's target slice and the network's output slice,
+/// both `num_outputs` long. Any per-record averaging belongs inside `reduce` —
+/// MSLE and hinge deliberately do not average.
+///
+/// When `forward_only` is false the network's hidden state is cleared before
+/// each record, preserving stateless (`feedbackLoop = false`) semantics; when
+/// it is true the reset is skipped, which v4+ forward-only creatures allow.
+///
+/// Issue #444 — the single home of the per-record scan; SIMD dispatch stays at
+/// the callers, where it genuinely differs.
+fn packed_record_scan(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    forward_only: bool,
+    reduce: impl Fn(&[f32], &[f32]) -> f64,
+) -> f64 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
+        return 0.0;
+    };
+
+    // Reuse a small output buffer to avoid per-record allocation.
+    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
+    let mut sum_error: f64 = 0.0;
+
+    for record_idx in 0..layout.num_records {
+        if !forward_only {
+            // Ensure stateless behaviour for networks that may read stale activations.
+            network.reset_state();
+        }
+
+        let base = record_idx * layout.values_per_record;
+        let input_end = base + input_size;
+        let target_start = input_end;
+        // Activate into the reusable output buffer.
+        network.activate_into(&records[base..input_end], &mut outputs[..]);
+
+        sum_error += reduce(
+            &records[target_start..target_start + num_outputs],
+            &outputs[..],
+        );
+    }
+
+    sum_error
+}
+
 /// Fused activate + MSE (Mean Squared Error) calculation for batch scoring.
 ///
 /// This is a scoring fast-path designed to minimise JS/WASM boundary crossings:
@@ -301,37 +383,32 @@ pub fn mse_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
     // Falls back to 4-way for remainder handling, then single-record
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return mse_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
     // Issue #1202 - Use batched 4-record SIMD path for forward-only networks
-    if forward_only && num_records >= 4 {
+    if forward_only && layout.num_records >= 4 {
         return mse_sum_batch_4way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -341,33 +418,22 @@ pub fn mse_sum_batch_packed(
         0.0
     };
 
-    // Reuse a small output buffer to avoid per-record allocation.
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-
-    let mut sum_error: f64 = 0.0;
-    for record_idx in 0..num_records {
-        if !forward_only {
-            // Ensure stateless behaviour for networks that may read stale activations.
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-        // Activate into the reusable output buffer.
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MSE = mean((target - output)^2)
-        let mut sq_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_start + j] - outputs[j]) as f64;
-            sq_sum += diff * diff;
-        }
-        sum_error += sq_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MSE = mean((target - output)^2)
+            let mut sq_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let diff = (*t - *o) as f64;
+                sq_sum += diff * diff;
+            }
+            sq_sum * inv_outputs
+        },
+    )
 }
 
 /// Issue #1202 - Batched MSE with 4-record SIMD parallelism.
@@ -1312,24 +1378,19 @@ pub fn mae_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return mae_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -1339,31 +1400,21 @@ pub fn mae_sum_batch_packed(
         0.0
     };
 
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
-
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MAE = mean(|target - output|)
-        let mut abs_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_start + j] - outputs[j]) as f64;
-            abs_sum += diff.abs();
-        }
-        sum_error += abs_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MAE = mean(|target - output|)
+            let mut abs_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                abs_sum += ((*t - *o) as f64).abs();
+            }
+            abs_sum * inv_outputs
+        },
+    )
 }
 
 /// Fused activate + Cross Entropy calculation for batch scoring.
@@ -1388,24 +1439,19 @@ pub fn cross_entropy_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return cross_entropy_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -1416,34 +1462,25 @@ pub fn cross_entropy_sum_batch_packed(
     };
 
     const EPSILON: f64 = 1e-15;
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
 
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record Cross Entropy = -(1/n) * Σ(t * log(o) + (1-t) * log(1-o))
-        let mut ce_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = records[target_start + j] as f64;
-            let o_raw = outputs[j] as f64;
-            // Clamp to [epsilon, 1-epsilon] to prevent log(0)
-            let o = o_raw.clamp(EPSILON, 1.0 - EPSILON);
-            ce_sum -= t * o.ln() + (1.0 - t) * (1.0 - o).ln();
-        }
-        sum_error += ce_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record Cross Entropy = -(1/n) * Σ(t * log(o) + (1-t) * log(1-o))
+            let mut ce_sum: f64 = 0.0;
+            for (t, o_raw) in targets.iter().zip(outputs.iter()) {
+                let t = *t as f64;
+                // Clamp to [epsilon, 1-epsilon] to prevent log(0)
+                let o = (*o_raw as f64).clamp(EPSILON, 1.0 - EPSILON);
+                ce_sum -= t * o.ln() + (1.0 - t) * (1.0 - o).ln();
+            }
+            ce_sum * inv_outputs
+        },
+    )
 }
 
 /// Fused activate + MAPE (Mean Absolute Percentage Error) calculation for batch scoring.
@@ -1467,24 +1504,19 @@ pub fn mape_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return mape_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
@@ -1495,32 +1527,23 @@ pub fn mape_sum_batch_packed(
     };
 
     const EPSILON: f64 = 1e-15;
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
 
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MAPE = (1/n) * Σ|(output - target) / max(target, ε)|
-        let mut mape_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = (records[target_start + j] as f64).max(EPSILON);
-            let o = outputs[j] as f64;
-            mape_sum += ((o - t) / t).abs();
-        }
-        sum_error += mape_sum * inv_outputs;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MAPE = (1/n) * Σ|(output - target) / max(target, ε)|
+            let mut mape_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let t = (*t as f64).max(EPSILON);
+                mape_sum += ((*o as f64 - t) / t).abs();
+            }
+            mape_sum * inv_outputs
+        },
+    )
 }
 
 /// Fused activate + MSLE (Mean Squared Logarithmic Error) calculation for batch scoring.
@@ -1545,55 +1568,42 @@ pub fn msle_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return msle_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
     const EPSILON: f64 = 1e-15;
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
 
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MSLE = Σ(log(max(target, ε)) - log(max(output, ε)))
-        // Note: No averaging per record to match JS implementation
-        let mut msle_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = (records[target_start + j] as f64).max(EPSILON);
-            let o = (outputs[j] as f64).max(EPSILON);
-            msle_sum += t.ln() - o.ln();
-        }
-        sum_error += msle_sum;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record MSLE = Σ(log(max(target, ε)) - log(max(output, ε)))
+            // Note: No averaging per record to match JS implementation
+            let mut msle_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let t = (*t as f64).max(EPSILON);
+                let o = (*o as f64).max(EPSILON);
+                msle_sum += t.ln() - o.ln();
+            }
+            msle_sum
+        },
+    )
 }
 
 /// Fused activate + Hinge Loss calculation for batch scoring.
@@ -1618,54 +1628,38 @@ pub fn hinge_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     // Issue #1209 - Use batched 8-record SIMD path for forward-only networks
-    if forward_only && num_records >= 8 {
+    if forward_only && layout.num_records >= 8 {
         return hinge_sum_batch_8way(
             network,
             records,
-            values_per_record,
+            layout.values_per_record,
             input_size,
             num_outputs,
-            num_records,
+            layout.num_records,
         );
     }
 
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
-
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record Hinge = Σmax(0, 1 - target * output)
-        // Note: No averaging per record to match JS implementation
-        let mut hinge_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let t = records[target_start + j] as f64;
-            let o = outputs[j] as f64;
-            hinge_sum += (1.0 - t * o).max(0.0);
-        }
-        sum_error += hinge_sum;
-    }
-
-    sum_error
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            // Per-record Hinge = Σmax(0, 1 - target * output)
+            // Note: No averaging per record to match JS implementation
+            let mut hinge_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                hinge_sum += (1.0 - (*t as f64) * (*o as f64)).max(0.0);
+            }
+            hinge_sum
+        },
+    )
 }
 
 /// Fused activate + Categorical Error (argmax misclassification) for batch scoring.
@@ -1706,58 +1700,40 @@ pub fn categorical_error_sum_batch_packed(
     num_outputs: usize,
     forward_only: bool,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
-        return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 || num_outputs == 0 {
+    // A record with no outputs has no class to predict — guard before the scan,
+    // whose closure indexes the first target and output.
+    if num_outputs == 0 {
         return 0.0;
     }
 
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut misclassified: f64 = 0.0;
-
-    for record_idx in 0..num_records {
-        if !forward_only {
-            network.reset_state();
-        }
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Argmax with first-index tie-breaking — matches the TS reference
-        // (`a > b` so equal values keep the earlier index).
-        let mut target_argmax: usize = 0;
-        let mut target_best: f32 = records[target_start];
-        for j in 1..num_outputs {
-            let v = records[target_start + j];
-            if v > target_best {
-                target_best = v;
-                target_argmax = j;
+    /// Argmax with first-index tie-breaking — matches the TS reference
+    /// (`a > b` so equal values keep the earlier index).
+    fn argmax(values: &[f32]) -> usize {
+        let mut best_idx: usize = 0;
+        let mut best: f32 = values[0];
+        for (idx, v) in values.iter().enumerate().skip(1) {
+            if *v > best {
+                best = *v;
+                best_idx = idx;
             }
         }
-
-        let mut output_argmax: usize = 0;
-        let mut output_best: f32 = outputs[0];
-        for j in 1..num_outputs {
-            let v = outputs[j];
-            if v > output_best {
-                output_best = v;
-                output_argmax = j;
-            }
-        }
-
-        if target_argmax != output_argmax {
-            misclassified += 1.0;
-        }
+        best_idx
     }
 
-    misclassified
+    packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        forward_only,
+        |targets, outputs| {
+            if argmax(targets) != argmax(outputs) {
+                1.0
+            } else {
+                0.0
+            }
+        },
+    )
 }
 
 /// Non-fused recurrent-path MSE for `forwardOnly: false` networks.
@@ -1790,14 +1766,9 @@ pub fn mse_mean_record(
     input_size: usize,
     num_outputs: usize,
 ) -> f64 {
-    let values_per_record = input_size + num_outputs;
-    if values_per_record == 0 {
+    let Some(layout) = packed_layout(records.len(), input_size, num_outputs) else {
         return 0.0;
-    }
-    let num_records = records.len() / values_per_record;
-    if num_records == 0 {
-        return 0.0;
-    }
+    };
 
     let inv_outputs: f64 = if num_outputs > 0 {
         1.0 / (num_outputs as f64)
@@ -1805,31 +1776,26 @@ pub fn mse_mean_record(
         0.0
     };
 
-    // Reuse a small output buffer to avoid per-record allocation.
-    let mut outputs: Vec<f32> = vec![0.0; num_outputs];
-    let mut sum_error: f64 = 0.0;
+    // Non-fused recurrent path: `forward_only = false` clears hidden state
+    // between records so the previous record's activations cannot leak in.
+    let sum_error = packed_record_scan(
+        network,
+        records,
+        input_size,
+        num_outputs,
+        false,
+        |targets, outputs| {
+            // Per-record MSE = mean over outputs of (target - output)^2.
+            let mut sq_sum: f64 = 0.0;
+            for (t, o) in targets.iter().zip(outputs.iter()) {
+                let diff = (*t - *o) as f64;
+                sq_sum += diff * diff;
+            }
+            sq_sum * inv_outputs
+        },
+    );
 
-    for record_idx in 0..num_records {
-        // Non-fused recurrent path: clear hidden state between records so the
-        // previous record's activations cannot leak into this activation.
-        network.reset_state();
-
-        let base = record_idx * values_per_record;
-        let input_start = base;
-        let input_end = base + input_size;
-        let target_start = input_end;
-        network.activate_into(&records[input_start..input_end], &mut outputs[..]);
-
-        // Per-record MSE = mean over outputs of (target - output)^2.
-        let mut sq_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_start + j] - outputs[j]) as f64;
-            sq_sum += diff * diff;
-        }
-        sum_error += sq_sum * inv_outputs;
-    }
-
-    sum_error / (num_records as f64)
+    sum_error / (layout.num_records as f64)
 }
 
 #[cfg(test)]

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -6,13 +6,12 @@
 //!
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
-use crate::batch_scoring::SCORING_LANES;
+use crate::batch_scoring::{SCORING_LANES, neuron_activation_scalar};
 use crate::network::CompiledNetwork;
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
 use crate::squash::{SquashType, apply_squash};
 use crate::squash_simd::{squash_x4, squash_x8};
-use crate::synapse_type::SynapseType;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -86,109 +85,13 @@ macro_rules! batch_8way_activation {
                         | SquashType::Hypotenuse
                         | SquashType::HypotenuseV2
                         | SquashType::Mean => {
-                            for (r, act) in [
-                                (0, &mut act0),
-                                (1, &mut act1),
-                                (2, &mut act2),
-                                (3, &mut act3),
-                                (4, &mut act4),
-                                (5, &mut act5),
-                                (6, &mut act6),
-                                (7, &mut act7),
+                            for act in [
+                                &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
+                                &mut act6, &mut act7,
                             ] {
-                                let _ = r;
-                                let activation = match squash {
-                                    SquashType::Minimum => {
-                                        let mut min_val = f32::INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val < min_val {
-                                                min_val = val;
-                                            }
-                                        }
-                                        if min_val == f32::INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            min_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::Maximum => {
-                                        let mut max_val = f32::NEG_INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val > max_val {
-                                                max_val = val;
-                                            }
-                                        }
-                                        if max_val == f32::NEG_INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            max_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::If => {
-                                        let mut condition_sum = 0.0f32;
-                                        let mut positive_sum = 0.0f32;
-                                        let mut negative_sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            match SynapseType::from(synapse.synapse_type) {
-                                                SynapseType::Condition => condition_sum += val,
-                                                SynapseType::Negative => negative_sum += val,
-                                                SynapseType::Positive | SynapseType::Standard => {
-                                                    positive_sum += val
-                                                }
-                                            }
-                                        }
-                                        if condition_sum > 0.0 {
-                                            positive_sum + neuron.bias
-                                        } else {
-                                            negative_sum + neuron.bias
-                                        }
-                                    }
-                                    SquashType::Hypotenuse => {
-                                        let mut sum_sq = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            sum_sq += val * val;
-                                        }
-                                        sum_sq.sqrt() + neuron.bias
-                                    }
-                                    SquashType::HypotenuseV2 => {
-                                        let mut sum_sq = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &$network.synapses[synapse_idx];
-                                            let val = neuron.bias
-                                                + act[synapse.from_index as usize] * synapse.weight;
-                                            sum_sq += val * val;
-                                        }
-                                        sum_sq.sqrt()
-                                    }
-                                    SquashType::Mean => {
-                                        let n = (end_synapse - start_synapse) as f32;
-                                        if n <= 0.0 {
-                                            neuron.bias
-                                        } else {
-                                            let mut sum = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                sum += act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                            }
-                                            sum / n + neuron.bias
-                                        }
-                                    }
-                                    _ => unreachable!(),
-                                };
-                                act[actual_idx] = apply_limit_range(squash, activation);
+                                let value =
+                                    neuron_activation_scalar(&$network.synapses, act, neuron);
+                                act[actual_idx] = value;
                             }
                         }
                         _ => {
@@ -306,105 +209,10 @@ macro_rules! batch_8way_activation {
                             | SquashType::Hypotenuse
                             | SquashType::HypotenuseV2
                             | SquashType::Mean => {
-                                for (r, act) in [
-                                    (0, &mut act0),
-                                    (1, &mut act1),
-                                    (2, &mut act2),
-                                    (3, &mut act3),
-                                ] {
-                                    let _ = r;
-                                    let activation = match squash {
-                                        SquashType::Minimum => {
-                                            let mut min_val = f32::INFINITY;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                if val < min_val {
-                                                    min_val = val;
-                                                }
-                                            }
-                                            if min_val == f32::INFINITY {
-                                                neuron.bias
-                                            } else {
-                                                min_val + neuron.bias
-                                            }
-                                        }
-                                        SquashType::Maximum => {
-                                            let mut max_val = f32::NEG_INFINITY;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                if val > max_val {
-                                                    max_val = val;
-                                                }
-                                            }
-                                            if max_val == f32::NEG_INFINITY {
-                                                neuron.bias
-                                            } else {
-                                                max_val + neuron.bias
-                                            }
-                                        }
-                                        SquashType::If => {
-                                            let mut condition_sum = 0.0f32;
-                                            let mut positive_sum = 0.0f32;
-                                            let mut negative_sum = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                match SynapseType::from(synapse.synapse_type) {
-                                                    SynapseType::Condition => condition_sum += val,
-                                                    SynapseType::Negative => negative_sum += val,
-                                                    SynapseType::Positive
-                                                    | SynapseType::Standard => positive_sum += val,
-                                                }
-                                            }
-                                            if condition_sum > 0.0 {
-                                                positive_sum + neuron.bias
-                                            } else {
-                                                negative_sum + neuron.bias
-                                            }
-                                        }
-                                        SquashType::Hypotenuse => {
-                                            let mut sum_sq = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = act[synapse.from_index as usize]
-                                                    * synapse.weight;
-                                                sum_sq += val * val;
-                                            }
-                                            sum_sq.sqrt() + neuron.bias
-                                        }
-                                        SquashType::HypotenuseV2 => {
-                                            let mut sum_sq = 0.0f32;
-                                            for synapse_idx in start_synapse..end_synapse {
-                                                let synapse = &$network.synapses[synapse_idx];
-                                                let val = neuron.bias
-                                                    + act[synapse.from_index as usize]
-                                                        * synapse.weight;
-                                                sum_sq += val * val;
-                                            }
-                                            sum_sq.sqrt()
-                                        }
-                                        SquashType::Mean => {
-                                            let n = (end_synapse - start_synapse) as f32;
-                                            if n <= 0.0 {
-                                                neuron.bias
-                                            } else {
-                                                let mut sum = 0.0f32;
-                                                for synapse_idx in start_synapse..end_synapse {
-                                                    let synapse = &$network.synapses[synapse_idx];
-                                                    sum += act[synapse.from_index as usize]
-                                                        * synapse.weight;
-                                                }
-                                                sum / n + neuron.bias
-                                            }
-                                        }
-                                        _ => unreachable!(),
-                                    };
-                                    act[actual_idx] = apply_limit_range(squash, activation);
+                                for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
+                                    let value =
+                                        neuron_activation_scalar(&$network.synapses, act, neuron);
+                                    act[actual_idx] = value;
                                 }
                             }
                             _ => {
@@ -477,84 +285,8 @@ macro_rules! batch_8way_activation {
             }
 
             for (neuron_idx, neuron) in $network.neurons.iter().enumerate() {
-                let actual_idx = num_inputs + neuron_idx;
-
-                if neuron.is_constant {
-                    act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-                } else {
-                    let squash = SquashType::from(neuron.squash_type);
-                    let start_synapse = neuron.start_synapse as usize;
-                    let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                    let activation = match squash {
-                        SquashType::Minimum => {
-                            let mut min_val = f32::INFINITY;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                let val = act0[synapse.from_index as usize] * synapse.weight;
-                                if val < min_val {
-                                    min_val = val;
-                                }
-                            }
-                            if min_val == f32::INFINITY {
-                                neuron.bias
-                            } else {
-                                min_val + neuron.bias
-                            }
-                        }
-                        SquashType::Maximum => {
-                            let mut max_val = f32::NEG_INFINITY;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                let val = act0[synapse.from_index as usize] * synapse.weight;
-                                if val > max_val {
-                                    max_val = val;
-                                }
-                            }
-                            if max_val == f32::NEG_INFINITY {
-                                neuron.bias
-                            } else {
-                                max_val + neuron.bias
-                            }
-                        }
-                        SquashType::If => {
-                            let mut condition_sum = 0.0f32;
-                            let mut positive_sum = 0.0f32;
-                            let mut negative_sum = 0.0f32;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                let val = act0[synapse.from_index as usize] * synapse.weight;
-                                match SynapseType::from(synapse.synapse_type) {
-                                    SynapseType::Condition => condition_sum += val,
-                                    SynapseType::Negative => negative_sum += val,
-                                    SynapseType::Positive | SynapseType::Standard => {
-                                        positive_sum += val
-                                    }
-                                }
-                            }
-                            if condition_sum > 0.0 {
-                                positive_sum + neuron.bias
-                            } else {
-                                negative_sum + neuron.bias
-                            }
-                        }
-                        _ => {
-                            let mut sum = neuron.bias;
-                            for synapse_idx in start_synapse..end_synapse {
-                                let synapse = &$network.synapses[synapse_idx];
-                                sum += act0[synapse.from_index as usize] * synapse.weight;
-                            }
-                            match neuron.squash_type {
-                                0 => sum,
-                                1 => sum.max(0.0),
-                                6 => 1.0 / (1.0 + (-sum).exp()),
-                                7 => sum.tanh(),
-                                _ => apply_squash(squash, sum),
-                            }
-                        }
-                    };
-                    act0[actual_idx] = apply_limit_range(squash, activation);
-                }
+                let value = neuron_activation_scalar(&$network.synapses, &act0, neuron);
+                act0[num_inputs + neuron_idx] = value;
             }
 
             sum_error += $error_fn($records, target_base, &act0, output_start, $num_outputs);
@@ -729,102 +461,12 @@ fn mse_sum_batch_4way(
                     | SquashType::Hypotenuse
                     | SquashType::HypotenuseV2
                     | SquashType::Mean => {
-                        // Fall back to scalar for special squash functions
-                        for (r, act) in [
-                            (0, &mut act0),
-                            (1, &mut act1),
-                            (2, &mut act2),
-                            (3, &mut act3),
-                        ] {
-                            let _ = r;
-                            let activation = match squash {
-                                SquashType::Minimum => {
-                                    let mut min_val = f32::INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val < min_val {
-                                            min_val = val;
-                                        }
-                                    }
-                                    if min_val == f32::INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        min_val + neuron.bias
-                                    }
-                                }
-                                SquashType::Maximum => {
-                                    let mut max_val = f32::NEG_INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val > max_val {
-                                            max_val = val;
-                                        }
-                                    }
-                                    if max_val == f32::NEG_INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        max_val + neuron.bias
-                                    }
-                                }
-                                SquashType::If => {
-                                    let mut condition_sum = 0.0f32;
-                                    let mut positive_sum = 0.0f32;
-                                    let mut negative_sum = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        match SynapseType::from(synapse.synapse_type) {
-                                            SynapseType::Condition => condition_sum += val,
-                                            SynapseType::Negative => negative_sum += val,
-                                            SynapseType::Positive | SynapseType::Standard => {
-                                                positive_sum += val
-                                            }
-                                        }
-                                    }
-                                    if condition_sum > 0.0 {
-                                        positive_sum + neuron.bias
-                                    } else {
-                                        negative_sum + neuron.bias
-                                    }
-                                }
-                                SquashType::Hypotenuse => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt() + neuron.bias
-                                }
-                                SquashType::HypotenuseV2 => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = neuron.bias
-                                            + act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt()
-                                }
-                                SquashType::Mean => {
-                                    let n = (end_synapse - start_synapse) as f32;
-                                    if n <= 0.0 {
-                                        neuron.bias
-                                    } else {
-                                        let mut sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            sum +=
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                        }
-                                        sum / n + neuron.bias
-                                    }
-                                }
-                                _ => unreachable!(),
-                            };
-                            act[actual_idx] = apply_limit_range(squash, activation);
+                        // One shared activation rule (Issue #441): the scalar
+                        // helper covers every aggregate squash exactly as the
+                        // single-record reference does.
+                        for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
+                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
+                            act[actual_idx] = value;
                         }
                     }
                     _ => {
@@ -907,86 +549,11 @@ fn mse_sum_batch_4way(
             *activation = 0.0;
         }
 
-        // Process each neuron
+        // Process each neuron through the one shared activation rule
+        // (Issue #441) so the tail record matches the reference exactly.
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                let activation = match squash {
-                    SquashType::Minimum => {
-                        let mut min_val = f32::INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val < min_val {
-                                min_val = val;
-                            }
-                        }
-                        if min_val == f32::INFINITY {
-                            neuron.bias
-                        } else {
-                            min_val + neuron.bias
-                        }
-                    }
-                    SquashType::Maximum => {
-                        let mut max_val = f32::NEG_INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val > max_val {
-                                max_val = val;
-                            }
-                        }
-                        if max_val == f32::NEG_INFINITY {
-                            neuron.bias
-                        } else {
-                            max_val + neuron.bias
-                        }
-                    }
-                    SquashType::If => {
-                        let mut condition_sum = 0.0f32;
-                        let mut positive_sum = 0.0f32;
-                        let mut negative_sum = 0.0f32;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            match SynapseType::from(synapse.synapse_type) {
-                                SynapseType::Condition => condition_sum += val,
-                                SynapseType::Negative => negative_sum += val,
-                                SynapseType::Positive | SynapseType::Standard => {
-                                    positive_sum += val
-                                }
-                            }
-                        }
-                        if condition_sum > 0.0 {
-                            positive_sum + neuron.bias
-                        } else {
-                            negative_sum + neuron.bias
-                        }
-                    }
-                    _ => {
-                        let mut sum = neuron.bias;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            sum += act0[synapse.from_index as usize] * synapse.weight;
-                        }
-                        match neuron.squash_type {
-                            0 => sum,
-                            1 => sum.max(0.0),
-                            6 => 1.0 / (1.0 + (-sum).exp()),
-                            7 => sum.tanh(),
-                            _ => apply_squash(squash, sum),
-                        }
-                    }
-                };
-                act0[actual_idx] = apply_limit_range(squash, activation);
-            }
+            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
+            act0[num_inputs + neuron_idx] = value;
         }
 
         // Calculate MSE
@@ -1205,25 +772,8 @@ fn mse_sum_batch_8way_interleaved(
             *activation = 0.0;
         }
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-            if neuron.is_constant {
-                act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-                continue;
-            }
-            let squash = SquashType::from(neuron.squash_type);
-            let start_synapse = neuron.start_synapse as usize;
-            let end_synapse = start_synapse + neuron.num_synapses as usize;
-            let mut sum = neuron.bias;
-            for synapse in network
-                .synapses
-                .iter()
-                .take(end_synapse)
-                .skip(start_synapse)
-            {
-                sum += act0[synapse.from_index as usize] * synapse.weight;
-            }
-            let activation = inline_squash_scalar(neuron.squash_type, squash, sum);
-            act0[actual_idx] = apply_limit_range(squash, activation);
+            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
+            act0[num_inputs + neuron_idx] = value;
         }
         let mut sq_sum: f64 = 0.0;
         for j in 0..num_outputs {
@@ -1346,106 +896,15 @@ fn mse_sum_batch_8way_scattered(
                     | SquashType::Hypotenuse
                     | SquashType::HypotenuseV2
                     | SquashType::Mean => {
-                        // Fall back to scalar for special squash functions
-                        for (r, act) in [
-                            (0, &mut act0),
-                            (1, &mut act1),
-                            (2, &mut act2),
-                            (3, &mut act3),
-                            (4, &mut act4),
-                            (5, &mut act5),
-                            (6, &mut act6),
-                            (7, &mut act7),
+                        // One shared activation rule (Issue #441): the scalar
+                        // helper covers every aggregate squash exactly as the
+                        // single-record reference does.
+                        for act in [
+                            &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
+                            &mut act6, &mut act7,
                         ] {
-                            let _ = r;
-                            let activation = match squash {
-                                SquashType::Minimum => {
-                                    let mut min_val = f32::INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val < min_val {
-                                            min_val = val;
-                                        }
-                                    }
-                                    if min_val == f32::INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        min_val + neuron.bias
-                                    }
-                                }
-                                SquashType::Maximum => {
-                                    let mut max_val = f32::NEG_INFINITY;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        if val > max_val {
-                                            max_val = val;
-                                        }
-                                    }
-                                    if max_val == f32::NEG_INFINITY {
-                                        neuron.bias
-                                    } else {
-                                        max_val + neuron.bias
-                                    }
-                                }
-                                SquashType::If => {
-                                    let mut condition_sum = 0.0f32;
-                                    let mut positive_sum = 0.0f32;
-                                    let mut negative_sum = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        match SynapseType::from(synapse.synapse_type) {
-                                            SynapseType::Condition => condition_sum += val,
-                                            SynapseType::Negative => negative_sum += val,
-                                            SynapseType::Positive | SynapseType::Standard => {
-                                                positive_sum += val
-                                            }
-                                        }
-                                    }
-                                    if condition_sum > 0.0 {
-                                        positive_sum + neuron.bias
-                                    } else {
-                                        negative_sum + neuron.bias
-                                    }
-                                }
-                                SquashType::Hypotenuse => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt() + neuron.bias
-                                }
-                                SquashType::HypotenuseV2 => {
-                                    let mut sum_sq = 0.0f32;
-                                    for synapse_idx in start_synapse..end_synapse {
-                                        let synapse = &network.synapses[synapse_idx];
-                                        let val = neuron.bias
-                                            + act[synapse.from_index as usize] * synapse.weight;
-                                        sum_sq += val * val;
-                                    }
-                                    sum_sq.sqrt()
-                                }
-                                SquashType::Mean => {
-                                    let n = (end_synapse - start_synapse) as f32;
-                                    if n <= 0.0 {
-                                        neuron.bias
-                                    } else {
-                                        let mut sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            sum +=
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                        }
-                                        sum / n + neuron.bias
-                                    }
-                                }
-                                _ => unreachable!(),
-                            };
-                            act[actual_idx] = apply_limit_range(squash, activation);
+                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
+                            act[actual_idx] = value;
                         }
                     }
                     _ => {
@@ -1573,71 +1032,11 @@ fn mse_sum_batch_8way_scattered(
                         | SquashType::Hypotenuse
                         | SquashType::HypotenuseV2
                         | SquashType::Mean => {
-                            for (r, act) in [
-                                (0, &mut act0),
-                                (1, &mut act1),
-                                (2, &mut act2),
-                                (3, &mut act3),
-                            ] {
-                                let _ = r;
-                                let activation = match squash {
-                                    SquashType::Minimum => {
-                                        let mut min_val = f32::INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val < min_val {
-                                                min_val = val;
-                                            }
-                                        }
-                                        if min_val == f32::INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            min_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::Maximum => {
-                                        let mut max_val = f32::NEG_INFINITY;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            if val > max_val {
-                                                max_val = val;
-                                            }
-                                        }
-                                        if max_val == f32::NEG_INFINITY {
-                                            neuron.bias
-                                        } else {
-                                            max_val + neuron.bias
-                                        }
-                                    }
-                                    SquashType::If => {
-                                        let mut condition_sum = 0.0f32;
-                                        let mut positive_sum = 0.0f32;
-                                        let mut negative_sum = 0.0f32;
-                                        for synapse_idx in start_synapse..end_synapse {
-                                            let synapse = &network.synapses[synapse_idx];
-                                            let val =
-                                                act[synapse.from_index as usize] * synapse.weight;
-                                            match SynapseType::from(synapse.synapse_type) {
-                                                SynapseType::Condition => condition_sum += val,
-                                                SynapseType::Negative => negative_sum += val,
-                                                SynapseType::Positive | SynapseType::Standard => {
-                                                    positive_sum += val
-                                                }
-                                            }
-                                        }
-                                        if condition_sum > 0.0 {
-                                            positive_sum + neuron.bias
-                                        } else {
-                                            negative_sum + neuron.bias
-                                        }
-                                    }
-                                    _ => unreachable!(),
-                                };
-                                act[actual_idx] = apply_limit_range(squash, activation);
+                            // One shared activation rule (Issue #441).
+                            for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
+                                let value =
+                                    neuron_activation_scalar(&network.synapses, act, neuron);
+                                act[actual_idx] = value;
                             }
                         }
                         _ => {
@@ -1719,86 +1118,11 @@ fn mse_sum_batch_8way_scattered(
             *activation = 0.0;
         }
 
-        // Process each neuron
+        // Process each neuron through the one shared activation rule
+        // (Issue #441) so the tail record matches the reference exactly.
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                act0[actual_idx] = apply_limit_range(SquashType::Identity, neuron.bias);
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                let activation = match squash {
-                    SquashType::Minimum => {
-                        let mut min_val = f32::INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val < min_val {
-                                min_val = val;
-                            }
-                        }
-                        if min_val == f32::INFINITY {
-                            neuron.bias
-                        } else {
-                            min_val + neuron.bias
-                        }
-                    }
-                    SquashType::Maximum => {
-                        let mut max_val = f32::NEG_INFINITY;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            if val > max_val {
-                                max_val = val;
-                            }
-                        }
-                        if max_val == f32::NEG_INFINITY {
-                            neuron.bias
-                        } else {
-                            max_val + neuron.bias
-                        }
-                    }
-                    SquashType::If => {
-                        let mut condition_sum = 0.0f32;
-                        let mut positive_sum = 0.0f32;
-                        let mut negative_sum = 0.0f32;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            let val = act0[synapse.from_index as usize] * synapse.weight;
-                            match SynapseType::from(synapse.synapse_type) {
-                                SynapseType::Condition => condition_sum += val,
-                                SynapseType::Negative => negative_sum += val,
-                                SynapseType::Positive | SynapseType::Standard => {
-                                    positive_sum += val
-                                }
-                            }
-                        }
-                        if condition_sum > 0.0 {
-                            positive_sum + neuron.bias
-                        } else {
-                            negative_sum + neuron.bias
-                        }
-                    }
-                    _ => {
-                        let mut sum = neuron.bias;
-                        for synapse_idx in start_synapse..end_synapse {
-                            let synapse = &network.synapses[synapse_idx];
-                            sum += act0[synapse.from_index as usize] * synapse.weight;
-                        }
-                        match neuron.squash_type {
-                            0 => sum,
-                            1 => sum.max(0.0),
-                            6 => 1.0 / (1.0 + (-sum).exp()),
-                            7 => sum.tanh(),
-                            _ => apply_squash(squash, sum),
-                        }
-                    }
-                };
-                act0[actual_idx] = apply_limit_range(squash, activation);
-            }
+            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
+            act0[num_inputs + neuron_idx] = value;
         }
 
         // Calculate MSE

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -6,7 +6,7 @@
 //!
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
-use crate::batch_scoring::{SCORING_LANES, inline_squash, neuron_activation_scalar};
+use crate::batch_scoring::{SCORING_LANES, inline_squash, load_record, neuron_activation_scalar};
 use crate::network::CompiledNetwork;
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
@@ -20,6 +20,13 @@ use wasm_bindgen::prelude::*;
 ///
 /// This macro generates the neuron activation loop for 8 records in parallel,
 /// then calls a provided error calculation closure for each record.
+///
+/// The single home of the batched record-scan skeleton (Issue #445): records are
+/// grouped 8 → 4 → 1, each group's inputs are loaded through the shared
+/// [`load_record`] loader, and the per-record errors accumulate into one `f64`
+/// sum. `$error_fn` carries **only** the per-record reduction
+/// (`(records, target_base, act, output_start, num_outputs) -> f64`), so every
+/// loss kind — MSE included — shares one iteration rule.
 macro_rules! batch_8way_activation {
     ($network:expr_2021, $records:expr_2021, $values_per_record:expr_2021, $input_size:expr_2021, $num_outputs:expr_2021, $num_records:expr_2021, $error_fn:expr_2021) => {{
         let num_neurons = $network.num_neurons;
@@ -56,7 +63,7 @@ macro_rules! batch_8way_activation {
                     6 => &mut act6,
                     _ => &mut act7,
                 };
-                act[..$input_size].copy_from_slice(inputs);
+                load_record(act, inputs, num_inputs);
             }
 
             // Process each neuron for all 8 records
@@ -176,7 +183,7 @@ macro_rules! batch_8way_activation {
                         2 => &mut act2,
                         _ => &mut act3,
                     };
-                    act[..$input_size].copy_from_slice(inputs);
+                    load_record(act, inputs, num_inputs);
                 }
 
                 for (neuron_idx, neuron) in $network.neurons.iter().enumerate() {
@@ -259,7 +266,7 @@ macro_rules! batch_8way_activation {
             let inputs = &$records[base..base + $input_size];
             let target_base = base + $input_size;
 
-            act0[..$input_size].copy_from_slice(inputs);
+            load_record(&mut act0, inputs, num_inputs);
 
             for i in num_inputs..num_neurons {
                 act0[i] = 0.0;
@@ -400,9 +407,11 @@ pub fn mse_sum_batch_packed(
         );
     }
 
-    // Issue #1202 - Use batched 4-record SIMD path for forward-only networks
+    // Issue #1202 - Use batched 4-record SIMD path for forward-only networks.
+    // The shared skeleton's remainder handling is the 4-way path (Issue #445):
+    // with 4..7 records it runs one 4-record group then the scalar tail.
     if forward_only && layout.num_records >= 4 {
-        return mse_sum_batch_4way(
+        return mse_sum_batch_scattered(
             network,
             records,
             layout.values_per_record,
@@ -436,174 +445,6 @@ pub fn mse_sum_batch_packed(
     )
 }
 
-/// Issue #1202 - Batched MSE with 4-record SIMD parallelism.
-///
-/// Processes 4 records simultaneously using SIMD across records.
-/// This is an internal helper that only works for forward-only networks
-/// with standard squash functions. Falls back to single-record for edge cases.
-fn mse_sum_batch_4way(
-    network: &CompiledNetwork,
-    records: &[f32],
-    values_per_record: usize,
-    input_size: usize,
-    num_outputs: usize,
-    num_records: usize,
-) -> f64 {
-    let inv_outputs: f64 = if num_outputs > 0 {
-        1.0 / (num_outputs as f64)
-    } else {
-        return 0.0;
-    };
-
-    // Allocate 4 activation buffers
-    let num_neurons = network.num_neurons;
-    let num_inputs = network.num_inputs;
-    let mut act0: Vec<f32> = vec![0.0; num_neurons];
-    let mut act1: Vec<f32> = vec![0.0; num_neurons];
-    let mut act2: Vec<f32> = vec![0.0; num_neurons];
-    let mut act3: Vec<f32> = vec![0.0; num_neurons];
-
-    let mut sum_error: f64 = 0.0;
-    let output_start = num_neurons - num_outputs;
-
-    // Process in batches of 4
-    let full_batches = num_records / 4;
-    for batch in 0..full_batches {
-        let base_idx = batch * 4;
-
-        // Load inputs for all 4 records
-        for r in 0..4 {
-            let record_idx = base_idx + r;
-            let base = record_idx * values_per_record;
-            let inputs = &records[base..base + input_size];
-            let act = match r {
-                0 => &mut act0,
-                1 => &mut act1,
-                2 => &mut act2,
-                _ => &mut act3,
-            };
-            act[..input_size].copy_from_slice(inputs);
-        }
-
-        // Process each neuron for all 4 records
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                let val = apply_limit_range(SquashType::Identity, neuron.bias);
-                act0[actual_idx] = val;
-                act1[actual_idx] = val;
-                act2[actual_idx] = val;
-                act3[actual_idx] = val;
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                // Only use batched path for standard squash functions
-                match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
-                        // One shared activation rule (Issue #441): the scalar
-                        // helper covers every aggregate squash exactly as the
-                        // single-record reference does.
-                        for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
-                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
-                            act[actual_idx] = value;
-                        }
-                    }
-                    _ => {
-                        // Use SIMD for standard squash functions
-                        let (sum0, sum1, sum2, sum3) = weighted_sum_simd_4records(
-                            &network.synapses,
-                            &act0,
-                            &act1,
-                            &act2,
-                            &act3,
-                            start_synapse,
-                            end_synapse,
-                            neuron.bias,
-                        );
-
-                        // Vectorised squash for the hot transcendental types
-                        // (Issue #180 approximations, wired into MSE by #246);
-                        // scalar inline fallback otherwise so numerics are
-                        // unchanged for the non-vectorised squashes.
-                        let sums = [sum0, sum1, sum2, sum3];
-                        let squashed = match squash_x4(squash, sums) {
-                            Some(vec) => vec,
-                            None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
-                        };
-
-                        // Issue #245: resolve the output range once per neuron.
-                        let (low, high) = apply_get_range(squash);
-                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
-                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
-                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
-                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
-                    }
-                }
-            }
-        }
-
-        // Calculate MSE for all 4 records
-        for r in 0..4 {
-            let record_idx = base_idx + r;
-            let target_base = record_idx * values_per_record + input_size;
-            let act = match r {
-                0 => &act0,
-                1 => &act1,
-                2 => &act2,
-                _ => &act3,
-            };
-
-            let mut sq_sum: f64 = 0.0;
-            for j in 0..num_outputs {
-                let diff = (records[target_base + j] - act[output_start + j]) as f64;
-                sq_sum += diff * diff;
-            }
-            sum_error += sq_sum * inv_outputs;
-        }
-    }
-
-    // Handle remainder with single-record processing
-    let remainder_start = full_batches * 4;
-    for record_idx in remainder_start..num_records {
-        let base = record_idx * values_per_record;
-        let inputs = &records[base..base + input_size];
-        let target_base = base + input_size;
-
-        // Reuse act0 for single record
-        act0[..input_size].copy_from_slice(inputs);
-
-        // Reset non-input activations
-        for activation in act0.iter_mut().take(num_neurons).skip(num_inputs) {
-            *activation = 0.0;
-        }
-
-        // Process each neuron through the one shared activation rule
-        // (Issue #441) so the tail record matches the reference exactly.
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
-            act0[num_inputs + neuron_idx] = value;
-        }
-
-        // Calculate MSE
-        let mut sq_sum: f64 = 0.0;
-        for j in 0..num_outputs {
-            let diff = (records[target_base + j] - act0[output_start + j]) as f64;
-            sq_sum += diff * diff;
-        }
-        sum_error += sq_sum * inv_outputs;
-    }
-
-    sum_error
-}
-
 /// Issue #1209 - Batched MSE with 8-record SIMD parallelism.
 ///
 /// Processes 8 records simultaneously using two SIMD vectors across records.
@@ -617,7 +458,7 @@ fn mse_sum_batch_4way(
 /// ([`mse_sum_batch_8way_interleaved`]), so each synapse reads one cache line
 /// instead of eight scattered per-lane buffers; networks containing an
 /// aggregate squash keep the exact per-lane scattered path
-/// ([`mse_sum_batch_8way_scattered`]) unchanged. Both are bit-identical to the
+/// ([`mse_sum_batch_scattered`]) unchanged. Both are bit-identical to the
 /// pre-#384 result.
 fn mse_sum_batch_8way(
     network: &CompiledNetwork,
@@ -628,7 +469,7 @@ fn mse_sum_batch_8way(
     num_records: usize,
 ) -> f64 {
     if network.has_aggregate_squash() {
-        return mse_sum_batch_8way_scattered(
+        return mse_sum_batch_scattered(
             network,
             records,
             values_per_record,
@@ -729,28 +570,13 @@ fn mse_sum_batch_8way_interleaved(
 
     if remaining >= 4 {
         let base_idx = remainder_start;
-        load_batch_input(&mut act0, records, base_idx, values_per_record, input_size);
-        load_batch_input(
-            &mut act1,
-            records,
-            base_idx + 1,
-            values_per_record,
-            input_size,
-        );
-        load_batch_input(
-            &mut act2,
-            records,
-            base_idx + 2,
-            values_per_record,
-            input_size,
-        );
-        load_batch_input(
-            &mut act3,
-            records,
-            base_idx + 3,
-            values_per_record,
-            input_size,
-        );
+        for (r, act) in [&mut act0, &mut act1, &mut act2, &mut act3]
+            .into_iter()
+            .enumerate()
+        {
+            let base = (base_idx + r) * values_per_record;
+            load_record(act, &records[base..base + input_size], num_inputs);
+        }
 
         for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
             let actual_idx = num_inputs + neuron_idx;
@@ -803,7 +629,7 @@ fn mse_sum_batch_8way_interleaved(
     for record_idx in final_remainder_start..num_records {
         let base = record_idx * values_per_record;
         let target_base = base + input_size;
-        act0[..input_size].copy_from_slice(&records[base..base + input_size]);
+        load_record(&mut act0, &records[base..base + input_size], num_inputs);
         for activation in act0.iter_mut().take(num_neurons).skip(num_inputs) {
             *activation = 0.0;
         }
@@ -822,25 +648,16 @@ fn mse_sum_batch_8way_interleaved(
     sum_error
 }
 
-/// Copy one record's `input_size` inputs into a per-lane activation buffer and
-/// zero the remaining non-input slots, matching the scattered 8-way loader.
-#[inline]
-fn load_batch_input(
-    act: &mut [f32],
-    records: &[f32],
-    record_idx: usize,
-    values_per_record: usize,
-    input_size: usize,
-) {
-    let base = record_idx * values_per_record;
-    act[..input_size].copy_from_slice(&records[base..base + input_size]);
-}
-
-/// Scattered per-lane fused activate + MSE (Issue #1209), retained unchanged for
-/// networks containing an aggregate squash (Issue #384). Processes 8 records via
-/// two SIMD vectors across records, falling back to 4-way for remainder < 8,
-/// then single-record for remainder < 4.
-fn mse_sum_batch_8way_scattered(
+/// Scattered per-lane fused activate + MSE (Issue #1209), used for networks
+/// containing an aggregate squash (Issue #384) and for the 4..7-record
+/// remainder of any forward-only batch.
+///
+/// Issue #445 — MSE runs the shared [`batch_8way_activation`] skeleton like
+/// every other loss kind: 8-record groups, then a 4-record group, then a scalar
+/// tail, with only the per-record squared-error reduction supplied here. The
+/// numerics are unchanged — the same kernels in the same order as the
+/// hand-inlined 8-way and 4-way copies this replaces.
+fn mse_sum_batch_scattered(
     network: &CompiledNetwork,
     records: &[f32],
     values_per_record: usize,
@@ -854,290 +671,30 @@ fn mse_sum_batch_8way_scattered(
         return 0.0;
     };
 
-    // Allocate 8 activation buffers
-    let num_neurons = network.num_neurons;
-    let num_inputs = network.num_inputs;
-    let mut act0: Vec<f32> = vec![0.0; num_neurons];
-    let mut act1: Vec<f32> = vec![0.0; num_neurons];
-    let mut act2: Vec<f32> = vec![0.0; num_neurons];
-    let mut act3: Vec<f32> = vec![0.0; num_neurons];
-    let mut act4: Vec<f32> = vec![0.0; num_neurons];
-    let mut act5: Vec<f32> = vec![0.0; num_neurons];
-    let mut act6: Vec<f32> = vec![0.0; num_neurons];
-    let mut act7: Vec<f32> = vec![0.0; num_neurons];
-
-    let mut sum_error: f64 = 0.0;
-    let output_start = num_neurons - num_outputs;
-
-    // Process in batches of 8
-    let full_batches = num_records / 8;
-    for batch in 0..full_batches {
-        let base_idx = batch * 8;
-
-        // Load inputs for all 8 records
-        for r in 0..8 {
-            let record_idx = base_idx + r;
-            let base = record_idx * values_per_record;
-            let inputs = &records[base..base + input_size];
-            let act = match r {
-                0 => &mut act0,
-                1 => &mut act1,
-                2 => &mut act2,
-                3 => &mut act3,
-                4 => &mut act4,
-                5 => &mut act5,
-                6 => &mut act6,
-                _ => &mut act7,
-            };
-            act[..input_size].copy_from_slice(inputs);
-        }
-
-        // Process each neuron for all 8 records
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let actual_idx = num_inputs + neuron_idx;
-
-            if neuron.is_constant {
-                let val = apply_limit_range(SquashType::Identity, neuron.bias);
-                act0[actual_idx] = val;
-                act1[actual_idx] = val;
-                act2[actual_idx] = val;
-                act3[actual_idx] = val;
-                act4[actual_idx] = val;
-                act5[actual_idx] = val;
-                act6[actual_idx] = val;
-                act7[actual_idx] = val;
-            } else {
-                let squash = SquashType::from(neuron.squash_type);
-                let start_synapse = neuron.start_synapse as usize;
-                let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                // Only use batched path for standard squash functions
-                match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => {
-                        // One shared activation rule (Issue #441): the scalar
-                        // helper covers every aggregate squash exactly as the
-                        // single-record reference does.
-                        for act in [
-                            &mut act0, &mut act1, &mut act2, &mut act3, &mut act4, &mut act5,
-                            &mut act6, &mut act7,
-                        ] {
-                            let value = neuron_activation_scalar(&network.synapses, act, neuron);
-                            act[actual_idx] = value;
-                        }
-                    }
-                    _ => {
-                        // Use SIMD for standard squash functions
-                        let (sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7) =
-                            weighted_sum_simd_8records(
-                                &network.synapses,
-                                &act0,
-                                &act1,
-                                &act2,
-                                &act3,
-                                &act4,
-                                &act5,
-                                &act6,
-                                &act7,
-                                start_synapse,
-                                end_synapse,
-                                neuron.bias,
-                            );
-
-                        // Vectorised squash for the hot transcendental types
-                        // (Issue #180 approximations, wired into MSE by #246);
-                        // scalar inline fallback otherwise so numerics are
-                        // unchanged for the non-vectorised squashes.
-                        let sums = [sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7];
-                        let squashed = match squash_x8(squash, sums) {
-                            Some(vec) => vec,
-                            None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
-                        };
-
-                        // Issue #245: resolve the output range once per neuron
-                        // and clamp all 8 lanes through the bounds.
-                        let (low, high) = apply_get_range(squash);
-                        act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
-                        act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
-                        act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
-                        act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
-                        act4[actual_idx] = apply_limit_range_bounds(low, high, squashed[4]);
-                        act5[actual_idx] = apply_limit_range_bounds(low, high, squashed[5]);
-                        act6[actual_idx] = apply_limit_range_bounds(low, high, squashed[6]);
-                        act7[actual_idx] = apply_limit_range_bounds(low, high, squashed[7]);
-                    }
-                }
-            }
-        }
-
-        // Calculate MSE for all 8 records
-        for r in 0..8 {
-            let record_idx = base_idx + r;
-            let target_base = record_idx * values_per_record + input_size;
-            let act = match r {
-                0 => &act0,
-                1 => &act1,
-                2 => &act2,
-                3 => &act3,
-                4 => &act4,
-                5 => &act5,
-                6 => &act6,
-                _ => &act7,
-            };
-
-            let mut sq_sum: f64 = 0.0;
-            for j in 0..num_outputs {
-                let diff = (records[target_base + j] - act[output_start + j]) as f64;
-                sq_sum += diff * diff;
-            }
-            sum_error += sq_sum * inv_outputs;
-        }
-    }
-
-    // Handle remainder: use 4-way for 4-7 remaining records
-    let remainder_start = full_batches * 8;
-    let remaining = num_records - remainder_start;
-
-    if remaining >= 4 {
-        // Process 4 records at a time
-        let four_way_batches = remaining / 4;
-        for batch in 0..four_way_batches {
-            let base_idx = remainder_start + batch * 4;
-
-            // Load inputs for 4 records
-            for r in 0..4 {
-                let record_idx = base_idx + r;
-                let base = record_idx * values_per_record;
-                let inputs = &records[base..base + input_size];
-                let act = match r {
-                    0 => &mut act0,
-                    1 => &mut act1,
-                    2 => &mut act2,
-                    _ => &mut act3,
-                };
-                act[..input_size].copy_from_slice(inputs);
-            }
-
-            // Process each neuron for all 4 records
-            for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-                let actual_idx = num_inputs + neuron_idx;
-
-                if neuron.is_constant {
-                    let val = apply_limit_range(SquashType::Identity, neuron.bias);
-                    act0[actual_idx] = val;
-                    act1[actual_idx] = val;
-                    act2[actual_idx] = val;
-                    act3[actual_idx] = val;
-                } else {
-                    let squash = SquashType::from(neuron.squash_type);
-                    let start_synapse = neuron.start_synapse as usize;
-                    let end_synapse = start_synapse + neuron.num_synapses as usize;
-
-                    match squash {
-                        SquashType::Minimum
-                        | SquashType::Maximum
-                        | SquashType::If
-                        | SquashType::Hypotenuse
-                        | SquashType::HypotenuseV2
-                        | SquashType::Mean => {
-                            // One shared activation rule (Issue #441).
-                            for act in [&mut act0, &mut act1, &mut act2, &mut act3] {
-                                let value =
-                                    neuron_activation_scalar(&network.synapses, act, neuron);
-                                act[actual_idx] = value;
-                            }
-                        }
-                        _ => {
-                            let (sum0, sum1, sum2, sum3) = weighted_sum_simd_4records(
-                                &network.synapses,
-                                &act0,
-                                &act1,
-                                &act2,
-                                &act3,
-                                start_synapse,
-                                end_synapse,
-                                neuron.bias,
-                            );
-
-                            // Vectorised squash for the hot transcendental
-                            // types (Issue #180 approximations, wired into MSE
-                            // by #246); scalar inline fallback otherwise.
-                            let sums = [sum0, sum1, sum2, sum3];
-                            let squashed = match squash_x4(squash, sums) {
-                                Some(vec) => vec,
-                                None => {
-                                    sums.map(|sum| inline_squash(neuron.squash_type, squash, sum))
-                                }
-                            };
-
-                            // Issue #245: resolve the range once per neuron.
-                            let (low, high) = apply_get_range(squash);
-                            act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
-                            act1[actual_idx] = apply_limit_range_bounds(low, high, squashed[1]);
-                            act2[actual_idx] = apply_limit_range_bounds(low, high, squashed[2]);
-                            act3[actual_idx] = apply_limit_range_bounds(low, high, squashed[3]);
-                        }
-                    }
-                }
-            }
-
-            // Calculate MSE for 4 records
-            for r in 0..4 {
-                let record_idx = base_idx + r;
-                let target_base = record_idx * values_per_record + input_size;
-                let act = match r {
-                    0 => &act0,
-                    1 => &act1,
-                    2 => &act2,
-                    _ => &act3,
-                };
-
-                let mut sq_sum: f64 = 0.0;
-                for j in 0..num_outputs {
-                    let diff = (records[target_base + j] - act[output_start + j]) as f64;
-                    sq_sum += diff * diff;
-                }
-                sum_error += sq_sum * inv_outputs;
-            }
-        }
-    }
-
-    // Handle final remainder with single-record processing
-    let final_remainder_start = remainder_start + (remaining / 4) * 4;
-    for record_idx in final_remainder_start..num_records {
-        let base = record_idx * values_per_record;
-        let inputs = &records[base..base + input_size];
-        let target_base = base + input_size;
-
-        // Reuse act0 for single record
-        act0[..input_size].copy_from_slice(inputs);
-
-        // Reset non-input activations
-        for activation in act0.iter_mut().take(num_neurons).skip(num_inputs) {
-            *activation = 0.0;
-        }
-
-        // Process each neuron through the one shared activation rule
-        // (Issue #441) so the tail record matches the reference exactly.
-        for (neuron_idx, neuron) in network.neurons.iter().enumerate() {
-            let value = neuron_activation_scalar(&network.synapses, &act0, neuron);
-            act0[num_inputs + neuron_idx] = value;
-        }
-
-        // Calculate MSE
+    // MSE error calculation: mean((target - output)^2)
+    let mse_error = |records: &[f32],
+                     target_base: usize,
+                     act: &[f32],
+                     output_start: usize,
+                     num_outputs: usize|
+     -> f64 {
         let mut sq_sum: f64 = 0.0;
         for j in 0..num_outputs {
-            let diff = (records[target_base + j] - act0[output_start + j]) as f64;
+            let diff = (records[target_base + j] - act[output_start + j]) as f64;
             sq_sum += diff * diff;
         }
-        sum_error += sq_sum * inv_outputs;
-    }
+        sq_sum * inv_outputs
+    };
 
-    sum_error
+    batch_8way_activation!(
+        network,
+        records,
+        values_per_record,
+        input_size,
+        num_outputs,
+        num_records,
+        mse_error
+    )
 }
 
 /// Issue #1209 - Batched MAE with 8-record SIMD parallelism.
@@ -2051,7 +1608,7 @@ mod interleaved_mse_parity {
     //!
     //! `mse_sum_batch_8way` now dispatches standard-squash networks to
     //! [`mse_sum_batch_8way_interleaved`] and aggregate networks to the
-    //! unchanged [`mse_sum_batch_8way_scattered`]. These "what" tests assert the
+    //! unchanged [`mse_sum_batch_scattered`]. These "what" tests assert the
     //! interleaved result is **bit-identical** (`f64::to_bits`) to the scattered
     //! path it replaces across the record counts that straddle the 8-record
     //! group boundary, so a lane-transpose bug, a changed `f64` accumulation
@@ -2166,7 +1723,7 @@ mod interleaved_mse_parity {
             1,
             num_records,
         );
-        let scattered = mse_sum_batch_8way_scattered(
+        let scattered = mse_sum_batch_scattered(
             &net,
             &records,
             values_per_record,
@@ -2205,7 +1762,7 @@ mod interleaved_mse_parity {
     /// scattered kernel — never the interleaved gather (whose standard-only
     /// `squash_x8` fallback would mis-evaluate an aggregate neuron). Asserting
     /// the public `mse_sum_batch_8way` dispatcher is bit-identical to
-    /// `mse_sum_batch_8way_scattered` proves the routing, and keeps aggregate
+    /// `mse_sum_batch_scattered` proves the routing, and keeps aggregate
     /// networks bit-identical to their pre-#384 result.
     #[test]
     fn aggregate_dispatch_stays_on_scattered_path() {
@@ -2232,14 +1789,8 @@ mod interleaved_mse_parity {
                 let records = build_records(n, input_size);
                 let dispatched =
                     mse_sum_batch_8way(&net, &records, values_per_record, input_size, 1, n);
-                let scattered = mse_sum_batch_8way_scattered(
-                    &net,
-                    &records,
-                    values_per_record,
-                    input_size,
-                    1,
-                    n,
-                );
+                let scattered =
+                    mse_sum_batch_scattered(&net, &records, values_per_record, input_size, 1, n);
                 assert_eq!(
                     dispatched.to_bits(),
                     scattered.to_bits(),

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -6,11 +6,11 @@
 //!
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
-use crate::batch_scoring::{SCORING_LANES, neuron_activation_scalar};
+use crate::batch_scoring::{SCORING_LANES, inline_squash, neuron_activation_scalar};
 use crate::network::CompiledNetwork;
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{weighted_sum_simd_4records, weighted_sum_simd_8records};
-use crate::squash::{SquashType, apply_squash};
+use crate::squash::SquashType;
 use crate::squash_simd::{squash_x4, squash_x8};
 
 #[cfg(target_arch = "wasm32")]
@@ -119,16 +119,7 @@ macro_rules! batch_8way_activation {
                             let squashed = match squash_x8(squash, sums) {
                                 Some(vec) => vec,
                                 None => {
-                                    let apply_squash_inline = |sum: f32| -> f32 {
-                                        match neuron.squash_type {
-                                            0 => sum,
-                                            1 => sum.max(0.0),
-                                            6 => 1.0 / (1.0 + (-sum).exp()),
-                                            7 => sum.tanh(),
-                                            _ => apply_squash(squash, sum),
-                                        }
-                                    };
-                                    sums.map(apply_squash_inline)
+                                    sums.map(|sum| inline_squash(neuron.squash_type, squash, sum))
                                 }
                             };
 
@@ -232,18 +223,8 @@ macro_rules! batch_8way_activation {
                                 let sums = [sum0, sum1, sum2, sum3];
                                 let squashed = match squash_x4(squash, sums) {
                                     Some(vec) => vec,
-                                    None => {
-                                        let apply_squash_inline = |sum: f32| -> f32 {
-                                            match neuron.squash_type {
-                                                0 => sum,
-                                                1 => sum.max(0.0),
-                                                6 => 1.0 / (1.0 + (-sum).exp()),
-                                                7 => sum.tanh(),
-                                                _ => apply_squash(squash, sum),
-                                            }
-                                        };
-                                        sums.map(apply_squash_inline)
-                                    }
+                                    None => sums
+                                        .map(|sum| inline_squash(neuron.squash_type, squash, sum)),
                                 };
 
                                 // Issue #245: resolve the range once per neuron.
@@ -489,18 +470,7 @@ fn mse_sum_batch_4way(
                         let sums = [sum0, sum1, sum2, sum3];
                         let squashed = match squash_x4(squash, sums) {
                             Some(vec) => vec,
-                            None => {
-                                let apply_squash_inline = |sum: f32| -> f32 {
-                                    match neuron.squash_type {
-                                        0 => sum,                        // IDENTITY
-                                        1 => sum.max(0.0),               // ReLU
-                                        6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-                                        7 => sum.tanh(),                 // TANH
-                                        _ => apply_squash(squash, sum),  // Other
-                                    }
-                                };
-                                sums.map(apply_squash_inline)
-                            }
+                            None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
                         };
 
                         // Issue #245: resolve the output range once per neuron.
@@ -742,7 +712,7 @@ fn mse_sum_batch_8way_interleaved(
             let sums = [sum0, sum1, sum2, sum3];
             let squashed = match squash_x4(squash, sums) {
                 Some(vec) => vec,
-                None => sums.map(|sum| inline_squash_scalar(neuron.squash_type, squash, sum)),
+                None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
             };
             let (low, high) = apply_get_range(squash);
             act0[actual_idx] = apply_limit_range_bounds(low, high, squashed[0]);
@@ -784,19 +754,6 @@ fn mse_sum_batch_8way_interleaved(
     }
 
     sum_error
-}
-
-/// Scalar inline squash for the four hot standard types, matching the batched
-/// SIMD `None`-fallback branches (and `CompiledNetwork::activate_into`) exactly.
-#[inline]
-fn inline_squash_scalar(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
-    match squash_type {
-        0 => sum,                        // IDENTITY
-        1 => sum.max(0.0),               // ReLU
-        6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-        7 => sum.tanh(),                 // TANH
-        _ => apply_squash(squash, sum),  // Other
-    }
 }
 
 /// Copy one record's `input_size` inputs into a per-lane activation buffer and
@@ -932,18 +889,7 @@ fn mse_sum_batch_8way_scattered(
                         let sums = [sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7];
                         let squashed = match squash_x8(squash, sums) {
                             Some(vec) => vec,
-                            None => {
-                                let apply_squash_inline = |sum: f32| -> f32 {
-                                    match neuron.squash_type {
-                                        0 => sum,                        // IDENTITY
-                                        1 => sum.max(0.0),               // ReLU
-                                        6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-                                        7 => sum.tanh(),                 // TANH
-                                        _ => apply_squash(squash, sum),  // Other
-                                    }
-                                };
-                                sums.map(apply_squash_inline)
-                            }
+                            None => sums.map(|sum| inline_squash(neuron.squash_type, squash, sum)),
                         };
 
                         // Issue #245: resolve the output range once per neuron
@@ -1058,16 +1004,7 @@ fn mse_sum_batch_8way_scattered(
                             let squashed = match squash_x4(squash, sums) {
                                 Some(vec) => vec,
                                 None => {
-                                    let apply_squash_inline = |sum: f32| -> f32 {
-                                        match neuron.squash_type {
-                                            0 => sum,
-                                            1 => sum.max(0.0),
-                                            6 => 1.0 / (1.0 + (-sum).exp()),
-                                            7 => sum.tanh(),
-                                            _ => apply_squash(squash, sum),
-                                        }
-                                    };
-                                    sums.map(apply_squash_inline)
+                                    sums.map(|sum| inline_squash(neuron.squash_type, squash, sum))
                                 }
                             };
 

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -8,12 +8,13 @@
 //! NEAT-AI consumes. Public fields are skipped from the bindgen surface (they
 //! remain accessible to native Rust callers); the JS API is the public methods.
 
+use crate::batch_scoring::inline_squash;
 use crate::range::apply_limit_range;
 use crate::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
     weighted_sum_simd, weighted_sum_simd_4records,
 };
-use crate::squash::{SquashType, apply_squash};
+use crate::squash::SquashType;
 use crate::squash_simd::squash_x4;
 use crate::synapse_type::SynapseType;
 
@@ -497,13 +498,7 @@ impl CompiledNetwork {
                         );
                         // Issue #1177 - Inline common squash functions for performance
                         // These 4 functions cover ~80% of typical networks
-                        match neuron.squash_type {
-                            0 => sum,                        // IDENTITY
-                            1 => sum.max(0.0),               // ReLU
-                            6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-                            7 => sum.tanh(),                 // TANH
-                            _ => apply_squash(squash, sum),  // Other (fallback)
-                        }
+                        inline_squash(neuron.squash_type, squash, sum)
                     }
                 };
 
@@ -662,13 +657,7 @@ impl CompiledNetwork {
                         );
                         // Issue #1177 - Inline common squash functions for performance
                         // These 4 functions cover ~80% of typical networks
-                        match neuron.squash_type {
-                            0 => sum,                        // IDENTITY
-                            1 => sum.max(0.0),               // ReLU
-                            6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-                            7 => sum.tanh(),                 // TANH
-                            _ => apply_squash(squash, sum),  // Other (fallback)
-                        }
+                        inline_squash(neuron.squash_type, squash, sum)
                     }
                 };
 
@@ -909,13 +898,7 @@ impl CompiledNetwork {
                             neuron.bias,
                         );
                         // Issue #1177 - Inline common squash functions for performance
-                        let squashed = match neuron.squash_type {
-                            0 => sum,                        // IDENTITY
-                            1 => sum.max(0.0),               // ReLU
-                            6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-                            7 => sum.tanh(),                 // TANH
-                            _ => apply_squash(squash, sum),  // Other (fallback)
-                        };
+                        let squashed = inline_squash(neuron.squash_type, squash, sum);
                         // For standard squash, hintValue is the pre-squash value (sum)
                         (squashed, sum)
                     }
@@ -1181,10 +1164,10 @@ impl CompiledNetwork {
                         let [sq0, sq1, sq2, sq3] = match squash_x4(squash, [s0, s1, s2, s3]) {
                             Some(vec) => vec,
                             None => [
-                                Self::apply_inline_squash(neuron.squash_type, squash, s0),
-                                Self::apply_inline_squash(neuron.squash_type, squash, s1),
-                                Self::apply_inline_squash(neuron.squash_type, squash, s2),
-                                Self::apply_inline_squash(neuron.squash_type, squash, s3),
+                                inline_squash(neuron.squash_type, squash, s0),
+                                inline_squash(neuron.squash_type, squash, s1),
+                                inline_squash(neuron.squash_type, squash, s2),
+                                inline_squash(neuron.squash_type, squash, s3),
                             ],
                         };
 
@@ -1262,18 +1245,6 @@ impl CompiledNetwork {
 
 /// Issue #1212 - Helper methods for batch activate_and_trace processing
 impl CompiledNetwork {
-    /// Apply inline squash optimisation for common activation functions
-    #[inline]
-    fn apply_inline_squash(squash_type: u8, squash: SquashType, sum: f32) -> f32 {
-        match squash_type {
-            0 => sum,                        // IDENTITY
-            1 => sum.max(0.0),               // ReLU
-            6 => 1.0 / (1.0 + (-sum).exp()), // LOGISTIC
-            7 => sum.tanh(),                 // TANH
-            _ => apply_squash(squash, sum),  // Other (fallback)
-        }
-    }
-
     /// Process MINIMUM aggregate for 4 records
     #[allow(clippy::too_many_arguments)]
     fn process_minimum_4way(

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -912,14 +912,10 @@ impl CompiledNetwork {
 
                 // hintValues: for aggregate functions we expect hint==activation.
                 // For standard squashes keep the pre-squash value.
-                self.hint_values_buffer[neuron_idx] = match squash {
-                    SquashType::Minimum
-                    | SquashType::Maximum
-                    | SquashType::If
-                    | SquashType::Hypotenuse
-                    | SquashType::HypotenuseV2
-                    | SquashType::Mean => activation_limited,
-                    _ => hint_value,
+                self.hint_values_buffer[neuron_idx] = if squash.is_aggregate() {
+                    activation_limited
+                } else {
+                    hint_value
                 };
             }
         }

--- a/neat-core/src/safe_zone.rs
+++ b/neat-core/src/safe_zone.rs
@@ -5,6 +5,56 @@
 
 use crate::squash::SquashType;
 
+/// Gradient-flow factor for a squash whose safe band is `[safe_min, safe_max]`
+/// and which fades linearly to zero over `fade` either side of it.
+///
+/// The rule: no gradient when the raw input is already outside the band and the
+/// error pushes it further out; no gradient when the raw input is inside the
+/// band but the weight sits outside `[1e-3, 1e3]` and the error is already
+/// correcting it (let the weight recover first); full gradient inside the band;
+/// otherwise a linear fade to zero across `fade` past each edge.
+#[inline(always)]
+fn bounded_safe_zone(
+    raw_input: f32,
+    error: f32,
+    weight: f32,
+    safe_min: f32,
+    safe_max: f32,
+    fade: f32,
+) -> f32 {
+    const MIN_WEIGHT: f32 = 1e-3;
+    const MAX_WEIGHT: f32 = 1e3;
+
+    let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
+    let raw_getting_worse =
+        (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
+
+    let abs_weight = weight.abs();
+    let weight_too_small = abs_weight < MIN_WEIGHT;
+    let weight_too_large = abs_weight > MAX_WEIGHT;
+    let weight_improving =
+        (weight_too_small && weight * error > 0.0) || (weight_too_large && weight * error < 0.0);
+
+    if !in_safe_range && raw_getting_worse {
+        return 0.0;
+    }
+    if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
+        return 0.0;
+    }
+
+    if in_safe_range {
+        return 1.0;
+    }
+    if raw_input > safe_max && raw_input <= safe_max + fade {
+        return 1.0 - (raw_input - safe_max) / fade;
+    }
+    if raw_input < safe_min && raw_input >= safe_min - fade {
+        return 1.0 - (safe_min - raw_input) / fade;
+    }
+
+    0.0
+}
+
 /// Apply safe zone adjustment for a given activation function
 /// Issue #1140 - WASM Migration Phase 8: Implement safeZoneAdjustment() in Rust/WASM
 ///
@@ -81,118 +131,13 @@ pub fn apply_safe_zone_adjustment(
         }
 
         // LeakyReLU: Never fully saturates, but has weight-based logic
-        SquashType::LeakyRelu => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -50.0;
-            let safe_max = 50.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 20.0 {
-                return 1.0 - (raw_input - safe_max) / 20.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 20.0 {
-                return 1.0 - (safe_min - raw_input) / 20.0;
-            }
-
-            0.0
-        }
+        SquashType::LeakyRelu => bounded_safe_zone(raw_input, error, weight, -50.0, 50.0, 20.0),
 
         // SELU: Similar to ELU but with specific safe zones
-        SquashType::Selu => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Selu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // ELU: Similar pattern to SELU
-        SquashType::Elu => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Elu => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // LOGISTIC (Sigmoid): Classic sigmoid saturation
         SquashType::Logistic => {
@@ -289,192 +234,19 @@ pub fn apply_safe_zone_adjustment(
         }
 
         // Softsign: Slow saturation
-        SquashType::Softsign => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-
-            // Soft fade near edge zones
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Softsign => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Softplus: One-sided saturation
-        SquashType::Softplus => {
-            let safe_min = -10.0;
-            let safe_max = 20.0;
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improves = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_raw && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improves {
-                return 0.0;
-            }
-
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Softplus => bounded_safe_zone(raw_input, error, weight, -10.0, 20.0, 10.0),
 
         // Swish: Similar to tanh in behaviour
-        SquashType::Swish => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Swish => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Mish: Similar to Swish
-        SquashType::Mish => {
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-            let raw_worsening =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_raw && raw_worsening {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Mish => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // GELU: Similar to ReLU but smoother
-        SquashType::Gelu => {
-            let safe_min = -6.0;
-            let safe_max = 6.0;
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improves = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_raw && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improves {
-                return 0.0;
-            }
-
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Gelu => bounded_safe_zone(raw_input, error, weight, -6.0, 6.0, 10.0),
 
         // SINE: Periodic, always varying
         SquashType::Sine => {
@@ -803,168 +575,16 @@ pub fn apply_safe_zone_adjustment(
         }
 
         // StdInverse: Sensitive around zero
-        SquashType::StdInverse => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::StdInverse => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Exponential: Grows rapidly
-        SquashType::Exponential => {
-            // Safe zone for Exponential raw input
-            let safe_min = -10.0;
-            let safe_max = 30.0;
-            let in_safe_raw = raw_input >= safe_min && raw_input <= safe_max;
-
-            // Check if pushing raw input would make it worse
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            // Safe weight bounds
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-
-            // Is weight improvement in direction of error?
-            let weight_improves = (weight_too_small && weight * error > 0.0)
-                || // growing small weight
-                (weight_too_large && weight * error < 0.0); // shrinking big weight
-
-            // Fallback to weight adjustment
-            if !in_safe_raw && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_raw && (weight_too_small || weight_too_large) && weight_improves {
-                return 0.0;
-            }
-
-            // Default logic (fade outside the soft safe zone)
-            if in_safe_raw {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Exponential => bounded_safe_zone(raw_input, error, weight, -10.0, 30.0, 10.0),
 
         // LogSigmoid: Flattens sharply for large negative inputs
-        SquashType::LogSigmoid => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -20.0;
-            let safe_max = 20.0;
-            let fade_min = -30.0;
-            let fade_max = 30.0;
-
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            // Prefer not to propagate if the raw input is very bad and the weight would help
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-
-            // Soft fade zones
-            if raw_input > safe_max && raw_input <= fade_max {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= fade_min {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::LogSigmoid => bounded_safe_zone(raw_input, error, weight, -20.0, 20.0, 10.0),
 
         // ISRU: Saturates at large |x|
-        SquashType::Isru => {
-            let abs_weight = weight.abs();
-            let min_weight = 1e-3;
-            let max_weight = 1e3;
-
-            let safe_min = -10.0;
-            let safe_max = 10.0;
-            let in_safe_range = raw_input >= safe_min && raw_input <= safe_max;
-
-            let raw_getting_worse =
-                (raw_input < safe_min && error < 0.0) || (raw_input > safe_max && error > 0.0);
-
-            let weight_too_small = abs_weight < min_weight;
-            let weight_too_large = abs_weight > max_weight;
-            let weight_improving = (weight_too_small && weight * error > 0.0)
-                || (weight_too_large && weight * error < 0.0);
-
-            if !in_safe_range && raw_getting_worse {
-                return 0.0;
-            }
-            if in_safe_range && (weight_too_small || weight_too_large) && weight_improving {
-                return 0.0;
-            }
-
-            if in_safe_range {
-                return 1.0;
-            }
-            if raw_input > safe_max && raw_input <= safe_max + 10.0 {
-                return 1.0 - (raw_input - safe_max) / 10.0;
-            }
-            if raw_input < safe_min && raw_input >= safe_min - 10.0 {
-                return 1.0 - (safe_min - raw_input) / 10.0;
-            }
-
-            0.0
-        }
+        SquashType::Isru => bounded_safe_zone(raw_input, error, weight, -10.0, 10.0, 10.0),
 
         // Aggregate functions - not differentiable, always return 0
         SquashType::Minimum | SquashType::Maximum | SquashType::If => 0.0,

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -5,8 +5,10 @@
 //!
 //! ## Optimisation strategies
 //!
-//! - **Dual accumulator**: Uses two independent SIMD accumulators to hide FMA latency
-//!   by allowing out-of-order execution of independent multiply-add chains.
+//! - **Dual accumulator**: [`weighted_sum_simd`] uses two independent SIMD
+//!   accumulators to hide FMA latency by allowing out-of-order execution of
+//!   independent multiply-add chains. The other three single-record kernels run
+//!   a single accumulator in chunks of four.
 //! - **FMA (fused multiply-add)**: Uses `f32x4_relaxed_madd` from relaxed-simd to
 //!   perform multiply and add in a single instruction with better precision.
 //! - **Multi-record batching**: Processes the same neuron across 4 or 8 input records
@@ -18,6 +20,9 @@
 //! - **ISA-neutral scalar layer**: the reference scalar kernels and the
 //!   small-count guard live once in [`scalar`] (Issue #447) and are shared by
 //!   the wasm and native paths.
+//! - **Shared chunk-walk scaffold**: the wasm kernels gather, reduce and finish
+//!   their remainder through one set of helpers (Issue #448) so an improvement
+//!   to the walk cannot land on one kernel only.
 
 // Issue #447 - the ISA-neutral scalar layer: reference kernels, the saturating
 // count guard, and the seed-taking tail helpers, shared by the wasm kernels
@@ -33,7 +38,82 @@ use crate::network::SynapseData;
 // SIMD intrinsics for vectorised synapse weight summation
 // Issue #1197 - Added f32x4_relaxed_madd for FMA optimisation
 #[cfg(target_arch = "wasm32")]
-use core::arch::wasm32::{f32x4, f32x4_add, f32x4_extract_lane, f32x4_relaxed_madd, f32x4_splat};
+use core::arch::wasm32::{
+    f32x4, f32x4_add, f32x4_extract_lane, f32x4_mul, f32x4_relaxed_madd, f32x4_splat, v128,
+};
+
+// ============================================================================
+// Chunk-walk scaffold (Issue #448)
+//
+// One home for *how* a wasm kernel walks a synapse span: gather four synapses
+// into `f32x4` lanes, reduce the lanes back to a scalar, then finish the 0..3
+// remainder through the seed-taking tail helpers in [`scalar`]. Every
+// single-record kernel below calls these, so an improvement to the walk cannot
+// land on one copy only — which is exactly how the Issue #1197 dual-accumulator
+// rework came to sit on `weighted_sum_simd` alone.
+//
+// The *fold* deliberately stays in each kernel: these are calls, not a
+// parameterised super-helper. Unifying the four folds would need a mode flag,
+// and a flag is what makes a shared helper drift back apart.
+//
+// Every helper here touches `v128`/`f32x4_*`, so each repeats the
+// `#[target_feature]` attributes — without them the intrinsics do not compile
+// and the vector arguments do not inline into the caller.
+//
+// Index precondition (Issue #207): the 0..3 remainder runs through the
+// `scalar::tail_*` helpers, which index `activations` with `get_unchecked`, so
+// every `from_index` in `start..end` must be a valid index into `activations`.
+// `CompiledNetwork::new` enforces exactly that at load time
+// (`NetworkError::InvalidSynapseIndex`), which is why the native kernels have
+// always carried this contract — the wasm kernels now share it rather than
+// re-inlining a checked copy of the same loop.
+// ============================================================================
+
+/// Gather the four synapses at `base..base + 4` into `(weights, activations)`
+/// lanes.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn gather4(synapses: &[SynapseData], activations: &[f32], base: usize) -> (v128, v128) {
+    let s0 = &synapses[base];
+    let s1 = &synapses[base + 1];
+    let s2 = &synapses[base + 2];
+    let s3 = &synapses[base + 3];
+
+    (
+        f32x4(s0.weight, s1.weight, s2.weight, s3.weight),
+        f32x4(
+            activations[s0.from_index as usize],
+            activations[s1.from_index as usize],
+            activations[s2.from_index as usize],
+            activations[s3.from_index as usize],
+        ),
+    )
+}
+
+/// Lane-wise `activation[from] * weight` for the four synapses at
+/// `base..base + 4`.
+///
+/// Bit-identical to computing each product scalar-wise and packing the lanes:
+/// `f32x4_mul` is a plain IEEE-754 multiply per lane, not a relaxed operation.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn gather4_products(synapses: &[SynapseData], activations: &[f32], base: usize) -> v128 {
+    let (weights, acts) = gather4(synapses, activations, base);
+    f32x4_mul(weights, acts)
+}
+
+/// Horizontal sum of the four lanes, in lane order.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn reduce4(acc: v128) -> f32 {
+    f32x4_extract_lane::<0>(acc)
+        + f32x4_extract_lane::<1>(acc)
+        + f32x4_extract_lane::<2>(acc)
+        + f32x4_extract_lane::<3>(acc)
+}
 
 /// Issue #1178 - SIMD-optimised weighted sum for standard activations
 /// Issue #1197 - Uses FMA (fused multiply-add) via relaxed-simd for better performance
@@ -41,6 +121,15 @@ use core::arch::wasm32::{f32x4, f32x4_add, f32x4_extract_lane, f32x4_relaxed_mad
 /// Uses a dual-accumulator approach: processes 8 synapses per iteration with two
 /// independent f32x4 accumulators to hide FMA latency via instruction-level
 /// parallelism. Falls back to 4-wide for counts 4..7 and scalar for < 4.
+///
+/// Walks the span through the shared chunk-walk scaffold ([`gather4`],
+/// [`reduce4`], the seed-taking tail in [`scalar`]) — Issue #448.
+///
+/// Issue #207 - the 0..3 tail delegates to a `get_unchecked` helper, so every
+/// `synapse.from_index` in `start..end` must be a valid index into
+/// `activations`. `CompiledNetwork::new` enforces this at load time
+/// (`NetworkError::InvalidSynapseIndex`), so callers holding a loaded network
+/// already satisfy the precondition.
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -70,76 +159,42 @@ pub fn weighted_sum_simd(
 
     for _ in 0..chunks_of_8 {
         // First group of 4 -> acc0
-        let s0 = &synapses[i];
-        let s1 = &synapses[i + 1];
-        let s2 = &synapses[i + 2];
-        let s3 = &synapses[i + 3];
-        let weights0 = f32x4(s0.weight, s1.weight, s2.weight, s3.weight);
-        let acts0 = f32x4(
-            activations[s0.from_index as usize],
-            activations[s1.from_index as usize],
-            activations[s2.from_index as usize],
-            activations[s3.from_index as usize],
-        );
+        let (weights0, acts0) = gather4(synapses, activations, i);
         acc0 = f32x4_relaxed_madd(weights0, acts0, acc0);
 
         // Second group of 4 -> acc1 (independent chain)
-        let s4 = &synapses[i + 4];
-        let s5 = &synapses[i + 5];
-        let s6 = &synapses[i + 6];
-        let s7 = &synapses[i + 7];
-        let weights1 = f32x4(s4.weight, s5.weight, s6.weight, s7.weight);
-        let acts1 = f32x4(
-            activations[s4.from_index as usize],
-            activations[s5.from_index as usize],
-            activations[s6.from_index as usize],
-            activations[s7.from_index as usize],
-        );
+        let (weights1, acts1) = gather4(synapses, activations, i + 4);
         acc1 = f32x4_relaxed_madd(weights1, acts1, acc1);
 
         i += 8;
     }
 
     // Handle remaining chunk of 4 if present
-    let remaining = end - i;
-    if remaining >= 4 {
-        let s0 = &synapses[i];
-        let s1 = &synapses[i + 1];
-        let s2 = &synapses[i + 2];
-        let s3 = &synapses[i + 3];
-        let weights = f32x4(s0.weight, s1.weight, s2.weight, s3.weight);
-        let acts = f32x4(
-            activations[s0.from_index as usize],
-            activations[s1.from_index as usize],
-            activations[s2.from_index as usize],
-            activations[s3.from_index as usize],
-        );
+    if scalar::synapse_count(i, end) >= 4 {
+        let (weights, acts) = gather4(synapses, activations, i);
         acc0 = f32x4_relaxed_madd(weights, acts, acc0);
         i += 4;
     }
 
-    // Merge accumulators
-    let merged = f32x4_add(acc0, acc1);
+    // Merge accumulators, then reduce the lanes
+    scalar_sum += reduce4(f32x4_add(acc0, acc1));
 
-    // Horizontal sum of merged SIMD accumulator
-    scalar_sum += f32x4_extract_lane::<0>(merged)
-        + f32x4_extract_lane::<1>(merged)
-        + f32x4_extract_lane::<2>(merged)
-        + f32x4_extract_lane::<3>(merged);
-
-    // Handle scalar remainder (0-3 synapses)
-    for idx in i..end {
-        let synapse = &synapses[idx];
-        scalar_sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
-
-    scalar_sum
+    // SAFETY: `end <= synapses.len()` (the caller's range indexes the chunk
+    // loop above), and every `from_index` in `i..end` indexes `activations` —
+    // load-time validation in `CompiledNetwork::new` (`AGENTS.md`,
+    // "Unsafe & SIMD invariants") is `tail_sum`'s stated precondition.
+    unsafe { scalar::tail_sum(synapses, activations, i, end, scalar_sum) }
 }
 
 /// Issue #1178 - SIMD-optimised sum of squared weighted activations for Hypotenuse.
 ///
-/// Computes sum((activation[from] * weight)^2) using SIMD with dual accumulators.
+/// Computes sum((activation[from] * weight)^2) using SIMD.
 /// Used by the Hypotenuse squash function: sqrt(sum_sq) + bias.
+///
+/// Shares the chunk-walk scaffold ([`gather4_products`], [`reduce4`], the
+/// seed-taking tail) with the other single-record kernels, and runs a single
+/// accumulator over chunks of four. Same index precondition as
+/// [`weighted_sum_simd`].
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -156,48 +211,32 @@ pub fn weighted_sum_of_squares_simd(
     }
 
     let mut acc = f32x4_splat(0.0);
-    let mut scalar_sum = 0.0f32;
     let chunks = count / 4;
 
     for chunk in 0..chunks {
-        let base = start + chunk * 4;
-        let s0 = &synapses[base];
-        let s1 = &synapses[base + 1];
-        let s2 = &synapses[base + 2];
-        let s3 = &synapses[base + 3];
-
-        // Compute weighted activations
-        let products = f32x4(
-            activations[s0.from_index as usize] * s0.weight,
-            activations[s1.from_index as usize] * s1.weight,
-            activations[s2.from_index as usize] * s2.weight,
-            activations[s3.from_index as usize] * s3.weight,
-        );
-
         // Square and accumulate: acc += products * products
+        let products = gather4_products(synapses, activations, start + chunk * 4);
         acc = f32x4_relaxed_madd(products, products, acc);
     }
 
-    scalar_sum += f32x4_extract_lane::<0>(acc)
-        + f32x4_extract_lane::<1>(acc)
-        + f32x4_extract_lane::<2>(acc)
-        + f32x4_extract_lane::<3>(acc);
-
+    let scalar_sum = reduce4(acc);
     let remainder_start = start + chunks * 4;
-    for i in remainder_start..end {
-        let synapse = &synapses[i];
-        let val = activations[synapse.from_index as usize] * synapse.weight;
-        scalar_sum += val * val;
-    }
 
-    scalar_sum
+    // SAFETY: same contract as `weighted_sum_simd`'s tail — load-time index
+    // validation in `CompiledNetwork::new`.
+    unsafe { scalar::tail_sum_of_squares(synapses, activations, remainder_start, end, scalar_sum) }
 }
 
 /// Issue #1178 - SIMD-optimised weighted sum for Mean activation.
 ///
 /// Computes the plain weighted sum (without bias) using SIMD, intended for
-/// the Mean squash: sum / n + bias. Shares the dual-accumulator approach
-/// with `weighted_sum_simd` but omits the bias to keep the division clean.
+/// the Mean squash: sum / n + bias. Omits the bias to keep the division clean.
+///
+/// Shares the chunk-walk scaffold ([`gather4`], [`reduce4`], the seed-taking
+/// tail) with the other single-record kernels, but runs a **single**
+/// accumulator over chunks of four — the Issue #1197 dual-accumulator form is
+/// on [`weighted_sum_simd`] only. Same index precondition as
+/// [`weighted_sum_simd`].
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -214,44 +253,30 @@ pub fn weighted_sum_no_bias_simd(
     }
 
     let mut acc = f32x4_splat(0.0);
-    let mut scalar_sum = 0.0f32;
     let chunks = count / 4;
 
     for chunk in 0..chunks {
-        let base = start + chunk * 4;
-        let s0 = &synapses[base];
-        let s1 = &synapses[base + 1];
-        let s2 = &synapses[base + 2];
-        let s3 = &synapses[base + 3];
-
-        let weights = f32x4(s0.weight, s1.weight, s2.weight, s3.weight);
-        let acts = f32x4(
-            activations[s0.from_index as usize],
-            activations[s1.from_index as usize],
-            activations[s2.from_index as usize],
-            activations[s3.from_index as usize],
-        );
+        let (weights, acts) = gather4(synapses, activations, start + chunk * 4);
         acc = f32x4_relaxed_madd(weights, acts, acc);
     }
 
-    scalar_sum += f32x4_extract_lane::<0>(acc)
-        + f32x4_extract_lane::<1>(acc)
-        + f32x4_extract_lane::<2>(acc)
-        + f32x4_extract_lane::<3>(acc);
-
+    let scalar_sum = reduce4(acc);
     let remainder_start = start + chunks * 4;
-    for i in remainder_start..end {
-        let synapse = &synapses[i];
-        scalar_sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
 
-    scalar_sum
+    // SAFETY: same contract as `weighted_sum_simd`'s tail — load-time index
+    // validation in `CompiledNetwork::new`.
+    unsafe { scalar::tail_sum(synapses, activations, remainder_start, end, scalar_sum) }
 }
 
 /// Issue #1178 - SIMD-optimised sum of squared (bias + weighted activation) for HypotenuseV2.
 ///
 /// Computes sum((bias + activation[from] * weight)^2) using SIMD.
 /// Used by the HypotenuseV2 squash function: sqrt(sum_sq).
+///
+/// Shares the chunk-walk scaffold ([`gather4_products`], [`reduce4`], the
+/// seed-taking tail) with the other single-record kernels, and runs a single
+/// accumulator over chunks of four. Same index precondition as
+/// [`weighted_sum_simd`].
 ///
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
@@ -270,42 +295,30 @@ pub fn weighted_sum_of_squares_v2_simd(
 
     let bias_vec = f32x4_splat(bias);
     let mut acc = f32x4_splat(0.0);
-    let mut scalar_sum = 0.0f32;
     let chunks = count / 4;
 
     for chunk in 0..chunks {
-        let base = start + chunk * 4;
-        let s0 = &synapses[base];
-        let s1 = &synapses[base + 1];
-        let s2 = &synapses[base + 2];
-        let s3 = &synapses[base + 3];
-
-        // Compute bias + activation * weight
-        let weighted = f32x4(
-            activations[s0.from_index as usize] * s0.weight,
-            activations[s1.from_index as usize] * s1.weight,
-            activations[s2.from_index as usize] * s2.weight,
-            activations[s3.from_index as usize] * s3.weight,
-        );
+        // Compute bias + activation * weight, then square and accumulate
+        let weighted = gather4_products(synapses, activations, start + chunk * 4);
         let vals = f32x4_add(bias_vec, weighted);
-
-        // Square and accumulate: acc += vals * vals
         acc = f32x4_relaxed_madd(vals, vals, acc);
     }
 
-    scalar_sum += f32x4_extract_lane::<0>(acc)
-        + f32x4_extract_lane::<1>(acc)
-        + f32x4_extract_lane::<2>(acc)
-        + f32x4_extract_lane::<3>(acc);
-
+    let scalar_sum = reduce4(acc);
     let remainder_start = start + chunks * 4;
-    for i in remainder_start..end {
-        let synapse = &synapses[i];
-        let val = bias + activations[synapse.from_index as usize] * synapse.weight;
-        scalar_sum += val * val;
-    }
 
-    scalar_sum
+    // SAFETY: same contract as `weighted_sum_simd`'s tail — load-time index
+    // validation in `CompiledNetwork::new`.
+    unsafe {
+        scalar::tail_sum_of_squares_v2(
+            synapses,
+            activations,
+            remainder_start,
+            end,
+            scalar_sum,
+            bias,
+        )
+    }
 }
 
 /// Issue #1202 - SIMD-optimised weighted sum for 4 records simultaneously.

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -15,6 +15,14 @@
 //!   on `x86_64`, **NEON** on `aarch64`; otherwise scalar (same numerics as the old fallback).
 //! - **SIMD aggregate helpers**: `weighted_sum_of_squares_simd` for Hypotenuse
 //!   and `weighted_sum_for_mean_simd` for Mean activation functions.
+//! - **ISA-neutral scalar layer**: the reference scalar kernels and the
+//!   small-count guard live once in [`scalar`] (Issue #447) and are shared by
+//!   the wasm and native paths.
+
+// Issue #447 - the ISA-neutral scalar layer: reference kernels, the saturating
+// count guard, and the seed-taking tail helpers, shared by the wasm kernels
+// below and the native kernels in `simd_native.rs`.
+pub mod scalar;
 
 // Native single-record/multi-record kernels live in `simd_native.rs`; only the
 // wasm32 implementations below reference `SynapseData` directly.
@@ -44,19 +52,10 @@ pub fn weighted_sum_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return bias;
-    }
-
-    // For very small counts, scalar is faster due to SIMD setup overhead
-    if count < 4 {
-        let mut sum = bias;
-        for i in start..end {
-            let synapse = &synapses[i];
-            sum += activations[synapse.from_index as usize] * synapse.weight;
-        }
-        return sum;
+    // For very small counts, scalar is faster due to SIMD setup overhead.
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum(synapses, activations, start, end, bias);
     }
 
     // Dual-accumulator approach: two independent accumulators hide FMA latency
@@ -151,19 +150,9 @@ pub fn weighted_sum_of_squares_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return 0.0;
-    }
-
-    if count < 4 {
-        let mut sum_sq = 0.0f32;
-        for i in start..end {
-            let synapse = &synapses[i];
-            let val = activations[synapse.from_index as usize] * synapse.weight;
-            sum_sq += val * val;
-        }
-        return sum_sq;
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum_of_squares(synapses, activations, start, end);
     }
 
     let mut acc = f32x4_splat(0.0);
@@ -219,18 +208,9 @@ pub fn weighted_sum_no_bias_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return 0.0;
-    }
-
-    if count < 4 {
-        let mut sum = 0.0f32;
-        for i in start..end {
-            let synapse = &synapses[i];
-            sum += activations[synapse.from_index as usize] * synapse.weight;
-        }
-        return sum;
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum_no_bias(synapses, activations, start, end);
     }
 
     let mut acc = f32x4_splat(0.0);
@@ -283,19 +263,9 @@ pub fn weighted_sum_of_squares_v2_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    let count = end - start;
-    if count == 0 {
-        return 0.0;
-    }
-
-    if count < 4 {
-        let mut sum_sq = 0.0f32;
-        for i in start..end {
-            let synapse = &synapses[i];
-            let val = bias + activations[synapse.from_index as usize] * synapse.weight;
-            sum_sq += val * val;
-        }
-        return sum_sq;
+    let count = scalar::synapse_count(start, end);
+    if count < scalar::SINGLE_RECORD_SIMD_MIN {
+        return scalar::weighted_sum_of_squares_v2(synapses, activations, start, end, bias);
     }
 
     let bias_vec = f32x4_splat(bias);
@@ -356,8 +326,7 @@ pub fn weighted_sum_simd_4records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32) {
-    let count = end - start;
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias);
     }
 
@@ -414,8 +383,7 @@ pub fn weighted_sum_simd_8records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
-    let count = end - start;
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias, bias, bias, bias, bias);
     }
 
@@ -474,7 +442,7 @@ pub fn weighted_sum_interleaved_8(
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    if end <= start {
+    if scalar::synapse_count(start, end) == 0 {
         return [bias; 8];
     }
 

--- a/neat-core/src/simd/scalar.rs
+++ b/neat-core/src/simd/scalar.rs
@@ -1,0 +1,195 @@
+//! ISA-neutral scalar layer of the weighted-sum kernels (Issue #447).
+//!
+//! This module is the single home of one rule: **the reference scalar semantics
+//! of each weighted-sum kernel, and the small-count guard in front of it** — the
+//! thing every SIMD path must agree with bit-for-bit. It carries no intrinsics
+//! and no `cfg`, so the `wasm32` kernels in [`crate::simd`] and the x86/aarch64
+//! kernels in `simd_native.rs` share one copy instead of drifting apart.
+//!
+//! Two layers, deliberately distinct:
+//!
+//! - **Reference kernels** ([`weighted_sum`], [`weighted_sum_of_squares`],
+//!   [`weighted_sum_no_bias`], [`weighted_sum_of_squares_v2`]) seed their own
+//!   accumulator and index the activation buffer safely. They are what a
+//!   below-threshold count falls back to on every target.
+//! - **Seed-taking tail helpers** ([`tail_sum`], [`tail_sum_of_squares`],
+//!   [`tail_sum_of_squares_v2`]) take the caller's *running* accumulator, so a
+//!   SIMD kernel's 0..3 remainder continues the same f32 rounding order rather
+//!   than starting a second sum. They index with `get_unchecked` under the
+//!   load-time index-validation invariant documented in `AGENTS.md`
+//!   ("Unsafe & SIMD invariants"), which is why they are `unsafe fn`.
+//!
+//! The two layers are pinned to each other by
+//! `neat-core/tests/simd_scalar_layer.rs`: splitting a range at any point and
+//! continuing through a tail helper reproduces the reference result exactly.
+
+use crate::network::SynapseData;
+
+/// SIMD setup (lane gather, horizontal reduce) only pays off once there is at
+/// least one full 4-wide chunk; below that the scalar reference kernels win.
+pub const SINGLE_RECORD_SIMD_MIN: usize = 4;
+
+/// Number of synapses in `start..end`.
+///
+/// Saturating: a reversed range (`end < start`) counts as zero rather than
+/// underflowing, so a caller that hands over a degenerate range gets the
+/// empty-range answer instead of a panic in debug or a colossal count in
+/// release.
+#[inline]
+pub fn synapse_count(start: usize, end: usize) -> usize {
+    end.saturating_sub(start)
+}
+
+/// Reference kernel: `bias + sum(activation[from] * weight)`.
+#[inline]
+pub fn weighted_sum(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> f32 {
+    let mut sum = bias;
+    for synapse in synapses.iter().take(end).skip(start) {
+        sum += activations[synapse.from_index as usize] * synapse.weight;
+    }
+    sum
+}
+
+/// Reference kernel: `sum((activation[from] * weight)^2)` (Hypotenuse).
+#[inline]
+pub fn weighted_sum_of_squares(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+) -> f32 {
+    let mut sum_sq = 0.0f32;
+    for synapse in synapses.iter().take(end).skip(start) {
+        let val = activations[synapse.from_index as usize] * synapse.weight;
+        sum_sq += val * val;
+    }
+    sum_sq
+}
+
+/// Reference kernel: `sum(activation[from] * weight)`, no bias (Mean).
+#[inline]
+pub fn weighted_sum_no_bias(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+) -> f32 {
+    let mut sum = 0.0f32;
+    for synapse in synapses.iter().take(end).skip(start) {
+        sum += activations[synapse.from_index as usize] * synapse.weight;
+    }
+    sum
+}
+
+/// Reference kernel: `sum((bias + activation[from] * weight)^2)` (HypotenuseV2).
+#[inline]
+pub fn weighted_sum_of_squares_v2(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> f32 {
+    let mut sum_sq = 0.0f32;
+    for synapse in synapses.iter().take(end).skip(start) {
+        let val = bias + activations[synapse.from_index as usize] * synapse.weight;
+        sum_sq += val * val;
+    }
+    sum_sq
+}
+
+/// Continue a running plain weighted sum over the `i..end` remainder.
+///
+/// Takes `acc` — the caller's running accumulator — so a SIMD kernel's tail
+/// keeps the reference f32 rounding order instead of starting a second sum and
+/// merging it. Seeding it with `bias` and `i == start` reproduces
+/// [`weighted_sum`] exactly.
+///
+/// # Safety
+/// `end` must be `<= synapses.len()`, and every `synapse.from_index` in
+/// `i..end` must be a valid index into `activations`. `CompiledNetwork::new`
+/// enforces the index range at load time (`NetworkError::InvalidSynapseIndex`),
+/// so callers holding a loaded network already satisfy this — see the
+/// "Unsafe & SIMD invariants" section of `AGENTS.md`.
+#[inline]
+pub unsafe fn tail_sum(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    i: usize,
+    end: usize,
+    acc: f32,
+) -> f32 {
+    let mut sum = acc;
+    let mut idx = i;
+    while idx < end {
+        // SAFETY: `idx < end <= synapses.len()`, and the caller guarantees
+        // every `from_index` in `i..end` indexes `activations` (load-time
+        // validation in `CompiledNetwork::new`).
+        let s = unsafe { synapses.get_unchecked(idx) };
+        sum += unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
+        idx += 1;
+    }
+    sum
+}
+
+/// Continue a running sum of squared weighted activations over `i..end`.
+///
+/// Seeding it with `0.0` and `i == start` reproduces
+/// [`weighted_sum_of_squares`] exactly.
+///
+/// # Safety
+/// Same contract as [`tail_sum`].
+#[inline]
+pub unsafe fn tail_sum_of_squares(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    i: usize,
+    end: usize,
+    acc: f32,
+) -> f32 {
+    let mut sum = acc;
+    let mut idx = i;
+    while idx < end {
+        // SAFETY: same as `tail_sum` — load-time index validation.
+        let s = unsafe { synapses.get_unchecked(idx) };
+        let val = unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
+        sum += val * val;
+        idx += 1;
+    }
+    sum
+}
+
+/// Continue a running sum of squared `(bias + weighted activation)` over
+/// `i..end`.
+///
+/// Seeding it with `0.0` and `i == start` reproduces
+/// [`weighted_sum_of_squares_v2`] exactly.
+///
+/// # Safety
+/// Same contract as [`tail_sum`].
+#[inline]
+pub unsafe fn tail_sum_of_squares_v2(
+    synapses: &[SynapseData],
+    activations: &[f32],
+    i: usize,
+    end: usize,
+    acc: f32,
+    bias: f32,
+) -> f32 {
+    let mut sum = acc;
+    let mut idx = i;
+    while idx < end {
+        // SAFETY: same as `tail_sum` — load-time index validation.
+        let s = unsafe { synapses.get_unchecked(idx) };
+        let val = bias + unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
+        sum += val * val;
+        idx += 1;
+    }
+    sum
+}

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -10,8 +10,13 @@
 //! gathering 4 indexed activations per step, FMA-accumulating, then horizontally
 //! reducing — with FMA+SSE on `x86_64`, NEON on `aarch64`, and scalar elsewhere and
 //! for the 0..3 synapse tail.
+//!
+//! The ISA-neutral scalar layer — the reference kernels, the saturating count
+//! guard, and the seed-taking tail helpers — lives once in
+//! [`crate::simd::scalar`] (Issue #447) and is shared with the wasm kernels.
 
 use crate::network::SynapseData;
+use crate::simd::scalar;
 
 #[inline]
 fn weighted_sum_simd_8records_scalar(
@@ -106,7 +111,7 @@ fn weighted_sum_interleaved_8_scalar(
 
 #[cfg(target_arch = "x86_64")]
 mod x86 {
-    use super::SynapseData;
+    use super::{SynapseData, scalar};
     use core::arch::x86_64::*;
 
     /// # Safety
@@ -260,7 +265,7 @@ mod x86 {
         bias: f32,
     ) -> f32 {
         let mut acc = _mm_setzero_ps();
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -281,13 +286,10 @@ mod x86 {
         }
         let mut out = [0.0_f32; 4];
         unsafe { _mm_storeu_ps(out.as_mut_ptr(), acc) };
-        let mut sum = bias + out[0] + out[1] + out[2] + out[3];
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            sum += unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            i += 1;
-        }
-        sum
+        let sum = bias + out[0] + out[1] + out[2] + out[3];
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum`'s contract — load-time validation in `CompiledNetwork::new`.
+        unsafe { scalar::tail_sum(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -305,7 +307,7 @@ mod x86 {
         end: usize,
     ) -> f32 {
         let mut acc = _mm_setzero_ps();
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -327,14 +329,10 @@ mod x86 {
         }
         let mut out = [0.0_f32; 4];
         unsafe { _mm_storeu_ps(out.as_mut_ptr(), acc) };
-        let mut sum = out[0] + out[1] + out[2] + out[3];
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val = unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = out[0] + out[1] + out[2] + out[3];
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -354,7 +352,7 @@ mod x86 {
     ) -> f32 {
         let bias_vec = _mm_set1_ps(bias);
         let mut acc = _mm_setzero_ps();
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -376,21 +374,16 @@ mod x86 {
         }
         let mut out = [0.0_f32; 4];
         unsafe { _mm_storeu_ps(out.as_mut_ptr(), acc) };
-        let mut sum = out[0] + out[1] + out[2] + out[3];
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val =
-                bias + unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = out[0] + out[1] + out[2] + out[3];
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares_v2`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares_v2(synapses, activations, i, end, sum, bias) }
     }
 }
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64 {
-    use super::SynapseData;
+    use super::{SynapseData, scalar};
     use core::arch::aarch64::*;
 
     /// # Safety
@@ -553,7 +546,7 @@ mod aarch64 {
         let mut acc = vdupq_n_f32(0.0);
         let mut wl = [0.0_f32; 4];
         let mut al = [0.0_f32; 4];
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -575,13 +568,10 @@ mod aarch64 {
             acc = vfmaq_f32(acc, weights, acts);
             i += 4;
         }
-        let mut sum = bias + vaddvq_f32(acc);
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            sum += unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            i += 1;
-        }
-        sum
+        let sum = bias + vaddvq_f32(acc);
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum`'s contract — load-time validation in `CompiledNetwork::new`.
+        unsafe { scalar::tail_sum(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -601,7 +591,7 @@ mod aarch64 {
         let mut acc = vdupq_n_f32(0.0);
         let mut wl = [0.0_f32; 4];
         let mut al = [0.0_f32; 4];
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -624,14 +614,10 @@ mod aarch64 {
             acc = vfmaq_f32(acc, products, products);
             i += 4;
         }
-        let mut sum = vaddvq_f32(acc);
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val = unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = vaddvq_f32(acc);
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares(synapses, activations, i, end, sum) }
     }
 
     /// # Safety
@@ -653,7 +639,7 @@ mod aarch64 {
         let mut acc = vdupq_n_f32(0.0);
         let mut wl = [0.0_f32; 4];
         let mut al = [0.0_f32; 4];
-        let chunk_end = start + ((end - start) / 4) * 4;
+        let chunk_end = start + (scalar::synapse_count(start, end) / 4) * 4;
         let mut i = start;
         while i < chunk_end {
             let s0 = unsafe { synapses.get_unchecked(i) };
@@ -676,15 +662,10 @@ mod aarch64 {
             acc = vfmaq_f32(acc, vals, vals);
             i += 4;
         }
-        let mut sum = vaddvq_f32(acc);
-        while i < end {
-            let s = unsafe { synapses.get_unchecked(i) };
-            let val =
-                bias + unsafe { *activations.get_unchecked(s.from_index as usize) } * s.weight;
-            sum += val * val;
-            i += 1;
-        }
-        sum
+        let sum = vaddvq_f32(acc);
+        // SAFETY: this fn's own index precondition (documented above) is exactly
+        // `tail_sum_of_squares_v2`'s contract — load-time validation.
+        unsafe { scalar::tail_sum_of_squares_v2(synapses, activations, i, end, sum, bias) }
     }
 }
 
@@ -705,8 +686,7 @@ pub fn weighted_sum_simd_8records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32, f32, f32, f32, f32) {
-    let count = end.saturating_sub(start);
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias, bias, bias, bias, bias);
     }
 
@@ -755,7 +735,7 @@ pub fn weighted_sum_interleaved_8(
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    if end <= start {
+    if scalar::synapse_count(start, end) == 0 {
         return [bias; 8];
     }
 
@@ -799,8 +779,7 @@ pub fn weighted_sum_simd_4records(
     end: usize,
     bias: f32,
 ) -> (f32, f32, f32, f32) {
-    let count = end.saturating_sub(start);
-    if count == 0 {
+    if scalar::synapse_count(start, end) == 0 {
         return (bias, bias, bias, bias);
     }
 
@@ -844,73 +823,8 @@ pub fn weighted_sum_simd_4records(
 // fall back to the scalar loop elsewhere and for the 0..3 synapse tail.
 // ============================================================================
 
-/// Scalar fallback: bias + sum(activation[from] * weight).
-#[inline]
-fn weighted_sum_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-    bias: f32,
-) -> f32 {
-    let mut sum = bias;
-    for synapse in synapses.iter().take(end).skip(start) {
-        sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
-    sum
-}
-
-/// Scalar fallback: sum((activation[from] * weight)^2).
-#[inline]
-fn weighted_sum_of_squares_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-) -> f32 {
-    let mut sum_sq = 0.0f32;
-    for synapse in synapses.iter().take(end).skip(start) {
-        let val = activations[synapse.from_index as usize] * synapse.weight;
-        sum_sq += val * val;
-    }
-    sum_sq
-}
-
-/// Scalar fallback: sum(activation[from] * weight), no bias.
-#[inline]
-fn weighted_sum_no_bias_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-) -> f32 {
-    let mut sum = 0.0f32;
-    for synapse in synapses.iter().take(end).skip(start) {
-        sum += activations[synapse.from_index as usize] * synapse.weight;
-    }
-    sum
-}
-
-/// Scalar fallback: sum((bias + activation[from] * weight)^2).
-#[inline]
-fn weighted_sum_of_squares_v2_scalar(
-    synapses: &[SynapseData],
-    activations: &[f32],
-    start: usize,
-    end: usize,
-    bias: f32,
-) -> f32 {
-    let mut sum_sq = 0.0f32;
-    for synapse in synapses.iter().take(end).skip(start) {
-        let val = bias + activations[synapse.from_index as usize] * synapse.weight;
-        sum_sq += val * val;
-    }
-    sum_sq
-}
-
-// SIMD setup (lane gather, horizontal reduce) only pays off once there is at
-// least one full 4-wide chunk; below that the scalar loop wins.
-const SINGLE_RECORD_SIMD_MIN: usize = 4;
+// The scalar fallbacks and the `SINGLE_RECORD_SIMD_MIN` threshold live in
+// `crate::simd::scalar` (Issue #447), shared with the wasm kernels.
 
 /// Single-record weighted sum: `bias + sum(activation[from] * weight)`.
 ///
@@ -930,7 +844,7 @@ pub fn weighted_sum_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -952,7 +866,7 @@ pub fn weighted_sum_simd(
             }
         }
     }
-    weighted_sum_scalar(synapses, activations, start, end, bias)
+    scalar::weighted_sum(synapses, activations, start, end, bias)
 }
 
 /// Single-record sum of squared weighted activations (Hypotenuse): `sum((a*w)^2)`.
@@ -966,7 +880,7 @@ pub fn weighted_sum_of_squares_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -988,7 +902,7 @@ pub fn weighted_sum_of_squares_simd(
             }
         }
     }
-    weighted_sum_of_squares_scalar(synapses, activations, start, end)
+    scalar::weighted_sum_of_squares(synapses, activations, start, end)
 }
 
 /// Single-record weighted sum without bias (Mean): `sum(activation[from] * weight)`.
@@ -1002,7 +916,7 @@ pub fn weighted_sum_no_bias_simd(
     start: usize,
     end: usize,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -1022,7 +936,7 @@ pub fn weighted_sum_no_bias_simd(
             }
         }
     }
-    weighted_sum_no_bias_scalar(synapses, activations, start, end)
+    scalar::weighted_sum_no_bias(synapses, activations, start, end)
 }
 
 /// Single-record sum of squared (bias + weighted activation) (HypotenuseV2):
@@ -1038,7 +952,7 @@ pub fn weighted_sum_of_squares_v2_simd(
     end: usize,
     bias: f32,
 ) -> f32 {
-    if end.saturating_sub(start) >= SINGLE_RECORD_SIMD_MIN {
+    if scalar::synapse_count(start, end) >= scalar::SINGLE_RECORD_SIMD_MIN {
         #[cfg(target_arch = "x86_64")]
         {
             if std::arch::is_x86_feature_detected!("fma") {
@@ -1066,7 +980,7 @@ pub fn weighted_sum_of_squares_v2_simd(
             }
         }
     }
-    weighted_sum_of_squares_v2_scalar(synapses, activations, start, end, bias)
+    scalar::weighted_sum_of_squares_v2(synapses, activations, start, end, bias)
 }
 
 #[cfg(test)]
@@ -1149,7 +1063,7 @@ mod tests {
     #[test]
     fn weighted_sum_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_scalar(&syn, &acts, 0, 6, 0.25);
+        let s = scalar::weighted_sum(&syn, &acts, 0, 6, 0.25);
         let n = weighted_sum_simd(&syn, &acts, 0, 6, 0.25);
         close(n, s);
     }
@@ -1157,7 +1071,7 @@ mod tests {
     #[test]
     fn weighted_sum_no_bias_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_no_bias_scalar(&syn, &acts, 0, 6);
+        let s = scalar::weighted_sum_no_bias(&syn, &acts, 0, 6);
         let n = weighted_sum_no_bias_simd(&syn, &acts, 0, 6);
         close(n, s);
     }
@@ -1165,7 +1079,7 @@ mod tests {
     #[test]
     fn weighted_sum_of_squares_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_of_squares_scalar(&syn, &acts, 0, 6);
+        let s = scalar::weighted_sum_of_squares(&syn, &acts, 0, 6);
         let n = weighted_sum_of_squares_simd(&syn, &acts, 0, 6);
         close(n, s);
     }
@@ -1173,7 +1087,7 @@ mod tests {
     #[test]
     fn weighted_sum_of_squares_v2_simd_matches_scalar() {
         let (syn, acts) = six_synapses();
-        let s = weighted_sum_of_squares_v2_scalar(&syn, &acts, 0, 6, -0.5);
+        let s = scalar::weighted_sum_of_squares_v2(&syn, &acts, 0, 6, -0.5);
         let n = weighted_sum_of_squares_v2_simd(&syn, &acts, 0, 6, -0.5);
         close(n, s);
     }

--- a/neat-core/src/squash.rs
+++ b/neat-core/src/squash.rs
@@ -116,6 +116,48 @@ pub enum SquashType {
     Mean = 37, // MEAN: (sum of weighted_inputs) / n + bias
 }
 
+/// The aggregate squash variants as an or-pattern — the single home of the
+/// membership list behind [`SquashType::is_aggregate`] (Issue #446).
+///
+/// Prefer `is_aggregate()`; reach for this macro only where an exhaustive
+/// `match` over `SquashType` needs the set as a *pattern* (a guard arm would
+/// forfeit the compiler's exhaustiveness check).
+macro_rules! aggregate_squash_patterns {
+    () => {
+        $crate::squash::SquashType::Minimum
+            | $crate::squash::SquashType::Maximum
+            | $crate::squash::SquashType::If
+            | $crate::squash::SquashType::Hypotenuse
+            | $crate::squash::SquashType::HypotenuseV2
+            | $crate::squash::SquashType::Mean
+    };
+}
+pub(crate) use aggregate_squash_patterns;
+
+impl SquashType {
+    /// True for the six **aggregate** squashes — `Minimum`, `Maximum`, `If`,
+    /// `Hypotenuse`, `HypotenuseV2` and `Mean` (Issue #446).
+    ///
+    /// These reduce a neuron's whole synapse range at once rather than
+    /// squashing a weighted sum, so they cannot be lane-vectorised: every
+    /// batched kernel routes them to the exact single-record kernel, and
+    /// tracing reports the activation itself as the hint. This predicate is
+    /// the single home of that membership rule — a site that restated the list
+    /// and missed a type would silently route it down the weighted-sum path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neat_core::squash::SquashType;
+    /// assert!(SquashType::Mean.is_aggregate());
+    /// assert!(!SquashType::Relu.is_aggregate());
+    /// ```
+    #[must_use]
+    pub const fn is_aggregate(self) -> bool {
+        matches!(self, aggregate_squash_patterns!())
+    }
+}
+
 impl From<u8> for SquashType {
     fn from(v: u8) -> Self {
         match v {

--- a/neat-core/src/unsquash.rs
+++ b/neat-core/src/unsquash.rs
@@ -5,7 +5,8 @@
 //! Issue #1139 - WASM Migration Phase 7.
 
 use crate::squash::{
-    GELU_COEFF, LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SQRT_2_OVER_PI, SquashType, apply_squash,
+    GELU_COEFF, LEAKY_RELU_ALPHA, SELU_ALPHA, SELU_LAMBDA, SQRT_2_OVER_PI, SquashType,
+    aggregate_squash_patterns, apply_squash,
 };
 
 /// Apply an inverse squash (unsquash) function to a value
@@ -617,13 +618,10 @@ pub fn apply_unsquash(squash_type: SquashType, activation: f32, hint: f32) -> f3
             safe / (1.0 - safe * safe).sqrt()
         }
 
-        // Aggregate functions - return hint or activation
-        SquashType::Minimum
-        | SquashType::Maximum
-        | SquashType::If
-        | SquashType::Hypotenuse
-        | SquashType::HypotenuseV2
-        | SquashType::Mean => {
+        // Aggregate functions (see `SquashType::is_aggregate`) - not
+        // invertible, so return the hint or fall back to the activation. The
+        // pattern form keeps this match exhaustive over `SquashType`.
+        aggregate_squash_patterns!() => {
             if hint.is_finite() {
                 hint
             } else {

--- a/neat-core/tests/aggregate_squash_set.rs
+++ b/neat-core/tests/aggregate_squash_set.rs
@@ -1,0 +1,223 @@
+//! Behavioural coverage for the aggregate-squash set (Issue #446).
+//!
+//! One rule decides *which squash types are aggregates* — `Minimum`,
+//! `Maximum`, `If`, `Hypotenuse`, `HypotenuseV2` and `Mean`: the six that
+//! cannot be lane-vectorised and must take the exact single-record kernel.
+//! That one rule drives both dispatch (scalar kernel vs SIMD lane path) and
+//! hint semantics, and every consumer must agree with it — a site that
+//! disagreed would route an aggregate down the weighted-sum path and silently
+//! produce numbers that differ from `activate()`.
+//!
+//! These are "what" tests: they call [`SquashType::is_aggregate`] and the
+//! public activation, scoring and unsquash entry points and assert on the
+//! observable results, so a drifted membership list fails here regardless of
+//! how the set is spelled.
+
+use neat_core::range::apply_limit_range;
+use neat_core::squash::{SquashType, apply_squash};
+use neat_core::unsquash::apply_unsquash;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// The six aggregate squashes.
+const AGGREGATES: [SquashType; 6] = [
+    SquashType::Minimum,
+    SquashType::Maximum,
+    SquashType::If,
+    SquashType::Hypotenuse,
+    SquashType::HypotenuseV2,
+    SquashType::Mean,
+];
+
+/// Highest discriminant currently defined on `SquashType` (`Mean = 37`).
+const MAX_SQUASH_ID: u8 = 37;
+
+const INPUT_SIZE: usize = 6;
+
+/// Enough records to cover the 8-record group, the 4-record group and the
+/// scalar tail in one scoring call (8 + 4 + 1).
+const RECORD_COUNT: usize = 13;
+
+/// The batched kernels reach the same activation rule as the single-record
+/// reference, so the only permitted gap is f32 summation order inside the SIMD
+/// weighted sums.
+const TOLERANCE: f32 = 1.0e-5;
+
+/// Every `SquashType`, in discriminant order.
+fn all_squash_types() -> Vec<SquashType> {
+    (0..=MAX_SQUASH_ID).map(SquashType::from).collect()
+}
+
+/// Build a network: `INPUT_SIZE` inputs fully connected into two hidden
+/// neurons and one output neuron, every non-input neuron using `squash`.
+/// Mirrors the fixture in `aggregate_squash_tail_parity.rs`.
+fn build_network(squash: SquashType) -> CompiledNetwork {
+    let num_inputs = INPUT_SIZE;
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.27 - 0.1 * (i as f32) + 0.06 * (h as f32),
+                from_index: i as u16,
+                // Alternate the synapse type so the `If` arm sees condition,
+                // positive and negative edges rather than one branch only.
+                synapse_type: (i % 3) as u8,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    synapses.push(SynapseData {
+        weight: 0.62,
+        from_index: num_inputs as u16,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.44,
+        from_index: num_inputs as u16 + 1,
+        synapse_type: 1,
+    });
+    neurons.push(NeuronData {
+        bias: 0.015,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Flat inputs, distinct per record so a mis-routed record cannot hide.
+fn build_inputs(num_records: usize) -> Vec<f32> {
+    let mut inputs = vec![0.0f32; num_records * INPUT_SIZE];
+    for r in 0..num_records {
+        for i in 0..INPUT_SIZE {
+            inputs[r * INPUT_SIZE + i] = (((r * 7 + i * 3) as f32) * 0.013).sin() * 0.9;
+        }
+    }
+    inputs
+}
+
+#[test]
+fn is_aggregate_holds_for_exactly_the_six_aggregate_squashes() {
+    for squash in all_squash_types() {
+        let expected = AGGREGATES.contains(&squash);
+        assert_eq!(
+            squash.is_aggregate(),
+            expected,
+            "{squash:?}: is_aggregate() disagrees with the aggregate set"
+        );
+    }
+}
+
+#[test]
+fn batched_scoring_matches_single_record_activation_for_every_squash_type() {
+    let inputs = build_inputs(RECORD_COUNT);
+
+    for squash in all_squash_types() {
+        let batched = build_network(squash).score_records_flat(&inputs, INPUT_SIZE, 1);
+        assert_eq!(batched.len(), RECORD_COUNT);
+
+        let mut reference_net = build_network(squash);
+        for r in 0..RECORD_COUNT {
+            let record = &inputs[r * INPUT_SIZE..(r + 1) * INPUT_SIZE];
+            let expected = reference_net.activate(record, 1)[0];
+            let diff = (expected - batched[r]).abs();
+            assert!(
+                diff <= TOLERANCE || (expected.is_nan() && batched[r].is_nan()),
+                "{squash:?} record {r}: batched {} diverged from single-record {expected} by {diff}",
+                batched[r]
+            );
+        }
+    }
+}
+
+#[test]
+fn traced_hint_equals_activation_for_aggregate_squashes() {
+    let inputs = build_inputs(1);
+
+    for squash in AGGREGATES {
+        let mut net = build_network(squash);
+        let result = net.activate_and_trace(&inputs, 1);
+        // Layout: [outputs, non-input activations, hint values, trace data].
+        let activations = &result[1..4];
+        let hints = &result[4..7];
+        for (idx, (&activation, &hint)) in activations.iter().zip(hints).enumerate() {
+            assert_eq!(
+                hint, activation,
+                "{squash:?} neuron {idx}: aggregate hint must be the activation"
+            );
+        }
+    }
+}
+
+#[test]
+fn traced_hint_is_the_pre_squash_value_for_standard_squashes() {
+    let inputs = build_inputs(1);
+
+    for squash in all_squash_types().into_iter().filter(|s| !s.is_aggregate()) {
+        let mut net = build_network(squash);
+        let result = net.activate_and_trace(&inputs, 1);
+        let activations = &result[1..4];
+        let hints = &result[4..7];
+        for (idx, (&activation, &hint)) in activations.iter().zip(hints).enumerate() {
+            let expected = apply_limit_range(squash, apply_squash(squash, hint));
+            let diff = (expected - activation).abs();
+            assert!(
+                diff <= TOLERANCE || (expected.is_nan() && activation.is_nan()),
+                "{squash:?} neuron {idx}: hint {hint} does not squash to activation {activation} (got {expected})"
+            );
+        }
+    }
+}
+
+#[test]
+fn unsquash_prefers_the_hint_for_every_aggregate_squash() {
+    for squash in all_squash_types().into_iter().filter(|s| s.is_aggregate()) {
+        // A finite hint is the recovered pre-squash value.
+        assert_eq!(
+            apply_unsquash(squash, 0.5, 1.25),
+            1.25,
+            "{squash:?}: aggregate unsquash must return the hint"
+        );
+        // Without a usable hint it falls back to the activation.
+        assert_eq!(
+            apply_unsquash(squash, 0.5, f32::NAN),
+            0.5,
+            "{squash:?}: aggregate unsquash must fall back to the activation"
+        );
+    }
+}

--- a/neat-core/tests/aggregate_squash_tail_parity.rs
+++ b/neat-core/tests/aggregate_squash_tail_parity.rs
@@ -1,0 +1,189 @@
+//! Parity guard for the **scalar tails** of the fused batch-loss kernels on
+//! aggregate-squash networks (Issue #441).
+//!
+//! The batched loss kernels group records into 8s, then a 4-record group, then
+//! a single-record scalar tail. Every group size must compute a neuron's
+//! activation by the same rule as the single-record reference
+//! ([`CompiledNetwork::activate_into`], reached with `forward_only = false`),
+//! including the aggregate squashes — `Minimum`, `Maximum`, `If`,
+//! `Hypotenuse`, `HypotenuseV2` and `Mean` — which are not a weighted sum.
+//!
+//! These are "what" tests: they score a real aggregate-squash network through
+//! the public packed entry points at record counts that leave a non-empty tail
+//! (5/6/7 → 4-way + tail, 9/13 → 8-way group + tail) and assert the batched
+//! error matches the per-record reference. A tail that falls through to a plain
+//! weighted sum shifts the tail record's output by orders of magnitude, so the
+//! tight tolerance below fails loudly.
+
+use neat_core::loss::{
+    cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
+    mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
+};
+use neat_core::squash::SquashType;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Every aggregate squash the activation rule dispatches on.
+const AGGREGATES: [SquashType; 6] = [
+    SquashType::Minimum,
+    SquashType::Maximum,
+    SquashType::If,
+    SquashType::Hypotenuse,
+    SquashType::HypotenuseV2,
+    SquashType::Mean,
+];
+
+/// Record counts with a non-empty scalar tail: 5/6/7 exercise the 4-way group
+/// plus tail, 9 and 13 the 8-way group plus (4-way plus) tail.
+const TAIL_COUNTS: [usize; 5] = [5, 6, 7, 9, 13];
+
+const INPUT_SIZE: usize = 6;
+
+/// The batched kernels reach the same activation rule as the reference, so the
+/// only permitted gap is f32 summation order inside the SIMD weighted sums.
+const TOLERANCE: f64 = 1.0e-5;
+
+/// Build a forward-only network: `num_inputs` inputs fully connected into two
+/// hidden neurons and one output neuron, every non-input neuron using `squash`.
+/// Mirrors the fixture in `mse_batch_interleaved_parity.rs`.
+fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.27 - 0.1 * (i as f32) + 0.06 * (h as f32),
+                from_index: i as u16,
+                // Alternate the synapse type so the `If` arm sees condition,
+                // positive and negative edges rather than one branch only.
+                synapse_type: (i % 3) as u8,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: squash as u8,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    let hidden0 = num_inputs as u16;
+    let hidden1 = num_inputs as u16 + 1;
+    synapses.push(SynapseData {
+        weight: 0.62,
+        from_index: hidden0,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.44,
+        from_index: hidden1,
+        synapse_type: 1,
+    });
+    neurons.push(NeuronData {
+        bias: 0.015,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: squash as u8,
+        is_constant: false,
+    });
+
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Packed `[inputs..., target]` records, distinct per record so a tail-record
+/// mix-up cannot hide. Targets stay in `(0, 1)` so cross-entropy, MAPE and MSLE
+/// are all well defined on the same fixture.
+fn build_records(num_records: usize, input_size: usize) -> Vec<f32> {
+    let values_per_record = input_size + 1;
+    let mut records = vec![0.0f32; num_records * values_per_record];
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        for i in 0..input_size {
+            records[base + i] = (((r * 7 + i * 3) as f32) * 0.013).sin() * 0.9;
+        }
+        records[base + input_size] = 0.5 + (((r * 5 + 1) as f32) * 0.011).cos() * 0.25;
+    }
+    records
+}
+
+type PackedLoss = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// Score `num_records` through `loss` on the batched (`forward_only = true`)
+/// and the per-record reference (`forward_only = false`) paths and assert they
+/// agree. The reference activates each record on its own through
+/// `CompiledNetwork::activate_into`.
+fn assert_tail_matches_reference(
+    name: &str,
+    loss: PackedLoss,
+    squash: SquashType,
+    num_records: usize,
+) {
+    let mut batched_net = build_network(INPUT_SIZE, squash);
+    let mut reference_net = build_network(INPUT_SIZE, squash);
+    let records = build_records(num_records, INPUT_SIZE);
+
+    let batched = loss(&mut batched_net, &records, INPUT_SIZE, 1, true);
+    let reference = loss(&mut reference_net, &records, INPUT_SIZE, 1, false);
+
+    let diff = (reference - batched).abs();
+    assert!(
+        diff <= TOLERANCE,
+        "{name} {squash:?} n={num_records}: batched {batched} diverged from per-record reference {reference} by {diff} (tol {TOLERANCE})"
+    );
+}
+
+#[test]
+fn mse_scalar_tail_matches_reference_for_every_aggregate_squash() {
+    for squash in AGGREGATES {
+        for &n in &TAIL_COUNTS {
+            assert_tail_matches_reference("mse", mse_sum_batch_packed, squash, n);
+        }
+    }
+}
+
+#[test]
+fn shared_8way_scalar_tail_matches_reference_for_every_aggregate_squash() {
+    // MAE, cross-entropy, MAPE, MSLE and hinge all share the 8-way activation
+    // macro, so they share one scalar tail. Counts 9 and 13 leave that tail
+    // non-empty; the 8-way path needs at least 8 records.
+    let losses: [(&str, PackedLoss); 5] = [
+        ("mae", mae_sum_batch_packed),
+        ("cross_entropy", cross_entropy_sum_batch_packed),
+        ("mape", mape_sum_batch_packed),
+        ("msle", msle_sum_batch_packed),
+        ("hinge", hinge_sum_batch_packed),
+    ];
+    for (name, loss) in losses {
+        for squash in AGGREGATES {
+            for &n in &[9usize, 13] {
+                assert_tail_matches_reference(name, loss, squash, n);
+            }
+        }
+    }
+}

--- a/neat-core/tests/batch_record_skeleton.rs
+++ b/neat-core/tests/batch_record_skeleton.rs
@@ -1,0 +1,351 @@
+//! Behavioural coverage for the batched record-scan skeleton (Issue #445).
+//!
+//! One rule says how a packed record buffer is walked and reduced by the fused
+//! loss kernels: records are grouped 8 → 4 → 1, each group's inputs are loaded
+//! into per-lane activation buffers through the shared loader, and the
+//! per-record errors accumulate into one `f64` sum. Every loss kind — MSE
+//! included — obeys it.
+//!
+//! These are "what" tests: they drive the public `*_sum_batch_packed` entry
+//! points with real networks and assert observable numbers against a
+//! single-record reference built from `CompiledNetwork::activate`. A copy of the
+//! skeleton that drifted — a loader that does not clamp the record to the
+//! network's input count, one that leaves an uncovered input slot stale, or a
+//! remainder split that drops or double-counts records — fails here no matter
+//! how the scan is implemented.
+
+use neat_core::loss::{
+    cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
+    mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
+};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+const IDENTITY: u8 = 0;
+const TANH: u8 = 7;
+const MEAN: u8 = 37;
+
+/// Every batched loss entry point shares the packed signature.
+type PackedEntry = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// A record's per-record reduction: `(targets, outputs) -> error`.
+type Reduce = fn(&[f32], &[f32]) -> f64;
+
+/// One batched loss entry point paired with its single-record reduction.
+type LossCase = (&'static str, PackedEntry, Reduce);
+
+/// Absolute tolerance for a batched sum against the single-record reference.
+/// The across-records SIMD kernels re-associate the weighted sums in `f32`, so
+/// parity is "within a small tolerance", not bit-for-bit.
+const TOL: f64 = 1e-5;
+
+fn network(
+    num_inputs: usize,
+    neurons: Vec<NeuronData>,
+    synapses: Vec<SynapseData>,
+) -> CompiledNetwork {
+    let num_non_inputs = neurons.len();
+    let num_neurons = num_inputs + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Three inputs → two hidden neurons → one output, all standard squashes, so
+/// the network routes through the interleaved/standard batch kernels.
+/// `num_neurons` is 6, deliberately smaller than the widest `input_size` a test
+/// passes, so an unclamped loader writes past the activation buffer.
+fn standard_network(hidden_squash: u8) -> CompiledNetwork {
+    let num_inputs = 3;
+    let mut synapses = Vec::new();
+    let mut neurons = Vec::new();
+
+    for h in 0..2 {
+        let start = synapses.len() as u32;
+        for i in 0..num_inputs {
+            synapses.push(SynapseData {
+                weight: 0.37 - 0.11 * (i as f32) + 0.13 * (h as f32),
+                from_index: i as u16,
+                synapse_type: 0,
+            });
+        }
+        neurons.push(NeuronData {
+            bias: 0.05 * (h as f32) - 0.02,
+            start_synapse: start,
+            num_synapses: num_inputs as u16,
+            squash_type: hidden_squash,
+            is_constant: false,
+        });
+    }
+
+    let start = synapses.len() as u32;
+    synapses.push(SynapseData {
+        weight: 0.61,
+        from_index: num_inputs as u16,
+        synapse_type: 0,
+    });
+    synapses.push(SynapseData {
+        weight: -0.44,
+        from_index: num_inputs as u16 + 1,
+        synapse_type: 0,
+    });
+    neurons.push(NeuronData {
+        bias: 0.03,
+        start_synapse: start,
+        num_synapses: 2,
+        squash_type: IDENTITY,
+        is_constant: false,
+    });
+
+    network(num_inputs, neurons, synapses)
+}
+
+/// Same topology with an aggregate (`MEAN`) hidden neuron, which routes the
+/// batch through the scattered per-lane kernels instead.
+fn aggregate_network() -> CompiledNetwork {
+    standard_network(MEAN)
+}
+
+/// Packed `[inputs…, targets…]` records with distinct per-record values, so a
+/// lane mix-up or a dropped record cannot hide. Input columns beyond the
+/// network's `num_inputs` are padding the network must ignore.
+fn build_records(num_records: usize, input_size: usize, num_outputs: usize) -> Vec<f32> {
+    let values_per_record = input_size + num_outputs;
+    let mut records = vec![0.0f32; num_records * values_per_record];
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        for i in 0..input_size {
+            records[base + i] = -0.9 + 0.23 * (r as f32) - 0.17 * (i as f32);
+        }
+        for j in 0..num_outputs {
+            records[base + input_size + j] = 0.2 + 0.031 * (r as f32) + 0.05 * (j as f32);
+        }
+    }
+    records
+}
+
+/// Single-record reference: activate each record on its own (which clamps the
+/// record to the network's input count) and reduce with `reduce`.
+fn reference_sum(
+    net: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    reduce: impl Fn(&[f32], &[f32]) -> f64,
+) -> f64 {
+    let values_per_record = input_size + num_outputs;
+    let num_records = records.len() / values_per_record;
+    let mut sum = 0.0;
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        let outputs = net.activate(&records[base..base + input_size], num_outputs);
+        sum += reduce(
+            &records[base + input_size..base + values_per_record],
+            &outputs,
+        );
+    }
+    sum
+}
+
+fn mse_reduce(targets: &[f32], outputs: &[f32]) -> f64 {
+    let mut sq = 0.0;
+    for (t, o) in targets.iter().zip(outputs.iter()) {
+        let d = (*t - *o) as f64;
+        sq += d * d;
+    }
+    sq / targets.len() as f64
+}
+
+fn mae_reduce(targets: &[f32], outputs: &[f32]) -> f64 {
+    let mut abs = 0.0;
+    for (t, o) in targets.iter().zip(outputs.iter()) {
+        abs += ((*t - *o) as f64).abs();
+    }
+    abs / targets.len() as f64
+}
+
+/// Every batched loss entry point paired with its per-record reduction.
+fn loss_entries() -> Vec<LossCase> {
+    vec![
+        (
+            "mse",
+            mse_sum_batch_packed as PackedEntry,
+            mse_reduce as Reduce,
+        ),
+        ("mae", mae_sum_batch_packed as PackedEntry, mae_reduce),
+        (
+            "cross_entropy",
+            cross_entropy_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                const EPSILON: f64 = 1e-15;
+                let mut ce = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    let t = *t as f64;
+                    let o = (*o as f64).clamp(EPSILON, 1.0 - EPSILON);
+                    ce -= t * o.ln() + (1.0 - t) * (1.0 - o).ln();
+                }
+                ce / targets.len() as f64
+            },
+        ),
+        (
+            "mape",
+            mape_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                const EPSILON: f64 = 1e-15;
+                let mut mape = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    let t = (*t as f64).max(EPSILON);
+                    mape += ((*o as f64 - t) / t).abs();
+                }
+                mape / targets.len() as f64
+            },
+        ),
+        (
+            "msle",
+            msle_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                const EPSILON: f64 = 1e-15;
+                let mut msle = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    msle += (*t as f64).max(EPSILON).ln() - (*o as f64).max(EPSILON).ln();
+                }
+                msle
+            },
+        ),
+        (
+            "hinge",
+            hinge_sum_batch_packed as PackedEntry,
+            |targets: &[f32], outputs: &[f32]| {
+                let mut hinge = 0.0;
+                for (t, o) in targets.iter().zip(outputs.iter()) {
+                    hinge += (1.0 - (*t as f64) * (*o as f64)).max(0.0);
+                }
+                hinge
+            },
+        ),
+    ]
+}
+
+/// The 8 → 4 → 1 grouping must not change the answer: for every record count
+/// that straddles a group boundary the batched sum equals the sum of the
+/// records scored one at a time.
+#[test]
+fn grouping_does_not_change_the_batched_sum() {
+    for (name, entry, reduce) in loss_entries() {
+        for &num_records in &[1usize, 3, 4, 5, 7, 8, 9, 11, 12, 13, 16, 17, 24, 33] {
+            let records = build_records(num_records, 3, 1);
+            let mut batched = standard_network(TANH);
+            let mut reference = standard_network(TANH);
+
+            let actual = entry(&mut batched, &records, 3, 1, true);
+            let expected = reference_sum(&mut reference, &records, 3, 1, reduce);
+
+            assert!(
+                (actual - expected).abs() < TOL,
+                "{name} n={num_records}: batched {actual} != single-record {expected}"
+            );
+        }
+    }
+}
+
+/// A network whose aggregate squash keeps it on the per-lane kernels obeys the
+/// same grouping rule.
+#[test]
+fn aggregate_network_grouping_does_not_change_the_batched_sum() {
+    for &num_records in &[4usize, 5, 8, 9, 12, 13, 17] {
+        let records = build_records(num_records, 3, 1);
+        let mut batched = aggregate_network();
+        let mut reference = aggregate_network();
+
+        let actual = mse_sum_batch_packed(&mut batched, &records, 3, 1, true);
+        let expected = reference_sum(&mut reference, &records, 3, 1, mse_reduce);
+
+        assert!(
+            (actual - expected).abs() < TOL,
+            "aggregate n={num_records}: batched {actual} != single-record {expected}"
+        );
+    }
+}
+
+/// Input columns beyond the network's `num_inputs` are padding: the batched
+/// loader clamps the copy exactly as `CompiledNetwork::activate` does, so the
+/// extras change nothing (and never write past the activation buffer).
+#[test]
+fn input_columns_beyond_the_network_inputs_are_ignored() {
+    // `input_size` (8) exceeds both `num_inputs` (3) and `num_neurons` (6).
+    let input_size = 8;
+    for (name, entry, reduce) in loss_entries() {
+        for &num_records in &[4usize, 5, 8, 9, 13, 17] {
+            let records = build_records(num_records, input_size, 1);
+            let mut batched = standard_network(TANH);
+            let mut reference = standard_network(TANH);
+
+            let actual = entry(&mut batched, &records, input_size, 1, true);
+            let expected = reference_sum(&mut reference, &records, input_size, 1, reduce);
+
+            assert!(
+                (actual - expected).abs() < TOL,
+                "{name} n={num_records}: padded-record batched {actual} != single-record {expected}"
+            );
+        }
+    }
+}
+
+/// The aggregate (scattered) route clamps the same way.
+#[test]
+fn aggregate_network_ignores_input_columns_beyond_the_network_inputs() {
+    let input_size = 8;
+    for &num_records in &[4usize, 8, 13] {
+        let records = build_records(num_records, input_size, 1);
+        let mut batched = aggregate_network();
+        let mut reference = aggregate_network();
+
+        let actual = mse_sum_batch_packed(&mut batched, &records, input_size, 1, true);
+        let expected = reference_sum(&mut reference, &records, input_size, 1, mse_reduce);
+
+        assert!(
+            (actual - expected).abs() < TOL,
+            "aggregate n={num_records}: padded-record batched {actual} != single-record {expected}"
+        );
+    }
+}
+
+/// A record that covers fewer columns than the network has inputs leaves the
+/// uncovered input slots reading zero for every record — no value from an
+/// earlier group leaks in.
+#[test]
+fn uncovered_input_slots_score_as_zero() {
+    // The network has 3 inputs; each record supplies only 1.
+    let input_size = 1;
+    for &num_records in &[4usize, 8, 9, 13, 17] {
+        let records = build_records(num_records, input_size, 1);
+        let mut batched = standard_network(TANH);
+        let mut reference = standard_network(TANH);
+
+        let actual = mse_sum_batch_packed(&mut batched, &records, input_size, 1, true);
+        let expected = reference_sum(&mut reference, &records, input_size, 1, mse_reduce);
+
+        assert!(
+            (actual - expected).abs() < TOL,
+            "n={num_records}: short-record batched {actual} != single-record {expected}"
+        );
+    }
+}

--- a/neat-core/tests/inline_squash_dispatch.rs
+++ b/neat-core/tests/inline_squash_dispatch.rs
@@ -1,0 +1,331 @@
+//! Behavioural coverage for the hot-squash inline dispatch rule (Issue #443).
+//!
+//! One rule decides which squash types are hot enough to branch inline
+//! (`Identity`, `Relu`, `Logistic`, `Tanh`) and what scalar formula each of
+//! them uses; everything else defers to [`apply_squash`]. That rule is reached
+//! from the single-record forward passes, the 4-way traced batch and the
+//! `None`-fallback branch of every batched loss kernel, and all of them must
+//! agree — the SIMD-batched and scalar-tail paths are only interchangeable
+//! while they do.
+//!
+//! These are "what" tests: they activate real networks through the public
+//! entry points and assert the observable activation equals the
+//! [`apply_squash`] reference for **every** standard squash type, hot arms
+//! included. A copy of the dispatch that drifted — a promoted fifth type, or a
+//! reformulated logistic — fails here regardless of how the dispatch is
+//! implemented.
+
+use neat_core::loss::{
+    cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
+    mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
+};
+use neat_core::range::apply_limit_range;
+use neat_core::squash::{SquashType, apply_squash};
+use neat_core::squash_simd::SQUASH_SIMD_MAX_ABS_ERR;
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Every standard (non-aggregate) squash type. Aggregates 32–37 are activated
+/// by a different rule and are covered by `aggregate_squash_tail_parity.rs`.
+const STANDARD_SQUASHES: [SquashType; 32] = [
+    SquashType::Identity,
+    SquashType::Relu,
+    SquashType::Relu6,
+    SquashType::LeakyRelu,
+    SquashType::Selu,
+    SquashType::Elu,
+    SquashType::Logistic,
+    SquashType::Tanh,
+    SquashType::HardTanh,
+    SquashType::Softsign,
+    SquashType::Softplus,
+    SquashType::Swish,
+    SquashType::Mish,
+    SquashType::Gelu,
+    SquashType::Sine,
+    SquashType::Cosine,
+    SquashType::Tan,
+    SquashType::ArcTan,
+    SquashType::Gaussian,
+    SquashType::BentIdentity,
+    SquashType::BipolarSigmoid,
+    SquashType::Bipolar,
+    SquashType::Step,
+    SquashType::Complement,
+    SquashType::Absolute,
+    SquashType::Square,
+    SquashType::Cube,
+    SquashType::Sqrt,
+    SquashType::StdInverse,
+    SquashType::Exponential,
+    SquashType::LogSigmoid,
+    SquashType::Isru,
+];
+
+/// Squash types the vectorised `squash_x4` / `squash_x8` approximations do not
+/// handle, so the batched loss kernels take the scalar `None`-fallback branch —
+/// the copies of the dispatch under test. `Identity` and `Relu` exercise the
+/// hot inline arms, the rest the `apply_squash` fall-through.
+const FALLBACK_SQUASHES: [SquashType; 6] = [
+    SquashType::Identity,
+    SquashType::Relu,
+    SquashType::Softplus,
+    SquashType::Step,
+    SquashType::Sqrt,
+    SquashType::LogSigmoid,
+];
+
+/// Sums that straddle every interesting part of the squash curves: negative,
+/// zero (the `Sqrt` / `StdInverse` guard), and positive.
+const PROBE_SUMS: [f32; 6] = [-3.25, -0.5, 0.0, 0.5, 1.75, 4.0];
+
+/// Single input wired straight into one output neuron at unit weight and zero
+/// bias, so the neuron's weighted sum is exactly the input value.
+fn unit_network(squash: SquashType) -> CompiledNetwork {
+    let synapses = vec![SynapseData {
+        weight: 1.0,
+        from_index: 0,
+        synapse_type: 0,
+    }];
+    let neurons = vec![NeuronData {
+        bias: 0.0,
+        start_synapse: 0,
+        num_synapses: 1,
+        squash_type: squash as u8,
+        is_constant: false,
+    }];
+
+    CompiledNetwork {
+        num_neurons: 2,
+        num_inputs: 1,
+        neurons,
+        synapses,
+        activations: vec![0.0; 2],
+        hint_values_buffer: vec![0.0; 1],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [vec![0.0; 2], vec![0.0; 2], vec![0.0; 2], vec![0.0; 2]],
+        batch_hints: [vec![0.0; 1], vec![0.0; 1], vec![0.0; 1], vec![0.0; 1]],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// The rule stated once: squash the sum, then clamp to the type's range.
+fn expected(squash: SquashType, sum: f32) -> f32 {
+    apply_limit_range(squash, apply_squash(squash, sum))
+}
+
+fn assert_exact(actual: f32, expected: f32, what: &str) {
+    assert_eq!(
+        actual.to_bits(),
+        expected.to_bits(),
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn activate_squashes_every_standard_type_like_apply_squash() {
+    for squash in STANDARD_SQUASHES {
+        let mut net = unit_network(squash);
+        for sum in PROBE_SUMS {
+            let got = net.activate(&[sum], 1)[0];
+            assert_exact(
+                got,
+                expected(squash, sum),
+                &format!("{squash:?} activate({sum})"),
+            );
+        }
+    }
+}
+
+#[test]
+fn activate_into_squashes_every_standard_type_like_apply_squash() {
+    for squash in STANDARD_SQUASHES {
+        let mut net = unit_network(squash);
+        for sum in PROBE_SUMS {
+            let mut out = [0.0f32; 1];
+            net.activate_into(&[sum], &mut out);
+            assert_exact(
+                out[0],
+                expected(squash, sum),
+                &format!("{squash:?} activate_into({sum})"),
+            );
+        }
+    }
+}
+
+#[test]
+fn activate_and_trace_squashes_every_standard_type_like_apply_squash() {
+    for squash in STANDARD_SQUASHES {
+        let mut net = unit_network(squash);
+        for sum in PROBE_SUMS {
+            let got = net.activate_and_trace(&[sum], 1)[0];
+            assert_exact(
+                got,
+                expected(squash, sum),
+                &format!("{squash:?} activate_and_trace({sum})"),
+            );
+        }
+    }
+}
+
+#[test]
+fn traced_4way_batch_squashes_every_standard_type_like_apply_squash() {
+    // The 4-way traced batch returns a 4-value length header followed by each
+    // record's `[outputs..., activations..., hints..., trace...]` block; the
+    // first value of a block is the record's single output activation.
+    for squash in STANDARD_SQUASHES {
+        let mut net = unit_network(squash);
+        let sums = [PROBE_SUMS[0], PROBE_SUMS[1], PROBE_SUMS[3], PROBE_SUMS[5]];
+        let result = net.activate_and_trace_batch_4way(&sums, 1, 1);
+
+        let mut start = 4;
+        for (lane, sum) in sums.iter().enumerate() {
+            let want = expected(squash, *sum);
+            let got = result[start];
+            // Types `squash_x4` vectorises are allowed their documented
+            // approximation error; the scalar fallback branch — the copy of the
+            // dispatch under test — must land exactly on the reference.
+            assert!(
+                (got - want).abs() <= SQUASH_SIMD_MAX_ABS_ERR,
+                "{squash:?} traced 4-way lane {lane} ({sum}): expected {want}, got {got}"
+            );
+            start += result[lane] as usize;
+        }
+    }
+}
+
+/// Packed records of `[input, target]` with distinct values per record, so a
+/// lane mix-up in the batched kernels would break the parity too. The input
+/// sign alternates so **every** group — the 8-record group, the 4-record
+/// remainder and the scalar tail — straddles zero and therefore exercises the
+/// sign-sensitive arms (`Relu`, `Step`, `Sqrt`) rather than one side only.
+fn packed_records(num_records: usize) -> Vec<f32> {
+    let mut records = vec![0.0f32; num_records * 2];
+    for r in 0..num_records {
+        let magnitude = 0.6 + 0.17 * (r as f32);
+        records[r * 2] = if r % 2 == 0 { -magnitude } else { magnitude };
+        records[r * 2 + 1] = 0.25 + 0.03 * (r as f32);
+    }
+    records
+}
+
+type PackedLoss = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// Every batched loss kernel carrying a copy of the dispatch in its scalar
+/// `None`-fallback branch.
+const PACKED_LOSSES: [(&str, PackedLoss); 6] = [
+    ("mse", mse_sum_batch_packed),
+    ("mae", mae_sum_batch_packed),
+    ("cross_entropy", cross_entropy_sum_batch_packed),
+    ("mape", mape_sum_batch_packed),
+    ("msle", msle_sum_batch_packed),
+    ("hinge", hinge_sum_batch_packed),
+];
+
+/// Two inputs feeding a `Minimum` aggregate hidden neuron and a `squash`
+/// output neuron. The aggregate routes MSE onto the *scattered* 8-way kernel,
+/// which carries its own copy of the dispatch for the standard-squash neurons
+/// travelling with it.
+fn mixed_aggregate_network(squash: SquashType) -> CompiledNetwork {
+    let synapses = vec![
+        SynapseData {
+            weight: 0.8,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: -0.6,
+            from_index: 1,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 1.0,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 0.5,
+            from_index: 2,
+            synapse_type: 0,
+        },
+    ];
+    let neurons = vec![
+        NeuronData {
+            bias: 0.0,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: SquashType::Minimum as u8,
+            is_constant: false,
+        },
+        NeuronData {
+            bias: 0.0,
+            start_synapse: 2,
+            num_synapses: 2,
+            squash_type: squash as u8,
+            is_constant: false,
+        },
+    ];
+
+    CompiledNetwork {
+        num_neurons: 4,
+        num_inputs: 2,
+        neurons,
+        synapses,
+        activations: vec![0.0; 4],
+        hint_values_buffer: vec![0.0; 2],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [vec![0.0; 4], vec![0.0; 4], vec![0.0; 4], vec![0.0; 4]],
+        batch_hints: [vec![0.0; 2], vec![0.0; 2], vec![0.0; 2], vec![0.0; 2]],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// Packed `[in0, in1, target]` records with alternating input signs.
+fn mixed_records(num_records: usize) -> Vec<f32> {
+    let mut records = vec![0.0f32; num_records * 3];
+    for r in 0..num_records {
+        let magnitude = 0.6 + 0.17 * (r as f32);
+        records[r * 3] = if r % 2 == 0 { -magnitude } else { magnitude };
+        records[r * 3 + 1] = 0.4 - 0.09 * (r as f32);
+        records[r * 3 + 2] = 0.25 + 0.03 * (r as f32);
+    }
+    records
+}
+
+#[test]
+fn scattered_mse_fallback_squash_matches_the_scalar_reference() {
+    for num_records in [8usize, 13] {
+        let records = mixed_records(num_records);
+        for squash in FALLBACK_SQUASHES {
+            let mut batched_net = mixed_aggregate_network(squash);
+            let mut scalar_net = mixed_aggregate_network(squash);
+            let batched = mse_sum_batch_packed(&mut batched_net, &records, 2, 1, true);
+            let scalar = mse_sum_batch_packed(&mut scalar_net, &records, 2, 1, false);
+            assert!(
+                (batched - scalar).abs() <= 1.0e-6 * (num_records as f64),
+                "scattered mse {squash:?} n={num_records}: batched {batched} vs scalar {scalar}"
+            );
+        }
+    }
+}
+
+#[test]
+fn batched_loss_fallback_squash_matches_the_scalar_reference() {
+    // 4 → 4-way group, 8 → 8-way group, 13 → 8-way plus 4-way plus tail.
+    for num_records in [4usize, 8, 13] {
+        let records = packed_records(num_records);
+        for squash in FALLBACK_SQUASHES {
+            for (name, loss_fn) in PACKED_LOSSES {
+                let mut batched_net = unit_network(squash);
+                let mut scalar_net = unit_network(squash);
+                // `forward_only = true` takes the SIMD-batched path with the
+                // inline squash fallback; `false` the single-record reference.
+                let batched = loss_fn(&mut batched_net, &records, 1, 1, true);
+                let scalar = loss_fn(&mut scalar_net, &records, 1, 1, false);
+                assert!(
+                    (batched - scalar).abs() <= 1.0e-6 * (num_records as f64),
+                    "{name} {squash:?} n={num_records}: batched {batched} vs scalar {scalar}"
+                );
+            }
+        }
+    }
+}

--- a/neat-core/tests/mse_squash_simd_parity.rs
+++ b/neat-core/tests/mse_squash_simd_parity.rs
@@ -1,5 +1,5 @@
 //! Parity guard for the SIMD squash wiring in the MSE batched loss paths
-//! (Issue #246). `mse_sum_batch_8way` / `mse_sum_batch_4way` now feed their
+//! (Issue #246). The batched MSE kernels feed their
 //! per-lane sums through the vectorised `squash_x8` / `squash_x4`
 //! approximations (shipped by #180) for the hot transcendental squashes,
 //! falling back to the scalar inline squash for every other type.
@@ -168,7 +168,8 @@ fn mse_8way_with_remainder_matches_scalar() {
     }
 }
 
-/// 5–7 records route through `mse_sum_batch_4way`, driving the 4-way SIMD block.
+/// 5–7 records fall to the shared skeleton's 4-record group, driving the 4-way
+/// SIMD block.
 #[test]
 fn mse_4way_matches_scalar_for_vectorised_squashes() {
     for squash in [

--- a/neat-core/tests/packed_record_scan.rs
+++ b/neat-core/tests/packed_record_scan.rs
@@ -1,0 +1,437 @@
+//! Behavioural coverage for the packed-record scan rule (Issue #444).
+//!
+//! One rule says how a packed `[inputs…, targets…]` buffer is carved into
+//! records: the record stride is `input_size + num_outputs`, only whole records
+//! count, a record's targets start immediately after its inputs, and each
+//! record is activated statelessly unless the caller declares the network
+//! forward-only. Every packed loss entry point in `neat_core::loss` obeys it.
+//!
+//! These are "what" tests: they drive the public entry points with real
+//! networks and assert observable numbers — a buffer's result equals the sum of
+//! its records' individual results, a trailing partial record contributes
+//! nothing, and targets are read from the slice that follows the inputs. A copy
+//! of the arithmetic that drifted — a different stride, an off-by-one target
+//! start, a dropped `reset_state()` — fails here no matter how the scan is
+//! implemented.
+
+use neat_core::loss::{
+    categorical_error_sum_batch_packed, cross_entropy_sum_batch_packed, hinge_sum_batch_packed,
+    mae_sum_batch_packed, mape_sum_batch_packed, mse_mean_record, mse_sum_batch_packed,
+    msle_sum_batch_packed,
+};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Identity squash — keeps every fixture's activation exact, so a mismatch is a
+/// carve bug rather than an approximation.
+const IDENTITY: u8 = 0;
+
+/// Two inputs feeding two independent output neurons, no hidden state:
+///   `out0 =  0.5*in0 - 0.3*in1 + 0.10`
+///   `out1 = -0.2*in0 + 0.7*in1 + 0.05`
+fn linear_network() -> CompiledNetwork {
+    let synapses = vec![
+        SynapseData {
+            weight: 0.5,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: -0.3,
+            from_index: 1,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: -0.2,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 0.7,
+            from_index: 1,
+            synapse_type: 0,
+        },
+    ];
+    let neurons = vec![
+        NeuronData {
+            bias: 0.10,
+            start_synapse: 0,
+            num_synapses: 2,
+            squash_type: IDENTITY,
+            is_constant: false,
+        },
+        NeuronData {
+            bias: 0.05,
+            start_synapse: 2,
+            num_synapses: 2,
+            squash_type: IDENTITY,
+            is_constant: false,
+        },
+    ];
+    network(4, 2, neurons, synapses)
+}
+
+/// One input into a single output neuron that also reads **its own** previous
+/// activation, so the record loop's `reset_state()` is observable: with the
+/// reset each record sees `out = in`, without it `out = in + 0.5 * previous`.
+fn self_loop_network() -> CompiledNetwork {
+    let synapses = vec![
+        SynapseData {
+            weight: 1.0,
+            from_index: 0,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 0.5,
+            from_index: 1,
+            synapse_type: 0,
+        },
+    ];
+    let neurons = vec![NeuronData {
+        bias: 0.0,
+        start_synapse: 0,
+        num_synapses: 2,
+        squash_type: IDENTITY,
+        is_constant: false,
+    }];
+    network(2, 1, neurons, synapses)
+}
+
+fn network(
+    num_neurons: usize,
+    num_inputs: usize,
+    neurons: Vec<NeuronData>,
+    synapses: Vec<SynapseData>,
+) -> CompiledNetwork {
+    let num_non_inputs = neurons.len();
+    CompiledNetwork {
+        num_neurons,
+        num_inputs,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+type PackedEntry = fn(&mut CompiledNetwork, &[f32], usize, usize, bool) -> f64;
+
+/// `mse_mean_record` always resets, so it takes no `forward_only` flag; the
+/// wrapper lets it join the table for the layout rules it shares.
+fn mse_mean_record_entry(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    _forward_only: bool,
+) -> f64 {
+    mse_mean_record(network, records, input_size, num_outputs)
+}
+
+/// The seven entry points that return a **sum** over records.
+const SUM_ENTRIES: [(&str, PackedEntry); 7] = [
+    ("mse", mse_sum_batch_packed),
+    ("mae", mae_sum_batch_packed),
+    ("cross_entropy", cross_entropy_sum_batch_packed),
+    ("mape", mape_sum_batch_packed),
+    ("msle", msle_sum_batch_packed),
+    ("hinge", hinge_sum_batch_packed),
+    ("categorical_error", categorical_error_sum_batch_packed),
+];
+
+/// Every entry point carving a packed buffer — the seven sums plus the mean.
+const ALL_ENTRIES: [(&str, PackedEntry); 8] = [
+    ("mse", mse_sum_batch_packed),
+    ("mae", mae_sum_batch_packed),
+    ("cross_entropy", cross_entropy_sum_batch_packed),
+    ("mape", mape_sum_batch_packed),
+    ("msle", msle_sum_batch_packed),
+    ("hinge", hinge_sum_batch_packed),
+    ("categorical_error", categorical_error_sum_batch_packed),
+    ("mse_mean_record", mse_mean_record_entry),
+];
+
+const INPUT_SIZE: usize = 2;
+const NUM_OUTPUTS: usize = 2;
+
+/// Packed `[in0, in1, t0, t1]` records with distinct, strictly positive targets
+/// — positive keeps MAPE and MSLE away from their epsilon clamps, distinct
+/// makes a record mix-up visible.
+fn packed_records(num_records: usize) -> Vec<f32> {
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+    let mut records = vec![0.0f32; num_records * values_per_record];
+    for r in 0..num_records {
+        let base = r * values_per_record;
+        let f = r as f32;
+        records[base] = 0.9 - 0.11 * f;
+        records[base + 1] = 0.2 + 0.07 * f;
+        records[base + 2] = 0.3 + 0.05 * f;
+        records[base + 3] = 0.8 - 0.04 * f;
+    }
+    records
+}
+
+fn assert_close(actual: f64, expected: f64, what: &str) {
+    let tolerance = 1e-6 * expected.abs().max(1.0);
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
+/// The record stride is `input_size + num_outputs` and only whole records are
+/// scanned, so trailing bytes that cannot complete a record are invisible.
+#[test]
+fn every_packed_entry_point_ignores_a_trailing_partial_record() {
+    for (name, entry) in ALL_ENTRIES {
+        for forward_only in [true, false] {
+            let whole = packed_records(9);
+            for extra in 1..(INPUT_SIZE + NUM_OUTPUTS) {
+                let mut ragged = whole.clone();
+                ragged.extend(std::iter::repeat_n(0.42f32, extra));
+
+                let mut net = linear_network();
+                let want = entry(&mut net, &whole, INPUT_SIZE, NUM_OUTPUTS, forward_only);
+                let mut net = linear_network();
+                let got = entry(&mut net, &ragged, INPUT_SIZE, NUM_OUTPUTS, forward_only);
+
+                assert_close(
+                    got,
+                    want,
+                    &format!("{name} (forward_only={forward_only}) with {extra} trailing values"),
+                );
+            }
+        }
+    }
+}
+
+/// A buffer holding no whole record — empty, short, or a zero-width record —
+/// has no error to report.
+#[test]
+fn every_packed_entry_point_returns_zero_without_a_whole_record() {
+    let empty: Vec<f32> = Vec::new();
+    let short = vec![0.5f32; INPUT_SIZE + NUM_OUTPUTS - 1];
+    let non_empty = packed_records(3);
+
+    for (name, entry) in ALL_ENTRIES {
+        for forward_only in [true, false] {
+            let mut net = linear_network();
+            assert_eq!(
+                entry(&mut net, &empty, INPUT_SIZE, NUM_OUTPUTS, forward_only),
+                0.0,
+                "{name}: empty buffer"
+            );
+            assert_eq!(
+                entry(&mut net, &short, INPUT_SIZE, NUM_OUTPUTS, forward_only),
+                0.0,
+                "{name}: buffer shorter than one record"
+            );
+            // Zero stride: no record can be carved out of any buffer.
+            assert_eq!(
+                entry(&mut net, &non_empty, 0, 0, forward_only),
+                0.0,
+                "{name}: zero-width record"
+            );
+        }
+    }
+}
+
+/// Records are independent: scanning a buffer of N records gives the same total
+/// as scanning each record on its own. This pins the stride, the per-record
+/// target start and the stateless activation protocol together — and, at nine
+/// records, that the SIMD-batched buffer agrees with the scalar single-record
+/// path.
+#[test]
+fn every_sum_entry_point_equals_the_sum_of_its_single_record_scans() {
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+    for (name, entry) in SUM_ENTRIES {
+        for forward_only in [true, false] {
+            for num_records in [1usize, 3, 4, 8, 9] {
+                let records = packed_records(num_records);
+
+                let mut net = linear_network();
+                let whole = entry(&mut net, &records, INPUT_SIZE, NUM_OUTPUTS, forward_only);
+
+                let mut per_record = 0.0f64;
+                for r in 0..num_records {
+                    let base = r * values_per_record;
+                    let mut net = linear_network();
+                    per_record += entry(
+                        &mut net,
+                        &records[base..base + values_per_record],
+                        INPUT_SIZE,
+                        NUM_OUTPUTS,
+                        forward_only,
+                    );
+                }
+
+                assert_close(
+                    whole,
+                    per_record,
+                    &format!("{name} (forward_only={forward_only}, {num_records} records)"),
+                );
+            }
+        }
+    }
+}
+
+/// `mse_mean_record` carves the same records and then averages them.
+#[test]
+fn mse_mean_record_equals_the_mean_of_its_single_record_scans() {
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+    for num_records in [1usize, 3, 9] {
+        let records = packed_records(num_records);
+
+        let mut net = linear_network();
+        let whole = mse_mean_record(&mut net, &records, INPUT_SIZE, NUM_OUTPUTS);
+
+        let mut per_record = 0.0f64;
+        for r in 0..num_records {
+            let base = r * values_per_record;
+            let mut net = linear_network();
+            per_record += mse_mean_record(
+                &mut net,
+                &records[base..base + values_per_record],
+                INPUT_SIZE,
+                NUM_OUTPUTS,
+            );
+        }
+
+        assert_close(
+            whole,
+            per_record / num_records as f64,
+            &format!("mse_mean_record over {num_records} records"),
+        );
+    }
+}
+
+/// A record's targets are the values packed *after* its own inputs. Swapping
+/// the two records' target blocks pairs each input with the other record's
+/// targets, which must change the total — an entry point reading targets from a
+/// fixed offset, or from the wrong record, would not notice.
+///
+/// MSLE is excluded by mathematics, not by exemption: its per-record reduction
+/// is `Σ(ln t) - Σ(ln o)`, so permuting whole target blocks across records
+/// cannot change its total. The next test covers MSLE's target reads.
+#[test]
+fn every_packed_entry_point_pairs_a_record_with_its_own_targets() {
+    #[rustfmt::skip]
+    let paired: Vec<f32> = vec![
+        0.9, 0.1, /* targets */ 0.2, 0.9,
+        0.1, 0.8, /* targets */ 0.8, 0.3,
+    ];
+    #[rustfmt::skip]
+    let swapped: Vec<f32> = vec![
+        0.9, 0.1, /* targets */ 0.8, 0.3,
+        0.1, 0.8, /* targets */ 0.2, 0.9,
+    ];
+
+    for (name, entry) in ALL_ENTRIES {
+        if name == "msle" {
+            continue;
+        }
+        let mut net = linear_network();
+        let as_packed = entry(&mut net, &paired, INPUT_SIZE, NUM_OUTPUTS, true);
+        let mut net = linear_network();
+        let as_swapped = entry(&mut net, &swapped, INPUT_SIZE, NUM_OUTPUTS, true);
+
+        assert!(
+            (as_packed - as_swapped).abs() > 1e-6,
+            "{name}: swapping the records' target blocks left the result unchanged \
+             ({as_packed} vs {as_swapped}) — targets are not being read per record"
+        );
+    }
+}
+
+/// Every record's target block is read from that record's own offset: editing
+/// the targets of *any* single record — first, middle or last — must move the
+/// result. An entry point that read targets from one fixed offset, or that
+/// mis-strided past a record, would leave at least one edit invisible.
+#[test]
+fn every_packed_entry_point_reads_the_target_block_of_every_record() {
+    const NUM_RECORDS: usize = 3;
+    // Inputs chosen so the network's output argmax is 1 for every record; the
+    // edited target block below flips the target argmax, which `categorical_error`
+    // needs in order to notice at all.
+    let mut base: Vec<f32> = Vec::new();
+    for r in 0..NUM_RECORDS {
+        let f = r as f32;
+        base.extend([0.1 + 0.05 * f, 0.9 - 0.05 * f, 0.2, 0.9]);
+    }
+    let values_per_record = INPUT_SIZE + NUM_OUTPUTS;
+
+    for (name, entry) in ALL_ENTRIES {
+        let mut net = linear_network();
+        let unedited = entry(&mut net, &base, INPUT_SIZE, NUM_OUTPUTS, true);
+
+        for r in 0..NUM_RECORDS {
+            let mut edited = base.clone();
+            let target_start = r * values_per_record + INPUT_SIZE;
+            edited[target_start] = 0.95;
+            edited[target_start + 1] = 0.1;
+
+            let mut net = linear_network();
+            let got = entry(&mut net, &edited, INPUT_SIZE, NUM_OUTPUTS, true);
+            assert!(
+                (got - unedited).abs() > 1e-6,
+                "{name}: editing record {r}'s target block left the result unchanged \
+                 ({got} vs {unedited})"
+            );
+        }
+    }
+}
+
+/// The per-record `reset_state()` is conditional on `forward_only`: with
+/// `forward_only=false` a stateful network is driven statelessly (records stay
+/// independent), and with `forward_only=true` the reset is skipped, so the
+/// previous record's activation carries over.
+#[test]
+fn stateless_reset_is_conditional_on_forward_only() {
+    // Single-output records `[in, target]` on the self-loop network.
+    let records: Vec<f32> = vec![0.6, 0.2, 0.5, 0.3, 0.4, 0.1];
+    let num_records = 3;
+
+    let mut net = self_loop_network();
+    let stateless = mse_sum_batch_packed(&mut net, &records, 1, 1, false);
+
+    let mut independent = 0.0f64;
+    for r in 0..num_records {
+        let mut net = self_loop_network();
+        independent += mse_sum_batch_packed(&mut net, &records[r * 2..r * 2 + 2], 1, 1, false);
+    }
+    assert_close(
+        stateless,
+        independent,
+        "forward_only=false must reset between records",
+    );
+
+    let mut net = self_loop_network();
+    let stateful = mse_sum_batch_packed(&mut net, &records, 1, 1, true);
+    assert!(
+        (stateful - stateless).abs() > 1e-6,
+        "forward_only=true must skip the reset, leaving the self-loop's state to \
+         carry over (got {stateful}, stateless {stateless})"
+    );
+
+    // `mse_mean_record` has no flag — it always resets.
+    let mut net = self_loop_network();
+    let mean = mse_mean_record(&mut net, &records, 1, 1);
+    assert_close(
+        mean,
+        independent / num_records as f64,
+        "mse_mean_record must reset between records",
+    );
+}

--- a/neat-core/tests/safe_zone_bounded.rs
+++ b/neat-core/tests/safe_zone_bounded.rs
@@ -1,0 +1,136 @@
+//! Behavioural coverage for the bounded safe-zone rule shared by twelve
+//! `SquashType` arms of `apply_safe_zone_adjustment` (Issue #442).
+//!
+//! Each arm below differs only in its safe band `[safe_min, safe_max]` and the
+//! fade width either side of it. These tests assert the observable factor
+//! returned for every branch of that rule, so the shared policy stays pinned
+//! regardless of how the arms are implemented.
+
+use neat_core::{SquashType, apply_safe_zone_adjustment};
+
+/// `(squash, safe_min, safe_max, fade)` for every arm using the bounded rule.
+const BOUNDED_ARMS: &[(SquashType, f32, f32, f32)] = &[
+    (SquashType::LeakyRelu, -50.0, 50.0, 20.0),
+    (SquashType::Selu, -10.0, 10.0, 10.0),
+    (SquashType::Elu, -10.0, 10.0, 10.0),
+    (SquashType::Softsign, -10.0, 10.0, 10.0),
+    (SquashType::Softplus, -10.0, 20.0, 10.0),
+    (SquashType::Swish, -10.0, 10.0, 10.0),
+    (SquashType::Mish, -10.0, 10.0, 10.0),
+    (SquashType::Gelu, -6.0, 6.0, 10.0),
+    (SquashType::StdInverse, -10.0, 10.0, 10.0),
+    (SquashType::Exponential, -10.0, 30.0, 10.0),
+    (SquashType::LogSigmoid, -20.0, 20.0, 10.0),
+    (SquashType::Isru, -10.0, 10.0, 10.0),
+];
+
+/// A weight comfortably inside the `[1e-3, 1e3]` guard band.
+const HEALTHY_WEIGHT: f32 = 1.0;
+
+fn assert_close(actual: f32, expected: f32, what: &str) {
+    assert!(
+        (actual - expected).abs() < 1e-5,
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn inside_band_with_healthy_weight_flows_fully() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        let centre = (safe_min + safe_max) / 2.0;
+        for raw in [safe_min, centre, safe_max] {
+            for error in [-1.0, 0.0, 1.0] {
+                let factor = apply_safe_zone_adjustment(squash, raw, error, HEALTHY_WEIGHT);
+                assert_close(factor, 1.0, &format!("{squash:?} raw={raw} error={error}"));
+            }
+        }
+    }
+}
+
+#[test]
+fn outside_band_with_worsening_error_blocks_gradient() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        // Below the band and the error pushes it further down.
+        let below = apply_safe_zone_adjustment(squash, safe_min - 1.0, -1.0, HEALTHY_WEIGHT);
+        assert_close(below, 0.0, &format!("{squash:?} below band, worsening"));
+
+        // Above the band and the error pushes it further up.
+        let above = apply_safe_zone_adjustment(squash, safe_max + 1.0, 1.0, HEALTHY_WEIGHT);
+        assert_close(above, 0.0, &format!("{squash:?} above band, worsening"));
+    }
+}
+
+#[test]
+fn inside_band_defers_to_a_correcting_tiny_weight() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        let centre = (safe_min + safe_max) / 2.0;
+        // |weight| < 1e-3 and weight * error > 0 -- let the weight grow first.
+        let factor = apply_safe_zone_adjustment(squash, centre, 1.0, 1e-4);
+        assert_close(factor, 0.0, &format!("{squash:?} tiny weight correcting"));
+
+        // Same tiny weight but the error is not correcting it -- gradient flows.
+        let factor = apply_safe_zone_adjustment(squash, centre, -1.0, 1e-4);
+        assert_close(
+            factor,
+            1.0,
+            &format!("{squash:?} tiny weight not correcting"),
+        );
+    }
+}
+
+#[test]
+fn inside_band_defers_to_a_correcting_huge_weight() {
+    for &(squash, safe_min, safe_max, _) in BOUNDED_ARMS {
+        let centre = (safe_min + safe_max) / 2.0;
+        // |weight| > 1e3 and weight * error < 0 -- let the weight shrink first.
+        let factor = apply_safe_zone_adjustment(squash, centre, -1.0, 1e4);
+        assert_close(factor, 0.0, &format!("{squash:?} huge weight correcting"));
+
+        let factor = apply_safe_zone_adjustment(squash, centre, 1.0, 1e4);
+        assert_close(
+            factor,
+            1.0,
+            &format!("{squash:?} huge weight not correcting"),
+        );
+    }
+}
+
+#[test]
+fn beyond_band_fades_linearly_to_zero() {
+    for &(squash, safe_min, safe_max, fade) in BOUNDED_ARMS {
+        for fraction in [0.25_f32, 0.5, 0.75, 1.0] {
+            let expected = 1.0 - fraction;
+
+            // Upper fade: error must not be worsening (error <= 0).
+            let raw = safe_max + fade * fraction;
+            let factor = apply_safe_zone_adjustment(squash, raw, -1.0, HEALTHY_WEIGHT);
+            assert_close(factor, expected, &format!("{squash:?} upper fade at {raw}"));
+
+            // Lower fade: error must not be worsening (error >= 0).
+            let raw = safe_min - fade * fraction;
+            let factor = apply_safe_zone_adjustment(squash, raw, 1.0, HEALTHY_WEIGHT);
+            assert_close(factor, expected, &format!("{squash:?} lower fade at {raw}"));
+        }
+    }
+}
+
+#[test]
+fn past_the_fade_width_no_gradient_flows() {
+    for &(squash, safe_min, safe_max, fade) in BOUNDED_ARMS {
+        let above = apply_safe_zone_adjustment(squash, safe_max + fade + 1.0, -1.0, HEALTHY_WEIGHT);
+        assert_close(above, 0.0, &format!("{squash:?} past upper fade"));
+
+        let below = apply_safe_zone_adjustment(squash, safe_min - fade - 1.0, 1.0, HEALTHY_WEIGHT);
+        assert_close(below, 0.0, &format!("{squash:?} past lower fade"));
+    }
+}
+
+#[test]
+fn non_finite_raw_input_is_never_safe() {
+    for &(squash, ..) in BOUNDED_ARMS {
+        for raw in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let factor = apply_safe_zone_adjustment(squash, raw, 1.0, HEALTHY_WEIGHT);
+            assert_close(factor, 0.0, &format!("{squash:?} raw={raw}"));
+        }
+    }
+}

--- a/neat-core/tests/simd_chunk_walk_scaffold.rs
+++ b/neat-core/tests/simd_chunk_walk_scaffold.rs
@@ -1,0 +1,147 @@
+//! Chunk-walk scaffold parity (Issue #448).
+//!
+//! The four single-record weighted-sum kernels share one walk over a synapse
+//! span: gather four synapses into lanes, fold, reduce the lanes, then finish
+//! the 0..3 remainder from the running accumulator. This file pins the
+//! observable consequence of that walk — **every** kernel reproduces its
+//! reference scalar result at **every** offset and count, not just at
+//! `start == 0`.
+//!
+//! `simd_weighted_sums.rs` sweeps counts from `start == 0`; the offset sweep
+//! here is what catches a scaffold that computes its chunk base from the chunk
+//! index alone, because then the first gather silently reads from the wrong
+//! synapse whenever `start > 0`.
+//!
+//! References come from `neat_core::simd::scalar` (Issue #447), the single home
+//! of what each kernel means, so this test cannot drift from the semantics it
+//! is checking.
+
+use neat_core::network::SynapseData;
+use neat_core::simd::scalar;
+use neat_core::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd,
+};
+
+/// Widest span the sweep builds: two dual-accumulator chunks of eight, a
+/// trailing chunk of four, and a 1..3 scalar remainder, from any offset.
+const MAX_SPAN: usize = 24;
+
+/// Fan-in wide enough to exercise repeated `from_index` gathers without the
+/// activation buffer dominating the arithmetic.
+const NUM_INPUTS: usize = 11;
+
+fn fixture() -> (Vec<SynapseData>, Vec<f32>) {
+    let synapses = (0..MAX_SPAN + 10)
+        .map(|i| SynapseData {
+            weight: ((i as f32) * 0.37).cos() * 1.5,
+            from_index: (i % NUM_INPUTS) as u16,
+            synapse_type: 0,
+        })
+        .collect();
+    let activations = (0..NUM_INPUTS)
+        .map(|i| ((i as f32) * 0.61).sin() - 0.25)
+        .collect();
+    (synapses, activations)
+}
+
+/// f32 accumulation over a span drifts from the reference by a few ULP once the
+/// SIMD path fuses multiply-adds, so compare relative to the magnitude.
+fn assert_close(got: f32, want: f32, what: &str) {
+    let tol = 1e-4 * (1.0 + want.abs());
+    assert!(
+        (got - want).abs() <= tol,
+        "{what}: got {got}, want {want} (tol {tol})"
+    );
+}
+
+#[test]
+fn every_kernel_matches_its_reference_from_any_offset() {
+    let (synapses, activations) = fixture();
+    let bias = -0.45f32;
+
+    for start in 0..10usize {
+        for count in 0..=MAX_SPAN {
+            let end = start + count;
+            let at = format!("start={start} count={count}");
+
+            assert_close(
+                weighted_sum_simd(&synapses, &activations, start, end, bias),
+                scalar::weighted_sum(&synapses, &activations, start, end, bias),
+                &format!("weighted_sum_simd {at}"),
+            );
+            assert_close(
+                weighted_sum_no_bias_simd(&synapses, &activations, start, end),
+                scalar::weighted_sum_no_bias(&synapses, &activations, start, end),
+                &format!("weighted_sum_no_bias_simd {at}"),
+            );
+            assert_close(
+                weighted_sum_of_squares_simd(&synapses, &activations, start, end),
+                scalar::weighted_sum_of_squares(&synapses, &activations, start, end),
+                &format!("weighted_sum_of_squares_simd {at}"),
+            );
+            assert_close(
+                weighted_sum_of_squares_v2_simd(&synapses, &activations, start, end, bias),
+                scalar::weighted_sum_of_squares_v2(&synapses, &activations, start, end, bias),
+                &format!("weighted_sum_of_squares_v2_simd {at}"),
+            );
+        }
+    }
+}
+
+#[test]
+fn the_remainder_continues_the_span_rather_than_restarting_it() {
+    // A span of 8 + 3 and a span of 8 + 0 must differ by exactly the three
+    // trailing synapses' contribution: the tail continues the running
+    // accumulator, it does not start a second sum that is merged in.
+    let (synapses, activations) = fixture();
+    let bias = 0.8f32;
+    let start = 3usize;
+
+    let body_only = weighted_sum_no_bias_simd(&synapses, &activations, start, start + 8);
+    let with_tail = weighted_sum_no_bias_simd(&synapses, &activations, start, start + 11);
+    let tail_contribution =
+        scalar::weighted_sum_no_bias(&synapses, &activations, start + 8, start + 11);
+    assert_close(
+        with_tail,
+        body_only + tail_contribution,
+        "no_bias tail continues the span",
+    );
+
+    let body_only = weighted_sum_simd(&synapses, &activations, start, start + 8, bias);
+    let with_tail = weighted_sum_simd(&synapses, &activations, start, start + 11, bias);
+    let tail_contribution =
+        scalar::weighted_sum_no_bias(&synapses, &activations, start + 8, start + 11);
+    assert_close(
+        with_tail,
+        body_only + tail_contribution,
+        "weighted_sum tail continues the span",
+    );
+}
+
+#[test]
+fn an_empty_or_reversed_span_is_the_kernel_seed() {
+    let (synapses, activations) = fixture();
+    let bias = 1.25f32;
+
+    // Reversed ranges saturate to a zero count (Issue #447), so each kernel
+    // returns its seed rather than walking a colossal span.
+    for (start, end) in [(5usize, 5usize), (9, 2)] {
+        assert_eq!(
+            weighted_sum_simd(&synapses, &activations, start, end, bias),
+            bias
+        );
+        assert_eq!(
+            weighted_sum_no_bias_simd(&synapses, &activations, start, end),
+            0.0
+        );
+        assert_eq!(
+            weighted_sum_of_squares_simd(&synapses, &activations, start, end),
+            0.0
+        );
+        assert_eq!(
+            weighted_sum_of_squares_v2_simd(&synapses, &activations, start, end, bias),
+            0.0
+        );
+    }
+}

--- a/neat-core/tests/simd_scalar_layer.rs
+++ b/neat-core/tests/simd_scalar_layer.rs
@@ -1,0 +1,240 @@
+//! Pins the ISA-neutral scalar layer shared by the wasm (`simd.rs`) and native
+//! (`simd_native.rs`) weighted-sum kernels (Issue #447).
+//!
+//! The rule under test: `neat_core::simd::scalar` is the single home of the
+//! reference scalar semantics of each weighted-sum kernel and of the
+//! small-count guard in front of it. Every SIMD path must agree with it
+//! bit-for-bit below the SIMD threshold, the guard must saturate rather than
+//! underflow on a reversed range, and the seed-taking tail helpers must
+//! continue the reference accumulation without reseeding.
+
+use neat_core::network::SynapseData;
+use neat_core::simd::scalar;
+use neat_core::simd::{
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd,
+};
+
+fn synapse(from_index: u16, weight: f32) -> SynapseData {
+    SynapseData {
+        weight,
+        from_index,
+        synapse_type: 0,
+    }
+}
+
+/// Nine synapses: enough for two full 4-wide SIMD chunks plus a scalar tail,
+/// with values chosen so re-ordering the f32 additions is observable.
+fn fixture() -> (Vec<SynapseData>, Vec<f32>) {
+    let synapses = vec![
+        synapse(0, 0.5),
+        synapse(2, -1.5),
+        synapse(1, 2.0),
+        synapse(3, 0.25),
+        synapse(4, -0.75),
+        synapse(2, 1.25),
+        synapse(0, 1e-7),
+        synapse(4, 3.5),
+        synapse(1, -0.125),
+    ];
+    let activations = vec![1.0_f32, 2.0, -3.0, 0.5, 4.0];
+    (synapses, activations)
+}
+
+// ---- The small-count guard -------------------------------------------------
+
+#[test]
+fn synapse_count_measures_the_range() {
+    assert_eq!(scalar::synapse_count(2, 7), 5);
+    assert_eq!(scalar::synapse_count(0, 0), 0);
+}
+
+#[test]
+fn synapse_count_saturates_when_end_precedes_start() {
+    assert_eq!(
+        scalar::synapse_count(9, 4),
+        0,
+        "a reversed range must saturate to zero, not underflow"
+    );
+    assert_eq!(scalar::synapse_count(1, 0), 0);
+}
+
+#[test]
+fn reference_kernels_return_their_seed_for_a_reversed_range() {
+    let (synapses, activations) = fixture();
+    assert_eq!(
+        scalar::weighted_sum(&synapses, &activations, 9, 4, 0.25),
+        0.25
+    );
+    assert_eq!(
+        scalar::weighted_sum_of_squares(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_no_bias(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_of_squares_v2(&synapses, &activations, 9, 4, 0.25),
+        0.0
+    );
+}
+
+#[test]
+fn public_kernels_survive_a_reversed_range() {
+    let (synapses, activations) = fixture();
+    assert_eq!(weighted_sum_simd(&synapses, &activations, 9, 4, 0.25), 0.25);
+    assert_eq!(
+        weighted_sum_of_squares_simd(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        weighted_sum_no_bias_simd(&synapses, &activations, 9, 4),
+        0.0
+    );
+    assert_eq!(
+        weighted_sum_of_squares_v2_simd(&synapses, &activations, 9, 4, 0.25),
+        0.0
+    );
+}
+
+/// Below the SIMD threshold the public kernels *are* the reference scalar
+/// kernels — bit-for-bit, not merely approximately.
+#[test]
+fn small_counts_are_bit_identical_to_the_reference_kernels() {
+    let (synapses, activations) = fixture();
+    for count in 0..scalar::SINGLE_RECORD_SIMD_MIN {
+        let end = count;
+        assert_eq!(
+            weighted_sum_simd(&synapses, &activations, 0, end, 0.25).to_bits(),
+            scalar::weighted_sum(&synapses, &activations, 0, end, 0.25).to_bits(),
+            "weighted_sum_simd drifted from the reference at count {count}"
+        );
+        assert_eq!(
+            weighted_sum_of_squares_simd(&synapses, &activations, 0, end).to_bits(),
+            scalar::weighted_sum_of_squares(&synapses, &activations, 0, end).to_bits(),
+            "weighted_sum_of_squares_simd drifted from the reference at count {count}"
+        );
+        assert_eq!(
+            weighted_sum_no_bias_simd(&synapses, &activations, 0, end).to_bits(),
+            scalar::weighted_sum_no_bias(&synapses, &activations, 0, end).to_bits(),
+            "weighted_sum_no_bias_simd drifted from the reference at count {count}"
+        );
+        assert_eq!(
+            weighted_sum_of_squares_v2_simd(&synapses, &activations, 0, end, -0.5).to_bits(),
+            scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, end, -0.5).to_bits(),
+            "weighted_sum_of_squares_v2_simd drifted from the reference at count {count}"
+        );
+    }
+}
+
+// ---- The seed-taking tail helpers ------------------------------------------
+//
+// A tail helper must continue the caller's running accumulator, never reseed
+// it: splitting a range anywhere has to reproduce the reference result exactly.
+
+#[test]
+fn tail_sum_continues_the_reference_accumulation_bit_for_bit() {
+    let (synapses, activations) = fixture();
+    let reference = scalar::weighted_sum(&synapses, &activations, 0, synapses.len(), 0.25);
+    for split in 0..=synapses.len() {
+        let head = scalar::weighted_sum(&synapses, &activations, 0, split, 0.25);
+        // SAFETY: every `from_index` in the fixture is < activations.len() and
+        // `end == synapses.len()`, satisfying the helper's index contract.
+        let full =
+            unsafe { scalar::tail_sum(&synapses, &activations, split, synapses.len(), head) };
+        assert_eq!(
+            full.to_bits(),
+            reference.to_bits(),
+            "tail_sum reseeded or reordered at split {split}"
+        );
+    }
+}
+
+#[test]
+fn tail_sum_of_squares_continues_the_reference_accumulation_bit_for_bit() {
+    let (synapses, activations) = fixture();
+    let reference = scalar::weighted_sum_of_squares(&synapses, &activations, 0, synapses.len());
+    for split in 0..=synapses.len() {
+        let head = scalar::weighted_sum_of_squares(&synapses, &activations, 0, split);
+        // SAFETY: as above — the fixture satisfies the index contract.
+        let full = unsafe {
+            scalar::tail_sum_of_squares(&synapses, &activations, split, synapses.len(), head)
+        };
+        assert_eq!(
+            full.to_bits(),
+            reference.to_bits(),
+            "tail_sum_of_squares reseeded or reordered at split {split}"
+        );
+    }
+}
+
+#[test]
+fn tail_sum_of_squares_v2_continues_the_reference_accumulation_bit_for_bit() {
+    let (synapses, activations) = fixture();
+    let bias = -0.5_f32;
+    let reference =
+        scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, synapses.len(), bias);
+    for split in 0..=synapses.len() {
+        let head = scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, split, bias);
+        // SAFETY: as above — the fixture satisfies the index contract.
+        let full = unsafe {
+            scalar::tail_sum_of_squares_v2(
+                &synapses,
+                &activations,
+                split,
+                synapses.len(),
+                head,
+                bias,
+            )
+        };
+        assert_eq!(
+            full.to_bits(),
+            reference.to_bits(),
+            "tail_sum_of_squares_v2 reseeded or reordered at split {split}"
+        );
+    }
+}
+
+#[test]
+fn tail_helpers_return_the_seed_for_an_empty_tail() {
+    let (synapses, activations) = fixture();
+    // SAFETY: an empty tail reads nothing.
+    unsafe {
+        assert_eq!(scalar::tail_sum(&synapses, &activations, 4, 4, 1.5), 1.5);
+        assert_eq!(
+            scalar::tail_sum_of_squares(&synapses, &activations, 4, 4, 1.5),
+            1.5
+        );
+        assert_eq!(
+            scalar::tail_sum_of_squares_v2(&synapses, &activations, 4, 4, 1.5, -0.5),
+            1.5
+        );
+    }
+}
+
+// ---- The reference kernels themselves --------------------------------------
+
+#[test]
+fn reference_kernels_compute_the_documented_formulas() {
+    let synapses = vec![synapse(1, 0.5), synapse(0, -2.0)];
+    let activations = vec![3.0_f32, 4.0];
+    // a*w = 4.0*0.5 = 2.0 and 3.0*-2.0 = -6.0
+    assert_eq!(
+        scalar::weighted_sum(&synapses, &activations, 0, 2, 1.0),
+        1.0 + 2.0 - 6.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_no_bias(&synapses, &activations, 0, 2),
+        2.0 - 6.0
+    );
+    assert_eq!(
+        scalar::weighted_sum_of_squares(&synapses, &activations, 0, 2),
+        4.0 + 36.0
+    );
+    // (bias + a*w)^2 with bias = 1.0 → 3.0^2 + (-5.0)^2
+    assert_eq!(
+        scalar::weighted_sum_of_squares_v2(&synapses, &activations, 0, 2, 1.0),
+        9.0 + 25.0
+    );
+}

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -104,10 +104,12 @@ sys.exit(1)
 PY
 }
 
-# Stubs `docker` (fails the first $1 invocations, then succeeds) and `sleep`
-# (returns immediately so backoff does not slow the suite), on PATH.
+# Stubs `docker` (fails the first $1 invocations, then succeeds), `pipx` (exits
+# with $2, default 0) and `sleep` (returns immediately so backoff does not slow
+# the suite), on PATH.
 make_stubs() {
   local fail_count="$1"
+  local pipx_status="${2:-0}"
   mkdir -p "${BATS_TEST_TMPDIR}/bin"
   echo 0 >"${BATS_TEST_TMPDIR}/calls"
   cat >"${BATS_TEST_TMPDIR}/bin/docker" <<STUB
@@ -122,47 +124,98 @@ if [ "\$calls" -le "${fail_count}" ]; then
 fi
 exit 0
 STUB
+  cat >"${BATS_TEST_TMPDIR}/bin/pipx" <<STUB
+#!/usr/bin/env bash
+echo "pipx \$*" >>"${BATS_TEST_TMPDIR}/pipx_args"
+exit ${pipx_status}
+STUB
   cat >"${BATS_TEST_TMPDIR}/bin/sleep" <<'STUB'
 #!/usr/bin/env bash
 exit 0
 STUB
-  chmod +x "${BATS_TEST_TMPDIR}/bin/docker" "${BATS_TEST_TMPDIR}/bin/sleep"
+  chmod +x "${BATS_TEST_TMPDIR}/bin/docker" "${BATS_TEST_TMPDIR}/bin/pipx" \
+    "${BATS_TEST_TMPDIR}/bin/sleep"
   PATH="${BATS_TEST_TMPDIR}/bin:$PATH"
   export PATH
+  # The step records which acquisition path it took via $GITHUB_OUTPUT.
+  GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+  : >"$GITHUB_OUTPUT"
+  export GITHUB_OUTPUT
+}
+
+# Sets up the "Obtain semgrep" script at $BATS_TEST_TMPDIR/pull.sh and the
+# environment the step reads. $1 = docker failures before success, $2 = pipx
+# exit status.
+setup_obtain_step() {
+  export WF
+  extract_step_script "${BATS_TEST_TMPDIR}/pull.sh" "Obtain semgrep"
+  make_stubs "$1" "${2:-0}"
+  export SEMGREP_IMAGE="semgrep/semgrep@sha256:$(printf 'a%.0s' {1..64})"
+  export SEMGREP_VERSION="1.170.1"
 }
 
 @test "pull step retries a failing registry and succeeds once the pull works" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
-  export WF
-  run extract_step_script "${BATS_TEST_TMPDIR}/pull.sh" "Pull semgrep image"
-  [ "$status" -eq 0 ]
+  setup_obtain_step 2 # two registry timeouts, then a good pull
 
-  make_stubs 2 # two registry timeouts, then a good pull
-  export SEMGREP_IMAGE="semgrep/semgrep@sha256:$(printf 'a%.0s' {1..64})"
   run bash "${BATS_TEST_TMPDIR}/pull.sh"
   [ "$status" -eq 0 ]
   # Three attempts total: the runner's own 3-attempt job-init pull is what
   # failed here, so a single retry would not have been enough.
   [ "$(cat "${BATS_TEST_TMPDIR}/calls")" -eq 3 ]
+  # The container is the primary path; no fallback install should have run.
+  [ ! -f "${BATS_TEST_TMPDIR}/pipx_args" ]
+  grep -q '^mode=docker$' "$GITHUB_OUTPUT"
 }
 
-@test "pull step fails loud when the registry stays unreachable" {
+# PR #468 — a Docker Hub outage exhausted all five attempts and the job failed
+# without semgrep ever running. The scan now falls back to the PyPI release.
+
+@test "pull step falls back to the pinned PyPI release when the registry stays unreachable" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
-  export WF
-  run extract_step_script "${BATS_TEST_TMPDIR}/pull.sh" "Pull semgrep image"
-  [ "$status" -eq 0 ]
+  setup_obtain_step 99 0 # registry never recovers, PyPI works
 
-  make_stubs 99 # registry never recovers
-  export SEMGREP_IMAGE="semgrep/semgrep@sha256:$(printf 'a%.0s' {1..64})"
   run bash "${BATS_TEST_TMPDIR}/pull.sh"
-  # An unpullable scanner must never be reported as a clean scan.
+  [ "$status" -eq 0 ]
+  [ "$(cat "${BATS_TEST_TMPDIR}/calls")" -eq 5 ]
+  # The fallback must pin the same version the digest pins — never floating.
+  grep -q 'semgrep==1.170.1' "${BATS_TEST_TMPDIR}/pipx_args"
+  grep -q '^mode=pypi$' "$GITHUB_OUTPUT"
+}
+
+@test "pull step fails loud when neither the registry nor PyPI yields a scanner" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  setup_obtain_step 99 1 # registry never recovers and the PyPI install fails
+
+  run bash "${BATS_TEST_TMPDIR}/pull.sh"
+  # An unobtainable scanner must never be reported as a clean scan.
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Could not pull"* ]]
   [[ "$output" == *"no SAST scan ran"* ]]
+  ! grep -q '^mode=' "$GITHUB_OUTPUT"
+}
+
+@test "the PyPI fallback version tracks the digest-pinned image version" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import re, yaml
+env = yaml.safe_load(open("$WF")).get("env") or {}
+version = str(env.get("SEMGREP_VERSION", ""))
+assert re.fullmatch(r"\d+\.\d+\.\d+", version), version
+# The image pin carries the version in a comment; both must name the same one.
+text = open("$WF").read()
+assert f"semgrep/semgrep:{version}" in text, (
+    f"SEMGREP_VERSION {version} does not match the digest pin's version comment"
+)
+PY
+  [ "$status" -eq 0 ]
 }
 
 @test "semgrep.yml has no job-level container, so the pull backoff is ours" {


### PR DESCRIPTION
## Milestone: Duplicate Knowledge

This PR merges the completed milestone branch into Develop.
Closes #474

### Issues addressed
- #448: 🟡 wasm SIMD kernels repeat chunk-loop scaffolding; dual-accumulator rework landed on one of four copies
- #447: 🟡 ISA-neutral scalar layer duplicated between simd.rs and simd_native.rs with drifted underflow hardening
- #446: 🟡 Six-member aggregate-squash set open-coded at ten sites; extract SquashType::is_aggregate
- #445: 🟡 MSE re-inlines the 8→4→1 batch-scoring skeleton already abstracted by batch_8way_activation!
- #444: 🟡 Packed-record scan arithmetic duplicated across eight loss entry points
- #443: 🟡 Fourteen sites inline the hot-squash dispatch that three helpers already encode
- #442: 🟡 Twelve SquashType arms re-implement the bounded safe-zone rule
- #441: 🟠 Aggregate-squash neuron activation duplicated at 11 sites — three scalar tails have diverged

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.