### PR TITLE
Document squash_x4 group in benches README table (Issue #508)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-508.md
+++ b/docs/archive/pr-summaries/pr-summary-508.md
@@ -1,0 +1,42 @@
+## Summary
+
+The "What is measured" table in `neat-core/benches/README.md` listed eight of
+the nine benchmark groups defined in `neat-core/benches/hot_paths.rs` —
+`squash_x4` (`hot_paths.rs:515`) was missing. Added one row for it, next to the
+related `squash` row, describing what the code actually does: the lane-parallel
+`squash_x4` approximation (Issue #180) against a four-call `apply_squash`
+baseline, over `Tanh`/`Logistic`/`Gelu`/`Mish`, with `scalar_x4` and `simd_x4`
+naming the two sides. The size column takes the fixed 4-lane fixture
+`[0.42, -1.3, 2.7, -0.05]` straight from the setup at `hot_paths.rs:517`.
+
+Every `c.benchmark_group("…")` name in `hot_paths.rs` now has a table row.
+Closes #508.
+
+## Evidence
+
+Docs-only change to a README table — no code, tests, or CI behaviour depends on
+it, so there is no UI to screenshot and no benchmark to run.
+
+Group names in `hot_paths.rs` versus README rows after the change:
+
+| `hot_paths.rs` group | Line | README row |
+| --- | --- | --- |
+| `forward_pass` | 41 | ✅ |
+| `batched_scoring` | 63 | ✅ |
+| `backprop` | 144 | ✅ |
+| `reverse_topological_order` | 176 | ✅ |
+| `scoring` | 213 | ✅ |
+| `topology_ops` | 344 | ✅ |
+| `weighted_sum_simd` | 396 | ✅ |
+| `squash` | 487 | ✅ |
+| `squash_x4` | 515 | ✅ (added) |
+
+`./quality.sh` passes cleanly.
+
+## Test Plan
+
+No tests added. AGENTS.md ("Testing: 'what' not 'how'") rules out source-grep
+tests, which is the only shape a README-versus-source consistency check could
+take; the issue's own Failure Detection section records the same conclusion
+(docs-only, drift resurfaces via a future documentation-audit scan). Existing
+`cargo test --workspace` suite re-run green via `./quality.sh`.

--- a/neat-core/benches/README.md
+++ b/neat-core/benches/README.md
@@ -33,6 +33,7 @@ There are three bench targets:
 | `topology_ops` | `scan_available_connections` — the mutation-time availability scan (Issue #387); `compute_reverse_topological_order` — the per-creature backprop-ordering setup (Issue #388) | `n1666_21513`, `n4127_21513` |
 | `weighted_sum_simd` | `weighted_sum_simd` family (single / no-bias / squares / 4- and 8-record) | 64-synapse block |
 | `squash` | `apply_squash` / `apply_unsquash` over a spread of `SquashType`s | scalar |
+| `squash_x4` | `squash_x4` — the lane-parallel 4-record approximation (Issue #180) against a baseline of four scalar `apply_squash` calls, over the hot transcendental squashes `Tanh`, `Logistic`, `Gelu`, `Mish`. The `scalar_x4` id is the four-call baseline; `simd_x4` is the vectorised kernel | one fixed 4-lane block, `[0.42, -1.3, 2.7, -0.05]` |
 
 The `scoring` group (Issue #228) pushes a full production-sized record batch
 through one creature via `score_records_flat`, so `hot_paths` reports


### PR DESCRIPTION
## Summary

The "What is measured" table in `neat-core/benches/README.md` listed eight of
the nine benchmark groups defined in `neat-core/benches/hot_paths.rs` —
`squash_x4` (`hot_paths.rs:515`) was missing. Added one row for it, next to the
related `squash` row, describing what the code actually does: the lane-parallel
`squash_x4` approximation (Issue #180) against a four-call `apply_squash`
baseline, over `Tanh`/`Logistic`/`Gelu`/`Mish`, with `scalar_x4` and `simd_x4`
naming the two sides. The size column takes the fixed 4-lane fixture
`[0.42, -1.3, 2.7, -0.05]` straight from the setup at `hot_paths.rs:517`.

Every `c.benchmark_group("…")` name in `hot_paths.rs` now has a table row.
Closes #508.

## Evidence

Docs-only change to a README table — no code, tests, or CI behaviour depends on
it, so there is no UI to screenshot and no benchmark to run.

Group names in `hot_paths.rs` versus README rows after the change:

| `hot_paths.rs` group | Line | README row |
| --- | --- | --- |
| `forward_pass` | 41 | ✅ |
| `batched_scoring` | 63 | ✅ |
| `backprop` | 144 | ✅ |
| `reverse_topological_order` | 176 | ✅ |
| `scoring` | 213 | ✅ |
| `topology_ops` | 344 | ✅ |
| `weighted_sum_simd` | 396 | ✅ |
| `squash` | 487 | ✅ |
| `squash_x4` | 515 | ✅ (added) |

`./quality.sh` passes cleanly.

## Test Plan

No tests added. AGENTS.md ("Testing: 'what' not 'how'") rules out source-grep
tests, which is the only shape a README-versus-source consistency check could
take; the issue's own Failure Detection section records the same conclusion
(docs-only, drift resurfaces via a future documentation-audit scan). Existing
`cargo test --workspace` suite re-run green via `./quality.sh`.



## Milestone
This PR is part of the **#497 🟠 BASELINE.md presents removed scoring entry points (score_records, score_records_parallel, scoring_flat, evaluate_mse) as current** milestone and targets the `milestone/497-baseline-md-presents-removed-scoring-entry-poi` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msfsbxoy-0d3f08`<!-- vibe-worker-issue-508 -->