### PR TITLE
docs: mark the removed evaluate_mse lane historical in BASELINE.md (Issue #506)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-506.md
+++ b/docs/archive/pr-summaries/pr-summary-506.md
@@ -1,0 +1,44 @@
+## Summary
+
+`neat-core/benches/BASELINE.md` described the `TrainingDataset::evaluate_mse`
+lane in the present tense ("It now bounds-checks once…"), even though the whole
+`wasm_dataset` module — `TrainingDataset`, `evaluate_mse`, `input_batch` and the
+`dataset_evaluate_mse` bench group — was removed as unconsumed dead code in
+Issue #415. The removal note sat twenty lines further down, attached to the
+results table, so a reader hit the present-tense claim first. Closes #506.
+
+Changes to the #386 *Flat-slice record input for batched scoring* section:
+
+1. The Issue #415 removal note is now a single blockquote placed **immediately
+   before** the `evaluate_mse` paragraph — the first mention of any removed
+   symbol in the file is inside that note.
+2. The paragraph is rewritten in past tense: "The biggest win at the time was …
+   #386 changed it to bounds-check once, take `input_batch(start, count)` as a
+   single slice, and drive it through the flat batched path…". No sentence
+   claims current behaviour for a removed symbol.
+3. The old note beside the table is reduced to a back-reference ("the
+   since-removed group — see the Issue #415 note above") so there is exactly one
+   removal note.
+
+The `dataset_evaluate_mse` results table and the drift-control table are
+unchanged — they are the explicitly retained historical record.
+
+## Evidence
+
+Docs-only prose edit; no code path, test, or CI gate consumes this file, so
+there is no web interface to screenshot and no behaviour to test.
+
+Verification performed:
+
+- `./quality.sh < /dev/null` — passed cleanly (fmt, clippy, deny, workspace
+  tests, doc build, release build).
+- `grep -n "evaluate_mse\|TrainingDataset\|input_batch\|wasm_dataset"
+  neat-core/benches/BASELINE.md` — the first hit is line 279, inside the
+  historical blockquote.
+- `git diff` confirms both measurement tables are byte-identical.
+
+## Test Plan
+
+No tests added or modified — the change is documentation prose with no
+executable surface. The existing suite was run via `./quality.sh` to confirm the
+edit introduces no regressions.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -276,15 +276,23 @@ output layout and the packed buffer the fused loss lane already takes
 over the same kernel, so both layouts are **bit-identical**
 (`tests/flat_record_scoring_parity.rs`).
 
-The real win is `TrainingDataset::evaluate_mse` (the >4 GB Memory64 offload lane
-from #298). It stored inputs contiguously in SoA layout yet scored **one record
-at a time** through `activate` — re-bounds-checking per record, allocating a
-fresh `Vec<f32>` per record via `to_vec()` (exactly the per-record allocation
-removed by #229), and never touching the 8-record interleaved SIMD path from
-issues #230/#287. It now bounds-checks once, takes `input_batch(start, count)` as a
-single slice, and drives it through the flat batched path in 1024-record chunks
-(a multiple of the 8-record SIMD group, so grouping and results are unchanged
-while the scratch output buffer stays a bounded constant).
+> **Historical — this lane no longer exists.** The `wasm_dataset` module, its
+> `TrainingDataset::evaluate_mse` / `input_batch` API, and the
+> `dataset_evaluate_mse` bench group were all removed as unconsumed dead code in
+> Issue #415. The paragraph and tables below are retained only as the historical
+> record of the #386 flat-batch change; none of them describes a current code
+> path.
+
+The biggest win at the time was `TrainingDataset::evaluate_mse` (the >4 GB
+Memory64 offload lane from #298). It had stored inputs contiguously in SoA
+layout yet scored **one record at a time** through `activate` —
+re-bounds-checking per record, allocating a fresh `Vec<f32>` per record via
+`to_vec()` (exactly the per-record allocation removed by #229), and never
+touching the 8-record interleaved SIMD path from issues #230/#287. #386 changed
+it to bounds-check once, take `input_batch(start, count)` as a single slice, and
+drive it through the flat batched path in 1024-record chunks (a multiple of the
+8-record SIMD group, so grouping and results were unchanged while the scratch
+output buffer stayed a bounded constant).
 
 **Methodology.** Same alternating-rounds protocol as #287 above, because
 separate `cargo bench` invocations on this laptop drift by more than the effect
@@ -296,10 +304,8 @@ captured alongside as a drift control.
 rustc 1.97.0, `--release`, Criterion
 `--sample-size 10 --measurement-time 5 --warm-up-time 1`.
 
-`dataset_evaluate_mse` (4096 records/iteration), mean of the alternating rounds.
-The group and the `wasm_dataset` module it measured were removed as unconsumed
-dead code in Issue #415; the numbers below are retained as the historical record
-of the #386 flat-batch change:
+`dataset_evaluate_mse` (4096 records/iteration), mean of the alternating rounds
+(the since-removed group — see the Issue #415 note above):
 
 | benchmark (mean of rounds) | old | new | change |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary

`neat-core/benches/BASELINE.md` described the `TrainingDataset::evaluate_mse`
lane in the present tense ("It now bounds-checks once…"), even though the whole
`wasm_dataset` module — `TrainingDataset`, `evaluate_mse`, `input_batch` and the
`dataset_evaluate_mse` bench group — was removed as unconsumed dead code in
Issue #415. The removal note sat twenty lines further down, attached to the
results table, so a reader hit the present-tense claim first. Closes #506.

Changes to the #386 *Flat-slice record input for batched scoring* section:

1. The Issue #415 removal note is now a single blockquote placed **immediately
   before** the `evaluate_mse` paragraph — the first mention of any removed
   symbol in the file is inside that note.
2. The paragraph is rewritten in past tense: "The biggest win at the time was …
   #386 changed it to bounds-check once, take `input_batch(start, count)` as a
   single slice, and drive it through the flat batched path…". No sentence
   claims current behaviour for a removed symbol.
3. The old note beside the table is reduced to a back-reference ("the
   since-removed group — see the Issue #415 note above") so there is exactly one
   removal note.

The `dataset_evaluate_mse` results table and the drift-control table are
unchanged — they are the explicitly retained historical record.

## Evidence

Docs-only prose edit; no code path, test, or CI gate consumes this file, so
there is no web interface to screenshot and no behaviour to test.

Verification performed:

- `./quality.sh < /dev/null` — passed cleanly (fmt, clippy, deny, workspace
  tests, doc build, release build).
- `grep -n "evaluate_mse\|TrainingDataset\|input_batch\|wasm_dataset"
  neat-core/benches/BASELINE.md` — the first hit is line 279, inside the
  historical blockquote.
- `git diff` confirms both measurement tables are byte-identical.

## Test Plan

No tests added or modified — the change is documentation prose with no
executable surface. The existing suite was run via `./quality.sh` to confirm the
edit introduces no regressions.



## Milestone
This PR is part of the **#497 🟠 BASELINE.md presents removed scoring entry points (score_records, score_records_parallel, scoring_flat, evaluate_mse) as current** milestone and targets the `milestone/497-baseline-md-presents-removed-scoring-entry-poi` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msfogpi9-e69936`<!-- vibe-worker-issue-506 -->