### PR TITLE
Replace vacuous test oracles with derived, falsifiable assertions (Issue #479)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-479.md
+++ b/docs/archive/pr-summaries/pr-summary-479.md
@@ -1,0 +1,88 @@
+## Summary
+
+Replaced four vacuous or unjustified test oracles with derived, falsifiable ones.
+Every site flagged by the audit now asserts the value the spec/formula requires,
+with the derivation written down beside it. Closes #479.
+
+| Site | Before | After |
+| --- | --- | --- |
+| `neat-core/src/accumulate.rs` — `test_limit_weight_clamping` | `assert!(result.abs() <= 100000.0)` (passes for a broken clamp) | `assert_eq!(result, 1.0)` — the value the comment already derived — plus the symmetric negative case and a case where the *global* scale limit bites instead of the adjustment clamp |
+| `neat-core/tests/accumulate_public.rs` — `test_calculate_weight_basic` | `assert!(result.is_finite())` | `assert_close(result, 1.5)` hand-derived from the documented formula (blend → `average_weight` 2.0 → adjustment clamp to `current + 1.0`) |
+| `neat-core/tests/accumulate_public.rs` — `test_calculate_bias_basic` | `assert!(result.is_finite())` | `assert_close(result, 1.5)` hand-derived (`effective_generations` 0 → `adjusted_bias` 1.5 → no clamp) |
+| `neat-core/tests/accumulate_public.rs` — magic lengths `28` / `12` | bare `assert_eq!(result.len(), 28)` | derived as `BATCH_4WAY * WEIGHT_SLOTS_PER_SYNAPSE` (4 × 7) and `BATCH_4WAY * BIAS_SLOTS_PER_NEURON` (4 × 3), with **every** slot asserted against a per-item derivation |
+| `neat-core/src/topological_backprop.rs` — `normalise_gradients_reduces_multi_path_delta` | single-path fixture (`count == 1`, branch a no-op) with the near-unfalsifiable `assert!(normalised <= unnormalised + 1e-6)` | split into two honest tests, one of which finally exercises the sqrt-scaling branch |
+
+### The gradient-normalisation split
+
+The old fixture wired 2 inputs → 4 hiddens → 1 output, which gives every hidden
+exactly **one** inbound path, so `count == 1` and the Issue #1872 sqrt-scaling
+branch never fired — as the test's own trailing comment admitted.
+
+- **`normalise_gradients_scales_two_path_delta_by_inverse_sqrt_count`** — new
+  fixture: 1 input → 1 hidden → **2 outputs**. The hidden neuron accumulates a
+  target delta from each output, reaching `count == 2`, which arms the branch.
+  Both outputs contribute the same signed delta, so the raw sum is identical in
+  both runs and the only difference is the scaling: the test asserts
+  `normalised == unnormalised / sqrt(2)`, with a guard that the fixture actually
+  produced a delta (no vacuous `0 == 0` pass).
+- **`normalise_gradients_is_a_no_op_for_single_path_neurons`** — keeps the old
+  single-path fixture, renamed to say what it actually tests, and strengthened
+  from the loose inequality to exact equality (`assert_eq!`).
+
+```mermaid
+flowchart LR
+    subgraph old["old fixture — count == 1, branch never fires"]
+        I0[in 0] --> H0[hidden]
+        I1[in 1] --> H0
+        H0 --> O0[out]
+    end
+    subgraph new["new fixture — count == 2, sqrt-scaling fires"]
+        NI[in 0] --> NH[hidden]
+        NH --> NO1[out 2]
+        NH --> NO2[out 3]
+        NO1 -. "delta 1" .-> NH
+        NO2 -. "delta 2" .-> NH
+    end
+```
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+**Mutation testing** — the two rewritten gradient tests were verified to
+genuinely falsify by mutating `topological_backprop.rs` and confirming a red run
+(each mutation was reverted afterwards):
+
+| Mutation | Result |
+| --- | --- |
+| `sum / (count as f64).sqrt()` → `sum / (count as f64)` | `..._scales_two_path_delta_by_inverse_sqrt_count` **FAILED** ✅ |
+| unconditional normalisation with an off-by-one count: `if normalise_gradients { sum / (count + 1).sqrt() }` | **both** tests **FAILED** ✅ |
+
+Against the unmutated tree all 23 lib tests and all 8 `accumulate_public` tests
+pass, and `./quality.sh` finishes with `✅ All quality checks passed!` (fmt,
+clippy, deny, full workspace tests, doc build, release build).
+
+## Test Plan
+
+Modified (strengthened oracles — no test was deleted or commented out):
+
+- `neat-core/src/accumulate.rs::tests::test_limit_weight_clamping` — exact
+  `assert_eq!` on the derived clamp result, plus negative-direction and
+  global-scale-limit cases.
+- `neat-core/tests/accumulate_public.rs::test_batch_4way_weight` — length
+  derived from the layout spec; all 28 slots asserted.
+- `neat-core/tests/accumulate_public.rs::test_batch_4way_bias` — length derived
+  from the layout spec; all 12 slots asserted.
+- `neat-core/tests/accumulate_public.rs::test_calculate_weight_basic` — derived
+  expected value replaces `is_finite()`.
+- `neat-core/tests/accumulate_public.rs::test_calculate_bias_basic` — derived
+  expected value replaces `is_finite()`.
+- `neat-core/src/topological_backprop.rs::tests::normalise_gradients_is_a_no_op_for_single_path_neurons`
+  — renamed from `normalise_gradients_reduces_multi_path_delta`; loose
+  inequality → exact equality.
+
+Added:
+
+- `neat-core/src/topological_backprop.rs::tests::normalise_gradients_scales_two_path_delta_by_inverse_sqrt_count`
+  — first test in this repo to actually execute the `count > 1` sqrt-scaling
+  branch.

--- a/neat-core/src/accumulate.rs
+++ b/neat-core/src/accumulate.rs
@@ -781,10 +781,22 @@ mod tests {
 
     #[test]
     fn test_limit_weight_clamping() {
-        // Weight exceeding limit_weight_scale should be clamped
+        // target 200000, current 0, learning_rate 1.0 ⇒ difference = 200000.
+        // |difference| > max_weight_adj_scale (1.0), so the adjustment clamp
+        // fires first: current + max_weight_adj_scale = 0.0 + 1.0 = 1.0.
+        // That is well inside limit_weight_scale (100000), and both decays are
+        // zero, so the exact result is 1.0.
         let result = limit_weight(200000.0, 0.0, 1e-7, 1.0, 1.0, 100000.0, 0.0, 0.0);
-        // max_weight_adj_scale is 1.0, so limited to current + 1.0 = 1.0
-        assert!(result.abs() <= 100000.0);
+        assert_eq!(result, 1.0);
+
+        // The negative direction clamps symmetrically: current − 1.0 = -1.0.
+        let result = limit_weight(-200000.0, 0.0, 1e-7, 1.0, 1.0, 100000.0, 0.0, 0.0);
+        assert_eq!(result, -1.0);
+
+        // With the adjustment clamp wide open (max_weight_adj_scale above the
+        // difference) the *global* scale limit is what bites: 100000.
+        let result = limit_weight(200000.0, 0.0, 1e-7, 1.0, 1e9, 100000.0, 0.0, 0.0);
+        assert_eq!(result, 100000.0);
     }
 
     #[test]

--- a/neat-core/src/topological_backprop.rs
+++ b/neat-core/src/topological_backprop.rs
@@ -996,13 +996,101 @@ mod tests {
         assert_eq!(out.neurons[1], PropagateOutcome::Skipped);
     }
 
+    /// Multi-path fixture: one input → one hidden → **two** outputs, so the
+    /// hidden neuron accumulates a target delta from each output and reaches
+    /// `count == 2` — the condition that arms the sqrt-scaling branch.
+    ///
+    /// Returns the hidden neuron's `total_error_absolute_delta`, which is
+    /// `|clamp(activation + total_delta) − activation|`; with the neuron range
+    /// left wide open that is exactly `|total_delta|`, so normalisation is
+    /// observable as a factor of `1/sqrt(2)` on the returned value.
+    fn run_two_path_hidden(normalise: bool) -> f32 {
+        let neurons = vec![
+            make_neuron(SquashType::Identity, NEURON_TYPE_INPUT, 0.5, 0.0),
+            make_neuron(SquashType::Identity, NEURON_TYPE_HIDDEN, 0.5, 0.0),
+            make_neuron(SquashType::Identity, NEURON_TYPE_OUTPUT, 0.0, 0.0),
+            make_neuron(SquashType::Identity, NEURON_TYPE_OUTPUT, 0.0, 0.0),
+        ];
+        // 0 → 1, then 1 → 2 and 1 → 3: two downstream sinks feeding neuron 1.
+        let synapses = vec![
+            SynapseInput {
+                from: 0,
+                to: 1,
+                original_weight: 1.0,
+                adjusted_weight: 1.0,
+                is_self_loop: false,
+            },
+            SynapseInput {
+                from: 1,
+                to: 2,
+                original_weight: 1.0,
+                adjusted_weight: 1.0,
+                is_self_loop: false,
+            },
+            SynapseInput {
+                from: 1,
+                to: 3,
+                original_weight: 1.0,
+                adjusted_weight: 1.0,
+                is_self_loop: false,
+            },
+        ];
+        // Inward lists: n0 none, n1 ← [s0], n2 ← [s1], n3 ← [s2].
+        let inward_starts = vec![0u32, 0, 1, 2];
+        let inward_counts = vec![0u32, 1, 1, 1];
+        let inward_indices = vec![0u32, 1, 2];
+        // Both outputs first, so neuron 1 is processed once both have
+        // contributed their delta.
+        let order = vec![2u32, 3, 1];
+        let expected = vec![1.0f32, 1.0f32];
+
+        let input = PropagateInput {
+            neurons: &neurons,
+            synapses: &synapses,
+            inward_starts: &inward_starts,
+            inward_counts: &inward_counts,
+            inward_synapse_indices: &inward_indices,
+            reverse_topo_order: &order,
+            expected: &expected,
+            input_count: 1,
+            output_count: 2,
+            plank_constant: 1e-7,
+            normalise_gradients: normalise,
+        };
+        let out = propagate_topological_loop(&input);
+        match out.neurons[1] {
+            PropagateOutcome::Standard(s) => s.total_error_absolute_delta,
+            other => panic!("expected Standard for the two-path hidden, got {:?}", other),
+        }
+    }
+
     #[test]
-    fn normalise_gradients_reduces_multi_path_delta() {
-        // Output neuron with 4 accumulated paths — sqrt-scaling halves the
-        // effective target delta compared to raw accumulation.
-        // We exercise this by running both paths through the same wiring
-        // and confirming that the Standard outcome's total_error_absolute_delta
-        // is smaller under normalisation.
+    fn normalise_gradients_scales_two_path_delta_by_inverse_sqrt_count() {
+        let unnormalised = run_two_path_hidden(false);
+        let normalised = run_two_path_hidden(true);
+
+        // Guard against a vacuous 0 == 0 pass: the fixture must actually
+        // propagate a delta to the hidden neuron.
+        assert!(
+            unnormalised > 1e-3,
+            "fixture produced no delta to normalise: {unnormalised}"
+        );
+
+        // Both outputs contribute the same signed delta, so the raw sum is
+        // identical in both runs and only the count == 2 sqrt-scaling differs:
+        // normalised == unnormalised / sqrt(2).
+        let want = unnormalised / 2.0f32.sqrt();
+        assert!(
+            (normalised - want).abs() <= 1e-4 * want,
+            "expected {want} (unnormalised {unnormalised} / sqrt(2)), got {normalised}"
+        );
+    }
+
+    #[test]
+    fn normalise_gradients_is_a_no_op_for_single_path_neurons() {
+        // Every neuron here has exactly one inbound path (count == 1), so the
+        // sqrt-scaling branch is skipped and normalisation must be bit-for-bit
+        // invisible.
         fn run(normalise: bool) -> f32 {
             let neurons = vec![
                 make_neuron(SquashType::Identity, NEURON_TYPE_INPUT, 0.5, 0.0),
@@ -1079,12 +1167,11 @@ mod tests {
 
         let unnormalised = run(false);
         let normalised = run(true);
-        // With a single inbound path to each hidden (from output only, via
-        // one synapse), count == 1 ⇒ branch is a no-op. This test therefore
-        // asserts that normalisation does not *increase* error magnitude —
-        // the full sqrt-scaling behaviour is exercised by multi-path
-        // integration tests in downstream consumers.
-        assert!(normalised <= unnormalised + 1e-6);
+        assert!(
+            unnormalised > 1e-3,
+            "fixture produced no delta at all: {unnormalised}"
+        );
+        assert_eq!(normalised, unnormalised);
     }
 
     #[test]

--- a/neat-core/tests/accumulate_public.rs
+++ b/neat-core/tests/accumulate_public.rs
@@ -5,6 +5,25 @@ use neat_core::{
     accumulate_bias_batch_4way, accumulate_weight_batch_4way, calculate_bias, calculate_weight,
 };
 
+/// Slots per synapse in the weight accumulation layout:
+/// `[count, totalPosAct, totalNegAct, countPos, countNeg, totalPosAdj, totalNegAdj]`.
+const WEIGHT_SLOTS_PER_SYNAPSE: usize = 7;
+/// Slots per neuron in the bias accumulation layout:
+/// `[count, totalBias, totalAdjustedBias]`.
+const BIAS_SLOTS_PER_NEURON: usize = 3;
+/// Items processed by the 4-way batch entry points.
+const BATCH_4WAY: usize = 4;
+
+/// Assert two f64s agree to within a tolerance that survives f64 rounding of
+/// the derived expected value but still fails on a wrong formula.
+#[track_caller]
+fn assert_close(actual: f64, expected: f64, what: &str) {
+    assert!(
+        (actual - expected).abs() <= 1e-12,
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
 #[test]
 fn test_batch_4way_weight() {
     let weights = vec![0.5, -0.3, 1.2, 0.0];
@@ -13,10 +32,35 @@ fn test_batch_4way_weight() {
 
     let result = accumulate_weight_batch_4way(&weights, &targets, &acts, 1e-7, 1.0, 1.0, 100000.0);
 
-    assert_eq!(result.len(), 28);
-    // First synapse: positive activation
-    assert_eq!(result[0], 1.0); // count
-    assert_eq!(result[1], 1.0); // positive activation
+    // Flat layout: 4 synapses × 7 slots.
+    assert_eq!(result.len(), BATCH_4WAY * WEIGHT_SLOTS_PER_SYNAPSE);
+
+    // Per synapse the rule is: tmpWeight = target / activation (both already
+    // above the plank constant here), then the activation's sign selects the
+    // positive or the negative accumulator.
+    //   [count, totalPosAct, totalNegAct, countPos, countNeg, totalPosAdj, totalNegAdj]
+    let expected: [[f64; WEIGHT_SLOTS_PER_SYNAPSE]; BATCH_4WAY] = [
+        // act +1.0 ⇒ tmpWeight = 2.0 / 1.0 = 2.0, posAdj = 2.0 × 1.0 = 2.0
+        [1.0, 1.0, 0.0, 1.0, 0.0, 2.0, 0.0],
+        // act +0.5 ⇒ tmpWeight = -1.5 / 0.5 = -3.0, posAdj = -3.0 × 0.5 = -1.5
+        [1.0, 0.5, 0.0, 1.0, 0.0, -1.5, 0.0],
+        // act -0.8 ⇒ tmpWeight = 0.8 / -0.8 = -1.0, negAct = |−0.8| = 0.8,
+        //            negAdj = -1.0 × -0.8 = 0.8
+        [1.0, 0.0, 0.8, 0.0, 1.0, 0.0, 0.8],
+        // act +2.0 ⇒ tmpWeight = 3.0 / 2.0 = 1.5, posAdj = 1.5 × 2.0 = 3.0
+        [1.0, 2.0, 0.0, 1.0, 0.0, 3.0, 0.0],
+    ];
+
+    for (synapse, slots) in expected.iter().enumerate() {
+        let base = synapse * WEIGHT_SLOTS_PER_SYNAPSE;
+        for (slot, &want) in slots.iter().enumerate() {
+            assert_close(
+                result[base + slot],
+                want,
+                &format!("synapse {synapse} slot {slot}"),
+            );
+        }
+    }
 }
 
 #[test]
@@ -28,10 +72,33 @@ fn test_batch_4way_bias() {
     let result =
         accumulate_bias_batch_4way(&targets, &pre_activations, &biases, 1e-7, 1.0, 1.0, 10000.0);
 
-    assert_eq!(result.len(), 12);
-    // First neuron: delta=1.0, target_bias=1.5
-    assert_eq!(result[0], 1.0); // count
-    assert_eq!(result[1], 1.5); // total_bias
+    // Flat layout: 4 neurons × 3 slots.
+    assert_eq!(result.len(), BATCH_4WAY * BIAS_SLOTS_PER_NEURON);
+
+    // Per neuron: targetBias = currentBias + (targetPreActivation − preActivation),
+    // accumulated raw into both the total and the adjusted total (the limit is
+    // applied later, in calculate_bias). Layout: [count, totalBias, totalAdjustedBias].
+    let expected: [[f64; BIAS_SLOTS_PER_NEURON]; BATCH_4WAY] = [
+        // delta = 2.0 − 1.0 = 1.0  ⇒ 0.5 + 1.0 = 1.5
+        [1.0, 1.5, 1.5],
+        // delta = -1.5 − -0.5 = -1.0 ⇒ -0.3 + -1.0 = -1.3
+        [1.0, -1.3, -1.3],
+        // delta = 0.8 − 0.2 = 0.6  ⇒ 1.2 + 0.6 = 1.8
+        [1.0, 1.8, 1.8],
+        // delta = 3.0 − 2.5 = 0.5  ⇒ 0.0 + 0.5 = 0.5
+        [1.0, 0.5, 0.5],
+    ];
+
+    for (neuron, slots) in expected.iter().enumerate() {
+        let base = neuron * BIAS_SLOTS_PER_NEURON;
+        for (slot, &want) in slots.iter().enumerate() {
+            assert_close(
+                result[base + slot],
+                want,
+                &format!("neuron {neuron} slot {slot}"),
+            );
+        }
+    }
 }
 
 #[test]
@@ -55,7 +122,17 @@ fn test_calculate_weight_basic() {
         0.0,      // l2_weight_decay
     );
 
-    assert!(result.is_finite());
+    // Derivation from the documented formula:
+    //   positiveWeight = totalPosAdj / totalPosAct = 2.0 / 1.0 = 2.0
+    //   negativeWeight = 0 (no negative activation above the plank constant)
+    //   totalActivationCount = 1 + 0 = 1
+    //   synapseAverageWeightTotal = 2.0 × 1 = 2.0
+    //   cappedGenerations = min(0 + 1 − 1, 1 × 2) = 0 ⇒ generational term = 0
+    //   averageWeight = (2.0 + 0) / (1 + 0) = 2.0
+    // limit_weight(2.0, current 0.5): difference = 1.0 × (2.0 − 0.5) = 1.5,
+    // which exceeds max_weight_adj_scale 1.0, so the result clamps to
+    // current + 1.0 = 1.5 (inside limit_weight_scale, no decay).
+    assert_close(result, 1.5, "calculate_weight");
 }
 
 #[test]
@@ -87,7 +164,14 @@ fn test_calculate_bias_basic() {
         0.0,     // l2_bias_decay
     );
 
-    assert!(result.is_finite());
+    // Derivation from the documented formula:
+    //   effectiveGenerations = min(0, 1 × 2) = 0
+    //   totalBias = 1.5 + 0.5 × 0 = 1.5, samples = 1 + 0 = 1
+    //   adjustedBias = 1.5 / 1 = 1.5
+    // limit_bias(1.5, current 0.5): difference = 1.0 × (1.5 − 0.5) = 1.0, which
+    // does not *exceed* max_bias_adj_scale 1.0, so no adjustment clamp; 1.5 is
+    // inside limit_bias_scale 10000 and both decays are zero.
+    assert_close(result, 1.5, "calculate_bias");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Replaced four vacuous or unjustified test oracles with derived, falsifiable ones.
Every site flagged by the audit now asserts the value the spec/formula requires,
with the derivation written down beside it. Closes #479.

| Site | Before | After |
| --- | --- | --- |
| `neat-core/src/accumulate.rs` — `test_limit_weight_clamping` | `assert!(result.abs() <= 100000.0)` (passes for a broken clamp) | `assert_eq!(result, 1.0)` — the value the comment already derived — plus the symmetric negative case and a case where the *global* scale limit bites instead of the adjustment clamp |
| `neat-core/tests/accumulate_public.rs` — `test_calculate_weight_basic` | `assert!(result.is_finite())` | `assert_close(result, 1.5)` hand-derived from the documented formula (blend → `average_weight` 2.0 → adjustment clamp to `current + 1.0`) |
| `neat-core/tests/accumulate_public.rs` — `test_calculate_bias_basic` | `assert!(result.is_finite())` | `assert_close(result, 1.5)` hand-derived (`effective_generations` 0 → `adjusted_bias` 1.5 → no clamp) |
| `neat-core/tests/accumulate_public.rs` — magic lengths `28` / `12` | bare `assert_eq!(result.len(), 28)` | derived as `BATCH_4WAY * WEIGHT_SLOTS_PER_SYNAPSE` (4 × 7) and `BATCH_4WAY * BIAS_SLOTS_PER_NEURON` (4 × 3), with **every** slot asserted against a per-item derivation |
| `neat-core/src/topological_backprop.rs` — `normalise_gradients_reduces_multi_path_delta` | single-path fixture (`count == 1`, branch a no-op) with the near-unfalsifiable `assert!(normalised <= unnormalised + 1e-6)` | split into two honest tests, one of which finally exercises the sqrt-scaling branch |

### The gradient-normalisation split

The old fixture wired 2 inputs → 4 hiddens → 1 output, which gives every hidden
exactly **one** inbound path, so `count == 1` and the Issue #1872 sqrt-scaling
branch never fired — as the test's own trailing comment admitted.

- **`normalise_gradients_scales_two_path_delta_by_inverse_sqrt_count`** — new
  fixture: 1 input → 1 hidden → **2 outputs**. The hidden neuron accumulates a
  target delta from each output, reaching `count == 2`, which arms the branch.
  Both outputs contribute the same signed delta, so the raw sum is identical in
  both runs and the only difference is the scaling: the test asserts
  `normalised == unnormalised / sqrt(2)`, with a guard that the fixture actually
  produced a delta (no vacuous `0 == 0` pass).
- **`normalise_gradients_is_a_no_op_for_single_path_neurons`** — keeps the old
  single-path fixture, renamed to say what it actually tests, and strengthened
  from the loose inequality to exact equality (`assert_eq!`).

```mermaid
flowchart LR
    subgraph old["old fixture — count == 1, branch never fires"]
        I0[in 0] --> H0[hidden]
        I1[in 1] --> H0
        H0 --> O0[out]
    end
    subgraph new["new fixture — count == 2, sqrt-scaling fires"]
        NI[in 0] --> NH[hidden]
        NH --> NO1[out 2]
        NH --> NO2[out 3]
        NO1 -. "delta 1" .-> NH
        NO2 -. "delta 2" .-> NH
    end
```

## Evidence

Backend/library change only — no web interface to screenshot.

**Mutation testing** — the two rewritten gradient tests were verified to
genuinely falsify by mutating `topological_backprop.rs` and confirming a red run
(each mutation was reverted afterwards):

| Mutation | Result |
| --- | --- |
| `sum / (count as f64).sqrt()` → `sum / (count as f64)` | `..._scales_two_path_delta_by_inverse_sqrt_count` **FAILED** ✅ |
| unconditional normalisation with an off-by-one count: `if normalise_gradients { sum / (count + 1).sqrt() }` | **both** tests **FAILED** ✅ |

Against the unmutated tree all 23 lib tests and all 8 `accumulate_public` tests
pass, and `./quality.sh` finishes with `✅ All quality checks passed!` (fmt,
clippy, deny, full workspace tests, doc build, release build).

## Test Plan

Modified (strengthened oracles — no test was deleted or commented out):

- `neat-core/src/accumulate.rs::tests::test_limit_weight_clamping` — exact
  `assert_eq!` on the derived clamp result, plus negative-direction and
  global-scale-limit cases.
- `neat-core/tests/accumulate_public.rs::test_batch_4way_weight` — length
  derived from the layout spec; all 28 slots asserted.
- `neat-core/tests/accumulate_public.rs::test_batch_4way_bias` — length derived
  from the layout spec; all 12 slots asserted.
- `neat-core/tests/accumulate_public.rs::test_calculate_weight_basic` — derived
  expected value replaces `is_finite()`.
- `neat-core/tests/accumulate_public.rs::test_calculate_bias_basic` — derived
  expected value replaces `is_finite()`.
- `neat-core/src/topological_backprop.rs::tests::normalise_gradients_is_a_no_op_for_single_path_neurons`
  — renamed from `normalise_gradients_reduces_multi_path_delta`; loose
  inequality → exact equality.

Added:

- `neat-core/src/topological_backprop.rs::tests::normalise_gradients_scales_two_path_delta_by_inverse_sqrt_count`
  — first test in this repo to actually execute the `count > 1` sqrt-scaling
  branch.



## Milestone
This PR is part of the **Clean Up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msatrdpx-ae7450`<!-- vibe-worker-issue-479 -->