### PR TITLE
docs: name score_records_parallel_flat as the native lane in BASELINE.md (Issue #505)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-505.md
+++ b/docs/archive/pr-summaries/pr-summary-505.md
@@ -1,0 +1,58 @@
+# PR Summary — Issue #505
+
+## Summary
+
+`neat-core/benches/BASELINE.md` named `CompiledNetwork::score_records_parallel`
+as the shipped native rayon lane in four places. That entry point was removed in
+Issue #409; the surviving native lane is
+`CompiledNetwork::score_records_parallel_flat`
+(`neat-core/src/parallel_scoring.rs:157`, with the sequential/wasm32 fallback at
+line 193). The worst offender was the **Issue #288 verdict** paragraph, which
+told readers the core-side path "is ready" while naming a symbol that no longer
+compiles.
+
+Renamed all four references to `score_records_parallel_flat`, matching the
+spelling already used in the #386 section. The one surviving occurrence of the
+old name is the historical framing, which now explicitly marks it as the
+pre-#409 name. No recorded measurement numbers were changed — the measurements
+remain valid for the same kernel; only the entry-point name changed.
+
+Docs-only change to prose in one file. Closes #505.
+
+| Line | Change |
+| --- | --- |
+| ~350 | historical framing — names `score_records_parallel_flat` today, notes `score_records_parallel` as the pre-#409 name |
+| ~360 | #288 verdict → `score_records_parallel_flat` |
+| ~381 | "fixed-size rayon pool … via" → `score_records_parallel_flat` |
+| ~435 | idle-core tail win → `score_records_parallel_flat` |
+
+## Evidence
+
+No web interface to screenshot — this is a documentation-only change.
+
+Acceptance grep from the issue (only the explicitly-marked historical mention
+remains):
+
+```
+$ grep -n 'score_records_parallel\b' neat-core/benches/BASELINE.md
+352:`score_records_parallel` before Issue #409 removed it — but it was never A/B'd
+```
+
+Every symbol the #288 verdict now names resolves in the source:
+
+```
+$ grep -n 'fn score_records_parallel_flat' neat-core/src/parallel_scoring.rs
+157:    pub fn score_records_parallel_flat(
+193:    pub fn score_records_parallel_flat(
+```
+
+`./quality.sh < /dev/null` passes cleanly (fmt, clippy, deny, full test suite,
+doc build, release build).
+
+## Test Plan
+
+No tests added or modified. Per the issue's own Failure Detection section this
+is prose in a benchmark note — no code, test, or CI behaviour depends on the
+symbol names in this file. A test asserting the file's text would be a source-
+grep "how" test, which `AGENTS.md` explicitly discourages. Verification is the
+acceptance grep above plus the unchanged green `./quality.sh` run.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -347,8 +347,9 @@ it drives the identical `score_batch_into`:
 
 ## Native (`--features parallel`) vs wasm32 scoring lane — decision (Issue #288)
 
-The `parallel` feature (rayon, #179) has always compiled the native
-`CompiledNetwork::score_records_parallel` entry point but was never A/B'd
+The `parallel` feature (rayon, #179) has always compiled a native rayon entry
+point — `CompiledNetwork::score_records_parallel_flat` today, named
+`score_records_parallel` before Issue #409 removed it — but it was never A/B'd
 against the wasm32 lane at production scale, so production never routed
 per-creature scoring to it. This section quantifies the trade-off and records
 the decision.
@@ -358,10 +359,9 @@ the native `rust_scorer` is built.** Native beats wasm32 on the production
 fixture on both axes — per-core codegen (NEON + FMA vs simd128 + relaxed-madd)
 and, decisively, by using idle cores the single-threaded wasm32 lane cannot.
 This is a **positive result**; the core-side native path
-(`score_records_parallel` with its sequential/wasm32 fallback) is ready, and the
-production wiring is raised
-cross-repo (a WorkerPool idle-tail change and a host-flags change in the
-downstream production repos) per the issue's
+(`score_records_parallel_flat` with its sequential/wasm32 fallback) is ready,
+and the production wiring is raised cross-repo (a WorkerPool idle-tail change
+and a host-flags change in the downstream production repos) per the issue's
 one-root-cause-one-repo rule — this issue owns only the neat-core native path,
 benchmark, and this decision.
 
@@ -379,7 +379,7 @@ count:
   ceiling.
 - **native** — the same source compiled for `aarch64-apple-darwin` (AVX2/FMA on
   x86, NEON on ARM), scored through a fixed-size rayon pool of 1 or 12 workers
-  via `score_records_parallel`.
+  via `score_records_parallel_flat`.
 
 ### Measured 2026-07-18 — Apple M4 Pro host class
 
@@ -433,9 +433,9 @@ Two distinct wins stack:
    un-scored creatures outnumber cores, but at the **generation-end tail** fewer
    creatures than cores remain and cores go idle. wasm32 workers are
    single-threaded per creature, so that idle time is wasted; native
-   `score_records_parallel` lets each remaining creature spread its record batch
-   across the idle cores. This tail is the **per-creature parallelism win zone**
-   — where native rayon converts otherwise-idle cores into throughput.
+   `score_records_parallel_flat` lets each remaining creature spread its record
+   batch across the idle cores. This tail is the **per-creature parallelism win
+   zone** — where native rayon converts otherwise-idle cores into throughput.
 
 ### Honesty caveats
 


### PR DESCRIPTION
# PR Summary — Issue #505

## Summary

`neat-core/benches/BASELINE.md` named `CompiledNetwork::score_records_parallel`
as the shipped native rayon lane in four places. That entry point was removed in
Issue #409; the surviving native lane is
`CompiledNetwork::score_records_parallel_flat`
(`neat-core/src/parallel_scoring.rs:157`, with the sequential/wasm32 fallback at
line 193). The worst offender was the **Issue #288 verdict** paragraph, which
told readers the core-side path "is ready" while naming a symbol that no longer
compiles.

Renamed all four references to `score_records_parallel_flat`, matching the
spelling already used in the #386 section. The one surviving occurrence of the
old name is the historical framing, which now explicitly marks it as the
pre-#409 name. No recorded measurement numbers were changed — the measurements
remain valid for the same kernel; only the entry-point name changed.

Docs-only change to prose in one file. Closes #505.

| Line | Change |
| --- | --- |
| ~350 | historical framing — names `score_records_parallel_flat` today, notes `score_records_parallel` as the pre-#409 name |
| ~360 | #288 verdict → `score_records_parallel_flat` |
| ~381 | "fixed-size rayon pool … via" → `score_records_parallel_flat` |
| ~435 | idle-core tail win → `score_records_parallel_flat` |

## Evidence

No web interface to screenshot — this is a documentation-only change.

Acceptance grep from the issue (only the explicitly-marked historical mention
remains):

```
$ grep -n 'score_records_parallel\b' neat-core/benches/BASELINE.md
352:`score_records_parallel` before Issue #409 removed it — but it was never A/B'd
```

Every symbol the #288 verdict now names resolves in the source:

```
$ grep -n 'fn score_records_parallel_flat' neat-core/src/parallel_scoring.rs
157:    pub fn score_records_parallel_flat(
193:    pub fn score_records_parallel_flat(
```

`./quality.sh < /dev/null` passes cleanly (fmt, clippy, deny, full test suite,
doc build, release build).

## Test Plan

No tests added or modified. Per the issue's own Failure Detection section this
is prose in a benchmark note — no code, test, or CI behaviour depends on the
symbol names in this file. A test asserting the file's text would be a source-
grep "how" test, which `AGENTS.md` explicitly discourages. Verification is the
acceptance grep above plus the unchanged green `./quality.sh` run.



## Milestone
This PR is part of the **#497 🟠 BASELINE.md presents removed scoring entry points (score_records, score_records_parallel, scoring_flat, evaluate_mse) as current** milestone and targets the `milestone/497-baseline-md-presents-removed-scoring-entry-poi` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msfogpi9-e69936`<!-- vibe-worker-issue-505 -->