### PR TITLE
Couple self-testing regex tests to the live gate (Issue #478)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-478.md
+++ b/docs/archive/pr-summaries/pr-summary-478.md
@@ -1,0 +1,75 @@
+# PR Summary — Issue #478
+
+## Summary
+
+Three BATS "regex rejects known-bad input" tests asserted against a **private
+copy** of the regex they claimed to protect, so weakening the live gate failed
+nothing and the two copies could silently diverge. Each pattern now has exactly
+one definition — exported from the file's `setup()` and compiled by both the
+sweep over the real workflows and the good/bad literal check — which is
+resolution (a) from the issue. Closes #478.
+
+| File | Shared variable | Copies collapsed |
+| --- | --- | --- |
+| `tests/scripts/workflow_sha_pinning.bats` | `SHA_PIN_RE` | 2 → 1 |
+| `tests/scripts/workflow_container_pinning.bats` | `IMAGE_DIGEST_RE` | 3 → 1 |
+| `tests/scripts/workflow_script_injection.bats` | `TAINTED_CONTEXT_RE` | 2 → 1 |
+
+Heredocs that read a shared pattern switched from `<<PY` to quoted `<<'PY'`
+with `os.environ[...]`, so the shell no longer interpolates regex text (this
+also removes the `\$` escaping the digest copy needed). No gate's behaviour
+changed — the patterns are byte-identical to the live originals.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — two copies"]
+        G1["sweep test<br/>regex copy A"] --> W1[".github/workflows"]
+        S1["self-test<br/>regex copy B"] --> L1["inline literals"]
+    end
+    subgraph after["After — one definition"]
+        R["setup(): export SHA_PIN_RE"] --> G2["sweep test"] --> W2[".github/workflows"]
+        R --> S2["self-test"] --> L2["inline literals"]
+    end
+```
+
+## Evidence
+
+Backend/CLI test change — no web interface to screenshot. Falsifiability was
+proven by mutation, since a passing test is not evidence for this class of bug.
+
+**Before** — gutting the live gate regex on `workflow_sha_pinning.bats:31` to
+`re.compile(r".*")` (accepts every floating tag):
+
+```text
+ok 1 every action in every workflow is pinned to a 40-char commit SHA
+ok 2 every SHA-pinned action has a version comment alongside it
+ok 3 no workflow uses an action pinned to a deprecated Node runtime
+ok 4 SHA-pin regex rejects floating tags and branch refs     <-- should have failed
+```
+
+**After** — weakening each single definition (`SHA_PIN_RE='.*'`,
+`IMAGE_DIGEST_RE='.*'`, `TAINTED_CONTEXT_RE='NEVER_MATCHES_XYZ'`):
+
+```text
+not ok 4  SHA-pin regex rejects floating tags and branch refs
+not ok 8  digest regex rejects bare image names and mutable tags
+not ok 10 tainted-context detector regex catches known-bad patterns
+```
+
+Unmutated tree: `bats tests/scripts` → **281 passed, 0 failed**;
+`./quality.sh < /dev/null` → `✅ All quality checks passed!`.
+
+## Test Plan
+
+No tests were removed or disabled — the three self-tests were rewired to
+exercise the live pattern, and their good/bad literal lists are unchanged.
+
+- `tests/scripts/workflow_sha_pinning.bats::SHA-pin regex rejects floating tags and branch refs`
+- `tests/scripts/workflow_container_pinning.bats::digest regex rejects bare image names and mutable tags`
+- `tests/scripts/workflow_script_injection.bats::tainted-context detector regex catches known-bad patterns`
+
+Each now fails when its gate is weakened (mutation results above) and passes
+against the real pattern. The four sweep tests that consume the same variables
+(`every action …`, `every job container …`, `every *_IMAGE env value …`,
+`no run: block …`) still pass against the real `.github/workflows`, confirming
+the extracted patterns are equivalent to the originals.

--- a/tests/scripts/workflow_container_pinning.bats
+++ b/tests/scripts/workflow_container_pinning.bats
@@ -17,18 +17,23 @@
 
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
-  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+  export WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+  # Single source of truth for the digest shape (Issue #478). Both sweeps over
+  # the real workflows and the good/bad literal check below compile this one
+  # definition, so weakening the gate fails the literal check too — previously
+  # the literal check owned a private copy and passed regardless.
+  export IMAGE_DIGEST_RE='^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}$'
 }
 
 @test "every job container and service image is pinned to a sha256 digest" {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
-  run python3 - <<PY
+  run python3 - <<'PY'
 import glob, os, re, sys, yaml
 
-workflows_dir = "$WORKFLOWS_DIR"
-digest_re = re.compile(r"^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}$")
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+digest_re = re.compile(os.environ["IMAGE_DIGEST_RE"])
 
 def image_of(spec):
     """A container/service entry is either a bare image string or a mapping."""
@@ -76,11 +81,11 @@ PY
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
-  run python3 - <<PY
+  run python3 - <<'PY'
 import glob, os, re, sys, yaml
 
-workflows_dir = "$WORKFLOWS_DIR"
-digest_re = re.compile(r"^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}$")
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+digest_re = re.compile(os.environ["IMAGE_DIGEST_RE"])
 
 def env_blocks(data):
     yield "workflow", data.get("env") or {}
@@ -152,12 +157,13 @@ PY
   [ "$status" -eq 0 ]
 }
 
-# Behavioural sanity check: the digest regex must reject the mutable forms
-# this gate exists to keep out. If someone weakens it, this test fails.
+# Behavioural sanity check: the live gate's regex — read from $IMAGE_DIGEST_RE,
+# the same value the sweeps above compile — must reject the mutable forms this
+# gate exists to keep out. If someone weakens it, this test fails (Issue #478).
 @test "digest regex rejects bare image names and mutable tags" {
-  run python3 - <<PY
-import re
-digest_re = re.compile(r"^[A-Za-z0-9_.\-/:]+@sha256:[0-9a-f]{64}\$")
+  run python3 - <<'PY'
+import os, re
+digest_re = re.compile(os.environ["IMAGE_DIGEST_RE"])
 bad = [
     "semgrep/semgrep",
     "semgrep/semgrep:latest",

--- a/tests/scripts/workflow_script_injection.bats
+++ b/tests/scripts/workflow_script_injection.bats
@@ -24,6 +24,23 @@
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
   export WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+
+  # Contexts that come from outside the trust boundary. Branch names, PR
+  # titles/bodies, issue bodies, comments, commit messages, and workflow_run
+  # event payloads are all user-controlled.
+  local ctx='head_ref'
+  ctx="${ctx}"'|event\.pull_request\.(?:title|body|head\.ref|head\.label|head\.repo\.[A-Za-z_.]+)'
+  ctx="${ctx}"'|event\.issue\.(?:title|body)'
+  ctx="${ctx}"'|event\.comment\.body'
+  ctx="${ctx}"'|event\.review\.body'
+  ctx="${ctx}"'|event\.commits\.[^}]*'
+  ctx="${ctx}"'|event\.workflow_run\.head_branch'
+  # Single source of truth for the detector (Issue #478). The sweep over the
+  # real workflows and the known-bad/known-safe snippet check below both
+  # compile this one definition, so narrowing the detector fails the snippet
+  # check too — previously that check owned a private copy and passed
+  # regardless.
+  export TAINTED_CONTEXT_RE='\$\{\{\s*github\.(?:'"${ctx}"')\s*\}\}'
 }
 
 @test "no run: block interpolates tainted github contexts directly" {
@@ -34,21 +51,7 @@ setup() {
 import glob, os, re, sys, yaml
 
 workflows_dir = os.environ["WORKFLOWS_DIR"]
-
-# Contexts that come from outside the trust boundary. Branch names, PR
-# titles/bodies, issue bodies, comments, commit messages, and workflow_run
-# event payloads are all user-controlled.
-tainted_re = re.compile(
-    r"\$\{\{\s*github\.(?:"
-    r"head_ref"
-    r"|event\.pull_request\.(?:title|body|head\.ref|head\.label|head\.repo\.[A-Za-z_.]+)"
-    r"|event\.issue\.(?:title|body)"
-    r"|event\.comment\.body"
-    r"|event\.review\.body"
-    r"|event\.commits\.[^}]*"
-    r"|event\.workflow_run\.head_branch"
-    r")\s*\}\}"
-)
+tainted_re = re.compile(os.environ["TAINTED_CONTEXT_RE"])
 
 failures = []
 files = sorted(glob.glob(os.path.join(workflows_dir, "*.yml")))
@@ -87,21 +90,14 @@ PY
   [ "$status" -eq 0 ]
 }
 
+# Behavioural sanity check: the live detector — read from $TAINTED_CONTEXT_RE,
+# the same value the sweep above compiles — must still catch these. Narrowing
+# the detector fails this test (Issue #478).
 @test "tainted-context detector regex catches known-bad patterns" {
   run python3 - <<'PY'
-import re
+import os, re
 
-tainted_re = re.compile(
-    r"\$\{\{\s*github\.(?:"
-    r"head_ref"
-    r"|event\.pull_request\.(?:title|body|head\.ref|head\.label|head\.repo\.[A-Za-z_.]+)"
-    r"|event\.issue\.(?:title|body)"
-    r"|event\.comment\.body"
-    r"|event\.review\.body"
-    r"|event\.commits\.[^}]*"
-    r"|event\.workflow_run\.head_branch"
-    r")\s*\}\}"
-)
+tainted_re = re.compile(os.environ["TAINTED_CONTEXT_RE"])
 
 bad = [
     "git pull origin ${{ github.head_ref }}",

--- a/tests/scripts/workflow_sha_pinning.bats
+++ b/tests/scripts/workflow_sha_pinning.bats
@@ -14,7 +14,12 @@
 
 setup() {
   REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
-  WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+  export WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+  # Single source of truth for the pin shape (Issue #478). The sweep over the
+  # real workflows and the good/bad literal check below both compile this one
+  # definition, so weakening the gate fails the literal check too — previously
+  # the literal check owned a private copy and passed regardless.
+  export SHA_PIN_RE='^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$'
 }
 
 # Helper: assert every uses: in every workflow under WORKFLOWS_DIR is pinned
@@ -24,11 +29,11 @@ setup() {
   if ! command -v python3 &>/dev/null; then
     skip "python3 required for YAML parsing"
   fi
-  run python3 - <<PY
+  run python3 - <<'PY'
 import glob, os, re, sys, yaml
 
-workflows_dir = "$WORKFLOWS_DIR"
-sha_re = re.compile(r"^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$")
+workflows_dir = os.environ["WORKFLOWS_DIR"]
+sha_re = re.compile(os.environ["SHA_PIN_RE"])
 local_re = re.compile(r"^\./")
 
 failures = []
@@ -166,12 +171,13 @@ PY
   [ "$status" -eq 0 ]
 }
 
-# Behavioural sanity check: the regex actually rejects a known-bad ref. If
-# someone weakens the regex this test catches it.
+# Behavioural sanity check: the live gate's regex — read from $SHA_PIN_RE, the
+# same value the sweep above compiles — actually rejects a known-bad ref. If
+# someone weakens the gate this test catches it (Issue #478).
 @test "SHA-pin regex rejects floating tags and branch refs" {
-  run python3 - <<PY
-import re
-sha_re = re.compile(r"^[A-Za-z0-9_.\-/]+@[0-9a-f]{40}$")
+  run python3 - <<'PY'
+import os, re
+sha_re = re.compile(os.environ["SHA_PIN_RE"])
 bad = [
     "actions/checkout@v4",
     "actions/checkout@v4.1.1",


### PR DESCRIPTION
# PR Summary — Issue #478

## Summary

Three BATS "regex rejects known-bad input" tests asserted against a **private
copy** of the regex they claimed to protect, so weakening the live gate failed
nothing and the two copies could silently diverge. Each pattern now has exactly
one definition — exported from the file's `setup()` and compiled by both the
sweep over the real workflows and the good/bad literal check — which is
resolution (a) from the issue. Closes #478.

| File | Shared variable | Copies collapsed |
| --- | --- | --- |
| `tests/scripts/workflow_sha_pinning.bats` | `SHA_PIN_RE` | 2 → 1 |
| `tests/scripts/workflow_container_pinning.bats` | `IMAGE_DIGEST_RE` | 3 → 1 |
| `tests/scripts/workflow_script_injection.bats` | `TAINTED_CONTEXT_RE` | 2 → 1 |

Heredocs that read a shared pattern switched from `<<PY` to quoted `<<'PY'`
with `os.environ[...]`, so the shell no longer interpolates regex text (this
also removes the `\$` escaping the digest copy needed). No gate's behaviour
changed — the patterns are byte-identical to the live originals.

```mermaid
flowchart LR
    subgraph before["Before — two copies"]
        G1["sweep test<br/>regex copy A"] --> W1[".github/workflows"]
        S1["self-test<br/>regex copy B"] --> L1["inline literals"]
    end
    subgraph after["After — one definition"]
        R["setup(): export SHA_PIN_RE"] --> G2["sweep test"] --> W2[".github/workflows"]
        R --> S2["self-test"] --> L2["inline literals"]
    end
```

## Evidence

Backend/CLI test change — no web interface to screenshot. Falsifiability was
proven by mutation, since a passing test is not evidence for this class of bug.

**Before** — gutting the live gate regex on `workflow_sha_pinning.bats:31` to
`re.compile(r".*")` (accepts every floating tag):

```text
ok 1 every action in every workflow is pinned to a 40-char commit SHA
ok 2 every SHA-pinned action has a version comment alongside it
ok 3 no workflow uses an action pinned to a deprecated Node runtime
ok 4 SHA-pin regex rejects floating tags and branch refs     <-- should have failed
```

**After** — weakening each single definition (`SHA_PIN_RE='.*'`,
`IMAGE_DIGEST_RE='.*'`, `TAINTED_CONTEXT_RE='NEVER_MATCHES_XYZ'`):

```text
not ok 4  SHA-pin regex rejects floating tags and branch refs
not ok 8  digest regex rejects bare image names and mutable tags
not ok 10 tainted-context detector regex catches known-bad patterns
```

Unmutated tree: `bats tests/scripts` → **281 passed, 0 failed**;
`./quality.sh < /dev/null` → `✅ All quality checks passed!`.

## Test Plan

No tests were removed or disabled — the three self-tests were rewired to
exercise the live pattern, and their good/bad literal lists are unchanged.

- `tests/scripts/workflow_sha_pinning.bats::SHA-pin regex rejects floating tags and branch refs`
- `tests/scripts/workflow_container_pinning.bats::digest regex rejects bare image names and mutable tags`
- `tests/scripts/workflow_script_injection.bats::tainted-context detector regex catches known-bad patterns`

Each now fails when its gate is weakened (mutation results above) and passes
against the real pattern. The four sweep tests that consume the same variables
(`every action …`, `every job container …`, `every *_IMAGE env value …`,
`no run: block …`) still pass against the real `.github/workflows`, confirming
the extracted patterns are equivalent to the originals.



## Milestone
This PR is part of the **Clean Up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msaau9dg-4e6f00`<!-- vibe-worker-issue-478 -->