### PR TITLE
perf candidate: raise the fused-MSE record tile from 8 to a tunable R (16/32/64) to amortise the synapse stream (Issue #530)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,10 +277,19 @@ per-record reduction (`(records, target_base, act, output_start, num_outputs) ->
 f64`). Changing the grouping (a 16-lane tier, a different remainder strategy) is
 an edit **there and nowhere else**; do not re-inline the skeleton.
 
-The record-**interleaved** 8-group path (`mse_sum_batch_8way_interleaved`,
-Issue #384) is a genuinely different memory layout and stays separate — its
-`< 8` remainder still runs the same per-lane kernels, so the two are
-bit-identical.
+The record-**interleaved** tiled path (`mse_sum_batch_8way_interleaved` →
+`mse_sum_batch_interleaved::<R>`, Issue #384) is a genuinely different memory
+layout and stays separate. Its tile width is the single constant
+`loss::MSE_TILE_LANES` (Issue #530, `32`); the `< R` remainder steps down whole
+8-record interleaved tiles, then the same 4-way and scalar per-lane kernels, so
+every tier is bit-identical. Two rules make the width a free knob and both are
+load-bearing: `interleaved_tile_mse` is **seed-taking** — it takes the running
+`f64 sum_error` and returns it, because a per-tile partial sum re-associates the
+reduction and breaks bit-parity — and the tile transpose walks **input-major**,
+writing a neuron's `R` lanes to consecutive `mse_inter` slots, because
+lane-major revisits the whole `num_inputs * R` region once per lane and stops
+fitting in L1 as `R` grows. `loss::interleaved_mse_parity` pins both across
+widths 8/16/32/64.
 
 `load_record` (`neat-core/src/batch_scoring.rs`) owns the loading sub-rule:
 copy `min(record.len(), num_inputs)` values and **zero** every input slot the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.12"
+version = "0.8.13"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -171,9 +171,46 @@ flowchart LR
     B --> O[outputs in input order]
 ```
 
+### Fused-MSE record tile (Issue #530)
+
+`mse_sum_batch_packed` — the fused activate + MSE entry point production
+scoring calls — walks records in **record-interleaved tiles** of
+`loss::MSE_TILE_LANES` (`32`), not the 8 the scoring lane uses. The interleaved
+kernel re-streams the network's whole synapse array once per *tile*, so a wider
+tile divides per-record synapse traffic by `MSE_TILE_LANES / 8`; the cost is a
+proportionally larger `mse_inter` scratch buffer,
+`num_neurons * MSE_TILE_LANES * 4` bytes **per compiled network** (~528 KB on
+the production creature at 32 lanes, ~132 KB at 8). Directory scoring holds one
+compiled network per worker, so budget that against the worker-count RAM ceiling
+before raising it.
+
+`MSE_TILE_LANES` is a single constant, must be a non-zero multiple of 8 and at
+most `simd::MAX_INTERLEAVED_LANES` (`64`) — both checked at compile time — and
+every width is **bit-identical**: each lane accumulates its own
+`bias + Σ w·a` in synapse order and every tier reduces in record order.
+The `< MSE_TILE_LANES` remainder steps down the unchanged ladder.
+
+```mermaid
+flowchart LR
+    R["packed records"] --> T{"records left"}
+    T -- "&ge; MSE_TILE_LANES" --> A["R-record interleaved tile<br/>one synapse sweep per R records"]
+    T -- "8..R-1" --> B["8-record interleaved tile"]
+    T -- "4..7" --> C["4-record scattered group"]
+    T -- "&lt; 4" --> D["scalar tail — exact activate"]
+    A --> T
+    B --> T
+    C --> S["running f64 sum_error<br/>in record order"]
+    D --> S
+    A --> S
+    B --> S
+```
+
 ```bash
 # Run the data-parallel scoring throughput bench (1 vs all cores).
 cargo bench -p neat-core --features parallel --bench parallel_scoring
+
+# A/B the fused-MSE tile width (edit MSE_TILE_LANES, rebuild, compare medians).
+cargo bench -p neat-core --bench hot_paths -- mse_sum_production
 ```
 
 ## Related Repositories

--- a/docs/archive/pr-summaries/pr-summary-530.md
+++ b/docs/archive/pr-summaries/pr-summary-530.md
@@ -1,0 +1,203 @@
+# Widen the fused-MSE record tile to a tunable `MSE_TILE_LANES` (Issue #530)
+
+## Summary
+
+The fused MSE forward pass (`mse_sum_batch_packed` → `mse_sum_batch_8way` →
+the #287 record-interleaved gather) processed records in groups of **8**, so the
+network's entire synapse array was re-streamed once per eight records. On the
+production creature that array is ~172 KB (21,513 × 8 B `SynapseData`) and the
+8-lane `mse_inter` is ~132 KB — together well past an Apple M4 performance
+core's 128 KB L1D, so every group re-fetched the synapses from L2.
+
+This makes the tile width a single constant, `loss::MSE_TILE_LANES` (**32**),
+gathered by const-generic kernels — `R / 8` `__m256` accumulators on AVX2,
+`R / 4` `float32x4` on NEON, contiguous `f32x4` quads on wasm `simd128`, scalar
+elsewhere. Per-record synapse traffic falls by `R / 8`.
+
+Two supporting changes turned out to be load-bearing, and both are pinned by
+tests:
+
+- **The tile transpose walks input-major.** A neuron's `R` lanes go to
+  consecutive `mse_inter` slots, so the scratch buffer is filled by one linear
+  sweep. The original lane-major order revisits the whole `num_inputs * R`
+  region once per lane, which stops fitting in L1 as `R` grows and would have
+  eaten most of the gain.
+- **`interleaved_tile_mse` is seed-taking** — it takes the running `f64`
+  `sum_error` and returns it, like the SIMD tail helpers in
+  `simd::scalar` (Issue #447). Returning a per-tile partial sum re-associates
+  the reduction; that was caught during development as a 12-ULP parity failure
+  at n = 4096, which is exactly what the oracle is for.
+
+Numerics are unchanged at **every** tile width: each lane accumulates its own
+`bias + Σ w·a` in synapse order independently of the other lanes, and every tier
+reduces into `sum_error` in strict record order. The `< R` remainder steps down
+whole 8-record interleaved tiles, then the unchanged 4-way and scalar tiers.
+
+The batched **scoring** lane (`score_records_flat` → `BatchScratch::inter`)
+is deliberately untouched and stays at 8 lanes — this issue scopes the fused MSE
+loss path only.
+
+Closes #530.
+
+## Evidence
+
+### Benchmark — this is a performance change
+
+`cargo bench --bench hot_paths -- mse_sum_production/production_exact`
+(4,096 records per iteration, the exact committed production topology: 2,461
+inputs, 1,666 non-input neurons, 21,513 synapses).
+
+**Method.** 5 interleaved A/B rounds; each round rebuilds and runs every arm
+back to back so thermal drift hits all arms alike. `base` is the pre-change code
+run from a separate `git worktree` at the parent commit; the `R = 8/16/32/64`
+arms are this branch with only `MSE_TILE_LANES` changed — one constant apart, as
+the issue asks. Apple M4 (10 cores), rustc 1.97.1, `--release`, quiet host.
+**Medians:**
+
+| arm | n | median | min | max | vs `base` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `base` (pre-#530, 8-record groups) | 6 | 21.343 ms | 19.877 | 21.819 | — |
+| `MSE_TILE_LANES = 8` | 6 | 17.994 ms | 16.978 | 19.127 | **−15.7%** |
+| `MSE_TILE_LANES = 16` | 6 | 14.468 ms | 13.659 | 15.281 | **−32.2%** |
+| **`MSE_TILE_LANES = 32` (shipped)** | 5 | **11.558 ms** | 10.252 | 12.152 | **−45.8%** |
+| `MSE_TILE_LANES = 64` | 5 | 12.728 ms | 12.130 | 13.496 | −40.4% |
+
+**The arms do not overlap at all** — `R = 32`'s worst round (12.152 ms) beats
+`base`'s best (19.877 ms) and `R = 8`'s best (16.978 ms) — so the ordering does
+not rest on the medians alone. Against the same-code `R = 8` arm, `R = 32` is
+**−35.8%**.
+
+The issue's bar was a reproducible **≥1–2%** median gain with the change staying
+minor; the measured **−45.8%** clears it by more than an order of magnitude.
+
+**Where the curve turns.** `R = 64` gives back ~10% against `R = 32`:
+`mse_inter` reaches ~1 MB on this creature and the NEON kernel needs 16 live
+accumulators, so capacity and register pressure both bite. 32 is the shipped
+default. The `R = 8` row also shows the input-major transpose is worth ~15% on
+its own, before any tile widening.
+
+> **Scope caveat.** The issue's acceptance gate names the *production* fixture
+> in NEAT-AI-scorer — N ≈ 50 distinct creature variants over the ≈22 GiB
+> multi-file corpus in directory mode. Neither the 3 MB production
+> `network.json` nor the corpus is available in this repo (`BASELINE.md`,
+> "Bench-only baseline"), so that end-to-end A/B cannot run here. What is
+> measured above is the exact kernel the issue targets, on the committed
+> `production_exact` topology at production record volume, which is the
+> closest reproducible proxy this repo has. The scorer-side confirmation on the
+> full corpus remains the human-run gate before the wall-clock claim is made
+> there.
+
+### Memory
+
+`mse_inter` is `num_neurons * MSE_TILE_LANES * 4` bytes **per compiled
+network** — ~132 KB at 8 lanes, **~528 KB at 32**, ~1 MB at 64 on the
+~4,127-neuron production creature. Directory scoring holds one compiled network
+per worker, so at N = 50 workers the shipped width costs ~26 MB of scratch.
+That figure is documented in `README.md`, on the constant itself, and in
+`BASELINE.md` so it can be budgeted against the scorer's worker-count RAM
+ceiling before anyone raises the constant.
+
+### Mutation evidence — the tests can fail
+
+Per AGENTS.md rule 2, each mutation was applied alone and reverted afterwards.
+`cargo test -p neat-core --lib interleaved_mse_parity` (4 tests):
+
+| # | mutation | result |
+| --- | --- | --- |
+| M1 | `interleaved_tile_mse` returns a per-tile partial sum instead of taking the running seed | **3 of 4 red** |
+| M2 | tile transpose drops the lane offset (`base_idx + l` → `base_idx`) | **3 of 4 red** |
+| M3 | `< R` remainder skips the whole 8-record interleaved tier | **2 of 4 red** |
+| M4 | NEON kernel accumulates `R / 8` quads instead of `R / 4` (upper lanes never FMA'd) | **3 of 4 red** |
+| M5 | forward pass strides output lanes by `SCORING_LANES` instead of `R` | **2 of 4 red** |
+| — | all mutations reverted | **4 of 4 green** |
+
+M3 and M5 kill only the wide-tile tests, which is correct: both mutations are
+no-ops when `R == SCORING_LANES`, and that is precisely the blind spot the new
+`every_tile_width_is_bit_identical_to_scattered` test exists to cover. M1 is not
+hypothetical — it is the bug this suite actually caught during development.
+
+The oracle is independent per AGENTS.md rule 1: `mse_sum_batch_scattered`
+reaches the same value through the per-lane scattered kernels driven by the
+shared 8 → 4 → 1 skeleton, sharing no code with the interleaved tile path, so a
+fault in the tiled kernel moves only one side of the assertion. Because the
+paths are genuinely bit-identical the assertion is `f64::to_bits` equality, not
+a tolerance.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    R["packed records"] --> T{"records left"}
+    T -- "&ge; MSE_TILE_LANES" --> A["R-record interleaved tile<br/>one synapse sweep per R records"]
+    T -- "8..R-1" --> B["8-record interleaved tile"]
+    T -- "4..7" --> C["4-record scattered group"]
+    T -- "&lt; 4" --> D["scalar tail — exact activate"]
+    A --> T
+    B --> T
+    A --> S["running f64 sum_error<br/>seeded through every tier,<br/>in record order"]
+    B --> S
+    C --> S
+    D --> S
+```
+
+### No UI
+
+This is a backend SIMD/loss-kernel change with no web interface, so there is no
+screenshot. It was verified by the test suite, the mutation sweep above, the
+benchmark A/B, `./quality.sh` (green), and
+`cargo check -p neat-core --target wasm32-unknown-unknown` — the manual gate
+AGENTS.md requires, since no PR job compiles the `wasm32` half of this hot path
+and this change edits it.
+
+## Test Plan
+
+Added to `loss::interleaved_mse_parity` (`neat-core/src/loss.rs`):
+
+- `every_tile_width_is_bit_identical_to_scattered` — **new.** Asserts tiles of
+  16, 32 and 64 are `f64::to_bits`-identical to the independent scattered oracle
+  across 15 record counts and 7 squash types. This is the guard that makes
+  `MSE_TILE_LANES` a free knob.
+- `shipped_tile_width_is_a_supported_multiple_of_eight` — **new.** States the
+  contract on the shipped constant (multiple of 8, within
+  `simd::MAX_INTERLEAVED_LANES`) and runs the same bit-identity sweep at
+  whatever width is actually shipped, so flipping the constant cannot ship an
+  unproven width.
+- `interleaved_mse_bit_identical_to_scattered_across_boundaries` — **extended,
+  not weakened.** Now parameterised over the tile width and run at 8 lanes, with
+  the record-count set grown from 9 to 15 values (adding 31, 32, 33, 40, 64, 71)
+  to straddle the wide-tile boundaries the new ladder introduces.
+
+No existing test was removed, commented out, or loosened. The whole workspace
+suite (`cargo test --workspace`) and `./quality.sh` pass.
+
+Unchanged tests that keep the surrounding contracts honest:
+`tests/mse_batch_interleaved_parity.rs` (public entry point vs the scalar
+single-record reference), `tests/simd_weighted_sums.rs`
+(`weighted_sum_interleaved_8` vs the scattered 8-record kernel — the 8-lane
+alias is retained precisely so this public-API guard still applies), and
+`loss::interleaved_mse_parity::aggregate_dispatch_stays_on_scattered_path`
+(aggregate-squash networks never reach the tiled gather).
+
+## Documentation
+
+- `README.md` — new "Fused-MSE record tile" section: the constant, its bounds,
+  the per-network memory cost, the bit-identity guarantee, and a Mermaid diagram
+  of the tier ladder.
+- `neat-core/benches/BASELINE.md` — full methodology and the A/B table above.
+- `AGENTS.md` — the Issue #445 "one batched record-scan skeleton" section now
+  records the tunable tile and the two load-bearing invariants (seed-taking
+  reduction, input-major transpose), so a future edit does not silently
+  reintroduce M1 or the lane-major transpose.
+
+## Security self-check
+
+- No new external input surface: `MSE_TILE_LANES` is a compile-time constant,
+  and its bounds (non-zero multiple of 8, `≤ MAX_INTERLEAVED_LANES`) are
+  enforced by a `const` assertion that fails the **build**, not at runtime.
+- The widened `get_unchecked` / `_mm256_loadu_ps` / `vld1q_f32` reads rest on
+  the same load-time invariant as before — `CompiledNetwork::new` rejects any
+  `from_index >= num_neurons`, so `from_index * R + R <= inter.len()` holds for
+  every supported `R`. Each `unsafe` block carries a `// SAFETY:` note naming
+  the `is_*_feature_detected!` guard, per the AGENTS.md SIMD rules.
+- No secrets, no new dependencies, no new shell/SQL/HTTP call sites, no
+  user-facing error strings changed.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -263,6 +263,73 @@ the vectorised path, so they gain at least as much.
 > comparable within this section's own old/new pair, which is what the
 > gain claim rests on.
 
+## Fused-MSE record tile widened from 8 to a tunable `R` (Issue #530)
+
+Issue #384 routed the fused MSE lane through the #287 interleaved gather but
+kept the record group at **8**, so the network's whole synapse array was re-streamed once
+per eight records. On `production_exact` that array is ~172 KB (21,513 × 8 B
+`SynapseData`) and the 8-lane `mse_inter` is ~132 KB — together well past an
+M4 performance core's 128 KB L1D, so every group re-fetched the synapses from
+L2. #530 makes the tile a single constant, `loss::MSE_TILE_LANES`, gathered by
+const-generic kernels (`weighted_sum_interleaved::<R>`: `R / 8` `__m256`
+accumulators on AVX2, `R / 4` `float32x4` on NEON, contiguous `f32x4` quads on
+wasm `simd128`). Per-record synapse traffic falls by `R / 8`.
+
+Two changes are load-bearing beyond the width itself, and both are pinned by
+`loss::interleaved_mse_parity`:
+
+- The tile transpose walks **input-major** — a neuron's `R` lanes go to
+  consecutive `mse_inter` slots — so the scratch buffer is filled by one linear
+  sweep. The original lane-major order revisits the whole `num_inputs * R`
+  region once per lane, which stops fitting in L1 as `R` grows and would have
+  eaten the gain. This alone is most of the `R = 8` column below.
+- `interleaved_tile_mse` is **seed-taking**: it takes the running `f64`
+  `sum_error` and returns it. Returning a per-tile partial sum re-associates the
+  reduction — caught in development as a 12-ULP parity failure at n = 4096.
+
+**Measured 2026-08-06**, Apple M4 (10 cores, this host), rustc 1.97.1,
+`--release`, `hot_paths -- mse_sum_production/production_exact` (4,096 records
+per iteration). **5 interleaved A/B rounds**, each round rebuilding and running
+every arm back to back so thermal drift hits all arms alike; `base` is the
+pre-#530 code run from a separate `git worktree` at the parent commit.
+**Medians** (`n` rounds per arm):
+
+| arm | n | median | min | max | vs `base` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `base` (pre-#530, 8-record groups) | 6 | 21.343 ms | 19.877 | 21.819 | — |
+| `MSE_TILE_LANES = 8` | 6 | 17.994 ms | 16.978 | 19.127 | **−15.7%** |
+| `MSE_TILE_LANES = 16` | 6 | 14.468 ms | 13.659 | 15.281 | **−32.2%** |
+| **`MSE_TILE_LANES = 32` (shipped)** | 5 | **11.558 ms** | 10.252 | 12.152 | **−45.8%** |
+| `MSE_TILE_LANES = 64` | 5 | 12.728 ms | 12.130 | 13.496 | −40.4% |
+
+The arms do not overlap at all — `R = 32`'s worst round (12.152 ms) beats
+`base`'s best (19.877 ms) and `R = 8`'s best (16.978 ms) — so the ordering does
+not rest on the medians alone. Against the same-code `R = 8` arm (the A/B the
+issue asks for, one constant apart) `R = 32` is **−35.8%**.
+
+**The curve turns between 32 and 64.** At `R = 64` `mse_inter` reaches ~1 MB on
+this creature and the NEON kernel needs 16 live accumulators; both the extra
+capacity pressure and the register pressure show up as a partial give-back. 32
+is the shipped default.
+
+**Memory.** `mse_inter` is `num_neurons * MSE_TILE_LANES * 4` bytes per compiled
+network — ~132 KB at 8 lanes, **~528 KB at 32**, ~1 MB at 64 on the ~4,127-neuron
+production creature. Directory scoring holds one compiled network per worker, so
+at N = 50 workers that is ~26 MB of scratch at the shipped width. Budget it
+against the scorer's worker-count RAM ceiling before raising the constant.
+
+**Numerics.** Bit-identical at every width: each lane accumulates its own
+`bias + Σ w·a` in synapse order, independently of the other lanes, and every
+tier reduces into `sum_error` in strict record order. Asserted against the
+independent scattered oracle for widths 8/16/32/64 across 15 record counts
+straddling every tier boundary
+(`loss::interleaved_mse_parity::every_tile_width_is_bit_identical_to_scattered`).
+
+> Per the squash-homogeneity caveat above these all-`Tanh` figures isolate the
+> memory-traffic effect; this change is layout-only, so unlike a
+> squash-vectorisation lever it is neither a lower nor an upper bound on
+> varied-squash creatures.
+
 ## Flat-slice record **input** for batched scoring (Issue #386)
 
 Issue #229 flattened the scoring *output* to one contiguous buffer, but the

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -43,12 +43,12 @@
 use crate::network::{CompiledNetwork, NeuronData, SynapseData};
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
 use crate::simd::{
-    weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
+    weighted_sum_interleaved, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
     weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
     weighted_sum_simd_8records,
 };
 use crate::squash::{SquashType, apply_squash};
-use crate::squash_simd::{squash_x4, squash_x8};
+use crate::squash_simd::{squash_x4, squash_x8, squash_xn};
 use crate::synapse_type::SynapseType;
 
 /// Number of records processed per SIMD batch (one lane each).
@@ -141,21 +141,30 @@ impl BatchScratch {
 
 /// Free-function form of [`CompiledNetwork::interleaved_forward_8`] so the fused
 /// MSE path can borrow `mse_inter` mutably alongside immutable neuron/synapse
-/// slices (NEAT-AI-scorer#531 scratch reuse).
-pub(crate) fn run_interleaved_forward_8(
+/// slices (NEAT-AI-scorer#531 scratch reuse), generic over the record tile width
+/// `R` (Issue #530).
+///
+/// `inter` must hold exactly `num_neurons * R` values — lane `l` of neuron `n`
+/// at `inter[n * R + l]` — with the `num_inputs * R` input lanes already
+/// transposed in. `R` must be a non-zero multiple of 8 and at most
+/// [`crate::simd::MAX_INTERLEAVED_LANES`], enforced at compile time by the
+/// gather kernel.
+///
+/// Each lane is an independent `bias + Σ w·a` in synapse order and is squashed
+/// and clamped by the same per-lane rule, so a record's activation is
+/// **bit-identical** at every tile width.
+pub(crate) fn run_interleaved_forward<const R: usize>(
     neurons: &[NeuronData],
     synapses: &[SynapseData],
     num_inputs: usize,
     inter: &mut [f32],
 ) {
-    const L: usize = SCORING_LANES;
-
     for (neuron_idx, neuron) in neurons.iter().enumerate() {
-        let out_base = (num_inputs + neuron_idx) * L;
+        let out_base = (num_inputs + neuron_idx) * R;
 
         if neuron.is_constant {
             let v = apply_limit_range(SquashType::Identity, neuron.bias);
-            for slot in inter[out_base..out_base + L].iter_mut() {
+            for slot in inter[out_base..out_base + R].iter_mut() {
                 *slot = v;
             }
             continue;
@@ -164,16 +173,16 @@ pub(crate) fn run_interleaved_forward_8(
         let squash = SquashType::from(neuron.squash_type);
         let start = neuron.start_synapse as usize;
         let end = start + neuron.num_synapses as usize;
-        let sums = weighted_sum_interleaved_8(synapses, inter, start, end, neuron.bias);
+        let sums = weighted_sum_interleaved::<R>(synapses, inter, start, end, neuron.bias);
 
-        let squashed = squash_x8(squash, sums).unwrap_or_else(|| {
+        let squashed = squash_xn(squash, sums).unwrap_or_else(|| {
             let st = neuron.squash_type;
             sums.map(|s| inline_squash(st, squash, s))
         });
 
         let (low, high) = apply_get_range(squash);
-        for l in 0..L {
-            inter[out_base + l] = apply_limit_range_bounds(low, high, squashed[l]);
+        for (slot, value) in inter[out_base..out_base + R].iter_mut().zip(squashed) {
+            *slot = apply_limit_range_bounds(low, high, value);
         }
     }
 }
@@ -459,15 +468,20 @@ impl CompiledNetwork {
     /// `inter[i * 8 + l]` for every input neuron `i` and lane `l`. This fills
     /// each non-input neuron's eight output lanes at
     /// `inter[(num_inputs + neuron_idx) * 8 + l]`, gathering through
-    /// [`weighted_sum_interleaved_8`] so each synapse reads one cache line.
+    /// [`weighted_sum_interleaved`] so each synapse reads one cache line.
     ///
     /// Only valid when [`Self::has_aggregate_squash`] is false — every
     /// non-constant neuron is treated as standard-squash (vectorised
-    /// `squash_x8` with the scalar inline fallback), so aggregate networks must
+    /// `squash_xn` with the scalar inline fallback), so aggregate networks must
     /// use the exact per-lane path instead. Bit-identical to the per-lane
     /// 8-record path ([`weighted_sum_simd_8records`]) on the covered neurons.
     pub(crate) fn interleaved_forward_8(&self, inter: &mut [f32]) {
-        run_interleaved_forward_8(&self.neurons, &self.synapses, self.num_inputs, inter);
+        run_interleaved_forward::<SCORING_LANES>(
+            &self.neurons,
+            &self.synapses,
+            self.num_inputs,
+            inter,
+        );
     }
 
     /// Per-lane fallback scoring path — the original eight-buffer layout, kept

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -27,6 +27,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::loss::MSE_TILE_LANES;
 use crate::network::{CompiledNetwork, MAX_NODE_COUNT, NeuronData, SynapseData};
 use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
@@ -432,6 +433,6 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, Cr
             Vec::with_capacity(estimated_trace_size),
         ],
         // NEAT-AI-scorer#531 — fused MSE interleaved scratch (reused).
-        mse_inter: vec![0.0; num_neurons * 8],
+        mse_inter: vec![0.0; num_neurons * MSE_TILE_LANES],
     })
 }

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -7,7 +7,7 @@
 //! Issue #118x, #1202, #1209 - Batch scoring optimisations.
 
 use crate::batch_scoring::{
-    SCORING_LANES, inline_squash, load_record, neuron_activation_scalar, run_interleaved_forward_8,
+    SCORING_LANES, inline_squash, load_record, neuron_activation_scalar, run_interleaved_forward,
 };
 use crate::network::CompiledNetwork;
 use crate::range::{apply_get_range, apply_limit_range, apply_limit_range_bounds};
@@ -482,14 +482,39 @@ fn mse_sum_batch_8way(
     )
 }
 
+/// Record tile width for the fused-MSE record-interleaved forward pass
+/// (Issue #530).
+///
+/// The interleaved kernel re-streams the network's entire synapse array once per
+/// tile, so per-record synapse traffic is `synapse_bytes / MSE_TILE_LANES`.
+/// Widening the tile from the original 8 divides that traffic by
+/// `MSE_TILE_LANES / 8`, at the cost of a proportionally larger `mse_inter`
+/// scratch buffer: `num_neurons * MSE_TILE_LANES * 4` bytes **per network**,
+/// and directory scoring holds one compiled network per worker. On the
+/// production creature (~4,127 neurons) that is ~132 KB at 8 lanes and ~528 KB
+/// at 32 — budget it against the scorer's worker-count RAM ceiling before
+/// raising it further.
+///
+/// Must be a non-zero multiple of 8 and at most
+/// [`crate::simd::MAX_INTERLEAVED_LANES`]; both are checked at compile time by
+/// the gather kernel. Every tile width produces **bit-identical** results (see
+/// `interleaved_mse_parity`), so this constant is a pure
+/// memory-traffic/footprint trade-off.
+pub const MSE_TILE_LANES: usize = 32;
+
 /// Record-interleaved fused activate + MSE for standard-squash networks
-/// (Issue #384). Full 8-record groups run the shared interleaved forward pass
-/// ([`run_interleaved_forward_8`]) — the #287 gather that reads each synapse's
-/// eight lanes from one cache line — then the MSE reduction reads the eight
-/// contiguous output lanes. The `< 8` remainder (4-record group then scalar
-/// tail) is kept on the exact same per-lane kernels as the scattered path, so
-/// the whole result is bit-identical to the pre-#384 8-way path (the
-/// interleaved gather is proven bit-identical to `weighted_sum_simd_8records`).
+/// (Issue #384; tunable tile width in Issue #530). Full `R`-record tiles run the
+/// shared interleaved forward pass ([`run_interleaved_forward`]) — the #287
+/// gather that reads each synapse's lanes from contiguous memory — then the MSE
+/// reduction reads each lane's contiguous output slot. The `< R` remainder
+/// steps down the existing ladder: whole 8-record interleaved tiles, then one
+/// 4-record group, then the scalar tail, all on the exact same per-lane kernels
+/// as the scattered path.
+///
+/// Records are reduced into `sum_error` in strict record order at every tier, and
+/// each lane's weighted sum is an independent `bias + Σ w·a` in synapse order, so
+/// the result is bit-identical to the pre-#384 8-way path **and** to any other
+/// tile width.
 ///
 /// Only called when the network has no aggregate-squash neuron; the caller
 /// (`mse_sum_batch_8way`) routes aggregate networks to the scattered path.
@@ -504,7 +529,81 @@ fn mse_sum_batch_8way_interleaved(
     num_outputs: usize,
     num_records: usize,
 ) -> f64 {
-    const L: usize = SCORING_LANES;
+    mse_sum_batch_interleaved::<MSE_TILE_LANES>(
+        network,
+        records,
+        values_per_record,
+        input_size,
+        num_outputs,
+        num_records,
+    )
+}
+
+/// Transpose `R` records' inputs into the interleaved buffer and reduce their
+/// squared error after the forward pass — the body shared by every tile tier.
+///
+/// Walks **input-major**: for each input neuron the `R` lanes are written to
+/// consecutive `inter` slots, so the scratch buffer is filled by a single linear
+/// sweep whatever `R` is. (Lane-major would revisit the whole `num_inputs * R`
+/// region once per lane, which stops fitting in L1 as the tile widens.)
+///
+/// Takes the caller's **running** `sum_error` and returns it with this tile's
+/// per-record MSE added in record order — a seed-taking helper, like the SIMD
+/// tail helpers in [`crate::simd::scalar`]. Returning a per-tile partial sum
+/// instead would re-associate the `f64` reduction and break bit-parity with the
+/// scattered path.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn interleaved_tile_mse<const R: usize>(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    values_per_record: usize,
+    input_size: usize,
+    num_outputs: usize,
+    base_idx: usize,
+    inv_outputs: f64,
+    mut sum_error: f64,
+) -> f64 {
+    let num_neurons = network.num_neurons;
+    let num_inputs = network.num_inputs;
+    let output_start = num_neurons - num_outputs;
+    let input_lanes = input_size.min(num_inputs);
+    let inter = &mut network.mse_inter[..num_neurons * R];
+
+    for i in 0..input_lanes {
+        let row = &mut inter[i * R..i * R + R];
+        for (l, slot) in row.iter_mut().enumerate() {
+            *slot = records[(base_idx + l) * values_per_record + i];
+        }
+    }
+    // Zero every input slot the records do not cover (stateless scoring).
+    for slot in inter[input_lanes * R..num_inputs * R].iter_mut() {
+        *slot = 0.0;
+    }
+
+    run_interleaved_forward::<R>(&network.neurons, &network.synapses, num_inputs, inter);
+
+    for l in 0..R {
+        let target_base = (base_idx + l) * values_per_record + input_size;
+        let mut sq_sum: f64 = 0.0;
+        for j in 0..num_outputs {
+            let out_val = inter[(output_start + j) * R + l];
+            let diff = (records[target_base + j] - out_val) as f64;
+            sq_sum += diff * diff;
+        }
+        sum_error += sq_sum * inv_outputs;
+    }
+    sum_error
+}
+
+fn mse_sum_batch_interleaved<const R: usize>(
+    network: &mut CompiledNetwork,
+    records: &[f32],
+    values_per_record: usize,
+    input_size: usize,
+    num_outputs: usize,
+    num_records: usize,
+) -> f64 {
     let inv_outputs: f64 = if num_outputs > 0 {
         1.0 / (num_outputs as f64)
     } else {
@@ -514,7 +613,9 @@ fn mse_sum_batch_8way_interleaved(
     let num_neurons = network.num_neurons;
     let num_inputs = network.num_inputs;
     let output_start = num_neurons - num_outputs;
-    let needed = num_neurons * L;
+    // Sized for the widest tier used below, so the `< R` 8-lane remainder tiles
+    // can take a prefix of the same buffer.
+    let needed = num_neurons * R.max(SCORING_LANES);
     if network.mse_inter.len() != needed {
         network.mse_inter.resize(needed, 0.0);
     }
@@ -526,45 +627,41 @@ fn mse_sum_batch_8way_interleaved(
 
     let mut sum_error: f64 = 0.0;
 
-    // ---- full 8-record groups through the interleaved gather ----------------
-    let full_batches = num_records / L;
-    let input_lanes = input_size.min(num_inputs);
-    for batch in 0..full_batches {
-        let base_idx = batch * L;
-        let inter = &mut network.mse_inter;
+    // ---- full `R`-record tiles through the interleaved gather ---------------
+    let full_tiles = num_records / R;
+    for tile in 0..full_tiles {
+        sum_error = interleaved_tile_mse::<R>(
+            network,
+            records,
+            values_per_record,
+            input_size,
+            num_outputs,
+            tile * R,
+            inv_outputs,
+            sum_error,
+        );
+    }
 
-        // Transpose the eight records' inputs into the interleaved buffer;
-        // zero any input slot the record does not cover (stateless scoring).
-        for l in 0..L {
-            let base = (base_idx + l) * values_per_record;
-            for i in 0..input_lanes {
-                inter[i * L + l] = records[base + i];
-            }
-            for i in input_lanes..num_inputs {
-                inter[i * L + l] = 0.0;
-            }
-        }
-
-        run_interleaved_forward_8(&network.neurons, &network.synapses, num_inputs, inter);
-
-        // MSE reduction reads each lane's contiguous output lanes.
-        for l in 0..L {
-            let target_base = (base_idx + l) * values_per_record + input_size;
-            let mut sq_sum: f64 = 0.0;
-            for j in 0..num_outputs {
-                let out_val = inter[(output_start + j) * L + l];
-                let diff = (records[target_base + j] - out_val) as f64;
-                sq_sum += diff * diff;
-            }
-            sum_error += sq_sum * inv_outputs;
-        }
+    // ---- `< R` remainder: whole 8-record interleaved tiles ------------------
+    let mut remainder_start = full_tiles * R;
+    while num_records - remainder_start >= SCORING_LANES {
+        sum_error = interleaved_tile_mse::<SCORING_LANES>(
+            network,
+            records,
+            values_per_record,
+            input_size,
+            num_outputs,
+            remainder_start,
+            inv_outputs,
+            sum_error,
+        );
+        remainder_start += SCORING_LANES;
     }
 
     // ---- `< 8` remainder: 4-record group then scalar tail -------------------
     // Kept on the exact per-lane kernels of the scattered path so the numerics
     // match bit-for-bit. This branch never sees an aggregate neuron.
     // Reuses `batch_activations` (Issue #155 / NEAT-AI-scorer#531).
-    let remainder_start = full_batches * L;
     let remaining = num_records - remainder_start;
 
     if remaining >= 4 {
@@ -1721,7 +1818,12 @@ mod interleaved_mse_parity {
         records
     }
 
-    fn assert_bit_identical(squash: SquashType, num_records: usize) {
+    /// Assert the tile-`R` interleaved kernel is bit-identical to the scattered
+    /// oracle. The oracle reaches the same value by a genuinely independent
+    /// route — the per-lane scattered kernels driven by the shared 8 → 4 → 1
+    /// skeleton — so a lane-transpose slip, a wrong remainder split, or a
+    /// changed `f64` reduction order in the tiled path moves only one side.
+    fn assert_bit_identical<const R: usize>(squash: SquashType, num_records: usize) {
         let input_size = 6;
         let mut net = build_network(input_size, squash);
         assert!(
@@ -1731,7 +1833,7 @@ mod interleaved_mse_parity {
         let records = build_records(num_records, input_size);
         let values_per_record = input_size + 1;
 
-        let interleaved = mse_sum_batch_8way_interleaved(
+        let interleaved = mse_sum_batch_interleaved::<R>(
             &mut net,
             &records,
             values_per_record,
@@ -1750,26 +1852,68 @@ mod interleaved_mse_parity {
         assert_eq!(
             interleaved.to_bits(),
             scattered.to_bits(),
-            "{squash:?} n={num_records}: interleaved MSE {interleaved} not bit-identical to scattered {scattered}"
+            "{squash:?} R={R} n={num_records}: interleaved MSE {interleaved} not bit-identical to scattered {scattered}"
         );
     }
 
+    /// Record counts straddling every tier boundary of the 8-lane ladder:
+    /// 8 = one full group; 9 = group + scalar tail; 12 = group + 4-way
+    /// remainder; 13/15 = group + 4-way + scalar tail; 16 = two full groups;
+    /// 4096 = the production steady state (all full groups). At the wider tiles
+    /// these also cover "no full tile at all" (n < R) and "full tile + 8-record
+    /// remainder tiles", which is the ladder Issue #530 adds.
+    const BOUNDARY_COUNTS: [usize; 15] =
+        [8, 9, 12, 13, 15, 16, 17, 24, 31, 32, 33, 40, 64, 71, 4096];
+
+    const PARITY_SQUASHES: [SquashType; 7] = [
+        SquashType::Tanh,
+        SquashType::Logistic,
+        SquashType::Gelu,
+        SquashType::Mish,
+        SquashType::Relu,
+        SquashType::Identity,
+        SquashType::Sine,
+    ];
+
     #[test]
     fn interleaved_mse_bit_identical_to_scattered_across_boundaries() {
-        // 8 = one full group; 9 = group + scalar tail; 12 = group + 4-way
-        // remainder; 13/15 = group + 4-way + scalar tail; 16 = two full groups;
-        // 4096 = the production steady state (all full groups).
-        for squash in [
-            SquashType::Tanh,
-            SquashType::Logistic,
-            SquashType::Gelu,
-            SquashType::Mish,
-            SquashType::Relu,
-            SquashType::Identity,
-            SquashType::Sine,
-        ] {
-            for &n in &[8usize, 9, 12, 13, 15, 16, 17, 24, 4096] {
-                assert_bit_identical(squash, n);
+        for squash in PARITY_SQUASHES {
+            for &n in &BOUNDARY_COUNTS {
+                assert_bit_identical::<{ SCORING_LANES }>(squash, n);
+            }
+        }
+    }
+
+    /// Issue #530 — widening the record tile must not move a single bit. Each
+    /// lane accumulates its own `bias + Σ w·a` in synapse order and every tier
+    /// reduces in record order, so tiles of 16/32/64 must agree with the
+    /// scattered oracle exactly as the 8-lane tile does. This is the guard that
+    /// makes `MSE_TILE_LANES` a free memory-traffic knob.
+    #[test]
+    fn every_tile_width_is_bit_identical_to_scattered() {
+        for squash in PARITY_SQUASHES {
+            for &n in &BOUNDARY_COUNTS {
+                assert_bit_identical::<16>(squash, n);
+                assert_bit_identical::<32>(squash, n);
+                assert_bit_identical::<64>(squash, n);
+            }
+        }
+    }
+
+    /// The shipped tile width must itself be one of the widths proven above and
+    /// stay inside the kernel's compile-time bounds — a stray value would fail
+    /// the build, but this states the contract where a reader looks for it.
+    #[test]
+    fn shipped_tile_width_is_a_supported_multiple_of_eight() {
+        assert!(
+            MSE_TILE_LANES.is_multiple_of(SCORING_LANES)
+                && MSE_TILE_LANES >= SCORING_LANES
+                && MSE_TILE_LANES <= crate::simd::MAX_INTERLEAVED_LANES,
+            "MSE_TILE_LANES = {MSE_TILE_LANES} is not a supported tile width"
+        );
+        for squash in PARITY_SQUASHES {
+            for &n in &BOUNDARY_COUNTS {
+                assert_bit_identical::<MSE_TILE_LANES>(squash, n);
             }
         }
     }

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -8,7 +8,8 @@
 //! NEAT-AI consumes. Public fields are skipped from the bindgen surface (they
 //! remain accessible to native Rust callers); the JS API is the public methods.
 
-use crate::batch_scoring::{SCORING_LANES, inline_squash, load_record};
+use crate::batch_scoring::{inline_squash, load_record};
+use crate::loss::MSE_TILE_LANES;
 use crate::range::apply_limit_range;
 use crate::simd::{
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
@@ -203,8 +204,9 @@ pub struct CompiledNetwork {
     /// `trace_data_buffer`.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub batch_traces: [Vec<f32>; 4],
-    /// Record-interleaved scratch for the fused 8-way MSE path
-    /// (`inter[n * 8 + l]`). Sized `num_neurons * 8` and reused across
+    /// Record-interleaved scratch for the fused MSE path
+    /// (`inter[n * MSE_TILE_LANES + l]`). Sized
+    /// `num_neurons * `[`crate::loss::MSE_TILE_LANES`] and reused across
     /// `mse_sum_batch_packed` calls instead of allocating per chunk
     /// (NEAT-AI-scorer#531). The 4-way remainder of that path reuses
     /// [`Self::batch_activations`].
@@ -372,7 +374,7 @@ impl CompiledNetwork {
                 Vec::with_capacity(estimated_trace_size),
             ],
             // NEAT-AI-scorer#531 — fused MSE interleaved scratch (reused).
-            mse_inter: vec![0.0; num_neurons * SCORING_LANES],
+            mse_inter: vec![0.0; num_neurons * MSE_TILE_LANES],
         })
     }
 

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -490,16 +490,88 @@ pub fn weighted_sum_simd_8records(
     )
 }
 
-/// Issue #287 - record-interleaved 8-lane weighted sum for the batched scoring
-/// hot path.
+/// Widest record-interleaved tile the generic gather kernel supports
+/// (Issue #530). Mirrors `simd_native::MAX_INTERLEAVED_LANES`.
+#[cfg(target_arch = "wasm32")]
+pub const MAX_INTERLEAVED_LANES: usize = 64;
+
+/// Compile-time guard on a record-interleaved tile width (Issue #530): `R` must
+/// be a non-zero multiple of 8 and no wider than [`MAX_INTERLEAVED_LANES`].
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub(crate) const fn assert_interleaved_tile<const R: usize>() {
+    assert!(
+        R > 0 && R % 8 == 0 && R <= MAX_INTERLEAVED_LANES,
+        "record-interleaved tile width must be a non-zero multiple of 8 and at most MAX_INTERLEAVED_LANES"
+    );
+}
+
+/// Read one 4-lane quad out of a `v128` accumulator into `out`.
+///
+/// Lane extraction needs a *const* index, so a generic tile width cannot index
+/// the accumulator array element-wise — the quad is unpacked whole instead.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+fn store_quad(out: &mut [f32], acc: v128) {
+    out[0] = f32x4_extract_lane::<0>(acc);
+    out[1] = f32x4_extract_lane::<1>(acc);
+    out[2] = f32x4_extract_lane::<2>(acc);
+    out[3] = f32x4_extract_lane::<3>(acc);
+}
+
+/// Issue #287 - record-interleaved `R`-lane weighted sum for the batched
+/// scoring hot path; widened to a tunable tile in Issue #530.
 ///
 /// `inter` is the transposed batch activation buffer: lane `l` of source neuron
-/// `n` lives at `inter[n * 8 + l]`, so all eight records for a synapse's source
-/// are contiguous. Each gather is then two adjacent 4-wide reads from one cache
-/// line instead of eight scattered per-lane loads, cutting gather traffic on the
-/// gather-bound production topology. Numerically identical to
-/// [`weighted_sum_simd_8records`]: same per-synapse FMA order, bias seeded into
-/// every lane.
+/// `n` lives at `inter[n * R + l]`, so all `R` records for a synapse's source
+/// are contiguous. Each gather is then `R / 4` adjacent 4-wide reads instead of
+/// `R` scattered per-lane loads, cutting gather traffic on the gather-bound
+/// production topology; a wider `R` further amortises the synapse stream, which
+/// is re-read once per tile rather than once per eight records. Numerically
+/// identical to [`weighted_sum_simd_8records`]: same per-synapse FMA order,
+/// bias seeded into every lane, each lane summed independently.
+#[cfg(target_arch = "wasm32")]
+#[target_feature(enable = "simd128", enable = "relaxed-simd")]
+#[inline]
+pub fn weighted_sum_interleaved<const R: usize>(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; R] {
+    const { assert_interleaved_tile::<R>() };
+
+    if scalar::synapse_count(start, end) == 0 {
+        return [bias; R];
+    }
+
+    let quads = R / 4;
+    let mut acc = [f32x4_splat(bias); MAX_INTERLEAVED_LANES / 4];
+
+    for i in start..end {
+        let synapse = &synapses[i];
+        let base = synapse.from_index as usize * R;
+        let weights = f32x4_splat(synapse.weight);
+
+        // The R lanes are contiguous, so these reads walk whole cache lines.
+        for (q, a) in acc.iter_mut().take(quads).enumerate() {
+            let o = base + q * 4;
+            let acts = f32x4(inter[o], inter[o + 1], inter[o + 2], inter[o + 3]);
+            *a = f32x4_relaxed_madd(weights, acts, *a);
+        }
+    }
+
+    let mut out = [0.0_f32; R];
+    for (q, a) in acc.iter().take(quads).enumerate() {
+        store_quad(&mut out[q * 4..q * 4 + 4], *a);
+    }
+    out
+}
+
+/// The 8-lane tile of [`weighted_sum_interleaved`], kept as the name the
+/// batched **scoring** path (`BatchScratch::inter`) and its tests use.
 #[cfg(target_arch = "wasm32")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
@@ -510,46 +582,7 @@ pub fn weighted_sum_interleaved_8(
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    if scalar::synapse_count(start, end) == 0 {
-        return [bias; 8];
-    }
-
-    let mut acc03 = f32x4_splat(bias);
-    let mut acc47 = f32x4_splat(bias);
-
-    for i in start..end {
-        let synapse = &synapses[i];
-        let base = synapse.from_index as usize * 8;
-        let weights = f32x4_splat(synapse.weight);
-
-        // The eight lanes are contiguous, so these read one cache line.
-        let acts03 = f32x4(
-            inter[base],
-            inter[base + 1],
-            inter[base + 2],
-            inter[base + 3],
-        );
-        let acts47 = f32x4(
-            inter[base + 4],
-            inter[base + 5],
-            inter[base + 6],
-            inter[base + 7],
-        );
-
-        acc03 = f32x4_relaxed_madd(weights, acts03, acc03);
-        acc47 = f32x4_relaxed_madd(weights, acts47, acc47);
-    }
-
-    [
-        f32x4_extract_lane::<0>(acc03),
-        f32x4_extract_lane::<1>(acc03),
-        f32x4_extract_lane::<2>(acc03),
-        f32x4_extract_lane::<3>(acc03),
-        f32x4_extract_lane::<0>(acc47),
-        f32x4_extract_lane::<1>(acc47),
-        f32x4_extract_lane::<2>(acc47),
-        f32x4_extract_lane::<3>(acc47),
-    ]
+    weighted_sum_interleaved::<8>(synapses, inter, start, end, bias)
 }
 
 // Native (non-wasm32) multi-record helpers now live in `simd_native.rs` and use
@@ -564,7 +597,7 @@ mod simd_native;
 // kernels and run on the primary `activate()` forward-pass hot path.
 #[cfg(not(target_arch = "wasm32"))]
 pub use simd_native::{
-    weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
-    weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
-    weighted_sum_simd_8records,
+    MAX_INTERLEAVED_LANES, weighted_sum_interleaved, weighted_sum_interleaved_8,
+    weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,
+    weighted_sum_simd, weighted_sum_simd_4records, weighted_sum_simd_8records,
 };

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -18,6 +18,29 @@
 use crate::network::SynapseData;
 use crate::simd::scalar;
 
+/// Widest record-interleaved tile the generic gather kernels support
+/// (Issue #530).
+///
+/// The vector kernels hold their accumulators in a fixed-size array sized for
+/// this maximum and use only the leading `R / 8` (AVX2) or `R / 4` (NEON)
+/// entries, so the unused accumulators are eliminated at compile time. Every
+/// tile width `R` must be a multiple of 8 and no wider than this — both are
+/// checked at compile time by the kernels' `assert_interleaved_tile` guard.
+pub const MAX_INTERLEAVED_LANES: usize = 64;
+
+/// Compile-time guard on a record-interleaved tile width (Issue #530): `R` must
+/// be a non-zero multiple of 8 and no wider than [`MAX_INTERLEAVED_LANES`].
+///
+/// Fails the build rather than silently mis-sizing an accumulator array
+/// (fail-loud, Issue #3234).
+#[inline]
+pub(crate) const fn assert_interleaved_tile<const R: usize>() {
+    assert!(
+        R > 0 && R % 8 == 0 && R <= MAX_INTERLEAVED_LANES,
+        "record-interleaved tile width must be a non-zero multiple of 8 and at most MAX_INTERLEAVED_LANES"
+    );
+}
+
 #[inline]
 fn weighted_sum_simd_8records_scalar(
     synapses: &[SynapseData],
@@ -82,28 +105,30 @@ fn weighted_sum_simd_4records_scalar(
     (sum0, sum1, sum2, sum3)
 }
 
-/// Scalar fallback for the record-interleaved 8-lane weighted sum (Issue #287).
+/// Scalar fallback for the record-interleaved `R`-lane weighted sum
+/// (Issue #287; widened to a tunable tile in Issue #530).
 ///
 /// `inter` is the transposed batch activation buffer: lane `l` of neuron `n`
-/// lives at `inter[n * 8 + l]`, so all eight records for a source neuron are
+/// lives at `inter[n * R + l]`, so all `R` records for a source neuron are
 /// contiguous. This mirrors [`weighted_sum_simd_8records_scalar`] numerically —
-/// same per-synapse FMA order, bias seeded into every lane — so the covered
-/// scoring path is bit-identical whichever gather layout is used.
+/// same per-synapse FMA order, bias seeded into every lane, each lane summed
+/// independently — so the result is bit-identical whichever gather layout **and
+/// whichever tile width** is used.
 #[inline]
-fn weighted_sum_interleaved_8_scalar(
+fn weighted_sum_interleaved_scalar<const R: usize>(
     synapses: &[SynapseData],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
-) -> [f32; 8] {
-    let mut acc = [bias; 8];
+) -> [f32; R] {
+    let mut acc = [bias; R];
     for synapse in synapses.iter().take(end).skip(start) {
-        let base = synapse.from_index as usize * 8;
+        let base = synapse.from_index as usize * R;
         let w = synapse.weight;
-        let chunk = &inter[base..base + 8];
-        for l in 0..8 {
-            acc[l] += chunk[l] * w;
+        let chunk = &inter[base..base + R];
+        for (a, c) in acc.iter_mut().zip(chunk) {
+            *a += *c * w;
         }
     }
     acc
@@ -164,43 +189,52 @@ mod x86 {
         )
     }
 
-    /// Record-interleaved 8-lane weighted sum (Issue #287).
+    /// Record-interleaved `R`-lane weighted sum (Issue #287; widened to a
+    /// tunable tile in Issue #530).
     ///
-    /// `inter` holds the transposed batch: the eight records for source neuron
-    /// `n` are contiguous at `inter[n * 8 .. n * 8 + 8]`, so each synapse gather
-    /// is a single `_mm256_loadu_ps` from one cache line instead of eight
-    /// scattered scalar loads — the whole point of the layout change.
+    /// `inter` holds the transposed batch: the `R` records for source neuron
+    /// `n` are contiguous at `inter[n * R .. n * R + R]`, so each synapse gather
+    /// is `R / 8` adjacent `_mm256_loadu_ps` reads instead of `R` scattered
+    /// scalar loads. Widening `R` amortises the synapse stream: the whole
+    /// synapse array is re-read once per **tile**, not once per eight records.
     ///
     /// # Safety
     /// Caller must ensure AVX2 is enabled (`is_x86_feature_detected!("avx2")`).
-    /// Issue #287 - `inter.len()` must be `num_neurons * 8` and every
+    /// Issue #287 - `inter.len()` must be `num_neurons * R` and every
     /// `synapse.from_index` in `start..end` must be `< num_neurons`, so
-    /// `from_index * 8 + 8 <= inter.len()`; `CompiledNetwork::new` validates the
-    /// synapse index range at load time. The 8-wide read is then in bounds.
+    /// `from_index * R + R <= inter.len()`; `CompiledNetwork::new` validates the
+    /// synapse index range at load time. The `R`-wide read is then in bounds.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn weighted_sum_interleaved_8_avx2(
+    pub unsafe fn weighted_sum_interleaved_avx2<const R: usize>(
         synapses: &[SynapseData],
         inter: &[f32],
         start: usize,
         end: usize,
         bias: f32,
-    ) -> [f32; 8] {
-        let mut acc = _mm256_set1_ps(bias);
+    ) -> [f32; R] {
+        const { super::assert_interleaved_tile::<R>() };
+        let octs = R / 8;
+        let mut acc = [_mm256_set1_ps(bias); super::MAX_INTERLEAVED_LANES / 8];
         let ptr = inter.as_ptr();
         for i in start..end {
             let synapse = unsafe { synapses.get_unchecked(i) };
-            let base = synapse.from_index as usize * 8;
-            let w = synapse.weight;
-            // SAFETY: base + 8 <= inter.len() by the load-time index validation
-            // documented above; the unaligned 8-wide load is in bounds.
-            let acts = unsafe { _mm256_loadu_ps(ptr.add(base)) };
-            let ws = _mm256_set1_ps(w);
-            // `_mm256_fmadd_ps` needs `fma` (mirrors the 8records kernel above).
-            acc = unsafe { _mm256_fmadd_ps(ws, acts, acc) };
+            let base = synapse.from_index as usize * R;
+            let ws = _mm256_set1_ps(synapse.weight);
+            for (o, a) in acc.iter_mut().take(octs).enumerate() {
+                // SAFETY: base + R <= inter.len() by the load-time index
+                // validation documented above, and `o < R / 8`, so this
+                // unaligned 8-wide load is in bounds.
+                let acts = unsafe { _mm256_loadu_ps(ptr.add(base + o * 8)) };
+                // `_mm256_fmadd_ps` needs `fma` (mirrors the 8records kernel above).
+                *a = unsafe { _mm256_fmadd_ps(ws, acts, *a) };
+            }
         }
-        let mut out = [0.0_f32; 8];
-        unsafe { _mm256_storeu_ps(out.as_mut_ptr(), acc) };
+        let mut out = [0.0_f32; R];
+        for (o, a) in acc.iter().take(octs).enumerate() {
+            // SAFETY: `o < R / 8`, so `out[o * 8 .. o * 8 + 8]` is in bounds.
+            unsafe { _mm256_storeu_ps(out.as_mut_ptr().add(o * 8), *a) };
+        }
         out
     }
 
@@ -441,46 +475,53 @@ mod aarch64 {
         )
     }
 
-    /// Record-interleaved 8-lane weighted sum (Issue #287).
+    /// Record-interleaved `R`-lane weighted sum (Issue #287; widened to a
+    /// tunable tile in Issue #530).
     ///
-    /// `inter` holds the transposed batch: the eight records for source neuron
-    /// `n` are contiguous at `inter[n * 8 .. n * 8 + 8]`, so each synapse gather
-    /// is two adjacent `vld1q_f32` loads from one cache line instead of eight
-    /// scattered scalar loads staged through a stack array.
+    /// `inter` holds the transposed batch: the `R` records for source neuron
+    /// `n` are contiguous at `inter[n * R .. n * R + R]`, so each synapse gather
+    /// is `R / 4` adjacent `vld1q_f32` loads instead of `R` scattered scalar
+    /// loads staged through a stack array. Widening `R` amortises the synapse
+    /// stream: the whole synapse array is re-read once per **tile**, not once
+    /// per eight records.
     ///
     /// # Safety
     /// Caller must ensure NEON is available (typical on aarch64-apple-darwin /
-    /// linux-aarch64). Issue #287 - `inter.len()` must be `num_neurons * 8` and
+    /// linux-aarch64). Issue #287 - `inter.len()` must be `num_neurons * R` and
     /// every `synapse.from_index` in `start..end` must be `< num_neurons`, so
-    /// `from_index * 8 + 8 <= inter.len()`; `CompiledNetwork::new` validates the
-    /// synapse index range at load time, making the two 4-wide reads in bounds.
+    /// `from_index * R + R <= inter.len()`; `CompiledNetwork::new` validates the
+    /// synapse index range at load time, making the `R / 4` 4-wide reads in
+    /// bounds.
     #[target_feature(enable = "neon")]
     #[inline]
-    pub unsafe fn weighted_sum_interleaved_8_neon(
+    pub unsafe fn weighted_sum_interleaved_neon<const R: usize>(
         synapses: &[SynapseData],
         inter: &[f32],
         start: usize,
         end: usize,
         bias: f32,
-    ) -> [f32; 8] {
-        let mut acc03 = vdupq_n_f32(bias);
-        let mut acc47 = vdupq_n_f32(bias);
+    ) -> [f32; R] {
+        const { super::assert_interleaved_tile::<R>() };
+        let quads = R / 4;
+        let mut acc = [vdupq_n_f32(bias); super::MAX_INTERLEAVED_LANES / 4];
         let ptr = inter.as_ptr();
         for i in start..end {
             let synapse = unsafe { synapses.get_unchecked(i) };
-            let base = synapse.from_index as usize * 8;
-            let w = synapse.weight;
-            // SAFETY: base + 8 <= inter.len() by the load-time index validation
-            // documented above; both 4-wide reads are in bounds.
-            let a03 = unsafe { vld1q_f32(ptr.add(base)) };
-            let a47 = unsafe { vld1q_f32(ptr.add(base + 4)) };
-            let vw = vdupq_n_f32(w);
-            acc03 = vfmaq_f32(acc03, vw, a03);
-            acc47 = vfmaq_f32(acc47, vw, a47);
+            let base = synapse.from_index as usize * R;
+            let vw = vdupq_n_f32(synapse.weight);
+            for (q, a) in acc.iter_mut().take(quads).enumerate() {
+                // SAFETY: base + R <= inter.len() by the load-time index
+                // validation documented above, and `q < R / 4`, so this 4-wide
+                // read is in bounds.
+                let acts = unsafe { vld1q_f32(ptr.add(base + q * 4)) };
+                *a = vfmaq_f32(*a, vw, acts);
+            }
         }
-        let mut out = [0.0_f32; 8];
-        unsafe { vst1q_f32(out.as_mut_ptr(), acc03) };
-        unsafe { vst1q_f32(out.as_mut_ptr().add(4), acc47) };
+        let mut out = [0.0_f32; R];
+        for (q, a) in acc.iter().take(quads).enumerate() {
+            // SAFETY: `q < R / 4`, so `out[q * 4 .. q * 4 + 4]` is in bounds.
+            unsafe { vst1q_f32(out.as_mut_ptr().add(q * 4), *a) };
+        }
         out
     }
 
@@ -723,20 +764,29 @@ pub fn weighted_sum_simd_8records(
     )
 }
 
-/// Record-interleaved 8-lane weighted sum (Issue #287): AVX2+FMA on x86_64,
-/// NEON on aarch64, else scalar. `inter` is the transposed batch buffer
-/// (`inter[n * 8 + l]` = lane `l` of neuron `n`), so each synapse gather touches
-/// one cache line instead of eight scattered per-lane buffers.
+/// Record-interleaved `R`-lane weighted sum (Issue #287; widened to a tunable
+/// tile in Issue #530): AVX2+FMA on x86_64, NEON on aarch64, else scalar.
+/// `inter` is the transposed batch buffer (`inter[n * R + l]` = lane `l` of
+/// neuron `n`), so each synapse gather reads `R` contiguous floats instead of
+/// `R` scattered per-lane buffers.
+///
+/// `R` must be a non-zero multiple of 8 and at most
+/// [`MAX_INTERLEAVED_LANES`] — enforced at compile time.
+///
+/// Every lane accumulates `bias + Σ w·a` in synapse order, independently of the
+/// other lanes, so widening `R` leaves each record's sum **bit-identical**.
 #[inline]
-pub fn weighted_sum_interleaved_8(
+pub fn weighted_sum_interleaved<const R: usize>(
     synapses: &[SynapseData],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
-) -> [f32; 8] {
+) -> [f32; R] {
+    const { assert_interleaved_tile::<R>() };
+
     if scalar::synapse_count(start, end) == 0 {
-        return [bias; 8];
+        return [bias; R];
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -744,9 +794,9 @@ pub fn weighted_sum_interleaved_8(
         if std::arch::is_x86_feature_detected!("avx2") {
             // SAFETY: the `is_x86_feature_detected!("avx2")` guard proves AVX2 is
             // available, satisfying the `#[target_feature(enable = "avx2")]`
-            // precondition on `weighted_sum_interleaved_8_avx2`.
+            // precondition on `weighted_sum_interleaved_avx2`.
             return unsafe {
-                x86::weighted_sum_interleaved_8_avx2(synapses, inter, start, end, bias)
+                x86::weighted_sum_interleaved_avx2::<R>(synapses, inter, start, end, bias)
             };
         }
     }
@@ -756,14 +806,27 @@ pub fn weighted_sum_interleaved_8(
         if std::arch::is_aarch64_feature_detected!("neon") {
             // SAFETY: the `is_aarch64_feature_detected!("neon")` guard proves NEON
             // is available, satisfying the `#[target_feature(enable = "neon")]`
-            // precondition on `weighted_sum_interleaved_8_neon`.
+            // precondition on `weighted_sum_interleaved_neon`.
             return unsafe {
-                aarch64::weighted_sum_interleaved_8_neon(synapses, inter, start, end, bias)
+                aarch64::weighted_sum_interleaved_neon::<R>(synapses, inter, start, end, bias)
             };
         }
     }
 
-    weighted_sum_interleaved_8_scalar(synapses, inter, start, end, bias)
+    weighted_sum_interleaved_scalar::<R>(synapses, inter, start, end, bias)
+}
+
+/// The 8-lane tile of [`weighted_sum_interleaved`], kept as the name the
+/// batched **scoring** path (`BatchScratch::inter`) and its tests use.
+#[inline]
+pub fn weighted_sum_interleaved_8(
+    synapses: &[SynapseData],
+    inter: &[f32],
+    start: usize,
+    end: usize,
+    bias: f32,
+) -> [f32; 8] {
+    weighted_sum_interleaved::<8>(synapses, inter, start, end, bias)
 }
 
 /// 4-record weighted sum: FMA+SSE on x86_64, NEON on aarch64, else scalar.

--- a/neat-core/src/squash_simd.rs
+++ b/neat-core/src/squash_simd.rs
@@ -461,16 +461,26 @@ fn squash_lanes<const N: usize>(squash: SquashType, x: [f32; N]) -> Option<[f32;
     }
 }
 
+/// Vectorised squash for an `N`-record batch lane (Issue #530, so the
+/// record-interleaved tile width is tunable). See `squash_lanes`.
+///
+/// Every lane is squashed independently by the same approximation, so the
+/// result for a given lane value does not depend on `N`.
+#[inline]
+pub fn squash_xn<const N: usize>(squash: SquashType, x: [f32; N]) -> Option<[f32; N]> {
+    squash_lanes(squash, x)
+}
+
 /// Vectorised squash for a 4-record batch lane. See `squash_lanes`.
 #[inline]
 pub fn squash_x4(squash: SquashType, x: [f32; 4]) -> Option<[f32; 4]> {
-    squash_lanes(squash, x)
+    squash_xn(squash, x)
 }
 
 /// Vectorised squash for an 8-record batch lane. See `squash_lanes`.
 #[inline]
 pub fn squash_x8(squash: SquashType, x: [f32; 8]) -> Option<[f32; 8]> {
-    squash_lanes(squash, x)
+    squash_xn(squash, x)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Widen the fused-MSE record tile to a tunable `MSE_TILE_LANES` (Issue #530)

## Summary

The fused MSE forward pass (`mse_sum_batch_packed` → `mse_sum_batch_8way` →
the #287 record-interleaved gather) processed records in groups of **8**, so the
network's entire synapse array was re-streamed once per eight records. On the
production creature that array is ~172 KB (21,513 × 8 B `SynapseData`) and the
8-lane `mse_inter` is ~132 KB — together well past an Apple M4 performance
core's 128 KB L1D, so every group re-fetched the synapses from L2.

This makes the tile width a single constant, `loss::MSE_TILE_LANES` (**32**),
gathered by const-generic kernels — `R / 8` `__m256` accumulators on AVX2,
`R / 4` `float32x4` on NEON, contiguous `f32x4` quads on wasm `simd128`, scalar
elsewhere. Per-record synapse traffic falls by `R / 8`.

Two supporting changes turned out to be load-bearing, and both are pinned by
tests:

- **The tile transpose walks input-major.** A neuron's `R` lanes go to
  consecutive `mse_inter` slots, so the scratch buffer is filled by one linear
  sweep. The original lane-major order revisits the whole `num_inputs * R`
  region once per lane, which stops fitting in L1 as `R` grows and would have
  eaten most of the gain.
- **`interleaved_tile_mse` is seed-taking** — it takes the running `f64`
  `sum_error` and returns it, like the SIMD tail helpers in
  `simd::scalar` (Issue #447). Returning a per-tile partial sum re-associates
  the reduction; that was caught during development as a 12-ULP parity failure
  at n = 4096, which is exactly what the oracle is for.

Numerics are unchanged at **every** tile width: each lane accumulates its own
`bias + Σ w·a` in synapse order independently of the other lanes, and every tier
reduces into `sum_error` in strict record order. The `< R` remainder steps down
whole 8-record interleaved tiles, then the unchanged 4-way and scalar tiers.

The batched **scoring** lane (`score_records_flat` → `BatchScratch::inter`)
is deliberately untouched and stays at 8 lanes — this issue scopes the fused MSE
loss path only.

Closes #530.

## Evidence

### Benchmark — this is a performance change

`cargo bench --bench hot_paths -- mse_sum_production/production_exact`
(4,096 records per iteration, the exact committed production topology: 2,461
inputs, 1,666 non-input neurons, 21,513 synapses).

**Method.** 5 interleaved A/B rounds; each round rebuilds and runs every arm
back to back so thermal drift hits all arms alike. `base` is the pre-change code
run from a separate `git worktree` at the parent commit; the `R = 8/16/32/64`
arms are this branch with only `MSE_TILE_LANES` changed — one constant apart, as
the issue asks. Apple M4 (10 cores), rustc 1.97.1, `--release`, quiet host.
**Medians:**

| arm | n | median | min | max | vs `base` |
| --- | ---: | ---: | ---: | ---: | ---: |
| `base` (pre-#530, 8-record groups) | 6 | 21.343 ms | 19.877 | 21.819 | — |
| `MSE_TILE_LANES = 8` | 6 | 17.994 ms | 16.978 | 19.127 | **−15.7%** |
| `MSE_TILE_LANES = 16` | 6 | 14.468 ms | 13.659 | 15.281 | **−32.2%** |
| **`MSE_TILE_LANES = 32` (shipped)** | 5 | **11.558 ms** | 10.252 | 12.152 | **−45.8%** |
| `MSE_TILE_LANES = 64` | 5 | 12.728 ms | 12.130 | 13.496 | −40.4% |

**The arms do not overlap at all** — `R = 32`'s worst round (12.152 ms) beats
`base`'s best (19.877 ms) and `R = 8`'s best (16.978 ms) — so the ordering does
not rest on the medians alone. Against the same-code `R = 8` arm, `R = 32` is
**−35.8%**.

The issue's bar was a reproducible **≥1–2%** median gain with the change staying
minor; the measured **−45.8%** clears it by more than an order of magnitude.

**Where the curve turns.** `R = 64` gives back ~10% against `R = 32`:
`mse_inter` reaches ~1 MB on this creature and the NEON kernel needs 16 live
accumulators, so capacity and register pressure both bite. 32 is the shipped
default. The `R = 8` row also shows the input-major transpose is worth ~15% on
its own, before any tile widening.

> **Scope caveat.** The issue's acceptance gate names the *production* fixture
> in NEAT-AI-scorer — N ≈ 50 distinct creature variants over the ≈22 GiB
> multi-file corpus in directory mode. Neither the 3 MB production
> `network.json` nor the corpus is available in this repo (`BASELINE.md`,
> "Bench-only baseline"), so that end-to-end A/B cannot run here. What is
> measured above is the exact kernel the issue targets, on the committed
> `production_exact` topology at production record volume, which is the
> closest reproducible proxy this repo has. The scorer-side confirmation on the
> full corpus remains the human-run gate before the wall-clock claim is made
> there.

### Memory

`mse_inter` is `num_neurons * MSE_TILE_LANES * 4` bytes **per compiled
network** — ~132 KB at 8 lanes, **~528 KB at 32**, ~1 MB at 64 on the
~4,127-neuron production creature. Directory scoring holds one compiled network
per worker, so at N = 50 workers the shipped width costs ~26 MB of scratch.
That figure is documented in `README.md`, on the constant itself, and in
`BASELINE.md` so it can be budgeted against the scorer's worker-count RAM
ceiling before anyone raises the constant.

### Mutation evidence — the tests can fail

Per AGENTS.md rule 2, each mutation was applied alone and reverted afterwards.
`cargo test -p neat-core --lib interleaved_mse_parity` (4 tests):

| # | mutation | result |
| --- | --- | --- |
| M1 | `interleaved_tile_mse` returns a per-tile partial sum instead of taking the running seed | **3 of 4 red** |
| M2 | tile transpose drops the lane offset (`base_idx + l` → `base_idx`) | **3 of 4 red** |
| M3 | `< R` remainder skips the whole 8-record interleaved tier | **2 of 4 red** |
| M4 | NEON kernel accumulates `R / 8` quads instead of `R / 4` (upper lanes never FMA'd) | **3 of 4 red** |
| M5 | forward pass strides output lanes by `SCORING_LANES` instead of `R` | **2 of 4 red** |
| — | all mutations reverted | **4 of 4 green** |

M3 and M5 kill only the wide-tile tests, which is correct: both mutations are
no-ops when `R == SCORING_LANES`, and that is precisely the blind spot the new
`every_tile_width_is_bit_identical_to_scattered` test exists to cover. M1 is not
hypothetical — it is the bug this suite actually caught during development.

The oracle is independent per AGENTS.md rule 1: `mse_sum_batch_scattered`
reaches the same value through the per-lane scattered kernels driven by the
shared 8 → 4 → 1 skeleton, sharing no code with the interleaved tile path, so a
fault in the tiled kernel moves only one side of the assertion. Because the
paths are genuinely bit-identical the assertion is `f64::to_bits` equality, not
a tolerance.

### Architecture

```mermaid
flowchart LR
    R["packed records"] --> T{"records left"}
    T -- "&ge; MSE_TILE_LANES" --> A["R-record interleaved tile<br/>one synapse sweep per R records"]
    T -- "8..R-1" --> B["8-record interleaved tile"]
    T -- "4..7" --> C["4-record scattered group"]
    T -- "&lt; 4" --> D["scalar tail — exact activate"]
    A --> T
    B --> T
    A --> S["running f64 sum_error<br/>seeded through every tier,<br/>in record order"]
    B --> S
    C --> S
    D --> S
```

### No UI

This is a backend SIMD/loss-kernel change with no web interface, so there is no
screenshot. It was verified by the test suite, the mutation sweep above, the
benchmark A/B, `./quality.sh` (green), and
`cargo check -p neat-core --target wasm32-unknown-unknown` — the manual gate
AGENTS.md requires, since no PR job compiles the `wasm32` half of this hot path
and this change edits it.

## Test Plan

Added to `loss::interleaved_mse_parity` (`neat-core/src/loss.rs`):

- `every_tile_width_is_bit_identical_to_scattered` — **new.** Asserts tiles of
  16, 32 and 64 are `f64::to_bits`-identical to the independent scattered oracle
  across 15 record counts and 7 squash types. This is the guard that makes
  `MSE_TILE_LANES` a free knob.
- `shipped_tile_width_is_a_supported_multiple_of_eight` — **new.** States the
  contract on the shipped constant (multiple of 8, within
  `simd::MAX_INTERLEAVED_LANES`) and runs the same bit-identity sweep at
  whatever width is actually shipped, so flipping the constant cannot ship an
  unproven width.
- `interleaved_mse_bit_identical_to_scattered_across_boundaries` — **extended,
  not weakened.** Now parameterised over the tile width and run at 8 lanes, with
  the record-count set grown from 9 to 15 values (adding 31, 32, 33, 40, 64, 71)
  to straddle the wide-tile boundaries the new ladder introduces.

No existing test was removed, commented out, or loosened. The whole workspace
suite (`cargo test --workspace`) and `./quality.sh` pass.

Unchanged tests that keep the surrounding contracts honest:
`tests/mse_batch_interleaved_parity.rs` (public entry point vs the scalar
single-record reference), `tests/simd_weighted_sums.rs`
(`weighted_sum_interleaved_8` vs the scattered 8-record kernel — the 8-lane
alias is retained precisely so this public-API guard still applies), and
`loss::interleaved_mse_parity::aggregate_dispatch_stays_on_scattered_path`
(aggregate-squash networks never reach the tiled gather).

## Documentation

- `README.md` — new "Fused-MSE record tile" section: the constant, its bounds,
  the per-network memory cost, the bit-identity guarantee, and a Mermaid diagram
  of the tier ladder.
- `neat-core/benches/BASELINE.md` — full methodology and the A/B table above.
- `AGENTS.md` — the Issue #445 "one batched record-scan skeleton" section now
  records the tunable tile and the two load-bearing invariants (seed-taking
  reduction, input-major transpose), so a future edit does not silently
  reintroduce M1 or the lane-major transpose.

## Security self-check

- No new external input surface: `MSE_TILE_LANES` is a compile-time constant,
  and its bounds (non-zero multiple of 8, `≤ MAX_INTERLEAVED_LANES`) are
  enforced by a `const` assertion that fails the **build**, not at runtime.
- The widened `get_unchecked` / `_mm256_loadu_ps` / `vld1q_f32` reads rest on
  the same load-time invariant as before — `CompiledNetwork::new` rejects any
  `from_index >= num_neurons`, so `from_index * R + R <= inter.len()` holds for
  every supported `R`. Each `unsafe` block carries a `// SAFETY:` note naming
  the `is_*_feature_detected!` guard, per the AGENTS.md SIMD rules.
- No secrets, no new dependencies, no new shell/SQL/HTTP call sites, no
  user-facing error strings changed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msh88yca-22da7e`<!-- vibe-worker-issue-530 -->