### PR TITLE
🟡 Job `typescript-gate` has no `permissions:` block and persists credentials (ci.yml) (Issue #482)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,11 +424,19 @@ jobs:
     name: TypeScript validity gate
     runs-on: ubuntu-latest
     timeout-minutes: 10 # deno check over committed .ts helpers
+    # Issue #482 — least-privilege GITHUB_TOKEN. This job only reads the repo
+    # (checkout, install Deno, deno check); it never writes.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # Issue #482 — keep the workflow token out of .git/config; nothing in
+          # this read-only job pushes back.
+          persist-credentials: false
 
       - name: Install Deno
         # denoland/setup-deno@v2.0.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-482.md
+++ b/docs/archive/pr-summaries/pr-summary-482.md
@@ -1,0 +1,47 @@
+# PR Summary — Issue #482
+
+## Summary
+
+Hardened the `typescript-gate` job in `.github/workflows/ci.yml` — the only job
+in the repository still without a `permissions:` block and still persisting the
+workflow `GITHUB_TOKEN` on disk. The job now declares least-privilege
+`contents: read` and its checkout sets `persist-credentials: false`, matching
+every sibling job hardened in the earlier sweep (#309–#313, #331/#332).
+The job only reads the repo (checkout, install Deno, run
+`scripts/typescript-check.sh`), so neither write scopes nor an on-disk token
+were ever needed. Closes #482.
+
+## Evidence
+
+Backend/CI-configuration change — no web interface to screenshot. Verified with
+the new bats suite (failing before the workflow edit, passing after) plus
+`actionlint .github/workflows/ci.yml` (clean) and a full `./quality.sh` run
+(`✅ All quality checks passed!`).
+
+```mermaid
+flowchart LR
+    A["typescript-gate job"] --> B["permissions: contents: read"]
+    A --> C["checkout persist-credentials: false"]
+    B --> D["no write scopes on GITHUB_TOKEN"]
+    C --> E["no token written to .git/config"]
+```
+
+Before the fix:
+
+```text
+not ok 2 typescript-gate job declares an explicit permissions block
+not ok 3 typescript-gate job grants read-only contents and no write scopes
+not ok 4 typescript-gate checkout does not persist credentials on disk
+```
+
+After the fix: all 4 tests pass.
+
+## Test Plan
+
+- Added `tests/scripts/ci_typescript_gate_permissions.bats` (run by
+  `./quality.sh` via `bats tests/scripts`), asserting on the parsed YAML:
+  - `ci.yml` defines a `typescript-gate` job,
+  - the job declares an explicit `permissions:` block,
+  - it grants `contents: read` and no `write` scopes,
+  - every `actions/checkout` step in the job sets `persist-credentials: false`.
+- Existing test suites unchanged and green.

--- a/tests/scripts/ci_typescript_gate_permissions.bats
+++ b/tests/scripts/ci_typescript_gate_permissions.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Tests for the CI `typescript-gate` job hardening (Issue #482).
+#
+# Contract under test: the `typescript-gate` job in .github/workflows/ci.yml
+# only reads the repository (checkout, install Deno, run
+# scripts/typescript-check.sh). With no `permissions:` block it inherits the
+# repository's broad default GITHUB_TOKEN scopes, and a default checkout writes
+# that token into .git/config where every later step can read it. The job never
+# writes, so both are pure blast radius.
+#
+# Asserts on the observable CI contract, not private implementation detail.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "ci workflow defines a typescript-gate job" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+assert "typescript-gate" in data["jobs"], sorted(data["jobs"])
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "typescript-gate job declares an explicit permissions block" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["typescript-gate"]
+# Job-level permissions win; fall back to the workflow top-level block.
+perms = job.get("permissions")
+if perms is None:
+    perms = data.get("permissions")
+assert perms is not None, "typescript-gate has no permissions: block at job or workflow level"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "typescript-gate job grants read-only contents and no write scopes" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+job = data["jobs"]["typescript-gate"]
+perms = job.get("permissions") or data.get("permissions")
+assert isinstance(perms, dict), f"expected a mapping of scopes, got {perms!r}"
+assert perms.get("contents") == "read", f"contents must be read, got {perms.get('contents')!r}"
+writes = sorted(k for k, v in perms.items() if v == "write")
+assert writes == [], f"typescript-gate is read-only; unexpected write scopes: {writes}"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "typescript-gate checkout does not persist credentials on disk" {
+  if ! command -v python3 &>/dev/null; then
+    skip "python3 required for YAML parsing"
+  fi
+  run python3 - <<PY
+import yaml
+data = yaml.safe_load(open("$WORKFLOW"))
+checkouts = [
+    s for s in data["jobs"]["typescript-gate"]["steps"]
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, "no actions/checkout step found in typescript-gate"
+for step in checkouts:
+    with_ = step.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"checkout persists credentials: {step}"
+    )
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #482

## Summary

Hardened the `typescript-gate` job in `.github/workflows/ci.yml` — the only job
in the repository still without a `permissions:` block and still persisting the
workflow `GITHUB_TOKEN` on disk. The job now declares least-privilege
`contents: read` and its checkout sets `persist-credentials: false`, matching
every sibling job hardened in the earlier sweep (#309–#313, #331/#332).
The job only reads the repo (checkout, install Deno, run
`scripts/typescript-check.sh`), so neither write scopes nor an on-disk token
were ever needed. Closes #482.

## Evidence

Backend/CI-configuration change — no web interface to screenshot. Verified with
the new bats suite (failing before the workflow edit, passing after) plus
`actionlint .github/workflows/ci.yml` (clean) and a full `./quality.sh` run
(`✅ All quality checks passed!`).

```mermaid
flowchart LR
    A["typescript-gate job"] --> B["permissions: contents: read"]
    A --> C["checkout persist-credentials: false"]
    B --> D["no write scopes on GITHUB_TOKEN"]
    C --> E["no token written to .git/config"]
```

Before the fix:

```text
not ok 2 typescript-gate job declares an explicit permissions block
not ok 3 typescript-gate job grants read-only contents and no write scopes
not ok 4 typescript-gate checkout does not persist credentials on disk
```

After the fix: all 4 tests pass.

## Test Plan

- Added `tests/scripts/ci_typescript_gate_permissions.bats` (run by
  `./quality.sh` via `bats tests/scripts`), asserting on the parsed YAML:
  - `ci.yml` defines a `typescript-gate` job,
  - the job declares an explicit `permissions:` block,
  - it grants `contents: read` and no `write` scopes,
  - every `actions/checkout` step in the job sets `persist-credentials: false`.
- Existing test suites unchanged and green.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msb2oim0-314245`<!-- vibe-worker-issue-482 -->