### PR TITLE
Express the batch-parity contract once, fixing a latent len0/len2 slice bug (Issue #476)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-476.md
+++ b/docs/archive/pr-summaries/pr-summary-476.md
@@ -1,0 +1,122 @@
+# Express the batch-parity contract once (Issue #476)
+
+## Summary
+
+`neat-core/tests/network_activate_trace_batch.rs` carried seven near-duplicate
+tests, each repeating the same ~40-line "parse the batch header, slice out four
+records, compare against the single-record run" block and differing only in
+fixture and inputs. One copy had already been mis-transcribed: record 2 was
+sliced as `&batch_result[start2..start2 + len0]` — `len0` where `len2` was
+intended. It passed only because every record in that fixture happens to be the
+same length, so the parity check it exists to provide was silently weakened.
+
+Resolution (a) from the issue: the contract is now stated once and driven from a
+table.
+
+- **`split_batch_records`** walks the four-value length header in a loop,
+  accumulating each record's `start` from the preceding lengths. A record is
+  therefore always sliced with its **own** length — the `len0`/`len2` class of
+  bug is no longer expressible.
+- It also **fails loud** rather than silently comparing a prefix: a header that
+  overruns the buffer, or whose lengths do not cover the payload exactly, is an
+  explicit assertion failure with a named cause instead of an opaque slice panic
+  or a quietly-truncated comparison.
+- **`assert_batch_matches_single`** holds the single copy of the
+  batch-vs-single oracle, driven from **`parity_cases()`** — the same seven
+  fixtures (ReLU, TANH/LOGISTIC, MINIMUM, MAXIMUM, IF, constant neuron,
+  multi-layer), now as data rather than as seven hand-copied function bodies.
+
+Net: 404 lines removed, 290 added, with no loss of fixture coverage.
+
+`test_batch_4way_buffer_reuse_no_state_leak` (Issue #155) is a production
+regression test, not part of the family, and is unchanged.
+
+Closes #476.
+
+### Test restructuring (declared, per the "do not remove existing tests" rule)
+
+The seven `test_batch_4way_*` test functions are **replaced**, not deleted:
+every fixture and every input record survives as an entry in `parity_cases()`,
+and each is still asserted by the same oracle — now through one shared helper.
+Assertion messages carry the case name, so a failure still identifies which
+fixture broke. The seven `#[test]` functions collapse into one
+(`batch_4way_matches_single_record_for_every_fixture`), which is the
+consolidation the issue asked for.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1["test_..._relu"] --> H1["~40 lines: header parse<br/>+ hand-written slices<br/>+ compare loop"]
+        T2["test_..._tanh_logistic"] --> H2["~40 lines (copy)<br/>len0/len2 slip here"]
+        T3["...5 more copies"] --> H3["~40 lines each"]
+    end
+    subgraph After
+        C["parity_cases() table<br/>7 fixtures"] --> A["assert_batch_matches_single"]
+        A --> S["split_batch_records<br/>loop-derived start/len"]
+        S --> V["fails loud on a<br/>bad header"]
+    end
+```
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. The
+evidence is a mutation test: the old hand-copied slicing (including the
+`len0`/`len2` slip) was temporarily reintroduced into `split_batch_records` and
+the suite re-run. All three new oracle tests failed, confirming they catch the
+bug class rather than merely passing alongside it:
+
+```
+---- split_batch_records_uses_each_records_own_length ----
+  left: [30.0]
+ right: [30.0, 31.0, 32.0]
+
+failures:
+    split_batch_records_rejects_header_that_overruns_the_buffer
+    split_batch_records_rejects_header_that_undercovers_the_buffer
+    split_batch_records_uses_each_records_own_length
+
+test result: FAILED. 2 passed; 3 failed
+```
+
+With the loop-derived splitter restored:
+
+```
+running 5 tests
+test split_batch_records_uses_each_records_own_length ... ok
+test test_batch_4way_buffer_reuse_no_state_leak ... ok
+test split_batch_records_rejects_header_that_overruns_the_buffer - should panic ... ok
+test split_batch_records_rejects_header_that_undercovers_the_buffer - should panic ... ok
+test batch_4way_matches_single_record_for_every_fixture ... ok
+
+test result: ok. 5 passed; 0 failed
+```
+
+`./quality.sh` passes cleanly (fmt, clippy, deny, workspace tests, docs,
+release build).
+
+## Test Plan
+
+Tests in `neat-core/tests/network_activate_trace_batch.rs`:
+
+- `batch_4way_matches_single_record_for_every_fixture` — the parity contract
+  across all seven fixtures, replacing the seven copy-pasted variants.
+- `split_batch_records_uses_each_records_own_length` — **regression for the
+  reported defect.** A synthetic buffer whose four records have *distinct*
+  lengths (1, 2, 3, 4); fails against the old `len0`-for-`len2` slicing, passes
+  against the loop-derived splitter. The production code cannot produce
+  differing per-record lengths today (record size is fixed by topology), which
+  is exactly why the defect stayed latent — so the oracle itself is tested
+  directly.
+- `split_batch_records_rejects_header_that_overruns_the_buffer` — a header
+  claiming more data than the buffer holds fails with a named cause.
+- `split_batch_records_rejects_header_that_undercovers_the_buffer` — a header
+  that leaves payload unaccounted for fails instead of silently comparing a
+  prefix.
+- `test_batch_4way_buffer_reuse_no_state_leak` — unchanged (Issue #155).
+
+## Follow-up
+
+Filed **stSoftwareAU/NEAT-AI-core#484**: the same seven `test_batch_4way_*`
+tests still exist verbatim in `src/network.rs`'s `mod tests`, despite this
+file's header claiming they were moved out of it. That cross-file duplication is
+separate work and was left out of this change to keep it in scope.

--- a/neat-core/tests/network_activate_trace_batch.rs
+++ b/neat-core/tests/network_activate_trace_batch.rs
@@ -1,6 +1,19 @@
 //! Compiled network activation / trace batch tests (moved from `src/network.rs`).
+//!
+//! Issue #476 — the batch-vs-single parity contract is expressed **once**, in
+//! `assert_batch_matches_single`, and driven from the `parity_cases()` table.
+//! `split_batch_records` derives every record's `start`/`len` by walking the
+//! length header in a loop, so slicing one record with another record's length
+//! (the `len0`/`len2` transcription bug the hand-copied variants carried) is
+//! not expressible.
 
 use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+/// Records per `activate_and_trace_batch_4way` call — also the header length.
+const BATCH_RECORDS: usize = 4;
+
+/// Every fixture below has a single output neuron.
+const NUM_OUTPUTS: usize = 1;
 
 /// Helper to build a CompiledNetwork directly for testing
 fn make_network(
@@ -57,448 +70,321 @@ fn make_synapse_typed(from_index: u16, weight: f32, synapse_type: u8) -> Synapse
     }
 }
 
-/// Test that batch 4-way matches single-record activate_and_trace for standard squash (ReLU)
-#[test]
-fn test_batch_4way_matches_single_relu() {
-    // Network: 2 inputs, 1 hidden (ReLU), 1 output (Identity)
-    let synapses = vec![
-        make_synapse(0, 0.5),  // hidden <- input0
-        make_synapse(1, -0.3), // hidden <- input1
-        make_synapse(2, 1.0),  // output <- hidden
-    ];
-    let neurons = vec![
-        NeuronData {
-            bias: 0.1,
-            start_synapse: 0,
-            num_synapses: 2,
-            squash_type: 1, // ReLU
-            is_constant: false,
-        },
-        NeuronData {
-            bias: -0.2,
-            start_synapse: 2,
-            num_synapses: 1,
-            squash_type: 0, // Identity
-            is_constant: false,
-        },
-    ];
+/// Split the packed `activate_and_trace_batch_4way` output into its records.
+///
+/// The first [`BATCH_RECORDS`] values are the per-record lengths; the records
+/// follow back to back. Each `start` is accumulated from the preceding lengths
+/// as the header is walked, so a record is always sliced with **its own**
+/// length. The final offset must land exactly on the end of the buffer — a
+/// header that under- or over-covers the payload is a failure, not a silent
+/// truncation.
+fn split_batch_records(batch_result: &[f32]) -> Vec<&[f32]> {
+    assert!(
+        batch_result.len() >= BATCH_RECORDS,
+        "batch result is shorter than its {BATCH_RECORDS}-value length header"
+    );
 
-    let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[0.5, -1.0], &[-2.0, 3.0], &[0.0, 0.0]];
-
-    // Run single-record activate_and_trace for each
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(2, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
+    let mut records = Vec::with_capacity(BATCH_RECORDS);
+    let mut start = BATCH_RECORDS;
+    for (i, &len_value) in batch_result[..BATCH_RECORDS].iter().enumerate() {
+        let len = len_value as usize;
+        assert!(
+            start + len <= batch_result.len(),
+            "record {i}: header length {len} overruns the batch buffer"
+        );
+        records.push(&batch_result[start..start + len]);
+        start += len;
     }
+    assert_eq!(
+        start,
+        batch_result.len(),
+        "header lengths must cover the whole batch buffer exactly"
+    );
+    records
+}
 
-    // Run batch 4-way
-    let mut net = make_network(2, neurons.clone(), synapses.clone());
-    let packed_input: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed_input, 2, 1);
+/// One batch-parity fixture: a network plus the four input records to run.
+struct ParityCase {
+    name: &'static str,
+    num_inputs: usize,
+    neurons: Vec<NeuronData>,
+    synapses: Vec<SynapseData>,
+    inputs: [&'static [f32]; BATCH_RECORDS],
+}
 
-    // Parse batch result - first 4 values are record lengths
-    let len0 = batch_result[0] as usize;
-    let len1 = batch_result[1] as usize;
-    let len2 = batch_result[2] as usize;
-    let len3 = batch_result[3] as usize;
+/// The parity contract: every record of the 4-way batch must equal the
+/// single-record `activate_and_trace` result for the same inputs.
+fn assert_batch_matches_single(case: &ParityCase) {
+    let name = case.name;
 
-    let start0 = 4;
-    let start1 = start0 + len0;
-    let start2 = start1 + len1;
-    let start3 = start2 + len2;
+    // Run single-record activate_and_trace for each input, on a fresh network.
+    let single_results: Vec<Vec<f32>> = case
+        .inputs
+        .iter()
+        .map(|input| {
+            let mut net =
+                make_network(case.num_inputs, case.neurons.clone(), case.synapses.clone());
+            net.activate_and_trace(input, NUM_OUTPUTS)
+        })
+        .collect();
 
-    let batch_records = [
-        &batch_result[start0..start0 + len0],
-        &batch_result[start1..start1 + len1],
-        &batch_result[start2..start2 + len2],
-        &batch_result[start3..start3 + len3],
-    ];
+    // Run the same inputs as one packed 4-way batch.
+    let mut net = make_network(case.num_inputs, case.neurons.clone(), case.synapses.clone());
+    let packed: Vec<f32> = case.inputs.iter().flat_map(|i| i.iter().copied()).collect();
+    let batch_result = net.activate_and_trace_batch_4way(&packed, case.num_inputs, NUM_OUTPUTS);
 
-    // Compare each batch record with its single-record counterpart
+    let batch_records = split_batch_records(&batch_result);
+
     for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
         assert_eq!(
             single.len(),
             batch.len(),
-            "Record {i}: length mismatch (single={}, batch={})",
+            "{name}, record {i}: length mismatch (single={}, batch={})",
             single.len(),
             batch.len()
         );
         for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
             assert!(
                 (s - b).abs() < 1e-5,
-                "Record {i}, element {j}: single={s}, batch={b}"
+                "{name}, record {i}, element {j}: single={s}, batch={b}"
             );
         }
     }
 }
 
-/// Test batch 4-way with TANH and LOGISTIC squash functions
+/// The fixtures the parity contract is checked against — one per activation
+/// path the 4-way batch has to get right.
+fn parity_cases() -> Vec<ParityCase> {
+    vec![
+        // Standard squash: 2 inputs, 1 hidden (ReLU), 1 output (Identity).
+        ParityCase {
+            name: "relu_hidden_identity_output",
+            num_inputs: 2,
+            synapses: vec![
+                make_synapse(0, 0.5),  // hidden <- input0
+                make_synapse(1, -0.3), // hidden <- input1
+                make_synapse(2, 1.0),  // output <- hidden
+            ],
+            neurons: vec![
+                NeuronData {
+                    bias: 0.1,
+                    start_synapse: 0,
+                    num_synapses: 2,
+                    squash_type: 1, // ReLU
+                    is_constant: false,
+                },
+                NeuronData {
+                    bias: -0.2,
+                    start_synapse: 2,
+                    num_synapses: 1,
+                    squash_type: 0, // Identity
+                    is_constant: false,
+                },
+            ],
+            inputs: [&[1.0, 2.0], &[0.5, -1.0], &[-2.0, 3.0], &[0.0, 0.0]],
+        },
+        // TANH hidden into a LOGISTIC output.
+        ParityCase {
+            name: "tanh_hidden_logistic_output",
+            num_inputs: 2,
+            synapses: vec![
+                make_synapse(0, 1.0),
+                make_synapse(1, 0.5),
+                make_synapse(2, -0.7),
+            ],
+            neurons: vec![
+                NeuronData {
+                    bias: 0.0,
+                    start_synapse: 0,
+                    num_synapses: 2,
+                    squash_type: 7, // TANH
+                    is_constant: false,
+                },
+                NeuronData {
+                    bias: 0.5,
+                    start_synapse: 2,
+                    num_synapses: 1,
+                    squash_type: 6, // LOGISTIC
+                    is_constant: false,
+                },
+            ],
+            inputs: [&[1.0, 0.5], &[-1.0, 2.0], &[0.3, -0.3], &[2.0, -1.0]],
+        },
+        // MINIMUM aggregate: 2 inputs -> 1 MINIMUM neuron (output).
+        ParityCase {
+            name: "minimum_aggregate",
+            num_inputs: 2,
+            synapses: vec![make_synapse(0, 1.0), make_synapse(1, 1.0)],
+            neurons: vec![NeuronData {
+                bias: 0.0,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 32, // MINIMUM
+                is_constant: false,
+            }],
+            inputs: [
+                &[3.0, 1.0],  // min = 1.0
+                &[-1.0, 2.0], // min = -1.0
+                &[5.0, 5.0],  // min = 5.0
+                &[0.0, -3.0], // min = -3.0
+            ],
+        },
+        // MAXIMUM aggregate, with a non-zero bias.
+        ParityCase {
+            name: "maximum_aggregate",
+            num_inputs: 2,
+            synapses: vec![make_synapse(0, 1.0), make_synapse(1, 1.0)],
+            neurons: vec![NeuronData {
+                bias: 0.5,
+                start_synapse: 0,
+                num_synapses: 2,
+                squash_type: 33, // MAXIMUM
+                is_constant: false,
+            }],
+            inputs: [&[3.0, 1.0], &[-1.0, 2.0], &[5.0, 5.0], &[0.0, -3.0]],
+        },
+        // IF aggregate: 3 inputs -> 1 IF neuron, both branches exercised.
+        ParityCase {
+            name: "if_aggregate",
+            num_inputs: 3,
+            synapses: vec![
+                make_synapse_typed(0, 1.0, 1), // condition
+                make_synapse_typed(1, 1.0, 3), // positive
+                make_synapse_typed(2, 1.0, 2), // negative
+            ],
+            neurons: vec![NeuronData {
+                bias: 0.0,
+                start_synapse: 0,
+                num_synapses: 3,
+                squash_type: 34, // IF
+                is_constant: false,
+            }],
+            inputs: [
+                &[1.0, 5.0, 10.0],  // condition>0 -> positive=5.0
+                &[-1.0, 5.0, 10.0], // condition<=0 -> negative=10.0
+                &[0.5, 3.0, 7.0],   // condition>0 -> positive=3.0
+                &[-2.0, 3.0, 7.0],  // condition<=0 -> negative=7.0
+            ],
+        },
+        // Constant neuron feeding an Identity output.
+        ParityCase {
+            name: "constant_neuron",
+            num_inputs: 2,
+            synapses: vec![
+                make_synapse(2, 1.0), // output <- constant
+            ],
+            neurons: vec![
+                NeuronData {
+                    bias: 42.0,
+                    start_synapse: 0,
+                    num_synapses: 0,
+                    squash_type: 0,
+                    is_constant: true,
+                },
+                NeuronData {
+                    bias: 0.0,
+                    start_synapse: 0,
+                    num_synapses: 1,
+                    squash_type: 0, // Identity
+                    is_constant: false,
+                },
+            ],
+            inputs: [&[1.0, 2.0], &[3.0, 4.0], &[5.0, 6.0], &[7.0, 8.0]],
+        },
+        // Deeper network: 2 inputs -> 2 hidden (ReLU) -> 1 output (Identity).
+        ParityCase {
+            name: "multi_layer",
+            num_inputs: 2,
+            synapses: vec![
+                // Hidden 0 (idx 2): from input 0 and 1
+                make_synapse(0, 0.5),
+                make_synapse(1, 0.3),
+                // Hidden 1 (idx 3): from input 0 and 1
+                make_synapse(0, -0.4),
+                make_synapse(1, 0.6),
+                // Output (idx 4): from hidden 0 and hidden 1
+                make_synapse(2, 1.0),
+                make_synapse(3, -0.5),
+            ],
+            neurons: vec![
+                NeuronData {
+                    bias: 0.1,
+                    start_synapse: 0,
+                    num_synapses: 2,
+                    squash_type: 1, // ReLU
+                    is_constant: false,
+                },
+                NeuronData {
+                    bias: -0.1,
+                    start_synapse: 2,
+                    num_synapses: 2,
+                    squash_type: 1, // ReLU
+                    is_constant: false,
+                },
+                NeuronData {
+                    bias: 0.0,
+                    start_synapse: 4,
+                    num_synapses: 2,
+                    squash_type: 0, // Identity
+                    is_constant: false,
+                },
+            ],
+            inputs: [&[1.0, 2.0], &[-1.0, 0.5], &[3.0, -2.0], &[0.0, 0.0]],
+        },
+    ]
+}
+
+/// Every record of the 4-way batch matches the single-record trace, across all
+/// squash kinds, constant neurons and network depths in the fixture table.
 #[test]
-fn test_batch_4way_matches_single_tanh_logistic() {
-    let synapses = vec![
-        make_synapse(0, 1.0),
-        make_synapse(1, 0.5),
-        make_synapse(2, -0.7),
-    ];
-    let neurons = vec![
-        NeuronData {
-            bias: 0.0,
-            start_synapse: 0,
-            num_synapses: 2,
-            squash_type: 7, // TANH
-            is_constant: false,
-        },
-        NeuronData {
-            bias: 0.5,
-            start_synapse: 2,
-            num_synapses: 1,
-            squash_type: 6, // LOGISTIC
-            is_constant: false,
-        },
-    ];
-
-    let inputs: [&[f32]; 4] = [&[1.0, 0.5], &[-1.0, 2.0], &[0.3, -0.3], &[2.0, -1.0]];
-
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(2, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
-    }
-
-    let mut net = make_network(2, neurons.clone(), synapses.clone());
-    let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
-
-    let len0 = batch_result[0] as usize;
-    let len1 = batch_result[1] as usize;
-    let len2 = batch_result[2] as usize;
-
-    let start0 = 4;
-    let start1 = start0 + len0;
-    let start2 = start1 + len1;
-    let start3 = start2 + len2;
-
-    let batch_records = [
-        &batch_result[start0..start0 + len0],
-        &batch_result[start1..start1 + len1],
-        &batch_result[start2..start2 + len0],
-        &batch_result[start3..start3 + batch_result[3] as usize],
-    ];
-
-    for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
-        assert_eq!(single.len(), batch.len(), "Record {i}: length mismatch");
-        for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
-            assert!(
-                (s - b).abs() < 1e-5,
-                "Record {i}, element {j}: single={s}, batch={b}"
-            );
-        }
+fn batch_4way_matches_single_record_for_every_fixture() {
+    for case in parity_cases() {
+        assert_batch_matches_single(&case);
     }
 }
 
-/// Test batch 4-way with MINIMUM aggregate function
+/// Issue #476 - regression: records of **differing** lengths are each sliced
+/// with their own length. The hand-copied variants sliced record 2 with record
+/// 0's length, which only went unnoticed because every record in those fixtures
+/// happened to be the same size.
 #[test]
-fn test_batch_4way_minimum_aggregate() {
-    // 2 inputs -> 1 MINIMUM neuron (output)
-    let synapses = vec![make_synapse(0, 1.0), make_synapse(1, 1.0)];
-    let neurons = vec![NeuronData {
-        bias: 0.0,
-        start_synapse: 0,
-        num_synapses: 2,
-        squash_type: 32, // MINIMUM
-        is_constant: false,
-    }];
-
-    let inputs: [&[f32]; 4] = [
-        &[3.0, 1.0],  // min = 1.0
-        &[-1.0, 2.0], // min = -1.0
-        &[5.0, 5.0],  // min = 5.0
-        &[0.0, -3.0], // min = -3.0
+fn split_batch_records_uses_each_records_own_length() {
+    // Header [1, 2, 3, 4] then 10 payload values, all lengths distinct.
+    let batch_result: Vec<f32> = vec![
+        1.0, 2.0, 3.0, 4.0,  // header
+        10.0, // record 0
+        20.0, 21.0, // record 1
+        30.0, 31.0, 32.0, // record 2
+        40.0, 41.0, 42.0, 43.0, // record 3
     ];
 
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(2, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
-    }
+    let records = split_batch_records(&batch_result);
 
-    let mut net = make_network(2, neurons.clone(), synapses.clone());
-    let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
-
-    let len0 = batch_result[0] as usize;
-    let len1 = batch_result[1] as usize;
-    let len2 = batch_result[2] as usize;
-
-    let start0 = 4;
-    let start1 = start0 + len0;
-    let start2 = start1 + len1;
-    let start3 = start2 + len2;
-
-    let batch_records = [
-        &batch_result[start0..start0 + len0],
-        &batch_result[start1..start1 + len1],
-        &batch_result[start2..start2 + len2],
-        &batch_result[start3..start3 + batch_result[3] as usize],
-    ];
-
-    for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
-        assert_eq!(single.len(), batch.len(), "Record {i}: length mismatch");
-        for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
-            assert!(
-                (s - b).abs() < 1e-5,
-                "Record {i}, element {j}: single={s}, batch={b}"
-            );
-        }
-    }
+    assert_eq!(records.len(), BATCH_RECORDS);
+    assert_eq!(records[0], &[10.0]);
+    assert_eq!(records[1], &[20.0, 21.0]);
+    assert_eq!(records[2], &[30.0, 31.0, 32.0]);
+    assert_eq!(records[3], &[40.0, 41.0, 42.0, 43.0]);
 }
 
-/// Test batch 4-way with MAXIMUM aggregate function
+/// A header whose lengths do not account for the whole payload is a broken
+/// oracle and must fail loudly rather than silently comparing a prefix.
 #[test]
-fn test_batch_4way_maximum_aggregate() {
-    let synapses = vec![make_synapse(0, 1.0), make_synapse(1, 1.0)];
-    let neurons = vec![NeuronData {
-        bias: 0.5,
-        start_synapse: 0,
-        num_synapses: 2,
-        squash_type: 33, // MAXIMUM
-        is_constant: false,
-    }];
-
-    let inputs: [&[f32]; 4] = [&[3.0, 1.0], &[-1.0, 2.0], &[5.0, 5.0], &[0.0, -3.0]];
-
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(2, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
-    }
-
-    let mut net = make_network(2, neurons.clone(), synapses.clone());
-    let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
-
-    let len0 = batch_result[0] as usize;
-    let len1 = batch_result[1] as usize;
-    let len2 = batch_result[2] as usize;
-
-    let start0 = 4;
-    let start1 = start0 + len0;
-    let start2 = start1 + len1;
-    let start3 = start2 + len2;
-
-    let batch_records = [
-        &batch_result[start0..start0 + len0],
-        &batch_result[start1..start1 + len1],
-        &batch_result[start2..start2 + len2],
-        &batch_result[start3..start3 + batch_result[3] as usize],
-    ];
-
-    for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
-        assert_eq!(single.len(), batch.len(), "Record {i}: length mismatch");
-        for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
-            assert!(
-                (s - b).abs() < 1e-5,
-                "Record {i}, element {j}: single={s}, batch={b}"
-            );
-        }
-    }
+#[should_panic(expected = "cover the whole batch buffer")]
+fn split_batch_records_rejects_header_that_undercovers_the_buffer() {
+    // Header claims 1+1+1+1 = 4 values but 5 follow.
+    let batch_result: Vec<f32> = vec![1.0, 1.0, 1.0, 1.0, 10.0, 20.0, 30.0, 40.0, 50.0];
+    let _ = split_batch_records(&batch_result);
 }
 
-/// Test batch 4-way with IF aggregate function
+/// A header claiming more data than the buffer holds must fail loudly rather
+/// than panicking with an opaque slice-index message.
 #[test]
-fn test_batch_4way_if_aggregate() {
-    // 3 inputs -> 1 IF neuron
-    // synapse0: condition, synapse1: positive, synapse2: negative
-    let synapses = vec![
-        make_synapse_typed(0, 1.0, 1), // condition
-        make_synapse_typed(1, 1.0, 3), // positive
-        make_synapse_typed(2, 1.0, 2), // negative
-    ];
-    let neurons = vec![NeuronData {
-        bias: 0.0,
-        start_synapse: 0,
-        num_synapses: 3,
-        squash_type: 34, // IF
-        is_constant: false,
-    }];
-
-    let inputs: [&[f32]; 4] = [
-        &[1.0, 5.0, 10.0],  // condition>0 -> positive=5.0
-        &[-1.0, 5.0, 10.0], // condition<=0 -> negative=10.0
-        &[0.5, 3.0, 7.0],   // condition>0 -> positive=3.0
-        &[-2.0, 3.0, 7.0],  // condition<=0 -> negative=7.0
-    ];
-
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(3, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
-    }
-
-    let mut net = make_network(3, neurons.clone(), synapses.clone());
-    let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed, 3, 1);
-
-    let len0 = batch_result[0] as usize;
-    let len1 = batch_result[1] as usize;
-    let len2 = batch_result[2] as usize;
-
-    let start0 = 4;
-    let start1 = start0 + len0;
-    let start2 = start1 + len1;
-    let start3 = start2 + len2;
-
-    let batch_records = [
-        &batch_result[start0..start0 + len0],
-        &batch_result[start1..start1 + len1],
-        &batch_result[start2..start2 + len2],
-        &batch_result[start3..start3 + batch_result[3] as usize],
-    ];
-
-    for (i, (single, batch)) in single_results.iter().zip(batch_records.iter()).enumerate() {
-        assert_eq!(single.len(), batch.len(), "Record {i}: length mismatch");
-        for (j, (s, b)) in single.iter().zip(batch.iter()).enumerate() {
-            assert!(
-                (s - b).abs() < 1e-5,
-                "Record {i}, element {j}: single={s}, batch={b}"
-            );
-        }
-    }
-}
-
-/// Test batch 4-way with constant neurons
-#[test]
-fn test_batch_4way_constant_neuron() {
-    let synapses = vec![
-        make_synapse(2, 1.0), // output <- constant
-    ];
-    let neurons = vec![
-        NeuronData {
-            bias: 42.0,
-            start_synapse: 0,
-            num_synapses: 0,
-            squash_type: 0,
-            is_constant: true,
-        },
-        NeuronData {
-            bias: 0.0,
-            start_synapse: 0,
-            num_synapses: 1,
-            squash_type: 0, // Identity
-            is_constant: false,
-        },
-    ];
-
-    let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[3.0, 4.0], &[5.0, 6.0], &[7.0, 8.0]];
-
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(2, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
-    }
-
-    let mut net = make_network(2, neurons.clone(), synapses.clone());
-    let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
-
-    // All 4 records should produce the same output (constant 42.0 passed through identity)
-    for r in 0..4 {
-        let start = 4 + (0..r).map(|i| batch_result[i] as usize).sum::<usize>();
-        let len = batch_result[r] as usize;
-        let batch_record = &batch_result[start..start + len];
-        let single = &single_results[r];
-
-        assert_eq!(
-            single.len(),
-            batch_record.len(),
-            "Record {r}: length mismatch"
-        );
-        for (j, (s, b)) in single.iter().zip(batch_record.iter()).enumerate() {
-            assert!(
-                (s - b).abs() < 1e-5,
-                "Record {r}, element {j}: single={s}, batch={b}"
-            );
-        }
-    }
-}
-
-/// Test batch 4-way with a deeper network (multiple layers)
-#[test]
-fn test_batch_4way_multi_layer() {
-    // 2 inputs -> 2 hidden (ReLU) -> 1 output (Identity)
-    let synapses = vec![
-        // Hidden 0 (idx 2): from input 0 and 1
-        make_synapse(0, 0.5),
-        make_synapse(1, 0.3),
-        // Hidden 1 (idx 3): from input 0 and 1
-        make_synapse(0, -0.4),
-        make_synapse(1, 0.6),
-        // Output (idx 4): from hidden 0 and hidden 1
-        make_synapse(2, 1.0),
-        make_synapse(3, -0.5),
-    ];
-    let neurons = vec![
-        NeuronData {
-            bias: 0.1,
-            start_synapse: 0,
-            num_synapses: 2,
-            squash_type: 1, // ReLU
-            is_constant: false,
-        },
-        NeuronData {
-            bias: -0.1,
-            start_synapse: 2,
-            num_synapses: 2,
-            squash_type: 1, // ReLU
-            is_constant: false,
-        },
-        NeuronData {
-            bias: 0.0,
-            start_synapse: 4,
-            num_synapses: 2,
-            squash_type: 0, // Identity
-            is_constant: false,
-        },
-    ];
-
-    let inputs: [&[f32]; 4] = [&[1.0, 2.0], &[-1.0, 0.5], &[3.0, -2.0], &[0.0, 0.0]];
-
-    let mut single_results = Vec::new();
-    for input in &inputs {
-        let mut net = make_network(2, neurons.clone(), synapses.clone());
-        let result = net.activate_and_trace(input, 1);
-        single_results.push(result);
-    }
-
-    let mut net = make_network(2, neurons.clone(), synapses.clone());
-    let packed: Vec<f32> = inputs.iter().flat_map(|i| i.iter().copied()).collect();
-    let batch_result = net.activate_and_trace_batch_4way(&packed, 2, 1);
-
-    for r in 0..4 {
-        let start = 4 + (0..r).map(|i| batch_result[i] as usize).sum::<usize>();
-        let len = batch_result[r] as usize;
-        let batch_record = &batch_result[start..start + len];
-        let single = &single_results[r];
-
-        assert_eq!(
-            single.len(),
-            batch_record.len(),
-            "Record {r}: length mismatch"
-        );
-        for (j, (s, b)) in single.iter().zip(batch_record.iter()).enumerate() {
-            assert!(
-                (s - b).abs() < 1e-5,
-                "Record {r}, element {j}: single={s}, batch={b}"
-            );
-        }
-    }
+#[should_panic(expected = "overruns the batch buffer")]
+fn split_batch_records_rejects_header_that_overruns_the_buffer() {
+    // Header claims 1+1+1+9 = 12 values but only 4 follow.
+    let batch_result: Vec<f32> = vec![1.0, 1.0, 1.0, 9.0, 10.0, 20.0, 30.0, 40.0];
+    let _ = split_batch_records(&batch_result);
 }
 
 /// Issue #155 - Regression test for buffer reuse in `activate_and_trace_batch_4way`.


### PR DESCRIPTION
# Express the batch-parity contract once (Issue #476)

## Summary

`neat-core/tests/network_activate_trace_batch.rs` carried seven near-duplicate
tests, each repeating the same ~40-line "parse the batch header, slice out four
records, compare against the single-record run" block and differing only in
fixture and inputs. One copy had already been mis-transcribed: record 2 was
sliced as `&batch_result[start2..start2 + len0]` — `len0` where `len2` was
intended. It passed only because every record in that fixture happens to be the
same length, so the parity check it exists to provide was silently weakened.

Resolution (a) from the issue: the contract is now stated once and driven from a
table.

- **`split_batch_records`** walks the four-value length header in a loop,
  accumulating each record's `start` from the preceding lengths. A record is
  therefore always sliced with its **own** length — the `len0`/`len2` class of
  bug is no longer expressible.
- It also **fails loud** rather than silently comparing a prefix: a header that
  overruns the buffer, or whose lengths do not cover the payload exactly, is an
  explicit assertion failure with a named cause instead of an opaque slice panic
  or a quietly-truncated comparison.
- **`assert_batch_matches_single`** holds the single copy of the
  batch-vs-single oracle, driven from **`parity_cases()`** — the same seven
  fixtures (ReLU, TANH/LOGISTIC, MINIMUM, MAXIMUM, IF, constant neuron,
  multi-layer), now as data rather than as seven hand-copied function bodies.

Net: 404 lines removed, 290 added, with no loss of fixture coverage.

`test_batch_4way_buffer_reuse_no_state_leak` (Issue #155) is a production
regression test, not part of the family, and is unchanged.

Closes #476.

### Test restructuring (declared, per the "do not remove existing tests" rule)

The seven `test_batch_4way_*` test functions are **replaced**, not deleted:
every fixture and every input record survives as an entry in `parity_cases()`,
and each is still asserted by the same oracle — now through one shared helper.
Assertion messages carry the case name, so a failure still identifies which
fixture broke. The seven `#[test]` functions collapse into one
(`batch_4way_matches_single_record_for_every_fixture`), which is the
consolidation the issue asked for.

```mermaid
flowchart LR
    subgraph Before
        T1["test_..._relu"] --> H1["~40 lines: header parse<br/>+ hand-written slices<br/>+ compare loop"]
        T2["test_..._tanh_logistic"] --> H2["~40 lines (copy)<br/>len0/len2 slip here"]
        T3["...5 more copies"] --> H3["~40 lines each"]
    end
    subgraph After
        C["parity_cases() table<br/>7 fixtures"] --> A["assert_batch_matches_single"]
        A --> S["split_batch_records<br/>loop-derived start/len"]
        S --> V["fails loud on a<br/>bad header"]
    end
```

## Evidence

Backend/library change with no web interface, so no screenshot applies. The
evidence is a mutation test: the old hand-copied slicing (including the
`len0`/`len2` slip) was temporarily reintroduced into `split_batch_records` and
the suite re-run. All three new oracle tests failed, confirming they catch the
bug class rather than merely passing alongside it:

```
---- split_batch_records_uses_each_records_own_length ----
  left: [30.0]
 right: [30.0, 31.0, 32.0]

failures:
    split_batch_records_rejects_header_that_overruns_the_buffer
    split_batch_records_rejects_header_that_undercovers_the_buffer
    split_batch_records_uses_each_records_own_length

test result: FAILED. 2 passed; 3 failed
```

With the loop-derived splitter restored:

```
running 5 tests
test split_batch_records_uses_each_records_own_length ... ok
test test_batch_4way_buffer_reuse_no_state_leak ... ok
test split_batch_records_rejects_header_that_overruns_the_buffer - should panic ... ok
test split_batch_records_rejects_header_that_undercovers_the_buffer - should panic ... ok
test batch_4way_matches_single_record_for_every_fixture ... ok

test result: ok. 5 passed; 0 failed
```

`./quality.sh` passes cleanly (fmt, clippy, deny, workspace tests, docs,
release build).

## Test Plan

Tests in `neat-core/tests/network_activate_trace_batch.rs`:

- `batch_4way_matches_single_record_for_every_fixture` — the parity contract
  across all seven fixtures, replacing the seven copy-pasted variants.
- `split_batch_records_uses_each_records_own_length` — **regression for the
  reported defect.** A synthetic buffer whose four records have *distinct*
  lengths (1, 2, 3, 4); fails against the old `len0`-for-`len2` slicing, passes
  against the loop-derived splitter. The production code cannot produce
  differing per-record lengths today (record size is fixed by topology), which
  is exactly why the defect stayed latent — so the oracle itself is tested
  directly.
- `split_batch_records_rejects_header_that_overruns_the_buffer` — a header
  claiming more data than the buffer holds fails with a named cause.
- `split_batch_records_rejects_header_that_undercovers_the_buffer` — a header
  that leaves payload unaccounted for fails instead of silently comparing a
  prefix.
- `test_batch_4way_buffer_reuse_no_state_leak` — unchanged (Issue #155).

## Follow-up

Filed **stSoftwareAU/NEAT-AI-core#484**: the same seven `test_batch_4way_*`
tests still exist verbatim in `src/network.rs`'s `mod tests`, despite this
file's header claiming they were moved out of it. That cross-file duplication is
separate work and was left out of this change to keep it in scope.



## Milestone
This PR is part of the **Clean Up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms9xqhck-4afc93`<!-- vibe-worker-issue-476 -->