### PR TITLE
docs: name score_records_flat in BASELINE.md (Issue #504)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-504.md
+++ b/docs/archive/pr-summaries/pr-summary-504.md
@@ -1,0 +1,67 @@
+# BASELINE.md: `score_records` → `score_records_flat` (Issue #504)
+
+## Summary
+
+`neat-core/benches/BASELINE.md` named `score_records` in the present tense at
+seven sites, but that per-record `&[Vec<f32>]` entry point was removed in Issue
+#409 (`neat-core/src/parallel_scoring.rs:58-61`). The document already
+contradicted itself — the wasm32 harness was described as calling
+`score_records` in one place and `CompiledNetwork::score_records_flat` a few
+hundred lines later in the same *Reproducing* area.
+
+Six sites are renamed to `score_records_flat` (the sequential record-scoring
+method that exists today) because they describe the path a reader would use now.
+One site is genuinely historical and is left as `score_records` with an explicit
+removal pointer. No recorded measurement number was touched — this is a
+naming/tense correction, not a re-benchmark.
+
+Closes #504.
+
+| Line | Change |
+| --- | --- |
+| 106 | renamed → `score_records_flat` |
+| 168 | renamed → `score_records_flat` |
+| 180 | renamed → `score_records_flat` |
+| 225 | kept historical: "the then-current per-record `score_records` entry point (removed in Issue #409; `score_records_flat` is its successor)" |
+| 370 | renamed → `score_records_flat` |
+| 394 | renamed → `score_records_flat` (now matches line 524) |
+| 454 | renamed → `score_records_flat` |
+
+Out of scope, handled separately by sibling sub-issues of #497:
+`score_records_parallel` renames, the `evaluate_mse` section, the `scoring_flat`
+section, and the `benches/README.md` table row.
+
+## Evidence
+
+Docs-only prose change — no web interface to screenshot and no runtime surface,
+so correctness is verified by the acceptance grep from the issue:
+
+```
+$ grep -n 'score_records\b' neat-core/benches/BASELINE.md
+225:locality win #287 landed for the then-current per-record `score_records` entry
+```
+
+The single remaining bare occurrence is past tense and carries the Issue #409
+pointer on the following line. Every symbol the file now presents as current
+exists in `neat-core/src`:
+
+```
+$ grep -rn 'pub fn score_records' neat-core/src/
+neat-core/src/parallel_scoring.rs:96:    pub fn score_records_flat(
+neat-core/src/parallel_scoring.rs:113:    pub fn score_records_flat_into(
+neat-core/src/parallel_scoring.rs:157:    pub fn score_records_parallel_flat(
+neat-core/src/parallel_scoring.rs:193:    pub fn score_records_parallel_flat(
+```
+
+Line 394 and line 524 now name the same symbol (`score_records_flat`), removing
+the internal contradiction.
+
+`./quality.sh < /dev/null` passes cleanly (fmt, clippy, TypeScript gate, Mermaid
+gate, `cargo test --workspace`, doc build, release build).
+
+## Test Plan
+
+No tests added or modified. The change is documentation prose in
+`neat-core/benches/BASELINE.md`; per AGENTS.md, source-grep assertions are "how"
+tests and are not written here. The existing workspace test suite was run
+unchanged via `./quality.sh` to confirm nothing regressed.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -103,7 +103,8 @@ Throughput highlights: `forward_pass` ≈ 126 Melem/s (production) / 123 Melem/s
 
 The single-core `parallel_scoring` figure (16.86 Krecords/s for `production`)
 matches the `hot_paths` `scoring` group (16.87 Krecords/s) — both drive the same
-sequential `score_records` path, an internal consistency check on the fixture.
+sequential `score_records_flat` path, an internal consistency check on the
+fixture.
 
 ## Production-exact topology baseline (Issue #286)
 
@@ -164,8 +165,9 @@ lane sub-issue's optimisation is measured against.
 
 > **Scoring-lane variance (be honest about it).** The ~90 ms `hot_paths`
 > `scoring` figure and the ~62 ms `parallel_scoring` `1_core` figure exercise the
-> *same* sequential `score_records` path, so in principle they match — but they
-> were taken in separate `cargo bench` invocations and the ~90 ms → ~62 ms spread
+> *same* sequential `score_records_flat` path, so in principle they match — but
+> they were taken in separate `cargo bench` invocations and the ~90 ms → ~62 ms
+> spread
 > is real run-to-run variance (thermal state on the laptop-class M4 Pro under a
 > ~90 ms single-shot benchmark with 100 iterations). Treat the **`parallel_scoring`
 > 1-core/12-core pair as the authoritative scoring anchor** — both were measured
@@ -175,8 +177,8 @@ lane sub-issue's optimisation is measured against.
 
 ## Record-interleaved scoring optimisation (Issue #287)
 
-The single-thread scoring hot path (`score_records` → `score_batch_into`, the
-same lane NEAT-AI's per-creature wasm32 workers drive) now transposes each
+The single-thread scoring hot path (`score_records_flat` → `score_batch_into`,
+the same lane NEAT-AI's per-creature wasm32 workers drive) now transposes each
 group of eight records into a **record-interleaved** activation buffer:
 lane `l` of source neuron `n` lives at `inter[n * 8 + l]`, so all eight records
 for a synapse's source are contiguous. Each gather in
@@ -220,8 +222,9 @@ bit-for-bit identical to `activate` (asserted by
 The `#[wasm_bindgen]` fused activate + MSE entry point (`mse_sum_batch_packed`)
 ran its **own** duplicate forward pass over the old eight-scattered-buffer
 per-lane layout (`mse_sum_batch_8way` → `weighted_sum_simd_8records`), so the
-locality win #287 landed for `score_records` never reached the loss lane
-production scoring actually calls. #384 dispatches standard-squash networks
+locality win #287 landed for the then-current per-record `score_records` entry
+point (removed in Issue #409; `score_records_flat` is its successor) never
+reached the loss lane production scoring actually calls. #384 dispatches standard-squash networks
 (the all-`Tanh` production topology) through the same record-interleaved gather
 (`interleaved_forward_8` → `weighted_sum_interleaved_8`) and keeps aggregate
 networks on the exact per-lane path. The full 8-record groups are **bit-identical**
@@ -364,7 +367,7 @@ benchmark, and this decision.
 
 ### The two lanes being compared
 
-Both lanes drive the **same** `score_records` forward pass (the #287
+Both lanes drive the **same** `score_records_flat` forward pass (the #287
 record-interleaved batched-SIMD gather); they differ only in codegen and thread
 count:
 
@@ -388,8 +391,9 @@ calibration above) scored through one creature.
   (Criterion, `--sample-size 30`), median estimate.
 - **wasm32**: `wasm-pack build --target nodejs --release` of a throwaway harness
   that reuses the committed `benches/common` fixtures and calls the identical
-  `score_records`, driven by `node` timing `score_once()` (median of 20, after a
-  5-iteration warm-up). Harness source and commands under **Reproducing** below.
+  `score_records_flat`, driven by `node` timing `score_once()` (median of 20,
+  after a 5-iteration warm-up). Harness source and commands under
+  **Reproducing** below.
 
 | Shape | wasm32 1-thread | native 1 core | native 12 cores |
 | --- | --- | --- | --- |
@@ -447,8 +451,9 @@ Two distinct wins stack:
   the native SIMD/`libm` split widens further — so the native advantage here is
   a lower bound, not an upper one.
 - **wasm32 lane is a codegen ceiling, not the production wasm scorer.** This
-  measures the shared `score_records` compiled to wasm32. NEAT-AI's production
-  wasm path additionally pays JS↔wasm orchestration per record, so the real
+  measures the shared `score_records_flat` compiled to wasm32. NEAT-AI's
+  production wasm path additionally pays JS↔wasm orchestration per record, so
+  the real
   wasm32 scoring lane is no faster than this row — reinforcing the verdict.
 
 ## Backprop-setup adjacency: `Vec<Vec<u32>>` → CSR (Issue #388)


### PR DESCRIPTION
# BASELINE.md: `score_records` → `score_records_flat` (Issue #504)

## Summary

`neat-core/benches/BASELINE.md` named `score_records` in the present tense at
seven sites, but that per-record `&[Vec<f32>]` entry point was removed in Issue
#409 (`neat-core/src/parallel_scoring.rs:58-61`). The document already
contradicted itself — the wasm32 harness was described as calling
`score_records` in one place and `CompiledNetwork::score_records_flat` a few
hundred lines later in the same *Reproducing* area.

Six sites are renamed to `score_records_flat` (the sequential record-scoring
method that exists today) because they describe the path a reader would use now.
One site is genuinely historical and is left as `score_records` with an explicit
removal pointer. No recorded measurement number was touched — this is a
naming/tense correction, not a re-benchmark.

Closes #504.

| Line | Change |
| --- | --- |
| 106 | renamed → `score_records_flat` |
| 168 | renamed → `score_records_flat` |
| 180 | renamed → `score_records_flat` |
| 225 | kept historical: "the then-current per-record `score_records` entry point (removed in Issue #409; `score_records_flat` is its successor)" |
| 370 | renamed → `score_records_flat` |
| 394 | renamed → `score_records_flat` (now matches line 524) |
| 454 | renamed → `score_records_flat` |

Out of scope, handled separately by sibling sub-issues of #497:
`score_records_parallel` renames, the `evaluate_mse` section, the `scoring_flat`
section, and the `benches/README.md` table row.

## Evidence

Docs-only prose change — no web interface to screenshot and no runtime surface,
so correctness is verified by the acceptance grep from the issue:

```
$ grep -n 'score_records\b' neat-core/benches/BASELINE.md
225:locality win #287 landed for the then-current per-record `score_records` entry
```

The single remaining bare occurrence is past tense and carries the Issue #409
pointer on the following line. Every symbol the file now presents as current
exists in `neat-core/src`:

```
$ grep -rn 'pub fn score_records' neat-core/src/
neat-core/src/parallel_scoring.rs:96:    pub fn score_records_flat(
neat-core/src/parallel_scoring.rs:113:    pub fn score_records_flat_into(
neat-core/src/parallel_scoring.rs:157:    pub fn score_records_parallel_flat(
neat-core/src/parallel_scoring.rs:193:    pub fn score_records_parallel_flat(
```

Line 394 and line 524 now name the same symbol (`score_records_flat`), removing
the internal contradiction.

`./quality.sh < /dev/null` passes cleanly (fmt, clippy, TypeScript gate, Mermaid
gate, `cargo test --workspace`, doc build, release build).

## Test Plan

No tests added or modified. The change is documentation prose in
`neat-core/benches/BASELINE.md`; per AGENTS.md, source-grep assertions are "how"
tests and are not written here. The existing workspace test suite was run
unchanged via `./quality.sh` to confirm nothing regressed.



## Milestone
This PR is part of the **#497 🟠 BASELINE.md presents removed scoring entry points (score_records, score_records_parallel, scoring_flat, evaluate_mse) as current** milestone and targets the `milestone/497-baseline-md-presents-removed-scoring-entry-poi` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msfmz089-4f2631`<!-- vibe-worker-issue-504 -->