### PR TITLE
🟡 Supply ACTIONS_PUSH just-in-time instead of persisting it in .git/config (Issue #483)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 # NEAT-AI-Discovery–style PR pipeline: auto patch version + rustfmt push, then strict checks.
-# Requires repository secret ACTIONS_PUSH (PAT with contents:write on this repo) so bots can
-# push to PR branches; default GITHUB_TOKEN alone is often insufficient.
+# Requires the org-level secret ACTIONS_PUSH (PAT with contents:write) so bots can push to PR
+# branches; default GITHUB_TOKEN alone is often insufficient. Issue #483 — this repository holds
+# no Actions secrets of its own, so ACTIONS_PUSH resolves from the organisation and its blast
+# radius is org-wide. It is therefore handed only to the single step that pushes, never persisted
+# into .git/config while PR-authored code (bump-deps.sh, cargo fmt) runs.
 name: CI
 
 on:
@@ -45,11 +48,17 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #483 — no PAT here and `persist-credentials: false`, so nothing
+        # writes ACTIONS_PUSH into .git/config. This job later executes
+        # `./bump-deps.sh` from the PR head; a persisted credential would be
+        # readable by that PR-authored code for the whole job. The repo is
+        # public, so the default GITHUB_TOKEN clones and `git pull` works
+        # anonymously — only the final push needs the PAT.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-          token: ${{ secrets.ACTIONS_PUSH }}
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -169,15 +178,18 @@ jobs:
           cargo outdated -R || true
 
       - name: Commit version and dependency changes
+        # Issue #483 — the PAT is supplied just-in-time to this one step and
+        # pushed through an explicit remote URL, so it never touches disk.
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PUSH_TOKEN: ${{ secrets.ACTIONS_PUSH }}
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "No changes after version bump / dependency upgrade"
           else
             git commit -m "chore: auto-increment versions for changed projects"
-            git push origin "$HEAD_REF"
+            git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/$HEAD_REF"
           fi
 
   # Issue #251 — fail a PR whose breaking change ships on a patch-only bump.
@@ -243,11 +255,15 @@ jobs:
     steps:
       - name: Checkout code
         # actions/checkout@v6.0.2
+        # Issue #483 — same rule as version-increment: no PAT on the checkout
+        # and no persisted credential, because the steps in between run
+        # PR-authored content (`cargo fmt` over the PR head). The PAT is
+        # supplied only to the push step below.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-          token: ${{ secrets.ACTIONS_PUSH }}
+          persist-credentials: false
 
       - name: Ensure bash scripts are executable
         run: |
@@ -275,13 +291,14 @@ jobs:
         id: fmt_commit
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PUSH_TOKEN: ${{ secrets.ACTIONS_PUSH }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if ! git diff --quiet; then
             git add -A
             git commit -m "chore: apply rustfmt fixes"
-            git push origin "$HEAD_REF"
+            git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/$HEAD_REF"
             echo "pushed=true" >> "$GITHUB_OUTPUT"
           else
             echo "pushed=false" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,7 @@ flowchart LR
 
 ## CI / secrets
 
-- PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (PAT with **contents:write**).
+- PR pipeline: version bump + **`cargo upgrade --incompatible`**, **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (**org-level** PAT with **contents:write**).
+- **`ACTIONS_PUSH` is supplied just-in-time** (Issue #483): the `version-increment` / `auto-format` checkouts run with **`persist-credentials: false`** and no `token:`, and the PAT reaches only the one step that pushes, through an explicit `https://x-access-token:…` remote URL. Never hand it to a checkout — those jobs execute PR-authored code (`bump-deps.sh`, `cargo fmt`) that would then be able to read an org-wide credential off `.git/config`.
 - **Versioning/release policy:** **`RELEASING.md`** is the single source of truth (Issue #251) — semver, what counts as breaking, and how to signal it. In CI the `version-increment` job bumps minor on a break (patch otherwise); the `version-gate` job **fails** a break shipped on a patch-only bump; `release.yml` cuts a **`v<version>`** tag + GitHub release on `Develop`, decoupled from `wasm-bundle-<sha>`.
 - **`clippy::uninlined_format_args`** is not denied in CI until the test corpus is cleaned up; workspace lints still deny **`filter_next`** / **`collapsible_if`**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,7 +118,21 @@ The workflows in [`.github/workflows/`](.github/workflows/) are privileged:
 `ci.yml` and `upgrade-dependencies.yml` use the `ACTIONS_PUSH` PAT, and
 `semgrep.yml` uses `SEMGREP_APP_TOKEN`. An unreviewed edit to any of them is a
 secret-exfiltration / artefact-signing attack path, so changes there require a
-designated owner's review. Two controls enforce that:
+designated owner's review.
+
+`ACTIONS_PUSH` resolves from the **organisation** (this repository defines no
+Actions secrets of its own), so a leak of it is an org-wide, not repo-wide,
+event. The two `ci.yml` jobs that push — *Auto-increment Versions* and
+*Auto-format Code* — check out the **PR head** and then execute code from it
+(`./bump-deps.sh`, `cargo fmt`). They therefore run with
+`persist-credentials: false` and no `token:` on the checkout, and the PAT is
+handed only to the single pushing step through an explicit
+`https://x-access-token:…` remote URL (Issue #483). Handing the PAT to a
+checkout would write it into `.git/config`, where PR-authored code could read it
+for the whole job — the credential-theft pattern behind the 2025–2026 CI
+attacks. `tests/scripts/ci_push_credential_persistence.bats` pins that rule.
+
+Two controls enforce the owner-review requirement:
 
 - **[`.github/CODEOWNERS`](.github/CODEOWNERS)** assigns the repo admins
   `@Green-Beret` and `@nleck` as owners of the privileged CI paths

--- a/docs/archive/pr-summaries/pr-summary-483.md
+++ b/docs/archive/pr-summaries/pr-summary-483.md
@@ -1,0 +1,88 @@
+# PR Summary — Issue #483
+
+## Summary
+
+The `version-increment` and `auto-format` jobs in `.github/workflows/ci.yml`
+checked out the **PR head** with `token: secrets.ACTIONS_PUSH` and the default
+`persist-credentials: true`, which writes the PAT into `.git/config`. Both jobs
+then execute code from that same PR head — `./bump-deps.sh` and `cargo fmt` —
+so a same-repo branch PR could read an org-wide credential off disk for the
+whole job lifetime, when only the final push step needs it.
+
+The PAT is now supplied **just-in-time**: the checkouts carry no `token:` and
+set `persist-credentials: false` (the repo is public, so the intermediate
+`git pull` works anonymously and the default `GITHUB_TOKEN` clones fine), and
+`ACTIONS_PUSH` is exposed as a step-level `PUSH_TOKEN` env var to the one step
+that pushes, through an explicit `https://x-access-token:…` remote URL.
+
+**Scope of `ACTIONS_PUSH` — confirmed org-level.** The issue flagged that
+`ci.yml:2` ("PAT with contents:write on this repo") and
+`upgrade-dependencies.yml` ("the org-level PAT") disagreed. This repository
+defines **no** Actions secrets of its own
+(`gh api repos/stSoftwareAU/NEAT-AI-core/actions/secrets` →
+`{"total_count":0,"secrets":[]}`), so `ACTIONS_PUSH` resolves from the
+organisation and the blast radius is org-wide. The `ci.yml` header, `AGENTS.md`
+and `SECURITY.md` now say so. Replacing it with a repo-scoped fine-grained PAT
+or GitHub App token remains a worthwhile follow-up, but it is a secret-rotation
+action only a repo/org admin can take — the persistence fix here is independent
+of it.
+
+Closes #483.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified with the BATS
+suite, `actionlint`, and `shellcheck`.
+
+```mermaid
+sequenceDiagram
+    participant CO as actions/checkout (PR head)
+    participant GC as .git/config
+    participant PR as PR-authored code<br/>(bump-deps.sh, cargo fmt)
+    participant PUSH as push step
+
+    rect rgb(255, 235, 235)
+        note over CO,PUSH: Before — PAT on disk for the whole job
+        CO->>GC: writes ACTIONS_PUSH (persist-credentials default)
+        PR->>GC: can read the org-wide PAT
+        PUSH->>GC: git push origin (uses persisted credential)
+    end
+
+    rect rgb(235, 250, 235)
+        note over CO,PUSH: After — PAT only in the pushing step
+        CO->>GC: persist-credentials false — nothing written
+        PR--xGC: no credential to read
+        PUSH->>PUSH: env PUSH_TOKEN → git push https://x-access-token:…
+    end
+```
+
+Command output:
+
+```text
+$ bats tests/scripts/ci_push_credential_persistence.bats
+1..4
+ok 1 version-increment keeps the push PAT off disk and out of PR-head steps
+ok 2 auto-format keeps the push PAT off disk and out of PR-head steps
+ok 3 no checkout anywhere in ci.yml persists the ACTIONS_PUSH PAT
+ok 4 ci.yml documents the real scope of the ACTIONS_PUSH PAT
+```
+
+All four fail against the unfixed `ci.yml` (e.g. *"version-increment: checkout
+persists credentials into .git/config"*), so they are genuine regression tests.
+The full `bats tests/scripts` suite (289 tests) passes, including the existing
+`workflow_checkout_credentials.bats` sweep, which deliberately exempts jobs that
+talk to the remote — precisely the gap this new file closes.
+
+## Test Plan
+
+- Added `tests/scripts/ci_push_credential_persistence.bats` — asserts, for both
+  pushing jobs, that every checkout sets `persist-credentials: false`, that no
+  checkout / job-level env / non-pushing step can see `ACTIONS_PUSH`, and that
+  the pushing step receives it as its own env var and pushes to an explicitly
+  authenticated `https://` remote rather than `origin`. A fourth test pins the
+  corrected org-level description in the `ci.yml` header.
+- Added `assert_just_in_time_push_credential` to `tests/scripts/helpers.bash`
+  (the shared-helper home established by Issue #477) so the rule has one
+  implementation across both jobs.
+- Documentation updated in the same change: `ci.yml` header, the CI/secrets
+  section of `AGENTS.md`, and the review-governance section of `SECURITY.md`.

--- a/tests/scripts/ci_push_credential_persistence.bats
+++ b/tests/scripts/ci_push_credential_persistence.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# Tests for the `ACTIONS_PUSH` PAT handling in the pushing CI jobs (Issue #483).
+#
+# Contract under test: the `version-increment` and `auto-format` jobs in
+# .github/workflows/ci.yml check out the *PR head* and then execute code from
+# that head (`./bump-deps.sh`, `cargo fmt`). A default checkout with
+# `token: secrets.ACTIONS_PUSH` writes the PAT into .git/config, so PR-authored
+# code runs for the whole job lifetime with the credential readable on disk.
+# Only the final push needs it, so the PAT must be supplied just-in-time to that
+# one step and never persisted.
+#
+# Asserts on the observable CI contract (which step can read the secret), not on
+# private implementation detail.
+
+setup() {
+  load helpers
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+}
+
+@test "version-increment keeps the push PAT off disk and out of PR-head steps" {
+  require_python3
+  run assert_just_in_time_push_credential "$WORKFLOW" version-increment ACTIONS_PUSH
+  [ "$status" -eq 0 ] || { echo "$output" >&2; return 1; }
+}
+
+@test "auto-format keeps the push PAT off disk and out of PR-head steps" {
+  require_python3
+  run assert_just_in_time_push_credential "$WORKFLOW" auto-format ACTIONS_PUSH
+  [ "$status" -eq 0 ] || { echo "$output" >&2; return 1; }
+}
+
+@test "no checkout anywhere in ci.yml persists the ACTIONS_PUSH PAT" {
+  require_python3
+  run python3 - "$WORKFLOW" <<'PY'
+import re
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1]))
+ref = re.compile(r"\$\{\{[^}]*\bsecrets\.ACTIONS_PUSH\b")
+offenders = []
+for name, job in (data.get("jobs") or {}).items():
+    for step in job.get("steps") or []:
+        if not str(step.get("uses", "")).startswith("actions/checkout@"):
+            continue
+        with_ = step.get("with") or {}
+        persisted = with_.get("persist-credentials") is not False
+        if persisted and ref.search(yaml.safe_dump(with_)):
+            offenders.append(name)
+assert not offenders, f"jobs persisting ACTIONS_PUSH in .git/config: {offenders}"
+PY
+  [ "$status" -eq 0 ] || { echo "$output" >&2; return 1; }
+}
+
+@test "ci.yml documents the real scope of the ACTIONS_PUSH PAT" {
+  # Issue #483: the header claimed a repository-scoped PAT while
+  # upgrade-dependencies.yml called the same secret org-level. The repository
+  # holds no Actions secrets, so ACTIONS_PUSH resolves from the organisation —
+  # the header must not understate that blast radius.
+  run grep -Eq '^#.*ACTIONS_PUSH.*org' "$WORKFLOW"
+  [ "$status" -eq 0 ] || {
+    echo "ci.yml header does not describe ACTIONS_PUSH as an org-level PAT" >&2
+    return 1
+  }
+}

--- a/tests/scripts/helpers.bash
+++ b/tests/scripts/helpers.bash
@@ -173,6 +173,83 @@ sys.exit(f"no step named like {needle!r} with a run: block in {workflow}")
 PY
 }
 
+# assert_just_in_time_push_credential <workflow> <job> <secret> — the job must
+# never leave <secret> where code it did not write can read it (Issue #483).
+# Concretely: every checkout in the job runs with `persist-credentials: false`
+# (so no credential lands in .git/config while PR-head scripts such as
+# bump-deps.sh execute), the secret is not exposed job-wide or to any
+# non-pushing step, and the one step that pushes receives it as its own env var
+# and pushes to an explicitly authenticated https remote rather than `origin`.
+assert_just_in_time_push_credential() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import re
+import sys
+
+import yaml
+
+workflow, job_name, secret = sys.argv[1], sys.argv[2], sys.argv[3]
+data = yaml.safe_load(open(workflow))
+jobs = data.get("jobs") or {}
+assert job_name in jobs, f"no {job_name!r} job; jobs are {sorted(jobs)}"
+job = jobs[job_name]
+steps = job.get("steps") or []
+ref = re.compile(r"\$\{\{[^}]*\bsecrets\." + re.escape(secret) + r"\b")
+
+
+def mentions(node):
+    return bool(ref.search(yaml.safe_dump(node, default_flow_style=False)))
+
+
+checkouts = [
+    i for i, s in enumerate(steps)
+    if str(s.get("uses", "")).startswith("actions/checkout@")
+]
+assert checkouts, f"{job_name}: no actions/checkout step found"
+for i in checkouts:
+    with_ = steps[i].get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"{job_name}: checkout persists credentials into .git/config: {steps[i]}"
+    )
+    assert not mentions(with_), (
+        f"{job_name}: checkout is handed {secret}; the PAT must reach only the "
+        f"pushing step"
+    )
+
+assert not mentions(job.get("env") or {}), (
+    f"{job_name}: {secret} is exposed to every step through job-level env"
+)
+
+pushers = [i for i, s in enumerate(steps) if "git push" in (s.get("run") or "")]
+assert pushers, f"{job_name}: no step runs git push"
+for i, step in enumerate(steps):
+    if i in pushers:
+        continue
+    assert not mentions(step), (
+        f"{job_name}: non-pushing step {step.get('name')!r} sees {secret}"
+    )
+
+for i in pushers:
+    step = steps[i]
+    env = step.get("env") or {}
+    names = sorted(k for k, v in env.items() if ref.search(str(v)))
+    assert names, (
+        f"{job_name}: pushing step {step.get('name')!r} does not receive "
+        f"{secret} just-in-time as a step env var"
+    )
+    for line in step["run"].splitlines():
+        if not re.search(r"\bgit push\b", line):
+            continue
+        assert re.search(r'git push\s+"?https://', line), (
+            f"{job_name}: push target is not an explicitly authenticated https "
+            f"remote — `origin` carries no credential once persist-credentials "
+            f"is false: {line.strip()!r}"
+        )
+        assert any(n in line for n in names), (
+            f"{job_name}: push URL does not interpolate {names}: {line.strip()!r}"
+        )
+PY
+}
+
 # assert_cyclonedx_sbom_release <workflow> <job> — the job must build a
 # CycloneDX SBOM with a version-pinned, --locked cargo-cyclonedx install and
 # publish the .cdx.json as an asset of the Release it cuts, generated before the


### PR DESCRIPTION
# PR Summary — Issue #483

## Summary

The `version-increment` and `auto-format` jobs in `.github/workflows/ci.yml`
checked out the **PR head** with `token: secrets.ACTIONS_PUSH` and the default
`persist-credentials: true`, which writes the PAT into `.git/config`. Both jobs
then execute code from that same PR head — `./bump-deps.sh` and `cargo fmt` —
so a same-repo branch PR could read an org-wide credential off disk for the
whole job lifetime, when only the final push step needs it.

The PAT is now supplied **just-in-time**: the checkouts carry no `token:` and
set `persist-credentials: false` (the repo is public, so the intermediate
`git pull` works anonymously and the default `GITHUB_TOKEN` clones fine), and
`ACTIONS_PUSH` is exposed as a step-level `PUSH_TOKEN` env var to the one step
that pushes, through an explicit `https://x-access-token:…` remote URL.

**Scope of `ACTIONS_PUSH` — confirmed org-level.** The issue flagged that
`ci.yml:2` ("PAT with contents:write on this repo") and
`upgrade-dependencies.yml` ("the org-level PAT") disagreed. This repository
defines **no** Actions secrets of its own
(`gh api repos/stSoftwareAU/NEAT-AI-core/actions/secrets` →
`{"total_count":0,"secrets":[]}`), so `ACTIONS_PUSH` resolves from the
organisation and the blast radius is org-wide. The `ci.yml` header, `AGENTS.md`
and `SECURITY.md` now say so. Replacing it with a repo-scoped fine-grained PAT
or GitHub App token remains a worthwhile follow-up, but it is a secret-rotation
action only a repo/org admin can take — the persistence fix here is independent
of it.

Closes #483.

## Evidence

Backend/CI change — no web interface to screenshot. Verified with the BATS
suite, `actionlint`, and `shellcheck`.

```mermaid
sequenceDiagram
    participant CO as actions/checkout (PR head)
    participant GC as .git/config
    participant PR as PR-authored code<br/>(bump-deps.sh, cargo fmt)
    participant PUSH as push step

    rect rgb(255, 235, 235)
        note over CO,PUSH: Before — PAT on disk for the whole job
        CO->>GC: writes ACTIONS_PUSH (persist-credentials default)
        PR->>GC: can read the org-wide PAT
        PUSH->>GC: git push origin (uses persisted credential)
    end

    rect rgb(235, 250, 235)
        note over CO,PUSH: After — PAT only in the pushing step
        CO->>GC: persist-credentials false — nothing written
        PR--xGC: no credential to read
        PUSH->>PUSH: env PUSH_TOKEN → git push https://x-access-token:…
    end
```

Command output:

```text
$ bats tests/scripts/ci_push_credential_persistence.bats
1..4
ok 1 version-increment keeps the push PAT off disk and out of PR-head steps
ok 2 auto-format keeps the push PAT off disk and out of PR-head steps
ok 3 no checkout anywhere in ci.yml persists the ACTIONS_PUSH PAT
ok 4 ci.yml documents the real scope of the ACTIONS_PUSH PAT
```

All four fail against the unfixed `ci.yml` (e.g. *"version-increment: checkout
persists credentials into .git/config"*), so they are genuine regression tests.
The full `bats tests/scripts` suite (289 tests) passes, including the existing
`workflow_checkout_credentials.bats` sweep, which deliberately exempts jobs that
talk to the remote — precisely the gap this new file closes.

## Test Plan

- Added `tests/scripts/ci_push_credential_persistence.bats` — asserts, for both
  pushing jobs, that every checkout sets `persist-credentials: false`, that no
  checkout / job-level env / non-pushing step can see `ACTIONS_PUSH`, and that
  the pushing step receives it as its own env var and pushes to an explicitly
  authenticated `https://` remote rather than `origin`. A fourth test pins the
  corrected org-level description in the `ci.yml` header.
- Added `assert_just_in_time_push_credential` to `tests/scripts/helpers.bash`
  (the shared-helper home established by Issue #477) so the rule has one
  implementation across both jobs.
- Documentation updated in the same change: `ci.yml` header, the CI/secrets
  section of `AGENTS.md`, and the review-governance section of `SECURITY.md`.



## Milestone
This PR is part of the **Clean Up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msbn1f0y-ad1ee7`<!-- vibe-worker-issue-483 -->