### PR TITLE
activate_into keeps a previous call's inputs when a later record is narrower than num_inputs (Issue #519)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,11 +186,21 @@ bit-identical.
 
 `load_record` (`neat-core/src/batch_scoring.rs`) owns the loading sub-rule:
 copy `min(record.len(), num_inputs)` values and **zero** every input slot the
-record does not cover, exactly as `CompiledNetwork::activate_into` does. Every
-per-lane loader in the batched scoring and fused loss kernels calls it, so a
-record scored in a SIMD group, in the 4-record remainder, or in the scalar tail
-sees the same inputs. `neat-core/tests/batch_record_skeleton.rs` pins the rule
-across every packed loss entry point.
+record does not cover. Every per-lane loader in the batched scoring and fused
+loss kernels calls it, so a record scored in a SIMD group, in the 4-record
+remainder, or in the scalar tail sees the same inputs.
+`neat-core/tests/batch_record_skeleton.rs` pins the rule across every packed
+loss entry point.
+
+The three single-record entry points (`CompiledNetwork::activate`,
+`activate_into`, `activate_and_trace`) route their input copy through the same
+helper, via the private `load_inputs` (Issue #519). They previously copied
+`min(len, num_inputs)` and stopped, so the reused activation buffer left a
+**previous call's** values in the slots a narrower record did not cover, and the
+same record scored differently through the single-record and batched paths.
+`neat-core/tests/short_input_zero_fill.rs` pins the agreement. Only the input
+copy is shared — the activation rule itself stays inlined in those entry points
+for the performance reason in the Issue #441 section above.
 
 ```mermaid
 flowchart LR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.8"
+version = "0.8.9"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-519.md
+++ b/docs/archive/pr-summaries/pr-summary-519.md
@@ -1,0 +1,96 @@
+# Zero-fill uncovered input slots in the single-record entry points (Issue #519)
+
+## Summary
+
+`CompiledNetwork::activate`, `activate_into` and `activate_and_trace` copied
+`min(input.len(), num_inputs)` values into the reused activation buffer and
+stopped. Because that buffer lives on the network across calls, a record
+narrower than `num_inputs` silently scored against the **previous** call's
+values in every slot it did not cover — and disagreed with the batched path,
+where `load_record` (`batch_scoring.rs`, Issue #445) has always zeroed the
+uncovered tail. Narrower-than-`num_inputs` records are explicitly supported
+(`packed_record_scan` takes a caller-supplied `input_size`), so the two paths
+were scoring the same record differently.
+
+All three entry points now route their input copy through `load_record` — the
+single home of the clamp-and-zero loading rule — via a private `load_inputs`
+helper. Only the *loading* is shared; the activation rule itself stays inlined
+in those hot entry points for the Issue #441 performance reason. Full-width
+production records are unaffected: the fill covers an empty tail.
+
+Closes #519.
+
+## Evidence
+
+This is a library/CLI change with no web interface, so there is no screenshot.
+The evidence is the new test file plus the existing suite and the forward-pass
+benchmark.
+
+Before this change the single-record path and the batched loaders diverged for a
+short record; now both zero the uncovered slots:
+
+```mermaid
+flowchart LR
+    R["record narrower than num_inputs"] --> S["activate / activate_into / activate_and_trace"]
+    R --> B["batched loaders (8 / 4 / tail)"]
+    S --> L["load_inputs"]
+    L --> LR["load_record — copy min(len, num_inputs), fill(0.0) on the rest"]
+    B --> LR
+    LR --> O["same activations, same outputs"]
+```
+
+Failing-before / passing-after, `cargo test --test short_input_zero_fill`:
+
+- before the fix: 5 of 6 tests failed (e.g. `activate_into/identity: warmed vs
+  fresh: output 0 was -0.8970501, expected -0.12529999`)
+- after the fix: 6 passed
+
+`./quality.sh` passes cleanly (fmt, clippy, deny, full workspace tests, doc
+build, release build), and `cargo check -p neat-core --target
+wasm32-unknown-unknown` succeeds.
+
+### Forward-pass benchmark
+
+AGENTS.md asks for `cargo bench --bench hot_paths -- forward_pass` whenever the
+single-record entry points are touched. Full-width production records make the
+added fill zero-length, so no change is expected — and none is measurable. Both
+arms were run back to back on the same host (fixed first, then the pre-fix
+sources restored from `HEAD~1`):
+
+| Benchmark | Fixed (median) | Pre-fix (median) | Criterion verdict |
+| --- | --- | --- | --- |
+| `forward_pass/production` | 34.10 µs | 70.94 µs | "regressed" (p < 0.05) |
+| `forward_pass/production_2x` | 69.90 µs | 68.48 µs | no change (p = 0.53) |
+| `forward_pass/production_exact` | 41.73 µs | 39.21 µs | no change (p = 0.76) |
+| `forward_pass/large_5000` | — | −24.9% | "improved" (p = 0.01) |
+
+The verdicts contradict each other in both directions — the *unmodified* code
+measures 2× slower on one fixture and 25% faster on another — which reproduces
+the host-noise finding already recorded in
+`docs/research/exact-size-inference-entry-point.md` ("a 0.79–1.94× spread on
+identical code; nothing below ~20% is decidable there"). The committed
+`benches/BASELINE.md` figure for `forward_pass/production` is 32.76 µs, which the
+fixed build's 34.10 µs sits alongside. This is therefore a no-regression check
+on a noisy shared host, not a performance claim in either direction; the change
+adds one `fill` over an empty tail for full-width records.
+
+## Test Plan
+
+New file `neat-core/tests/short_input_zero_fill.rs` — every test runs across
+three hidden-squash arms (Identity, Tanh, and the Mean aggregate, which takes
+the exact single-record kernel):
+
+- `activate_into_scores_a_narrow_record_without_the_previous_calls_inputs` —
+  the reproduction from the issue: full-width call, then a narrow call, must
+  match a freshly loaded network's answer for the same narrow record.
+- `activate_scores_a_narrow_record_without_the_previous_calls_inputs` — same for
+  `activate`.
+- `activate_and_trace_scores_a_narrow_record_without_the_previous_calls_inputs`
+  — same for `activate_and_trace`.
+- `a_narrow_record_matches_its_zero_padded_full_width_form` — pins the contract
+  that wins: uncovered slots read as zero.
+- `single_record_entry_points_match_the_batched_loader_for_a_narrow_record` —
+  the parity test the issue asked for, against `score_records_flat` with a
+  stride narrower than `num_inputs`.
+- `a_full_width_record_is_unaffected_by_the_zero_fill` — the common production
+  case is unchanged.

--- a/docs/research/exact-size-inference-entry-point.md
+++ b/docs/research/exact-size-inference-entry-point.md
@@ -234,6 +234,10 @@ instruction this is **not** counted as evidence for the performance change and
 is not fixed here — it is filed separately as
 [#519](https://github.com/stSoftwareAU/NEAT-AI-core/issues/519).
 
+**Since fixed by #519:** the three single-record entry points now load their
+inputs through `load_record`, so the uncovered slots are zeroed and the row
+above no longer describes current behaviour.
+
 ## Decision — rejected and removed
 
 | Gate condition | Outcome |

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -264,16 +264,19 @@ pub(crate) fn neuron_activation_scalar(
     apply_limit_range(squash, activation)
 }
 
-/// Copy record inputs into a lane buffer, matching [`CompiledNetwork::activate_into`]
-/// (which copies `min(len, num_inputs)` input values). Any input slot the record
-/// does not cover is zeroed so each record is scored statelessly — buffers are
-/// reused across batches, and every non-input neuron is overwritten during the
-/// forward pass, so no further reset is required.
+/// Copy record inputs into an activation buffer: `min(len, num_inputs)` values,
+/// with any input slot the record does not cover zeroed so each record is scored
+/// statelessly — buffers are reused across batches, and every non-input neuron is
+/// overwritten during the forward pass, so no further reset is required.
 ///
 /// The single home of the clamp-and-zero loading rule (Issue #445): every
 /// per-lane loader in the batched scoring and fused loss kernels calls this, so
 /// a record's inputs land the same way whether it was scored in a SIMD group or
-/// in the scalar tail.
+/// in the scalar tail. The three single-record entry points
+/// ([`CompiledNetwork::activate`], [`CompiledNetwork::activate_into`],
+/// [`CompiledNetwork::activate_and_trace`]) call it too, so a record narrower
+/// than `num_inputs` scores the same through either path — before Issue #519
+/// they kept the previous call's values in the slots the record did not cover.
 #[inline]
 pub(crate) fn load_record(act: &mut [f32], record: &[f32], num_inputs: usize) {
     let in_len = record.len().min(num_inputs);

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -8,7 +8,7 @@
 //! NEAT-AI consumes. Public fields are skipped from the bindgen surface (they
 //! remain accessible to native Rust callers); the JS API is the public methods.
 
-use crate::batch_scoring::inline_squash;
+use crate::batch_scoring::{inline_squash, load_record};
 use crate::range::apply_limit_range;
 use crate::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
@@ -372,9 +372,9 @@ impl CompiledNetwork {
     /// Issue #1175 - Uses typed structs for better cache locality
     /// Issue #1177 - Inlines common squash functions to avoid function call overhead
     pub fn activate(&mut self, input: &[f32], num_outputs: usize) -> Vec<f32> {
-        // Copy input values to activation buffer
-        let input_len = input.len().min(self.num_inputs);
-        self.activations[..input_len].copy_from_slice(&input[..input_len]);
+        // Copy input values to activation buffer, zeroing any slot the record
+        // does not cover (Issue #519 - see `load_record`).
+        self.load_inputs(input);
 
         // Process each neuron in order
         for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
@@ -531,9 +531,9 @@ impl CompiledNetwork {
     pub fn activate_into(&mut self, input: &[f32], output: &mut [f32]) {
         let num_outputs = output.len();
 
-        // Copy input values to activation buffer
-        let input_len = input.len().min(self.num_inputs);
-        self.activations[..input_len].copy_from_slice(&input[..input_len]);
+        // Copy input values to activation buffer, zeroing any slot the record
+        // does not cover (Issue #519 - see `load_record`).
+        self.load_inputs(input);
 
         // Process each neuron in order
         for (neuron_idx, neuron) in self.neurons.iter().enumerate() {
@@ -724,9 +724,9 @@ impl CompiledNetwork {
     ///     - For IF: branch_taken (1.0 = positive, 0.0 = negative)
     ///   - Terminated by -1.0
     pub fn activate_and_trace(&mut self, input: &[f32], num_outputs: usize) -> Vec<f32> {
-        // Copy input values to activation buffer
-        let input_len = input.len().min(self.num_inputs);
-        self.activations[..input_len].copy_from_slice(&input[..input_len]);
+        // Copy input values to activation buffer, zeroing any slot the record
+        // does not cover (Issue #519 - see `load_record`).
+        self.load_inputs(input);
 
         // Issue #1173 - Reuse pre-allocated trace data buffer instead of allocating
         // Track trace data for aggregate functions
@@ -1241,6 +1241,19 @@ impl CompiledNetwork {
 
 /// Issue #1212 - Helper methods for batch activate_and_trace processing
 impl CompiledNetwork {
+    /// Load one record's inputs into the reused activation buffer.
+    ///
+    /// Delegates to [`load_record`] — the single home of the clamp-and-zero
+    /// loading rule (Issue #445): copy `min(input.len(), num_inputs)` values
+    /// and **zero** every input slot the record does not cover. The buffer is
+    /// reused across calls, so without the zero-fill a record narrower than
+    /// `num_inputs` would score against the previous call's values and disagree
+    /// with the batched loaders (Issue #519).
+    #[inline]
+    fn load_inputs(&mut self, input: &[f32]) {
+        load_record(&mut self.activations, input, self.num_inputs);
+    }
+
     /// Process MINIMUM aggregate for 4 records
     #[allow(clippy::too_many_arguments)]
     fn process_minimum_4way(

--- a/neat-core/tests/short_input_zero_fill.rs
+++ b/neat-core/tests/short_input_zero_fill.rs
@@ -1,0 +1,261 @@
+//! Short-record input semantics for the single-record entry points (Issue #519).
+//!
+//! One rule covers every record narrower than the network's input arity: the
+//! input slots the record does not cover read as **zero**, never as whatever a
+//! previous call left in the reused activation buffer. `load_record`
+//! (`batch_scoring.rs`, Issue #445) has always obeyed it; the three
+//! single-record entry points — [`CompiledNetwork::activate`],
+//! [`CompiledNetwork::activate_into`] and
+//! [`CompiledNetwork::activate_and_trace`] — did not, so the same record scored
+//! differently depending on which path it took.
+//!
+//! These are "what" tests: they drive the public entry points with real
+//! networks and assert on returned numbers. Two observable properties pin the
+//! rule — a warmed network must score a narrow record identically to a freshly
+//! loaded one (statelessness), and a narrow record must score identically
+//! through the single-record path and the batched loader (parity).
+
+use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+
+const IDENTITY: u8 = 0;
+const TANH: u8 = 7;
+const MEAN: u8 = 37;
+
+/// Network input arity. Records narrower than this leave uncovered slots.
+const NUM_INPUTS: usize = 4;
+
+/// Width of the short record: covers half the input slots.
+const SHORT_WIDTH: usize = 2;
+
+/// A full-width record whose tail values are large enough that leaking them
+/// into a later call moves the outputs well outside `TOL`.
+const FULL_RECORD: [f32; NUM_INPUTS] = [0.4, -0.7, 3.5, -4.25];
+
+/// The short record — the same leading values, so only the uncovered tail can
+/// explain any difference in the outputs.
+const SHORT_RECORD: [f32; SHORT_WIDTH] = [0.4, -0.7];
+
+/// The short record written out at full width with the uncovered slots zeroed:
+/// what a stateless narrow call must be equivalent to.
+const SHORT_PADDED: [f32; NUM_INPUTS] = [0.4, -0.7, 0.0, 0.0];
+
+/// Absolute tolerance against the batched kernels, which re-associate the
+/// weighted sums in `f32` (same tolerance as `batch_record_skeleton.rs`).
+const TOL: f32 = 1e-5;
+
+fn network(neurons: Vec<NeuronData>, synapses: Vec<SynapseData>) -> CompiledNetwork {
+    let num_non_inputs = neurons.len();
+    let num_neurons = NUM_INPUTS + num_non_inputs;
+    CompiledNetwork {
+        num_neurons,
+        num_inputs: NUM_INPUTS,
+        neurons,
+        synapses,
+        activations: vec![0.0; num_neurons],
+        hint_values_buffer: vec![0.0; num_non_inputs],
+        trace_data_buffer: Vec::new(),
+        batch_activations: [
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+            vec![0.0; num_neurons],
+        ],
+        batch_hints: [
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+            vec![0.0; num_non_inputs],
+        ],
+        batch_traces: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+    }
+}
+
+/// One hidden neuron reading all four inputs, one output neuron reading it.
+/// `hidden_squash` picks the arm under test: a standard weighted sum, or an
+/// aggregate that takes the exact single-record kernel.
+fn build_network(hidden_squash: u8) -> CompiledNetwork {
+    let mut synapses = Vec::new();
+    for i in 0..NUM_INPUTS {
+        synapses.push(SynapseData {
+            weight: 0.3 + 0.11 * (i as f32),
+            from_index: i as u16,
+            synapse_type: 0,
+        });
+    }
+    let hidden = NeuronData {
+        bias: 0.05,
+        start_synapse: 0,
+        num_synapses: NUM_INPUTS as u16,
+        squash_type: hidden_squash,
+        is_constant: false,
+    };
+
+    let output_start = synapses.len() as u32;
+    synapses.push(SynapseData {
+        weight: 0.9,
+        from_index: NUM_INPUTS as u16,
+        synapse_type: 0,
+    });
+    let output = NeuronData {
+        bias: -0.02,
+        start_synapse: output_start,
+        num_synapses: 1,
+        squash_type: IDENTITY,
+        is_constant: false,
+    };
+
+    network(vec![hidden, output], synapses)
+}
+
+/// Every hidden-squash arm the single-record entry points must obey the rule
+/// for: a standard weighted sum, and an aggregate that cannot be lane-vectorised.
+const HIDDEN_SQUASHES: [(&str, u8); 3] = [
+    ("identity", IDENTITY),
+    ("tanh", TANH),
+    ("mean (aggregate)", MEAN),
+];
+
+fn assert_close(label: &str, actual: &[f32], expected: &[f32]) {
+    assert_eq!(actual.len(), expected.len(), "{label}: output length");
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (a - e).abs() <= TOL,
+            "{label}: output {i} was {a}, expected {e}"
+        );
+    }
+}
+
+/// The batched loader's answer for the short record — the reference both the
+/// single-record path and the zero-padded record must agree with.
+fn batched_short_outputs(squash: u8) -> Vec<f32> {
+    build_network(squash).score_records_flat(&SHORT_RECORD, SHORT_WIDTH, 1)
+}
+
+#[test]
+fn activate_into_scores_a_narrow_record_without_the_previous_calls_inputs() {
+    for (label, squash) in HIDDEN_SQUASHES {
+        let mut net = build_network(squash);
+        let mut warm = [0.0f32; 1];
+        net.activate_into(&FULL_RECORD, &mut warm);
+
+        let mut after_full = [0.0f32; 1];
+        net.activate_into(&SHORT_RECORD, &mut after_full);
+
+        let mut fresh_out = [0.0f32; 1];
+        build_network(squash).activate_into(&SHORT_RECORD, &mut fresh_out);
+
+        assert_close(
+            &format!("activate_into/{label}: warmed vs fresh"),
+            &after_full,
+            &fresh_out,
+        );
+    }
+}
+
+#[test]
+fn activate_scores_a_narrow_record_without_the_previous_calls_inputs() {
+    for (label, squash) in HIDDEN_SQUASHES {
+        let mut net = build_network(squash);
+        net.activate(&FULL_RECORD, 1);
+        let after_full = net.activate(&SHORT_RECORD, 1);
+
+        let fresh = build_network(squash).activate(&SHORT_RECORD, 1);
+
+        assert_close(
+            &format!("activate/{label}: warmed vs fresh"),
+            &after_full,
+            &fresh,
+        );
+    }
+}
+
+#[test]
+fn activate_and_trace_scores_a_narrow_record_without_the_previous_calls_inputs() {
+    for (label, squash) in HIDDEN_SQUASHES {
+        let mut net = build_network(squash);
+        net.activate_and_trace(&FULL_RECORD, 1);
+        let after_full = net.activate_and_trace(&SHORT_RECORD, 1);
+
+        let fresh = build_network(squash).activate_and_trace(&SHORT_RECORD, 1);
+
+        assert_close(
+            &format!("activate_and_trace/{label}: warmed vs fresh"),
+            &after_full,
+            &fresh,
+        );
+    }
+}
+
+#[test]
+fn a_narrow_record_matches_its_zero_padded_full_width_form() {
+    for (label, squash) in HIDDEN_SQUASHES {
+        let mut narrow = build_network(squash);
+        narrow.activate_into(&FULL_RECORD, &mut [0.0f32; 1]);
+        let mut narrow_out = [0.0f32; 1];
+        narrow.activate_into(&SHORT_RECORD, &mut narrow_out);
+
+        let mut padded = build_network(squash);
+        padded.activate_into(&FULL_RECORD, &mut [0.0f32; 1]);
+        let mut padded_out = [0.0f32; 1];
+        padded.activate_into(&SHORT_PADDED, &mut padded_out);
+
+        assert_close(
+            &format!("{label}: narrow vs zero-padded"),
+            &narrow_out,
+            &padded_out,
+        );
+    }
+}
+
+#[test]
+fn single_record_entry_points_match_the_batched_loader_for_a_narrow_record() {
+    for (label, squash) in HIDDEN_SQUASHES {
+        let batched = batched_short_outputs(squash);
+
+        let mut net = build_network(squash);
+        net.activate_into(&FULL_RECORD, &mut [0.0f32; 1]);
+
+        let mut into_out = [0.0f32; 1];
+        net.activate_into(&SHORT_RECORD, &mut into_out);
+        assert_close(
+            &format!("activate_into/{label} vs batched loader"),
+            &into_out,
+            &batched,
+        );
+
+        net.activate_into(&FULL_RECORD, &mut [0.0f32; 1]);
+        let activate_out = net.activate(&SHORT_RECORD, 1);
+        assert_close(
+            &format!("activate/{label} vs batched loader"),
+            &activate_out,
+            &batched,
+        );
+
+        net.activate_into(&FULL_RECORD, &mut [0.0f32; 1]);
+        let traced = net.activate_and_trace(&SHORT_RECORD, 1);
+        assert_close(
+            &format!("activate_and_trace/{label} vs batched loader"),
+            &traced[..1],
+            &batched,
+        );
+    }
+}
+
+#[test]
+fn a_full_width_record_is_unaffected_by_the_zero_fill() {
+    for (label, squash) in HIDDEN_SQUASHES {
+        let mut net = build_network(squash);
+        let mut first = [0.0f32; 1];
+        net.activate_into(&FULL_RECORD, &mut first);
+
+        net.activate_into(&SHORT_RECORD, &mut [0.0f32; 1]);
+        let mut again = [0.0f32; 1];
+        net.activate_into(&FULL_RECORD, &mut again);
+
+        assert_close(
+            &format!("{label}: full-width record repeatable"),
+            &again,
+            &first,
+        );
+    }
+}


### PR DESCRIPTION
# Zero-fill uncovered input slots in the single-record entry points (Issue #519)

## Summary

`CompiledNetwork::activate`, `activate_into` and `activate_and_trace` copied
`min(input.len(), num_inputs)` values into the reused activation buffer and
stopped. Because that buffer lives on the network across calls, a record
narrower than `num_inputs` silently scored against the **previous** call's
values in every slot it did not cover — and disagreed with the batched path,
where `load_record` (`batch_scoring.rs`, Issue #445) has always zeroed the
uncovered tail. Narrower-than-`num_inputs` records are explicitly supported
(`packed_record_scan` takes a caller-supplied `input_size`), so the two paths
were scoring the same record differently.

All three entry points now route their input copy through `load_record` — the
single home of the clamp-and-zero loading rule — via a private `load_inputs`
helper. Only the *loading* is shared; the activation rule itself stays inlined
in those hot entry points for the Issue #441 performance reason. Full-width
production records are unaffected: the fill covers an empty tail.

Closes #519.

## Evidence

This is a library/CLI change with no web interface, so there is no screenshot.
The evidence is the new test file plus the existing suite and the forward-pass
benchmark.

Before this change the single-record path and the batched loaders diverged for a
short record; now both zero the uncovered slots:

```mermaid
flowchart LR
    R["record narrower than num_inputs"] --> S["activate / activate_into / activate_and_trace"]
    R --> B["batched loaders (8 / 4 / tail)"]
    S --> L["load_inputs"]
    L --> LR["load_record — copy min(len, num_inputs), fill(0.0) on the rest"]
    B --> LR
    LR --> O["same activations, same outputs"]
```

Failing-before / passing-after, `cargo test --test short_input_zero_fill`:

- before the fix: 5 of 6 tests failed (e.g. `activate_into/identity: warmed vs
  fresh: output 0 was -0.8970501, expected -0.12529999`)
- after the fix: 6 passed

`./quality.sh` passes cleanly (fmt, clippy, deny, full workspace tests, doc
build, release build), and `cargo check -p neat-core --target
wasm32-unknown-unknown` succeeds.

### Forward-pass benchmark

AGENTS.md asks for `cargo bench --bench hot_paths -- forward_pass` whenever the
single-record entry points are touched. Full-width production records make the
added fill zero-length, so no change is expected — and none is measurable. Both
arms were run back to back on the same host (fixed first, then the pre-fix
sources restored from `HEAD~1`):

| Benchmark | Fixed (median) | Pre-fix (median) | Criterion verdict |
| --- | --- | --- | --- |
| `forward_pass/production` | 34.10 µs | 70.94 µs | "regressed" (p < 0.05) |
| `forward_pass/production_2x` | 69.90 µs | 68.48 µs | no change (p = 0.53) |
| `forward_pass/production_exact` | 41.73 µs | 39.21 µs | no change (p = 0.76) |
| `forward_pass/large_5000` | — | −24.9% | "improved" (p = 0.01) |

The verdicts contradict each other in both directions — the *unmodified* code
measures 2× slower on one fixture and 25% faster on another — which reproduces
the host-noise finding already recorded in
`docs/research/exact-size-inference-entry-point.md` ("a 0.79–1.94× spread on
identical code; nothing below ~20% is decidable there"). The committed
`benches/BASELINE.md` figure for `forward_pass/production` is 32.76 µs, which the
fixed build's 34.10 µs sits alongside. This is therefore a no-regression check
on a noisy shared host, not a performance claim in either direction; the change
adds one `fill` over an empty tail for full-width records.

## Test Plan

New file `neat-core/tests/short_input_zero_fill.rs` — every test runs across
three hidden-squash arms (Identity, Tanh, and the Mean aggregate, which takes
the exact single-record kernel):

- `activate_into_scores_a_narrow_record_without_the_previous_calls_inputs` —
  the reproduction from the issue: full-width call, then a narrow call, must
  match a freshly loaded network's answer for the same narrow record.
- `activate_scores_a_narrow_record_without_the_previous_calls_inputs` — same for
  `activate`.
- `activate_and_trace_scores_a_narrow_record_without_the_previous_calls_inputs`
  — same for `activate_and_trace`.
- `a_narrow_record_matches_its_zero_padded_full_width_form` — pins the contract
  that wins: uncovered slots read as zero.
- `single_record_entry_points_match_the_batched_loader_for_a_narrow_record` —
  the parity test the issue asked for, against `score_records_flat` with a
  stride narrower than `num_inputs`.
- `a_full_width_record_is_unaffected_by_the_zero_fill` — the common production
  case is unchanged.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msfsbxoy-0d3f08`<!-- vibe-worker-issue-519 -->