### PR TITLE
Mark the retired `scoring_flat` A/B as history in BASELINE.md (Issue #507)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-507.md
+++ b/docs/archive/pr-summaries/pr-summary-507.md
@@ -1,0 +1,49 @@
+## Summary
+
+`neat-core/benches/BASELINE.md` introduced `scoring_flat` as "the new group",
+implying it could still be run. It cannot: Issue #408 retired the A/B group and
+Issue #409 deleted the per-record `score_records` / `score_records_parallel`
+entry point it was compared against. The passage (and the `scoring`-as-
+no-regression-gate paragraph immediately above it, which described the same
+removed `&[Vec<f32>]` wrapper) is now framed as history, with the measured
+numbers kept as the evidence for the #386 flat-input win and clearly labelled as
+pre-retirement. Closes #507.
+
+Changes to `neat-core/benches/BASELINE.md` only:
+
+- The `scoring` no-regression-gate paragraph moved to past tense and notes that
+  #409 deleted the `&[Vec<f32>]` wrapper it gated; `scoring` now drives
+  `score_records_flat` directly.
+- The `scoring_flat` paragraph became a **Historical A/B** blockquote citing
+  #408 (group retired) and #409 (entry point removed), stating the Criterion
+  filter has matched no benchmark since #408.
+- The results table is retained, its header marked
+  `` `scoring_flat` — retired by #408, entry point removed by #409 ``.
+- Cross-references `neat-core/benches/README.md` ("The `scoring` group (Issue
+  #228)") and the `bench_scoring` doc comment in
+  `neat-core/benches/hot_paths.rs`, so all three documents agree.
+
+## Evidence
+
+Docs-only change — no code, benchmark, or CI behaviour changes, so there is no
+web interface to screenshot and no benchmark to re-run. Verified against the
+issue's acceptance criteria:
+
+```
+$ grep -n 'scoring_flat' neat-core/benches/BASELINE.md
+332:> **Historical A/B — `scoring_flat` was retired by Issue #408, and the
+347:| benchmark (mean of rounds, 2026-07-26) | `scoring` | `scoring_flat` — retired by #408, entry point removed by #409 | change |
+```
+
+Both remaining occurrences are marked as retired and cite Issue #408 (and #409
+for the entry-point removal); no text implies the group can be run today.
+
+`./quality.sh` passes cleanly (markdownlint, Mermaid gate, fmt, clippy, deny,
+`cargo test --workspace`, docs, release build).
+
+## Test Plan
+
+No automated tests added — this is a prose-only edit to a benchmark baseline
+document with no executable surface. Verification is the acceptance grep above
+plus the full `./quality.sh` gate, which includes the repo's markdownlint pass
+over `**/*.md`.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -322,17 +322,29 @@ Drift controls — both must be flat, and are:
 | `scoring/production_2x` (4096) | 165.17 ms | 163.06 ms | flat |
 | `scoring/production_exact` (4096) | 70.72 ms | 69.90 ms | flat |
 
-The `scoring` group is the no-regression gate for the `&[Vec<f32>]` wrapper: it
-routes through the same rewritten kernel and must not pay for the new input
-layout. It does not.
+At the time, the `scoring` group was the no-regression gate for the
+`&[Vec<f32>]` wrapper: it routed through the same rewritten kernel and had to
+not pay for the new input layout. It did not. That wrapper is also history —
+Issue #409 deleted `score_records` / `score_records_parallel` outright — so the
+group no longer gates anything about it; today it drives `score_records_flat`
+directly.
 
-`scoring_flat` is the new group scoring the *same* shard through the flat input
-entry point, so the delta against `scoring` isolates the per-record `Vec` header
-indirection (both fixtures are built outside the timed loop, so the caller-side
-one-allocation-per-record the `&[Vec<f32>]` signature forces is *additional*
-saving not counted here):
+> **Historical A/B — `scoring_flat` was retired by Issue #408, and the
+> per-record entry point it was compared against was removed by Issue #409.**
+> It was a second group added by #386 that scored the *same* shard through the
+> flat input entry point, so the delta against `scoring` isolated the per-record
+> `Vec` header indirection (both fixtures were built outside the timed loop, so
+> the caller-side one-allocation-per-record the `&[Vec<f32>]` signature forced
+> was *additional* saving not counted here). With only one input layout left
+> there was nothing to compare against, and `scoring` *is* the flat measurement.
+> The table below is the evidence for the #386 flat-input win, measured before
+> that retirement; it cannot be reproduced against the current tree, where the
+> group's Criterion filter has matched no benchmark since #408. The
+> "The `scoring` group (Issue #228)" paragraph in
+> `neat-core/benches/README.md` and the `bench_scoring` doc comment in
+> `neat-core/benches/hot_paths.rs` tell the same story.
 
-| benchmark (mean of rounds) | `scoring` | `scoring_flat` | change |
+| benchmark (mean of rounds, 2026-07-26) | `scoring` | `scoring_flat` — retired by #408, entry point removed by #409 | change |
 | --- | --- | --- | --- |
 | `production` (4096) | 72.87 ms | 70.34 ms | −3.5% |
 | `production_2x` (4096) | 163.06 ms | 149.70 ms | −8.2% |


### PR DESCRIPTION
## Summary

`neat-core/benches/BASELINE.md` introduced `scoring_flat` as "the new group",
implying it could still be run. It cannot: Issue #408 retired the A/B group and
Issue #409 deleted the per-record `score_records` / `score_records_parallel`
entry point it was compared against. The passage (and the `scoring`-as-
no-regression-gate paragraph immediately above it, which described the same
removed `&[Vec<f32>]` wrapper) is now framed as history, with the measured
numbers kept as the evidence for the #386 flat-input win and clearly labelled as
pre-retirement. Closes #507.

Changes to `neat-core/benches/BASELINE.md` only:

- The `scoring` no-regression-gate paragraph moved to past tense and notes that
  #409 deleted the `&[Vec<f32>]` wrapper it gated; `scoring` now drives
  `score_records_flat` directly.
- The `scoring_flat` paragraph became a **Historical A/B** blockquote citing
  #408 (group retired) and #409 (entry point removed), stating the Criterion
  filter has matched no benchmark since #408.
- The results table is retained, its header marked
  `` `scoring_flat` — retired by #408, entry point removed by #409 ``.
- Cross-references `neat-core/benches/README.md` ("The `scoring` group (Issue
  #228)") and the `bench_scoring` doc comment in
  `neat-core/benches/hot_paths.rs`, so all three documents agree.

## Evidence

Docs-only change — no code, benchmark, or CI behaviour changes, so there is no
web interface to screenshot and no benchmark to re-run. Verified against the
issue's acceptance criteria:

```
$ grep -n 'scoring_flat' neat-core/benches/BASELINE.md
332:> **Historical A/B — `scoring_flat` was retired by Issue #408, and the
347:| benchmark (mean of rounds, 2026-07-26) | `scoring` | `scoring_flat` — retired by #408, entry point removed by #409 | change |
```

Both remaining occurrences are marked as retired and cite Issue #408 (and #409
for the entry-point removal); no text implies the group can be run today.

`./quality.sh` passes cleanly (markdownlint, Mermaid gate, fmt, clippy, deny,
`cargo test --workspace`, docs, release build).

## Test Plan

No automated tests added — this is a prose-only edit to a benchmark baseline
document with no executable surface. Verification is the acceptance grep above
plus the full `./quality.sh` gate, which includes the repo's markdownlint pass
over `**/*.md`.



## Milestone
This PR is part of the **#497 🟠 BASELINE.md presents removed scoring entry points (score_records, score_records_parallel, scoring_flat, evaluate_mse) as current** milestone and targets the `milestone/497-baseline-md-presents-removed-scoring-entry-poi` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msfr5sm6-ef806e`<!-- vibe-worker-issue-507 -->