### PR TITLE
🟡 Document the CI blind spots: wasm32 is ungated on PRs, and gates must be repo-owned and unconditional (Issue #502)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ soundness rules. They are load-bearing — an edit that ignores one either fails
 the build or ships undefined behaviour. Absorbed from the SIMD/`unsafe`/
 buffer-reuse campaign (PRs #11, #112, #154, #155, #165, #207).
 
+The `wasm32` half of this hot path is **not** compiled by any PR gate — run
+`cargo check -p neat-core --target wasm32-unknown-unknown` before you merge a
+change to it, per [CI / secrets](#ci--secrets).
+
 ### Load-time index validation is the soundness precondition for `get_unchecked`
 
 The SIMD kernels read the activation buffer (sized to exactly `num_neurons`)
@@ -390,7 +394,10 @@ reversed span yields the kernel's seed. Those assertions run natively against
 the `simd_native.rs` kernels; to execute them against the **wasm** kernels, run
 them on a real runtime through `wasm-bench/` (Issue #509) — `neat-core`'s own
 test targets cannot be built for wasm because its `criterion` dev-dependency
-refuses to compile for wasi.
+refuses to compile for wasi. No PR gate compiles this file at all: check it with
+`cargo check -p neat-core --target wasm32-unknown-unknown`, and for a numeric
+edit diff the `f32` bit patterns under WASI, per
+[CI / secrets](#ci--secrets).
 
 ```mermaid
 flowchart LR
@@ -410,3 +417,5 @@ flowchart LR
 - **`ACTIONS_PUSH` is supplied just-in-time** (Issue #483): the `version-increment` / `auto-format` checkouts run with **`persist-credentials: false`** and no `token:`, and the PAT reaches only the one step that pushes, through an explicit `https://x-access-token:…` remote URL. Never hand it to a checkout — those jobs execute PR-authored code (`bump-deps.sh`, `cargo fmt`) that would then be able to read an org-wide credential off `.git/config`.
 - **Versioning/release policy:** **`RELEASING.md`** is the single source of truth (Issue #251) — semver, what counts as breaking, and how to signal it. In CI the `version-increment` job bumps minor on a break (patch otherwise); the `version-gate` job **fails** a break shipped on a patch-only bump; `release.yml` cuts a **`v<version>`** tag + GitHub release on `Develop`, decoupled from `wasm-bundle-<sha>`.
 - **`clippy::uninlined_format_args`** is not denied in CI until the test corpus is cleaned up; workspace lints still deny **`filter_next`** / **`collapsible_if`**.
+- **`wasm32` is not gated on PRs — check it yourself before touching wasm-only code.** Neither `quality.sh` nor any `ci.yml` job builds for `wasm32-unknown-unknown` (the `wasm64-memory64-smoke` job is a Deno Memory64 runtime test, not a wasm32 build); the target compiles only *after* merge — on **push to `Develop`** through `wasm-bundle.yml`, and on the scheduled `upgrade-dependencies.yml` run, whose `bump-deps.sh` dual build the PR lane skips with `--skip-build`. The load-bearing manual check is **`cargo check -p neat-core --target wasm32-unknown-unknown`**. What it catches: deleting the last consumer of a `#[cfg(target_arch = "wasm32")]` block leaves an orphaned `use core::arch::wasm32::{…}` that every host gate compiles right past and only the bundle build rejects (Issues #422, #423). For **numeric** wasm changes go further, as Issue #448 did — compile to `wasm32-wasip1`, run under Node's WASI with `-C target-feature=+simd128,+relaxed-simd`, and diff the raw `f32` bit patterns before against after.
+- **CI gates must be repo-owned and unconditional.** Never `if:`-gate a step on a file another repository owns: the Mermaid check was conditioned on a path that never exists here, so it skipped **every** run and a broken diagram merged (Issue #379). Its replacement, `scripts/check_mermaid.ts`, is owned by this repo and runs unconditionally from both `quality.sh` and `markdown-lint.yml`. Related budget rule: **GitHub rejects `timeout-minutes:` on a reusable-workflow *caller* job** — put it on the called workflow's own job instead (`ci.yml`'s `security` job calls `security.yml`, whose job carries `timeout-minutes: 30`; Issue #333).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.11"
+version = "0.8.12"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-502.md
+++ b/docs/archive/pr-summaries/pr-summary-502.md
@@ -1,0 +1,118 @@
+# Document the CI blind spots: ungated wasm32, repo-owned unconditional gates (Issue #502)
+
+## Summary
+
+Two CI blind spots were recorded only in the PR-summary archive, so nothing an
+agent reads before editing warned about either. Both now sit in `AGENTS.md`'s
+*CI / secrets* section. Closes #502.
+
+1. **`wasm32` is gated by nothing on a PR.** Verified against the tree:
+   `quality.sh` names no wasm target at all, and no `pull_request` workflow runs
+   a `cargo build/check/clippy` against `wasm32-unknown-unknown` (the
+   `wasm64-memory64-smoke` job is a Deno Memory64 runtime test). The target
+   compiles only *after* merge — `wasm-bundle.yml` on push to `Develop`, and the
+   scheduled `upgrade-dependencies.yml`, whose `bump-deps.sh` dual build the PR
+   lane skips with `--skip-build`. The new bullet names the load-bearing manual
+   check, `cargo check -p neat-core --target wasm32-unknown-unknown`, the
+   failure it catches (an orphaned `use core::arch::wasm32::{…}` left behind a
+   `#[cfg(target_arch = "wasm32")]` when its last consumer is deleted — Issues
+   #422, #423), and the `wasm32-wasip1`/Node-WASI `f32` bit-diff method for
+   numeric changes (Issue #448). Cross-referenced from both SIMD sections, since
+   that is where the blind spot bites.
+2. **CI gates must be repo-owned and unconditional.** The Mermaid step was
+   `if:`-gated on a file only another repo owns, so it never ran once and a
+   broken diagram merged (Issue #379); its replacement `scripts/check_mermaid.ts`
+   is repo-owned and unconditional in both `quality.sh` and `markdown-lint.yml`.
+   The same bullet records that GitHub rejects `timeout-minutes:` on a
+   reusable-workflow **caller** job — the budget belongs on the called
+   workflow's own job (`ci.yml`'s `security` job → `security.yml`, Issue #333).
+
+The four cited summaries are **kept**, not deleted: the issue conditions removal
+on "no other unabsorbed content", and each still holds PR-specific record that
+`AGENTS.md` does not carry — the breaking-change removal tables in `-422`/`-423`,
+the 492-span bit-identical diff evidence in `-448`, and the per-job timeout table
+in `-333`.
+
+```mermaid
+flowchart LR
+    A["edit wasm32-only code"] --> B["quality.sh — host only"]
+    A --> C["ci.yml PR jobs — host only"]
+    B --> D["green"]
+    C --> D
+    D --> E["merge"]
+    E --> F["wasm-bundle.yml on push to Develop"]
+    F --> G["build fails — after merge"]
+    A -.->|"AGENTS.md now says to run this first"| H["cargo check --target wasm32-unknown-unknown"]
+    H -.-> I["caught before merge"]
+```
+
+## Evidence
+
+Documentation change to a Rust/CLI repo — no web interface to screenshot. The
+evidence is the new test suite, which is a "what" test in the style of
+`docs_pipeline_accuracy.bats`: every doc claim is paired with a premise
+assertion read from the pipeline file it describes, so the suite fails both if
+the prose drifts and if the pipeline changes underneath the prose.
+
+Pre-fix (doc assertions only, run against `AGENTS.md` at `HEAD~1`) — the premise
+assertions already passed, confirming the blind spots are real:
+
+```
+not ok 3 AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check
+not ok 4 AGENTS.md records the WASI bit-diff method for numeric wasm changes
+not ok 5 the SIMD sections cross-reference the wasm32 check
+not ok 8 AGENTS.md CI section states the repo-owned, unconditional gate rule
+```
+
+Post-fix:
+
+```
+1..8
+ok 1 no pull_request workflow and no quality.sh step builds for wasm32
+ok 2 wasm-bundle.yml builds wasm32 only on push to Develop
+ok 3 AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check
+ok 4 AGENTS.md records the WASI bit-diff method for numeric wasm changes
+ok 5 the SIMD sections cross-reference the wasm32 check
+ok 6 the Mermaid gate is repo-owned and runs unconditionally
+ok 7 reusable-workflow callers carry no timeout-minutes and the callee does
+ok 8 AGENTS.md CI section states the repo-owned, unconditional gate rule
+```
+
+`./quality.sh < /dev/null` — green (shellcheck, the full bats suite including
+the new file, TypeScript gate, Mermaid gate, deny, fmt, clippy `-D warnings`,
+`cargo test --workspace`, doc, release build).
+
+## Test Plan
+
+New — `tests/scripts/docs_ci_blind_spots.bats` (8 tests). Premise assertions
+parse the committed YAML/shell; doc assertions read the *CI / secrets* section
+extracted by heading, so a matching phrase elsewhere in `AGENTS.md` cannot
+satisfy them.
+
+- `no pull_request workflow and no quality.sh step builds for wasm32` — parses
+  every workflow, skips those without a `pull_request` trigger, and fails if any
+  step compiles for `wasm32-unknown-unknown`; also asserts `quality.sh` never
+  names the target. Fails loudly if a wasm PR gate is ever added, since the doc
+  claim would then be stale.
+- `wasm-bundle.yml builds wasm32 only on push to Develop` — the trigger is
+  push-only on `Develop` and the workflow does build the target.
+- `AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check`
+  — the section states the absence *and* carries the `cargo check` command and
+  `wasm-bundle.yml`.
+- `AGENTS.md records the WASI bit-diff method for numeric wasm changes` —
+  `wasm32-wasip1` and `-C target-feature=+simd128,+relaxed-simd` are present.
+- `the SIMD sections cross-reference the wasm32 check` — the command is cited
+  from at least one section outside *CI / secrets* whose heading names SIMD or
+  wasm.
+- `the Mermaid gate is repo-owned and runs unconditionally` —
+  `scripts/check_mermaid.ts` exists, no `markdown-lint.yml` step running it
+  carries an `if:`, and the `quality.sh` invocation is at top level rather than
+  nested inside a guard.
+- `reusable-workflow callers carry no timeout-minutes and the callee does` —
+  `ci.yml`'s `uses:` jobs declare none, every `security.yml` job declares a
+  positive integer budget.
+- `AGENTS.md CI section states the repo-owned, unconditional gate rule` — the
+  rule, `check_mermaid.ts`, the caller/`timeout-minutes` carve-out and
+  `security.yml` all appear in the section.
+
+No existing tests were removed or modified.

--- a/tests/scripts/docs_ci_blind_spots.bats
+++ b/tests/scripts/docs_ci_blind_spots.bats
@@ -1,0 +1,218 @@
+#!/usr/bin/env bats
+# Regression assertions for Issue #502 (BP-4d74b443d1bd) — two CI blind spots
+# lived only in the PR-summary archive:
+#
+#   1. no PR gate builds `wasm32-unknown-unknown`, so an orphaned
+#      `use core::arch::wasm32::{…}` behind `#[cfg(target_arch = "wasm32")]` is
+#      green on every host gate and only fails at bundle-build time, after
+#      merge (Issues #422, #423, #448);
+#   2. a gate conditioned on a file another repo owns self-skips forever, and
+#      GitHub rejects `timeout-minutes:` on a reusable-workflow caller job
+#      (Issues #379, #333).
+#
+# Each test pairs a premise assertion against the committed pipeline files with
+# a doc assertion against AGENTS.md, so they fail both when the prose drifts and
+# when the pipeline changes underneath the prose.
+
+load helpers
+
+setup() {
+  require_python3
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  AGENTS="${REPO_ROOT}/AGENTS.md"
+  QUALITY="${REPO_ROOT}/quality.sh"
+  WORKFLOWS="${REPO_ROOT}/.github/workflows"
+  WASM_CHECK='cargo check -p neat-core --target wasm32-unknown-unknown'
+}
+
+# Emit the "CI / secrets" section of AGENTS.md, from its heading to the next
+# level-2 heading, so a claim elsewhere in the file cannot satisfy a test that
+# is about that section.
+ci_secrets_section() {
+  python3 - "$AGENTS" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+start = next(
+    (i for i, l in enumerate(lines) if l.strip().lower() == "## ci / secrets"),
+    None,
+)
+if start is None:
+    sys.exit("AGENTS.md has no '## CI / secrets' section")
+end = next(
+    (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+    len(lines),
+)
+print("\n".join(lines[start:end]))
+PY
+}
+
+# --- 1. wasm32 is ungated on PRs -------------------------------------------
+
+@test "no pull_request workflow and no quality.sh step builds for wasm32" {
+  # The premise the doc assertions rest on. `rustup target add` alone does not
+  # count as a build, so only the compile invocations are searched for.
+  run python3 - "$WORKFLOWS" <<'PY'
+import pathlib
+import re
+import sys
+
+import yaml
+
+build = re.compile(
+    r"cargo\s+(build|check|clippy|test|rustc)\b[^\n]*wasm32-unknown-unknown"
+)
+offenders = []
+for path in sorted(pathlib.Path(sys.argv[1]).glob("*.yml")):
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    triggers = data.get("on") or data.get(True) or {}
+    names = triggers if isinstance(triggers, (dict, list)) else [triggers]
+    if "pull_request" not in names:
+        continue
+    for job in (data.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if build.search(step.get("run") or ""):
+                offenders.append(f"{path.name}: {step.get('name')}")
+if offenders:
+    sys.exit("a PR workflow already builds wasm32 — update AGENTS.md:\n"
+             + "\n".join(offenders))
+PY
+  [ "$status" -eq 0 ]
+
+  ! grep -q 'wasm32' "$QUALITY"
+}
+
+@test "wasm-bundle.yml builds wasm32 only on push to Develop" {
+  run python3 - "${WORKFLOWS}/wasm-bundle.yml" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+triggers = data.get("on") or data.get(True)
+assert set(triggers) == {"push"}, f"expected a push-only trigger, got {triggers}"
+assert triggers["push"]["branches"] == ["Develop"], triggers["push"]
+body = yaml.safe_dump(data)
+assert "wasm32-unknown-unknown" in body, "wasm-bundle.yml never names the target"
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check" {
+  run ci_secrets_section
+  [ "$status" -eq 0 ]
+  local section="$output"
+
+  printf '%s\n' "$section" | grep -q -- "$WASM_CHECK"
+  printf '%s\n' "$section" | grep -q 'wasm-bundle\.yml'
+  # The negative claim itself — an agent must be told the gate is absent, not
+  # merely handed a command.
+  printf '%s\n' "$section" | grep -Eqi 'wasm32.{0,3} is not gated on PRs'
+}
+
+@test "AGENTS.md records the WASI bit-diff method for numeric wasm changes" {
+  run ci_secrets_section
+  [ "$status" -eq 0 ]
+  local section="$output"
+
+  printf '%s\n' "$section" | grep -q 'wasm32-wasip1'
+  printf '%s\n' "$section" | grep -q 'target-feature=+simd128,+relaxed-simd'
+}
+
+@test "the SIMD sections cross-reference the wasm32 check" {
+  # The blind spot bites while editing SIMD code, so the pointer has to be
+  # reachable from there — not only from the CI section.
+  run python3 - "$AGENTS" "$WASM_CHECK" <<'PY'
+import sys
+
+path, needle = sys.argv[1], sys.argv[2]
+section, hits = None, []
+for line in open(path, encoding="utf-8").read().splitlines():
+    if line.startswith("## "):
+        section = line[3:].strip()
+    if needle in line and section and section.lower() != "ci / secrets":
+        hits.append(section)
+simd = [s for s in hits if "simd" in s.lower() or "wasm" in s.lower()]
+if not simd:
+    sys.exit(f"no SIMD/wasm section cites {needle!r}; cited by: {hits}")
+PY
+  [ "$status" -eq 0 ]
+}
+
+# --- 2. gates are repo-owned and unconditional ------------------------------
+
+@test "the Mermaid gate is repo-owned and runs unconditionally" {
+  # Premise: the gate script lives here, and neither the CI step nor the
+  # quality.sh call is guarded by a condition.
+  [ -f "${REPO_ROOT}/scripts/check_mermaid.ts" ]
+
+  run python3 - "${WORKFLOWS}/markdown-lint.yml" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+steps = [
+    s
+    for job in (data.get("jobs") or {}).values()
+    for s in job.get("steps") or []
+    if "check_mermaid.ts" in (s.get("run") or "")
+]
+assert steps, "markdown-lint.yml never runs scripts/check_mermaid.ts"
+guarded = [s.get("name") for s in steps if s.get("if")]
+assert not guarded, f"Mermaid steps carry an if: guard: {guarded}"
+PY
+  [ "$status" -eq 0 ]
+
+  # In quality.sh the invocation must sit at top level under `set -e`, not
+  # inside an `if`/`command -v` guard that would let a missing tool pass.
+  run python3 - "$QUALITY" <<'PY'
+import sys
+
+for line in open(sys.argv[1], encoding="utf-8").read().splitlines():
+    if "check_mermaid.ts" in line and not line.lstrip().startswith("#"):
+        assert line == line.lstrip(), f"conditionally nested invocation: {line!r}"
+        break
+else:
+    sys.exit("quality.sh never runs scripts/check_mermaid.ts")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable-workflow callers carry no timeout-minutes and the callee does" {
+  run python3 - "${WORKFLOWS}/ci.yml" "${WORKFLOWS}/security.yml" <<'PY'
+import sys
+
+import yaml
+
+caller = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+callee = yaml.safe_load(open(sys.argv[2], encoding="utf-8"))
+
+callers = {
+    name: job
+    for name, job in (caller.get("jobs") or {}).items()
+    if job.get("uses")
+}
+assert callers, "ci.yml calls no reusable workflow"
+bad = [n for n, j in callers.items() if "timeout-minutes" in j]
+assert not bad, f"GitHub rejects timeout-minutes on caller jobs: {bad}"
+
+for name, job in (callee.get("jobs") or {}).items():
+    budget = job.get("timeout-minutes")
+    assert isinstance(budget, int) and budget > 0, (
+        f"security.yml job {name!r} has no job-level timeout-minutes"
+    )
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "AGENTS.md CI section states the repo-owned, unconditional gate rule" {
+  run ci_secrets_section
+  [ "$status" -eq 0 ]
+  local section="$output"
+
+  printf '%s\n' "$section" | grep -Eqi 'repo-owned and unconditional'
+  printf '%s\n' "$section" | grep -q 'check_mermaid\.ts'
+  printf '%s\n' "$section" | grep -Eqi 'timeout-minutes.*(caller|reusable)'
+  printf '%s\n' "$section" | grep -q 'security\.yml'
+}


### PR DESCRIPTION
# Document the CI blind spots: ungated wasm32, repo-owned unconditional gates (Issue #502)

## Summary

Two CI blind spots were recorded only in the PR-summary archive, so nothing an
agent reads before editing warned about either. Both now sit in `AGENTS.md`'s
*CI / secrets* section. Closes #502.

1. **`wasm32` is gated by nothing on a PR.** Verified against the tree:
   `quality.sh` names no wasm target at all, and no `pull_request` workflow runs
   a `cargo build/check/clippy` against `wasm32-unknown-unknown` (the
   `wasm64-memory64-smoke` job is a Deno Memory64 runtime test). The target
   compiles only *after* merge — `wasm-bundle.yml` on push to `Develop`, and the
   scheduled `upgrade-dependencies.yml`, whose `bump-deps.sh` dual build the PR
   lane skips with `--skip-build`. The new bullet names the load-bearing manual
   check, `cargo check -p neat-core --target wasm32-unknown-unknown`, the
   failure it catches (an orphaned `use core::arch::wasm32::{…}` left behind a
   `#[cfg(target_arch = "wasm32")]` when its last consumer is deleted — Issues
   #422, #423), and the `wasm32-wasip1`/Node-WASI `f32` bit-diff method for
   numeric changes (Issue #448). Cross-referenced from both SIMD sections, since
   that is where the blind spot bites.
2. **CI gates must be repo-owned and unconditional.** The Mermaid step was
   `if:`-gated on a file only another repo owns, so it never ran once and a
   broken diagram merged (Issue #379); its replacement `scripts/check_mermaid.ts`
   is repo-owned and unconditional in both `quality.sh` and `markdown-lint.yml`.
   The same bullet records that GitHub rejects `timeout-minutes:` on a
   reusable-workflow **caller** job — the budget belongs on the called
   workflow's own job (`ci.yml`'s `security` job → `security.yml`, Issue #333).

The four cited summaries are **kept**, not deleted: the issue conditions removal
on "no other unabsorbed content", and each still holds PR-specific record that
`AGENTS.md` does not carry — the breaking-change removal tables in `-422`/`-423`,
the 492-span bit-identical diff evidence in `-448`, and the per-job timeout table
in `-333`.

```mermaid
flowchart LR
    A["edit wasm32-only code"] --> B["quality.sh — host only"]
    A --> C["ci.yml PR jobs — host only"]
    B --> D["green"]
    C --> D
    D --> E["merge"]
    E --> F["wasm-bundle.yml on push to Develop"]
    F --> G["build fails — after merge"]
    A -.->|"AGENTS.md now says to run this first"| H["cargo check --target wasm32-unknown-unknown"]
    H -.-> I["caught before merge"]
```

## Evidence

Documentation change to a Rust/CLI repo — no web interface to screenshot. The
evidence is the new test suite, which is a "what" test in the style of
`docs_pipeline_accuracy.bats`: every doc claim is paired with a premise
assertion read from the pipeline file it describes, so the suite fails both if
the prose drifts and if the pipeline changes underneath the prose.

Pre-fix (doc assertions only, run against `AGENTS.md` at `HEAD~1`) — the premise
assertions already passed, confirming the blind spots are real:

```
not ok 3 AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check
not ok 4 AGENTS.md records the WASI bit-diff method for numeric wasm changes
not ok 5 the SIMD sections cross-reference the wasm32 check
not ok 8 AGENTS.md CI section states the repo-owned, unconditional gate rule
```

Post-fix:

```
1..8
ok 1 no pull_request workflow and no quality.sh step builds for wasm32
ok 2 wasm-bundle.yml builds wasm32 only on push to Develop
ok 3 AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check
ok 4 AGENTS.md records the WASI bit-diff method for numeric wasm changes
ok 5 the SIMD sections cross-reference the wasm32 check
ok 6 the Mermaid gate is repo-owned and runs unconditionally
ok 7 reusable-workflow callers carry no timeout-minutes and the callee does
ok 8 AGENTS.md CI section states the repo-owned, unconditional gate rule
```

`./quality.sh < /dev/null` — green (shellcheck, the full bats suite including
the new file, TypeScript gate, Mermaid gate, deny, fmt, clippy `-D warnings`,
`cargo test --workspace`, doc, release build).

## Test Plan

New — `tests/scripts/docs_ci_blind_spots.bats` (8 tests). Premise assertions
parse the committed YAML/shell; doc assertions read the *CI / secrets* section
extracted by heading, so a matching phrase elsewhere in `AGENTS.md` cannot
satisfy them.

- `no pull_request workflow and no quality.sh step builds for wasm32` — parses
  every workflow, skips those without a `pull_request` trigger, and fails if any
  step compiles for `wasm32-unknown-unknown`; also asserts `quality.sh` never
  names the target. Fails loudly if a wasm PR gate is ever added, since the doc
  claim would then be stale.
- `wasm-bundle.yml builds wasm32 only on push to Develop` — the trigger is
  push-only on `Develop` and the workflow does build the target.
- `AGENTS.md CI section says wasm32 is ungated on PRs and names the manual check`
  — the section states the absence *and* carries the `cargo check` command and
  `wasm-bundle.yml`.
- `AGENTS.md records the WASI bit-diff method for numeric wasm changes` —
  `wasm32-wasip1` and `-C target-feature=+simd128,+relaxed-simd` are present.
- `the SIMD sections cross-reference the wasm32 check` — the command is cited
  from at least one section outside *CI / secrets* whose heading names SIMD or
  wasm.
- `the Mermaid gate is repo-owned and runs unconditionally` —
  `scripts/check_mermaid.ts` exists, no `markdown-lint.yml` step running it
  carries an `if:`, and the `quality.sh` invocation is at top level rather than
  nested inside a guard.
- `reusable-workflow callers carry no timeout-minutes and the callee does` —
  `ci.yml`'s `uses:` jobs declare none, every `security.yml` job declares a
  positive integer budget.
- `AGENTS.md CI section states the repo-owned, unconditional gate rule` — the
  rule, `check_mermaid.ts`, the caller/`timeout-minutes` carve-out and
  `security.yml` all appear in the section.

No existing tests were removed or modified.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msg5agfx-376ec8`<!-- vibe-worker-issue-502 -->