### PR TITLE
perf candidate: struct-of-arrays hot synapse fields (weight + from_index) for the interleaved gather (Issue #533)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,27 @@ lane-major revisits the whole `num_inputs * R` region once per lane and stops
 fitting in L1 as `R` grows. `loss::interleaved_mse_parity` pins both across
 widths 8/16/32/64.
 
+## One struct-of-arrays hot view for the interleaved gather (Issue #533)
+
+`hot_synapse_soa` (`neat-core/src/network.rs`) is the single home of the rule
+that says what `CompiledNetwork::hot_weights` / `hot_from` contain: exactly
+`synapses[i].weight` and `synapses[i].from_index`, in the order `synapses` holds
+them. **Every** construction path calls it — the binary deserialiser
+`CompiledNetwork::new` and `compile_creature` — so the two views cannot drift.
+The record-interleaved kernels (`weighted_sum_interleaved::<R>` and its
+scalar/AVX2/NEON/wasm variants) take the two slices instead of
+`&[SynapseData]`, streaming **6 B** per synapse instead of 8; `synapse_type`
+stays on `SynapseData` for the aggregate/IF and single-record paths, which are
+untouched. Numerics are unchanged — same values, same order.
+
+The redundancy is the hazard, and the fields are public, so a caller can still
+assemble a `CompiledNetwork` literal (the test and bench fixtures do) or mutate
+`synapses` afterwards. `CompiledNetwork::debug_assert_hot_soa` is the fail-loud
+guard: every entry point into the interleaved gather calls it, so a drifted view
+panics in debug and test builds instead of silently scoring wrong numbers, and
+compiles away in release. `neat-core/tests/hot_synapse_soa.rs` pins the
+invariant across both construction paths, `Clone`, and the guard itself.
+
 `load_record` (`neat-core/src/batch_scoring.rs`) owns the loading sub-rule:
 copy `min(record.len(), num_inputs)` values and **zero** every input slot the
 record does not cover. Every per-lane loader in the batched scoring and fused

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.8.13"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.8.13"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,34 @@ flowchart LR
     B --> S
 ```
 
+### Struct-of-arrays hot synapse view (Issue #533)
+
+The interleaved gather reads only two of `SynapseData`'s three fields, so
+`CompiledNetwork` also carries a parallel **struct-of-arrays** view of them —
+`hot_weights: Vec<f32>` and `hot_from: Vec<u16>`, in the same order as
+`synapses`. The interleaved kernels take those two slices, streaming 6 B per
+synapse instead of the struct's 8 B; `synapse_type` stays on `SynapseData` for
+the aggregate/IF and single-record paths, which are unchanged. Values and
+accumulation order are identical, so every result stays bit-identical.
+
+Both views are built by `hot_synapse_soa` at every construction path
+(`CompiledNetwork::new`, `compile_creature`), and cost **+6 B per synapse per
+compiled network** — ~126 KB on the production creature, cloned once per
+directory-scoring worker. Because the fields are public they can be made to
+drift; `debug_assert_hot_soa` runs at every interleaved entry point and panics
+in debug builds if they have.
+
+```mermaid
+flowchart LR
+    C["compile_creature / CompiledNetwork::new"] --> S["synapses: Vec&lt;SynapseData&gt;<br/>weight + from_index + synapse_type"]
+    S --> H["hot_synapse_soa"]
+    H --> W["hot_weights: Vec&lt;f32&gt;"]
+    H --> F["hot_from: Vec&lt;u16&gt;"]
+    W --> G["weighted_sum_interleaved::&lt;R&gt;<br/>6 B per synapse"]
+    F --> G
+    S --> A["aggregate / IF / single-record paths<br/>unchanged, 8 B per synapse"]
+```
+
 ```bash
 # Run the data-parallel scoring throughput bench (1 vs all cores).
 cargo bench -p neat-core --features parallel --bench parallel_scoring

--- a/docs/archive/pr-summaries/pr-summary-533.md
+++ b/docs/archive/pr-summaries/pr-summary-533.md
@@ -1,0 +1,191 @@
+# Struct-of-arrays hot synapse fields for the interleaved gather (Issue #533)
+
+## Summary
+
+The record-interleaved gather reads only two of `SynapseData`'s three fields —
+`weight` and `from_index` — but streams all 8 bytes of the struct. This adds a
+parallel **struct-of-arrays** view, `CompiledNetwork::hot_weights: Vec<f32>` and
+`hot_from: Vec<u16>`, built by the new `hot_synapse_soa` at every construction
+path, and points `weighted_sum_interleaved::<R>` (scalar / AVX2 / NEON / wasm
+`simd128`) at those two slices. The hot loop's synapse stream drops from **8 B
+to 6 B** per synapse and the prefetcher gets two clean sequential streams over
+`start..end`.
+
+The change is **additive**: `synapse_type` stays on `SynapseData`, so
+`neuron_activation_scalar`, the aggregate/IF paths, the per-lane scattered
+kernels, the single-record forward passes and the binary format are all
+untouched. Numerics are bit-identical — the same values accumulate in the same
+order.
+
+The redundancy is the correctness hazard the issue calls out, so
+`CompiledNetwork::debug_assert_hot_soa` guards every interleaved entry point: a
+network whose hot view has drifted from `synapses` panics in debug and test
+builds rather than silently scoring wrong numbers, and compiles away entirely in
+release.
+
+Closes #533.
+
+### Breaking change
+
+Marked with a `perf(network)!:` Conventional Commit and a `BREAKING CHANGE:`
+footer, so the `version-increment` job bumps the **minor** per `RELEASING.md`:
+
+- `simd::weighted_sum_interleaved` / `weighted_sum_interleaved_8` now take
+  `hot_weights: &[f32], hot_from: &[u16]` instead of `&[SynapseData]`.
+- `CompiledNetwork` gains two public fields, so struct-literal construction must
+  supply them. `hot_synapse_soa` is exported from the crate root for exactly
+  that (the test and bench fixtures use it). Consumers that build networks
+  through `CompiledNetwork::new` or `compile_creature` — the normal route — need
+  no change.
+
+## Evidence
+
+### Benchmark — this is a performance change
+
+`cargo bench --bench hot_paths` on the committed `production_exact` topology
+(2,461 inputs, 1,666 non-input neurons, 21,513 synapses; 4,096 records per
+iteration). `base` is the parent commit run from a separate `git worktree`;
+`after` is this branch.
+
+**Method.** 24 **ABBA** pairs per group — each round runs `base, after, after,
+base` so the two arms bracket each other and thermal/load drift cancels within
+the round — with criterion `--warm-up-time 1 --measurement-time 3 --sample-size
+20`. Each arm's round score is the mean of its two runs. Apple M4 Pro
+(12 cores), rustc 1.97.1, `--release`.
+
+| group | base median | after median | Δ median | paired Δ (mean ± SE) | rounds favouring `after` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `mse_sum_production/production_exact` | 15.566 ms | 15.412 ms | **−0.99%** | −1.12% ± 0.72 | 18 / 24 |
+| `scoring/production_exact` | 24.621 ms | 24.061 ms | **−2.28%** | −1.02% ± 0.71 | 17 / 24 |
+
+**Read the sign, not the magnitude.** The host was **not quiet** — an unrelated
+process held the load average near 15 on a 12-core machine, so round-to-round
+noise is ~3.5% and neither group's mean clears its own standard error. What does
+clear is the direction: **35 of 48** paired rounds favour `after`, a two-sided
+sign test p ≈ 0.002, and symmetric noise cannot produce that. The honest reading
+is a real gain of roughly **1–2%** — at the low end of the issue's ≥1–2% bar,
+not the 3–8% it hoped for.
+
+**Why the upside shrank.** The issue's L1-residency argument was written against
+the pre-#530 world: 21,513 synapses × 8 B = 168 KB against an M4 core's 128 KB
+L1D, with an 8-lane `mse_inter` of 132 KB, so 6 B/synapse would have flipped the
+array into L1. At the shipped `MSE_TILE_LANES = 32` that framing no longer
+holds — `mse_inter` is ~528 KB and never L1-resident, and each synapse drives
+`R = 32` lanes (128 B of gather traffic) against its own 8 B, so trimming 2 B
+removes ~1.5% of the loop's bytes rather than crossing a capacity threshold. The
+8-lane `scoring` group, where the ratio is 8 B against 32 B, is the
+better-placed of the two and shows the larger median — which is why both groups
+were measured rather than just the one the issue names.
+
+> **Scope caveat** (same as `pr-summary-530.md`). The issue's acceptance gate
+> names the *production* fixture in NEAT-AI-scorer — N ≈ 50 distinct creature
+> variants over the ≈22 GiB multi-file corpus in directory mode. Neither the
+> 3 MB production `network.json` nor the corpus is available in this repo
+> (`BASELINE.md`, "Bench-only baseline"), so that end-to-end A/B cannot run
+> here. What is measured above is the exact kernel the issue targets, at
+> production record volume, on the closest reproducible proxy this repo has.
+> The scorer-side confirmation on the full corpus remains the human-run gate
+> before the wall-clock claim is made there — and given the measured margin sits
+> at the bar rather than above it, that confirmation matters more than usual.
+
+### Memory
+
+`hot_weights` + `hot_from` cost **+6 B per synapse per compiled network** —
+~126 KB on the production creature, ~6 MB across a 50-strong population, since
+`CompiledNetwork: Clone` means directory-mode scoring clones them once per
+worker. Documented in `README.md` and `benches/BASELINE.md`.
+
+### No UI to screenshot
+
+This is a library-internal performance change with no web interface. The
+evidence is the benchmark table above plus the test results below.
+
+### Mutation evidence — the tests can fail
+
+Per AGENTS.md rule 2, each mutation was applied alone and reverted afterwards.
+Suites: `hot_synapse_soa`, `mse_batch_interleaved_parity`,
+`interleaved_scoring_parity`.
+
+| # | mutation | result |
+| --- | --- | --- |
+| M1 | `hot_synapse_soa` builds the arrays in reverse order | **5 of 7 red** |
+| M2 | `compile_creature` builds the SoA from an empty slice | **3 of 7 red** |
+| M3 | `CompiledNetwork::new` drops the last synapse from the SoA | **3 of 7 red** |
+| M4 | NEON kernel reads `hot_from[start]` for every synapse (source slip) | **1 of 7 red** (`interleaved_scoring_matches_the_single_record_reference`) |
+| M5 | drop `debug_assert_hot_soa` from the MSE interleaved entry point | **1 of 7 red** (the fail-loud guard test) |
+| — | all mutations reverted | **all suites green** |
+
+M4 is caught only by the parity test, which is correct — a source slip does not
+change the SoA arrays themselves, only the numbers they produce, which is
+exactly why the suite carries an independent oracle as well as the structural
+assertions.
+
+The oracle is independent per AGENTS.md rule 1:
+`interleaved_scoring_matches_the_single_record_reference` scores each record on
+its own through the scalar `CompiledNetwork::activate` forward pass, which never
+reads `hot_weights` or `hot_from`, so a fault in the gather moves only one side
+of the assertion.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    C["compile_creature / CompiledNetwork::new"] --> S["synapses: Vec&lt;SynapseData&gt;<br/>weight + from_index + synapse_type"]
+    S --> H["hot_synapse_soa<br/>single home of the rule"]
+    H --> W["hot_weights: Vec&lt;f32&gt;"]
+    H --> F["hot_from: Vec&lt;u16&gt;"]
+    W --> G["weighted_sum_interleaved::&lt;R&gt;<br/>6 B per synapse"]
+    F --> G
+    S --> A["aggregate / IF / single-record paths<br/>unchanged, 8 B per synapse"]
+    G --> D{"debug_assert_hot_soa<br/>at every entry point"}
+    D -- "drifted" --> P["panic in debug — fail loud"]
+    D -- "consistent" --> O["bit-identical results"]
+```
+
+## Test Plan
+
+New suite `neat-core/tests/hot_synapse_soa.rs` (7 tests):
+
+- `compile_creature_builds_a_hot_view_matching_every_synapse` — the JSON
+  construction path, asserted element-for-element **and** against the fixture's
+  actual asymmetric weights/sources, so a zeroed or sorted copy fails.
+- `binary_deserialiser_builds_a_hot_view_matching_every_synapse` — the same for
+  `CompiledNetwork::new` over a hand-serialised `.bin` buffer.
+- `cloning_a_network_preserves_the_hot_view` — `Clone` is on the directory-mode
+  path, one network per worker.
+- `both_construction_paths_agree_on_the_hot_view` — the JSON and binary routes
+  describe one topology and must produce one hot view; this is what stops the
+  two construction paths drifting apart.
+- `hot_synapse_soa_preserves_order_and_handles_an_empty_array` — empty input,
+  plus repeated sources and a repeated weight that a de-duplicating or sorting
+  implementation would collapse.
+- `interleaved_scoring_matches_the_single_record_reference` — the independent
+  oracle, over record counts 1 / 5 / 8 / 33 / 70 straddling the scalar, 4-way,
+  8-record and 32-record interleaved tiers.
+- `a_drifted_hot_view_fails_loud_instead_of_scoring_wrong_numbers` — mutating
+  `synapses[0].weight` without rebuilding the view must panic, not score.
+
+Existing suites carried through unchanged (fixtures updated to supply the two
+new fields via `hot_synapse_soa`): `mse_batch_interleaved_parity`,
+`interleaved_scoring_parity`, `flat_record_scoring_parity`,
+`score_squash_simd_parity`, `mse_squash_simd_parity`, `simd_weighted_sums`,
+`aggregate_squash_set`, `aggregate_squash_tail_parity`,
+`batch_record_skeleton`, `packed_record_scan`, `inline_squash_dispatch`,
+`network_activate_trace_batch`, `short_input_zero_fill`. No test was commented
+out, skipped, or weakened.
+
+`./quality.sh` passes (fmt, clippy `-D warnings`, `cargo deny`, full workspace
+tests, doc build, release build). `cargo check -p neat-core --target
+wasm32-unknown-unknown` passes — required by AGENTS.md because no PR gate
+compiles the wasm half of `simd.rs`, which this change edits.
+
+### Security self-check
+
+- No new external input surface: `hot_synapse_soa` reads an in-memory slice the
+  loader has already validated.
+- The load-time `from_index < num_neurons` guard in `CompiledNetwork::new`
+  (Issue #207) is unchanged and still the soundness precondition for the
+  kernels' `get_unchecked`; the new `unsafe` reads of `hot_weights` / `hot_from`
+  are bounded by the same `start..end` span as the `synapses` reads they
+  replace, and carry `SAFETY:` notes saying so.
+- No secrets, no new dependencies, no shell/SQL/HTTP surface.

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -330,6 +330,47 @@ straddling every tier boundary
 > squash-vectorisation lever it is neither a lower nor an upper bound on
 > varied-squash creatures.
 
+## Struct-of-arrays hot synapse fields for the interleaved gather (Issue #533)
+
+The interleaved gather reads only two of `SynapseData`'s three fields, so #533
+adds a parallel struct-of-arrays view — `CompiledNetwork::hot_weights: Vec<f32>`
+and `hot_from: Vec<u16>`, built by `hot_synapse_soa` at every construction path
+— and points `weighted_sum_interleaved::<R>` (scalar/AVX2/NEON/wasm) at those
+two slices. The hot loop's synapse stream drops from **8 B to 6 B** per synapse;
+`synapse_type` stays on `SynapseData` for the aggregate/IF and single-record
+paths, which are untouched. Nothing is removed, the binary format is unchanged
+and the numbers are bit-identical — the same values accumulate in the same
+order.
+
+**Measured 2026-08-06**, Apple M4 Pro (12 cores, this host), rustc 1.97.1,
+`--release`. `base` is the parent commit run from a separate `git worktree`;
+`after` is this branch. **24 ABBA pairs per group** (`base, after, after, base`
+— each round's two arms bracket each other so drift cancels), criterion
+`--warm-up-time 1 --measurement-time 3 --sample-size 20`, comparing the mean of
+each arm's two runs within a round:
+
+| group | base median | after median | Δ median | paired Δ (mean ± SE) | rounds favouring `after` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `mse_sum_production/production_exact` | 15.566 ms | 15.412 ms | **−0.99%** | −1.12% ± 0.72 | 18 / 24 |
+| `scoring/production_exact` | 24.621 ms | 24.061 ms | **−2.28%** | −1.02% ± 0.71 | 17 / 24 |
+
+> **Read the sign, not the magnitude.** The host was **not quiet** — an
+> unrelated process held the load average near 15 on a 12-core machine, so
+> round-to-round noise is ~3.5% and neither group's mean clears its own standard
+> error. What does clear is the **direction**: 35 of 48 paired rounds favour
+> `after` (two-sided sign test p ≈ 0.002), and symmetric noise cannot produce
+> that. The honest reading is a real gain of roughly **1–2%**, at the low end of
+> the issue's ≥1–2% bar, not the 3–8% the issue hoped for.
+
+**Why the upside shrank.** The issue's L1-residency argument was written against
+the pre-#530 world: 21,513 synapses × 8 B = 168 KB against an M4 core's 128 KB
+L1D, with an 8-lane `mse_inter` of 132 KB. At the shipped `MSE_TILE_LANES = 32`
+that framing no longer holds — `mse_inter` is ~528 KB and never L1-resident, and
+each synapse now drives `R = 32` lanes (128 B of gather traffic) against its own
+8 B, so trimming 2 B removes ~1.5% of the loop's bytes rather than crossing a
+capacity threshold. The 8-lane `scoring` group, where the ratio is 8 B against
+32 B, is the better-placed of the two and shows the larger median.
+
 ## Flat-slice record **input** for batched scoring (Issue #386)
 
 Issue #229 flattened the scoring *output* to one contiguous buffer, but the

--- a/neat-core/benches/common/mod.rs
+++ b/neat-core/benches/common/mod.rs
@@ -7,7 +7,7 @@
 //! a single source of truth that is exercised by a real `cargo test` run rather
 //! than only compiled inside the `harness = false` bench.
 
-use neat_core::network::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::network::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 use neat_core::squash::SquashType;
 use neat_core::topological_backprop::{
     NEURON_TYPE_HIDDEN, NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, SynapseInput,
@@ -241,11 +241,14 @@ pub fn build_network(spec: &NetSpec, seed: u64) -> CompiledNetwork {
     }
 
     let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::with_capacity(estimated_trace_size),

--- a/neat-core/src/batch_scoring.rs
+++ b/neat-core/src/batch_scoring.rs
@@ -153,9 +153,15 @@ impl BatchScratch {
 /// Each lane is an independent `bias + Σ w·a` in synapse order and is squashed
 /// and clamped by the same per-lane rule, so a record's activation is
 /// **bit-identical** at every tile width.
+///
+/// The synapse stream comes in as the struct-of-arrays hot view (`hot_weights` /
+/// `hot_from`, Issue #533): the gather reads only weight and source index, so
+/// leaving `synapse_type` behind on [`SynapseData`] narrows the hot stream from
+/// 8 B to 6 B per synapse.
 pub(crate) fn run_interleaved_forward<const R: usize>(
     neurons: &[NeuronData],
-    synapses: &[SynapseData],
+    hot_weights: &[f32],
+    hot_from: &[u16],
     num_inputs: usize,
     inter: &mut [f32],
 ) {
@@ -173,7 +179,8 @@ pub(crate) fn run_interleaved_forward<const R: usize>(
         let squash = SquashType::from(neuron.squash_type);
         let start = neuron.start_synapse as usize;
         let end = start + neuron.num_synapses as usize;
-        let sums = weighted_sum_interleaved::<R>(synapses, inter, start, end, neuron.bias);
+        let sums =
+            weighted_sum_interleaved::<R>(hot_weights, hot_from, inter, start, end, neuron.bias);
 
         let squashed = squash_xn(squash, sums).unwrap_or_else(|| {
             let st = neuron.squash_type;
@@ -476,9 +483,12 @@ impl CompiledNetwork {
     /// use the exact per-lane path instead. Bit-identical to the per-lane
     /// 8-record path ([`weighted_sum_simd_8records`]) on the covered neurons.
     pub(crate) fn interleaved_forward_8(&self, inter: &mut [f32]) {
+        // Issue #533 - fail loud in debug if the SoA hot view has drifted.
+        self.debug_assert_hot_soa();
         run_interleaved_forward::<SCORING_LANES>(
             &self.neurons,
-            &self.synapses,
+            &self.hot_weights,
+            &self.hot_from,
             self.num_inputs,
             inter,
         );

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::loss::MSE_TILE_LANES;
-use crate::network::{CompiledNetwork, MAX_NODE_COUNT, NeuronData, SynapseData};
+use crate::network::{CompiledNetwork, MAX_NODE_COUNT, NeuronData, SynapseData, hot_synapse_soa};
 use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
 
@@ -405,11 +405,17 @@ pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, Cr
     // Estimate trace data buffer capacity (same heuristic as binary deserialisation)
     let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
 
+    // Issue #533 - struct-of-arrays view of the two fields the interleaved
+    // gather reads, built from the same vector so it cannot drift.
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
+
     Ok(CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::with_capacity(estimated_trace_size),

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -46,7 +46,7 @@ pub use creature::{
     creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
     squash_name_from, synapse_type_name_from,
 };
-pub use network::{CompiledNetwork, NetworkError, NeuronData, SynapseData};
+pub use network::{CompiledNetwork, NetworkError, NeuronData, SynapseData, hot_synapse_soa};
 pub use squash::SquashType;
 pub use synapse_type::SynapseType;
 pub use training_data::{

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -581,7 +581,13 @@ fn interleaved_tile_mse<const R: usize>(
         *slot = 0.0;
     }
 
-    run_interleaved_forward::<R>(&network.neurons, &network.synapses, num_inputs, inter);
+    run_interleaved_forward::<R>(
+        &network.neurons,
+        &network.hot_weights,
+        &network.hot_from,
+        num_inputs,
+        inter,
+    );
 
     for l in 0..R {
         let target_base = (base_idx + l) * values_per_record + input_size;
@@ -604,6 +610,8 @@ fn mse_sum_batch_interleaved<const R: usize>(
     num_outputs: usize,
     num_records: usize,
 ) -> f64 {
+    // Issue #533 - fail loud in debug if the SoA hot view has drifted.
+    network.debug_assert_hot_soa();
     let inv_outputs: f64 = if num_outputs > 0 {
         1.0 / (num_outputs as f64)
     } else {
@@ -1777,11 +1785,14 @@ mod interleaved_mse_parity {
 
         let num_non_inputs = neurons.len();
         let num_neurons = num_inputs + num_non_inputs;
+        let (hot_weights, hot_from) = crate::network::hot_synapse_soa(&synapses);
         CompiledNetwork {
             num_neurons,
             num_inputs,
             neurons,
             synapses,
+            hot_weights,
+            hot_from,
             activations: vec![0.0; num_neurons],
             hint_values_buffer: vec![0.0; num_non_inputs],
             trace_data_buffer: Vec::new(),

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -143,6 +143,29 @@ pub struct SynapseData {
     pub synapse_type: u8,
 }
 
+/// Build the struct-of-arrays view of the hot synapse fields (Issue #533).
+///
+/// The single home of the rule that says what
+/// [`CompiledNetwork::hot_weights`] / [`CompiledNetwork::hot_from`] contain:
+/// `synapses[i].weight` and `synapses[i].from_index` in **exactly** the order
+/// `synapses` holds them, one entry per synapse. Every construction path calls
+/// this — the binary deserialiser [`CompiledNetwork::new`] and
+/// [`crate::creature::compile_creature`] — so the two views cannot drift.
+///
+/// The interleaved gather reads only these two fields; splitting them out drops
+/// the hot loop's synapse stream from 8 B to 6 B per synapse and gives the
+/// prefetcher two clean sequential streams over `start..end`.
+/// `synapse_type` stays on [`SynapseData`] for the aggregate/IF paths.
+pub fn hot_synapse_soa(synapses: &[SynapseData]) -> (Vec<f32>, Vec<u16>) {
+    let mut weights = Vec::with_capacity(synapses.len());
+    let mut from = Vec::with_capacity(synapses.len());
+    for s in synapses {
+        weights.push(s.weight);
+        from.push(s.from_index);
+    }
+    (weights, from)
+}
+
 /// Compiled network data structure
 ///
 /// `Clone` is supported so native tools (for example the NEAT-AI scorer) can run
@@ -177,6 +200,16 @@ pub struct CompiledNetwork {
     /// Synapse data using typed struct for cache efficiency
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub synapses: Vec<SynapseData>,
+    /// Hot-path weights, struct-of-arrays view of `synapses[i].weight`
+    /// (Issue #533). Built by [`hot_synapse_soa`] at every construction path;
+    /// read only by the record-interleaved gather.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub hot_weights: Vec<f32>,
+    /// Hot-path source indices, struct-of-arrays view of
+    /// `synapses[i].from_index` (Issue #533). Same order and length as
+    /// [`Self::synapses`] and [`Self::hot_weights`].
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub hot_from: Vec<u16>,
     /// Activation buffer - reused across calls
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub activations: Vec<f32>,
@@ -212,6 +245,44 @@ pub struct CompiledNetwork {
     /// [`Self::batch_activations`].
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub mse_inter: Vec<f32>,
+}
+
+impl CompiledNetwork {
+    /// Debug-only guard that the Issue #533 struct-of-arrays hot view still
+    /// mirrors [`Self::synapses`] element-for-element.
+    ///
+    /// The two views are redundant by construction — [`hot_synapse_soa`] builds
+    /// them from the same vector at every construction path — but the fields are
+    /// public, so a caller assembling a [`CompiledNetwork`] literal (or mutating
+    /// `synapses` afterwards) could let them drift. Every entry point into the
+    /// record-interleaved gather calls this first, so a drifted network fails
+    /// loudly in debug and test builds rather than silently scoring wrong
+    /// numbers. Compiles away entirely in release.
+    #[inline]
+    pub(crate) fn debug_assert_hot_soa(&self) {
+        debug_assert_eq!(
+            self.hot_weights.len(),
+            self.synapses.len(),
+            "Issue #533 - hot_weights must hold one entry per synapse"
+        );
+        debug_assert_eq!(
+            self.hot_from.len(),
+            self.synapses.len(),
+            "Issue #533 - hot_from must hold one entry per synapse"
+        );
+        #[cfg(debug_assertions)]
+        for (i, s) in self.synapses.iter().enumerate() {
+            debug_assert_eq!(
+                self.hot_weights[i].to_bits(),
+                s.weight.to_bits(),
+                "Issue #533 - hot_weights[{i}] drifted from synapses[{i}].weight"
+            );
+            debug_assert_eq!(
+                self.hot_from[i], s.from_index,
+                "Issue #533 - hot_from[{i}] drifted from synapses[{i}].from_index"
+            );
+        }
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
@@ -344,11 +415,17 @@ impl CompiledNetwork {
         // Each aggregate records 2 floats (neuron_idx, trace_info), plus -1.0 terminator
         let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
 
+        // Issue #533 - struct-of-arrays view of the two fields the interleaved
+        // gather reads, built from the same vector so it cannot drift.
+        let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
+
         Ok(CompiledNetwork {
             num_neurons,
             num_inputs,
             neurons,
             synapses,
+            hot_weights,
+            hot_from,
             activations: vec![0.0; num_neurons],
             // Issue #1173 - Pre-allocate hint values buffer
             hint_values_buffer: vec![0.0; num_non_inputs],

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -523,6 +523,10 @@ fn store_quad(out: &mut [f32], acc: v128) {
 /// Issue #287 - record-interleaved `R`-lane weighted sum for the batched
 /// scoring hot path; widened to a tunable tile in Issue #530.
 ///
+/// The synapse stream is read through the struct-of-arrays hot view
+/// (`hot_weights` / `hot_from`, Issue #533) rather than `&[SynapseData]`, so the
+/// loop streams 6 B per synapse instead of 8 B.
+///
 /// `inter` is the transposed batch activation buffer: lane `l` of source neuron
 /// `n` lives at `inter[n * R + l]`, so all `R` records for a synapse's source
 /// are contiguous. Each gather is then `R / 4` adjacent 4-wide reads instead of
@@ -535,13 +539,19 @@ fn store_quad(out: &mut [f32], acc: v128) {
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_interleaved<const R: usize>(
-    synapses: &[SynapseData],
+    hot_weights: &[f32],
+    hot_from: &[u16],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
 ) -> [f32; R] {
     const { assert_interleaved_tile::<R>() };
+    debug_assert_eq!(
+        hot_weights.len(),
+        hot_from.len(),
+        "Issue #533 - the hot synapse arrays must be the same length"
+    );
 
     if scalar::synapse_count(start, end) == 0 {
         return [bias; R];
@@ -551,9 +561,8 @@ pub fn weighted_sum_interleaved<const R: usize>(
     let mut acc = [f32x4_splat(bias); MAX_INTERLEAVED_LANES / 4];
 
     for i in start..end {
-        let synapse = &synapses[i];
-        let base = synapse.from_index as usize * R;
-        let weights = f32x4_splat(synapse.weight);
+        let base = hot_from[i] as usize * R;
+        let weights = f32x4_splat(hot_weights[i]);
 
         // The R lanes are contiguous, so these reads walk whole cache lines.
         for (q, a) in acc.iter_mut().take(quads).enumerate() {
@@ -576,13 +585,14 @@ pub fn weighted_sum_interleaved<const R: usize>(
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_interleaved_8(
-    synapses: &[SynapseData],
+    hot_weights: &[f32],
+    hot_from: &[u16],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    weighted_sum_interleaved::<8>(synapses, inter, start, end, bias)
+    weighted_sum_interleaved::<8>(hot_weights, hot_from, inter, start, end, bias)
 }
 
 // Native (non-wasm32) multi-record helpers now live in `simd_native.rs` and use

--- a/neat-core/src/simd_native.rs
+++ b/neat-core/src/simd_native.rs
@@ -116,19 +116,19 @@ fn weighted_sum_simd_4records_scalar(
 /// whichever tile width** is used.
 #[inline]
 fn weighted_sum_interleaved_scalar<const R: usize>(
-    synapses: &[SynapseData],
+    hot_weights: &[f32],
+    hot_from: &[u16],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
 ) -> [f32; R] {
     let mut acc = [bias; R];
-    for synapse in synapses.iter().take(end).skip(start) {
-        let base = synapse.from_index as usize * R;
-        let w = synapse.weight;
+    for (w, from) in hot_weights[start..end].iter().zip(&hot_from[start..end]) {
+        let base = *from as usize * R;
         let chunk = &inter[base..base + R];
         for (a, c) in acc.iter_mut().zip(chunk) {
-            *a += *c * w;
+            *a += *c * *w;
         }
     }
     acc
@@ -201,13 +201,17 @@ mod x86 {
     /// # Safety
     /// Caller must ensure AVX2 is enabled (`is_x86_feature_detected!("avx2")`).
     /// Issue #287 - `inter.len()` must be `num_neurons * R` and every
-    /// `synapse.from_index` in `start..end` must be `< num_neurons`, so
+    /// `hot_from` entry in `start..end` must be `< num_neurons`, so
     /// `from_index * R + R <= inter.len()`; `CompiledNetwork::new` validates the
     /// synapse index range at load time. The `R`-wide read is then in bounds.
+    /// Issue #533 - `start..end` must also be in bounds for **both** hot arrays
+    /// (`end <= hot_weights.len() == hot_from.len()`), which holds because both
+    /// are built from `synapses` by `hot_synapse_soa` and carry its length.
     #[target_feature(enable = "avx2")]
     #[inline]
     pub unsafe fn weighted_sum_interleaved_avx2<const R: usize>(
-        synapses: &[SynapseData],
+        hot_weights: &[f32],
+        hot_from: &[u16],
         inter: &[f32],
         start: usize,
         end: usize,
@@ -218,9 +222,11 @@ mod x86 {
         let mut acc = [_mm256_set1_ps(bias); super::MAX_INTERLEAVED_LANES / 8];
         let ptr = inter.as_ptr();
         for i in start..end {
-            let synapse = unsafe { synapses.get_unchecked(i) };
-            let base = synapse.from_index as usize * R;
-            let ws = _mm256_set1_ps(synapse.weight);
+            // SAFETY: `i < end <= hot_from.len() == hot_weights.len()`, checked
+            // by the caller's `synapse_count` prologue against the same span
+            // that indexes `synapses`.
+            let base = unsafe { *hot_from.get_unchecked(i) } as usize * R;
+            let ws = _mm256_set1_ps(unsafe { *hot_weights.get_unchecked(i) });
             for (o, a) in acc.iter_mut().take(octs).enumerate() {
                 // SAFETY: base + R <= inter.len() by the load-time index
                 // validation documented above, and `o < R / 8`, so this
@@ -488,14 +494,18 @@ mod aarch64 {
     /// # Safety
     /// Caller must ensure NEON is available (typical on aarch64-apple-darwin /
     /// linux-aarch64). Issue #287 - `inter.len()` must be `num_neurons * R` and
-    /// every `synapse.from_index` in `start..end` must be `< num_neurons`, so
+    /// every `hot_from` entry in `start..end` must be `< num_neurons`, so
     /// `from_index * R + R <= inter.len()`; `CompiledNetwork::new` validates the
     /// synapse index range at load time, making the `R / 4` 4-wide reads in
     /// bounds.
+    /// Issue #533 - `start..end` must also be in bounds for **both** hot arrays
+    /// (`end <= hot_weights.len() == hot_from.len()`), which holds because both
+    /// are built from `synapses` by `hot_synapse_soa` and carry its length.
     #[target_feature(enable = "neon")]
     #[inline]
     pub unsafe fn weighted_sum_interleaved_neon<const R: usize>(
-        synapses: &[SynapseData],
+        hot_weights: &[f32],
+        hot_from: &[u16],
         inter: &[f32],
         start: usize,
         end: usize,
@@ -506,9 +516,11 @@ mod aarch64 {
         let mut acc = [vdupq_n_f32(bias); super::MAX_INTERLEAVED_LANES / 4];
         let ptr = inter.as_ptr();
         for i in start..end {
-            let synapse = unsafe { synapses.get_unchecked(i) };
-            let base = synapse.from_index as usize * R;
-            let vw = vdupq_n_f32(synapse.weight);
+            // SAFETY: `i < end <= hot_from.len() == hot_weights.len()`, checked
+            // by the caller's `synapse_count` prologue against the same span
+            // that indexes `synapses`.
+            let base = unsafe { *hot_from.get_unchecked(i) } as usize * R;
+            let vw = vdupq_n_f32(unsafe { *hot_weights.get_unchecked(i) });
             for (q, a) in acc.iter_mut().take(quads).enumerate() {
                 // SAFETY: base + R <= inter.len() by the load-time index
                 // validation documented above, and `q < R / 4`, so this 4-wide
@@ -777,13 +789,19 @@ pub fn weighted_sum_simd_8records(
 /// other lanes, so widening `R` leaves each record's sum **bit-identical**.
 #[inline]
 pub fn weighted_sum_interleaved<const R: usize>(
-    synapses: &[SynapseData],
+    hot_weights: &[f32],
+    hot_from: &[u16],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
 ) -> [f32; R] {
     const { assert_interleaved_tile::<R>() };
+    debug_assert_eq!(
+        hot_weights.len(),
+        hot_from.len(),
+        "Issue #533 - the hot synapse arrays must be the same length"
+    );
 
     if scalar::synapse_count(start, end) == 0 {
         return [bias; R];
@@ -796,7 +814,14 @@ pub fn weighted_sum_interleaved<const R: usize>(
             // available, satisfying the `#[target_feature(enable = "avx2")]`
             // precondition on `weighted_sum_interleaved_avx2`.
             return unsafe {
-                x86::weighted_sum_interleaved_avx2::<R>(synapses, inter, start, end, bias)
+                x86::weighted_sum_interleaved_avx2::<R>(
+                    hot_weights,
+                    hot_from,
+                    inter,
+                    start,
+                    end,
+                    bias,
+                )
             };
         }
     }
@@ -808,25 +833,33 @@ pub fn weighted_sum_interleaved<const R: usize>(
             // is available, satisfying the `#[target_feature(enable = "neon")]`
             // precondition on `weighted_sum_interleaved_neon`.
             return unsafe {
-                aarch64::weighted_sum_interleaved_neon::<R>(synapses, inter, start, end, bias)
+                aarch64::weighted_sum_interleaved_neon::<R>(
+                    hot_weights,
+                    hot_from,
+                    inter,
+                    start,
+                    end,
+                    bias,
+                )
             };
         }
     }
 
-    weighted_sum_interleaved_scalar::<R>(synapses, inter, start, end, bias)
+    weighted_sum_interleaved_scalar::<R>(hot_weights, hot_from, inter, start, end, bias)
 }
 
 /// The 8-lane tile of [`weighted_sum_interleaved`], kept as the name the
 /// batched **scoring** path (`BatchScratch::inter`) and its tests use.
 #[inline]
 pub fn weighted_sum_interleaved_8(
-    synapses: &[SynapseData],
+    hot_weights: &[f32],
+    hot_from: &[u16],
     inter: &[f32],
     start: usize,
     end: usize,
     bias: f32,
 ) -> [f32; 8] {
-    weighted_sum_interleaved::<8>(synapses, inter, start, end, bias)
+    weighted_sum_interleaved::<8>(hot_weights, hot_from, inter, start, end, bias)
 }
 
 /// 4-record weighted sum: FMA+SSE on x86_64, NEON on aarch64, else scalar.

--- a/neat-core/tests/aggregate_squash_set.rs
+++ b/neat-core/tests/aggregate_squash_set.rs
@@ -16,7 +16,7 @@
 use neat_core::range::apply_limit_range;
 use neat_core::squash::{SquashType, apply_squash};
 use neat_core::unsquash::apply_unsquash;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// The six aggregate squashes.
 const AGGREGATES: [SquashType; 6] = [
@@ -96,11 +96,14 @@ fn build_network(squash: SquashType) -> CompiledNetwork {
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/aggregate_squash_tail_parity.rs
+++ b/neat-core/tests/aggregate_squash_tail_parity.rs
@@ -20,7 +20,7 @@ use neat_core::loss::{
     mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
 };
 use neat_core::squash::SquashType;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Every aggregate squash the activation rule dispatches on.
 const AGGREGATES: [SquashType; 6] = [
@@ -92,11 +92,14 @@ fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/batch_record_skeleton.rs
+++ b/neat-core/tests/batch_record_skeleton.rs
@@ -18,7 +18,7 @@ use neat_core::loss::{
     cross_entropy_sum_batch_packed, hinge_sum_batch_packed, mae_sum_batch_packed,
     mape_sum_batch_packed, mse_sum_batch_packed, msle_sum_batch_packed,
 };
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 const IDENTITY: u8 = 0;
 const TANH: u8 = 7;
@@ -45,11 +45,14 @@ fn network(
 ) -> CompiledNetwork {
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/flat_record_scoring_parity.rs
+++ b/neat-core/tests/flat_record_scoring_parity.rs
@@ -19,7 +19,7 @@
 //! the 7/9/12 remainder counts.
 
 use neat_core::squash::SquashType;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 #[path = "../benches/common/mod.rs"]
 #[allow(dead_code)]
@@ -81,11 +81,14 @@ fn build_local_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/hot_synapse_soa.rs
+++ b/neat-core/tests/hot_synapse_soa.rs
@@ -1,0 +1,251 @@
+//! Issue #533 — the struct-of-arrays hot view of the synapse array.
+//!
+//! `CompiledNetwork::hot_weights` / `hot_from` mirror `synapses[i].weight` and
+//! `synapses[i].from_index` in the same order, so the record-interleaved gather
+//! streams 6 B per synapse instead of `SynapseData`'s 8 B. The view is
+//! redundant, and redundancy is a correctness hazard, so these tests pin it as
+//! a **public invariant** across every construction path:
+//!
+//! - the binary deserialiser `CompiledNetwork::new`,
+//! - `compile_creature` (JSON), and
+//! - `Clone` (directory-mode scoring clones one network per worker).
+//!
+//! They are "what" tests — they build real networks through the public entry
+//! points and assert on observable state and on scored numbers, not on how the
+//! gather is wired. The final test pins the fail-loud guard: a network whose
+//! hot view has drifted must panic in a debug build rather than silently
+//! scoring wrong numbers.
+
+use neat_core::loss::mse_sum_batch_packed;
+use neat_core::{
+    CompiledNetwork, SynapseData, compile_creature, hot_synapse_soa, parse_creature_json,
+};
+
+/// Assert the SoA view mirrors `synapses` element-for-element. Weights are
+/// compared by **bit pattern**: the hot view is a copy, not a recomputation, so
+/// anything short of bit equality is drift.
+fn assert_hot_view_mirrors_synapses(net: &CompiledNetwork, context: &str) {
+    assert_eq!(
+        net.hot_weights.len(),
+        net.synapses.len(),
+        "{context}: hot_weights must hold one entry per synapse"
+    );
+    assert_eq!(
+        net.hot_from.len(),
+        net.synapses.len(),
+        "{context}: hot_from must hold one entry per synapse"
+    );
+    for (i, s) in net.synapses.iter().enumerate() {
+        assert_eq!(
+            net.hot_weights[i].to_bits(),
+            s.weight.to_bits(),
+            "{context}: hot_weights[{i}] ({}) is not synapses[{i}].weight ({})",
+            net.hot_weights[i],
+            s.weight
+        );
+        assert_eq!(
+            net.hot_from[i], s.from_index,
+            "{context}: hot_from[{i}] is not synapses[{i}].from_index"
+        );
+    }
+}
+
+/// A creature with two hidden neurons and one output over `input` inputs, and
+/// deliberately **asymmetric** weights so a reordered or duplicated hot entry
+/// cannot coincide with the correct one.
+const CREATURE_JSON: &str = r#"{
+    "input": 3,
+    "output": 1,
+    "neurons": [
+        {"type": "hidden", "uuid": "hidden-0", "bias": 0.11, "squash": "TANH"},
+        {"type": "hidden", "uuid": "hidden-1", "bias": -0.07, "squash": "TANH"},
+        {"type": "output", "uuid": "output-0", "bias": 0.02, "squash": "TANH"}
+    ],
+    "synapses": [
+        {"fromUUID": "input-0", "toUUID": "hidden-0", "weight": 0.31},
+        {"fromUUID": "input-1", "toUUID": "hidden-0", "weight": -0.62},
+        {"fromUUID": "input-2", "toUUID": "hidden-0", "weight": 0.17},
+        {"fromUUID": "input-0", "toUUID": "hidden-1", "weight": -0.24},
+        {"fromUUID": "input-2", "toUUID": "hidden-1", "weight": 0.53},
+        {"fromUUID": "hidden-0", "toUUID": "output-0", "weight": 0.72},
+        {"fromUUID": "hidden-1", "toUUID": "output-0", "weight": -0.41}
+    ]
+}"#;
+
+/// Serialise the same topology in the compiled binary format
+/// (header `[num_neurons: u32, num_inputs: u32]`, then per non-input neuron a
+/// 12-byte header `[bias: f64, squash: u8, is_constant: u8, num_synapses: u16]`
+/// followed by 12-byte synapse records `[from: u16, type: u8, pad, weight: f64]`).
+fn serialise_binary_network() -> Vec<u8> {
+    /// `(bias, squash_type, [(from_index, weight)…])` for one non-input neuron.
+    type NeuronSpec = (f64, u8, Vec<(u16, f64)>);
+
+    // 3 inputs + hidden-0, hidden-1, output-0.
+    const TANH: u8 = 7;
+    let neurons: [NeuronSpec; 3] = [
+        (0.11, TANH, vec![(0, 0.31), (1, -0.62), (2, 0.17)]),
+        (-0.07, TANH, vec![(0, -0.24), (2, 0.53)]),
+        (0.02, TANH, vec![(3, 0.72), (4, -0.41)]),
+    ];
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&6u32.to_le_bytes()); // num_neurons
+    bytes.extend_from_slice(&3u32.to_le_bytes()); // num_inputs
+    for (bias, squash, synapses) in &neurons {
+        bytes.extend_from_slice(&bias.to_le_bytes());
+        bytes.push(*squash);
+        bytes.push(0); // is_constant
+        bytes.extend_from_slice(&(synapses.len() as u16).to_le_bytes());
+        for (from, weight) in synapses {
+            bytes.extend_from_slice(&from.to_le_bytes());
+            bytes.push(0); // synapse_type
+            bytes.push(0); // padding
+            bytes.extend_from_slice(&weight.to_le_bytes());
+        }
+    }
+    bytes
+}
+
+/// Packed `[inputs…, target]` records, distinct per record so a lane mix-up in
+/// the interleaved gather cannot hide.
+fn packed_records(num_records: usize, num_inputs: usize) -> Vec<f32> {
+    (0..num_records)
+        .flat_map(|r| {
+            let mut row: Vec<f32> = (0..num_inputs)
+                .map(|i| (((r * num_inputs + i) as f32) * 0.037).sin())
+                .collect();
+            row.push(((r as f32) * 0.11).cos() * 0.5);
+            row
+        })
+        .collect()
+}
+
+#[test]
+fn compile_creature_builds_a_hot_view_matching_every_synapse() {
+    let creature = parse_creature_json(CREATURE_JSON).expect("creature must parse");
+    let net = compile_creature(&creature).expect("creature must compile");
+
+    assert_eq!(net.synapses.len(), 7, "fixture must carry all 7 synapses");
+    assert_hot_view_mirrors_synapses(&net, "compile_creature");
+
+    // Non-vacuous: the hot view must carry the fixture's actual asymmetric
+    // weights and sources in declaration order, not zeros or a sorted copy.
+    assert_eq!(net.hot_from, vec![0u16, 1, 2, 0, 2, 3, 4]);
+    let expected: Vec<f32> = vec![0.31, -0.62, 0.17, -0.24, 0.53, 0.72, -0.41]
+        .into_iter()
+        .map(|w: f64| w as f32)
+        .collect();
+    assert_eq!(net.hot_weights, expected);
+}
+
+#[test]
+fn binary_deserialiser_builds_a_hot_view_matching_every_synapse() {
+    let net = CompiledNetwork::new(&serialise_binary_network()).expect("network must load");
+
+    assert_eq!(net.synapses.len(), 7, "fixture must carry all 7 synapses");
+    assert_hot_view_mirrors_synapses(&net, "CompiledNetwork::new");
+    assert_eq!(net.hot_from, vec![0u16, 1, 2, 0, 2, 3, 4]);
+}
+
+#[test]
+fn cloning_a_network_preserves_the_hot_view() {
+    // Directory-mode scoring clones one `CompiledNetwork` per worker, so the
+    // hot view has to survive `Clone` intact.
+    let net = CompiledNetwork::new(&serialise_binary_network()).expect("network must load");
+    let clone = net.clone();
+    assert_hot_view_mirrors_synapses(&clone, "clone");
+    assert_eq!(clone.hot_weights, net.hot_weights);
+    assert_eq!(clone.hot_from, net.hot_from);
+}
+
+#[test]
+fn both_construction_paths_agree_on_the_hot_view() {
+    // The JSON and binary routes describe the same topology, so their hot views
+    // must be identical — this is what stops one path drifting from the other.
+    let creature = parse_creature_json(CREATURE_JSON).expect("creature must parse");
+    let from_json = compile_creature(&creature).expect("creature must compile");
+    let from_binary = CompiledNetwork::new(&serialise_binary_network()).expect("must load");
+
+    assert_eq!(from_json.hot_from, from_binary.hot_from);
+    assert_eq!(from_json.hot_weights, from_binary.hot_weights);
+}
+
+#[test]
+fn hot_synapse_soa_preserves_order_and_handles_an_empty_array() {
+    // Edge case: no synapses at all yields two empty arrays, not a panic.
+    let (weights, from) = hot_synapse_soa(&[]);
+    assert!(weights.is_empty() && from.is_empty());
+
+    // Repeated sources and a repeated weight must survive in position order —
+    // a de-duplicating or sorting implementation would fail here.
+    let synapses = vec![
+        SynapseData {
+            weight: -1.5,
+            from_index: 9,
+            synapse_type: 0,
+        },
+        SynapseData {
+            weight: 0.25,
+            from_index: 9,
+            synapse_type: 1,
+        },
+        SynapseData {
+            weight: -1.5,
+            from_index: 2,
+            synapse_type: 2,
+        },
+    ];
+    let (weights, from) = hot_synapse_soa(&synapses);
+    assert_eq!(weights, vec![-1.5f32, 0.25, -1.5]);
+    assert_eq!(from, vec![9u16, 9, 2]);
+}
+
+#[test]
+fn interleaved_scoring_matches_the_single_record_reference() {
+    // The gather now reads the hot view, so the batched fused-MSE result must
+    // still equal an independent oracle: each record scored on its own through
+    // the scalar `activate` forward pass, which never touches `hot_weights` or
+    // `hot_from`. Record counts straddle the scalar, 4-way, 8-record and
+    // 32-record interleaved tiers.
+    const TOL: f64 = 1e-3;
+    let creature = parse_creature_json(CREATURE_JSON).expect("creature must parse");
+    let num_inputs = 3usize;
+
+    for num_records in [1usize, 5, 8, 33, 70] {
+        let mut net = compile_creature(&creature).expect("creature must compile");
+        let records = packed_records(num_records, num_inputs);
+        let batched = mse_sum_batch_packed(&mut net, &records, num_inputs, 1, true);
+
+        let mut reference = 0.0f64;
+        let mut oracle = compile_creature(&creature).expect("creature must compile");
+        for r in 0..num_records {
+            let base = r * (num_inputs + 1);
+            let out = oracle.activate(&records[base..base + num_inputs], 1);
+            let diff = (records[base + num_inputs] - out[0]) as f64;
+            reference += diff * diff;
+        }
+
+        assert!(
+            (batched - reference).abs() < TOL,
+            "n={num_records}: interleaved MSE {batched} vs single-record reference {reference}"
+        );
+    }
+}
+
+/// Fail-loud guard (debug builds): a drifted hot view must panic rather than
+/// score silently-wrong numbers. Only meaningful where `debug_assert!` is
+/// compiled in, which is how the test suite runs.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "Issue #533")]
+fn a_drifted_hot_view_fails_loud_instead_of_scoring_wrong_numbers() {
+    let creature = parse_creature_json(CREATURE_JSON).expect("creature must parse");
+    let mut net = compile_creature(&creature).expect("creature must compile");
+
+    // Simulate the redundancy hazard the issue calls out: a caller mutates a
+    // weight and forgets to rebuild the hot view.
+    net.synapses[0].weight = 12.5;
+
+    let records = packed_records(8, 3);
+    let _ = mse_sum_batch_packed(&mut net, &records, 3, 1, true);
+}

--- a/neat-core/tests/inline_squash_dispatch.rs
+++ b/neat-core/tests/inline_squash_dispatch.rs
@@ -22,7 +22,7 @@ use neat_core::loss::{
 use neat_core::range::apply_limit_range;
 use neat_core::squash::{SquashType, apply_squash};
 use neat_core::squash_simd::SQUASH_SIMD_MAX_ABS_ERR;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Every standard (non-aggregate) squash type. Aggregates 32–37 are activated
 /// by a different rule and are covered by `aggregate_squash_tail_parity.rs`.
@@ -94,11 +94,14 @@ fn unit_network(squash: SquashType) -> CompiledNetwork {
         is_constant: false,
     }];
 
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons: 2,
         num_inputs: 1,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; 2],
         hint_values_buffer: vec![0.0; 1],
         trace_data_buffer: Vec::new(),
@@ -267,11 +270,14 @@ fn mixed_aggregate_network(squash: SquashType) -> CompiledNetwork {
         },
     ];
 
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons: 4,
         num_inputs: 2,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; 4],
         hint_values_buffer: vec![0.0; 2],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/interleaved_scoring_parity.rs
+++ b/neat-core/tests/interleaved_scoring_parity.rs
@@ -12,7 +12,7 @@
 //! both the vectorised group path and the exact single-record tail are covered.
 
 use neat_core::squash::SquashType;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Build a two-hidden-plus-one-output feedforward network where every non-input
 /// neuron uses `squash`. `num_inputs` inputs fully connect into each hidden
@@ -62,11 +62,14 @@ fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/mse_batch_interleaved_parity.rs
+++ b/neat-core/tests/mse_batch_interleaved_parity.rs
@@ -17,7 +17,7 @@
 
 use neat_core::loss::mse_sum_batch_packed;
 use neat_core::squash::SquashType;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Build a forward-only network: `num_inputs` inputs fully connected into two
 /// hidden neurons and one output neuron, every non-input neuron using `squash`.
@@ -66,11 +66,14 @@ fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/mse_squash_simd_parity.rs
+++ b/neat-core/tests/mse_squash_simd_parity.rs
@@ -13,7 +13,7 @@
 
 use neat_core::loss::mse_sum_batch_packed;
 use neat_core::squash::SquashType;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Build a tiny forward-only network: `num_inputs` inputs fully connected into
 /// two hidden neurons and one output neuron, every non-input neuron using
@@ -65,11 +65,14 @@ fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/network_activate_trace_batch.rs
+++ b/neat-core/tests/network_activate_trace_batch.rs
@@ -5,7 +5,7 @@
 //! batch-parity cases belong here, exercised through the public API, so the trace
 //! header layout only ever has to be updated in one place.
 
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Records per `activate_and_trace_batch_4way` call — also the header length.
 const BATCH_RECORDS: usize = 4;
@@ -22,11 +22,14 @@ fn make_network(
     let num_neurons = num_inputs + neurons.len();
     let num_non_inputs = neurons.len();
     let estimated_trace_size = (num_non_inputs / 10).max(1) * 2 + 1;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::with_capacity(estimated_trace_size),

--- a/neat-core/tests/packed_record_scan.rs
+++ b/neat-core/tests/packed_record_scan.rs
@@ -19,7 +19,7 @@ use neat_core::loss::{
     mae_sum_batch_packed, mape_sum_batch_packed, mse_mean_record, mse_sum_batch_packed,
     msle_sum_batch_packed,
 };
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Identity squash — keeps every fixture's activation exact, so a mismatch is a
 /// carve bug rather than an approximation.
@@ -103,11 +103,14 @@ fn network(
     synapses: Vec<SynapseData>,
 ) -> CompiledNetwork {
     let num_non_inputs = neurons.len();
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/score_squash_simd_parity.rs
+++ b/neat-core/tests/score_squash_simd_parity.rs
@@ -13,7 +13,7 @@
 //! regression guard for the batching itself.
 
 use neat_core::squash::SquashType;
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 /// Build a small forward network: `num_inputs` inputs fully connected into two
 /// hidden neurons and one output neuron, every non-input neuron using `squash`.
@@ -62,11 +62,14 @@ fn build_network(num_inputs: usize, squash: SquashType) -> CompiledNetwork {
 
     let num_non_inputs = neurons.len();
     let num_neurons = num_inputs + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/short_input_zero_fill.rs
+++ b/neat-core/tests/short_input_zero_fill.rs
@@ -15,7 +15,7 @@
 //! loaded one (statelessness), and a narrow record must score identically
 //! through the single-record path and the batched loader (parity).
 
-use neat_core::{CompiledNetwork, NeuronData, SynapseData};
+use neat_core::{CompiledNetwork, NeuronData, SynapseData, hot_synapse_soa};
 
 const IDENTITY: u8 = 0;
 const TANH: u8 = 7;
@@ -46,11 +46,14 @@ const TOL: f32 = 1e-5;
 fn network(neurons: Vec<NeuronData>, synapses: Vec<SynapseData>) -> CompiledNetwork {
     let num_non_inputs = neurons.len();
     let num_neurons = NUM_INPUTS + num_non_inputs;
+    let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
     CompiledNetwork {
         num_neurons,
         num_inputs: NUM_INPUTS,
         neurons,
         synapses,
+        hot_weights,
+        hot_from,
         activations: vec![0.0; num_neurons],
         hint_values_buffer: vec![0.0; num_non_inputs],
         trace_data_buffer: Vec::new(),

--- a/neat-core/tests/simd_weighted_sums.rs
+++ b/neat-core/tests/simd_weighted_sums.rs
@@ -1,6 +1,6 @@
 //! SIMD weighted-sum tests (moved from `src/simd.rs`).
 
-use neat_core::network::SynapseData;
+use neat_core::network::{SynapseData, hot_synapse_soa};
 use neat_core::simd::{
     weighted_sum_interleaved_8, weighted_sum_no_bias_simd, weighted_sum_of_squares_simd,
     weighted_sum_of_squares_v2_simd, weighted_sum_simd, weighted_sum_simd_4records,
@@ -518,7 +518,9 @@ fn interleaved_8_is_bit_identical_to_scattered_8records() {
                 scattered.6,
                 scattered.7,
             ];
-            let interleaved = weighted_sum_interleaved_8(&synapses, &inter, 0, count, bias);
+            let (hot_weights, hot_from) = hot_synapse_soa(&synapses);
+            let interleaved =
+                weighted_sum_interleaved_8(&hot_weights, &hot_from, &inter, 0, count, bias);
             for l in 0..8 {
                 assert_eq!(
                     interleaved[l].to_bits(),


### PR DESCRIPTION
# Struct-of-arrays hot synapse fields for the interleaved gather (Issue #533)

## Summary

The record-interleaved gather reads only two of `SynapseData`'s three fields —
`weight` and `from_index` — but streams all 8 bytes of the struct. This adds a
parallel **struct-of-arrays** view, `CompiledNetwork::hot_weights: Vec<f32>` and
`hot_from: Vec<u16>`, built by the new `hot_synapse_soa` at every construction
path, and points `weighted_sum_interleaved::<R>` (scalar / AVX2 / NEON / wasm
`simd128`) at those two slices. The hot loop's synapse stream drops from **8 B
to 6 B** per synapse and the prefetcher gets two clean sequential streams over
`start..end`.

The change is **additive**: `synapse_type` stays on `SynapseData`, so
`neuron_activation_scalar`, the aggregate/IF paths, the per-lane scattered
kernels, the single-record forward passes and the binary format are all
untouched. Numerics are bit-identical — the same values accumulate in the same
order.

The redundancy is the correctness hazard the issue calls out, so
`CompiledNetwork::debug_assert_hot_soa` guards every interleaved entry point: a
network whose hot view has drifted from `synapses` panics in debug and test
builds rather than silently scoring wrong numbers, and compiles away entirely in
release.

Closes #533.

### Breaking change

Marked with a `perf(network)!:` Conventional Commit and a `BREAKING CHANGE:`
footer, so the `version-increment` job bumps the **minor** per `RELEASING.md`:

- `simd::weighted_sum_interleaved` / `weighted_sum_interleaved_8` now take
  `hot_weights: &[f32], hot_from: &[u16]` instead of `&[SynapseData]`.
- `CompiledNetwork` gains two public fields, so struct-literal construction must
  supply them. `hot_synapse_soa` is exported from the crate root for exactly
  that (the test and bench fixtures use it). Consumers that build networks
  through `CompiledNetwork::new` or `compile_creature` — the normal route — need
  no change.

## Evidence

### Benchmark — this is a performance change

`cargo bench --bench hot_paths` on the committed `production_exact` topology
(2,461 inputs, 1,666 non-input neurons, 21,513 synapses; 4,096 records per
iteration). `base` is the parent commit run from a separate `git worktree`;
`after` is this branch.

**Method.** 24 **ABBA** pairs per group — each round runs `base, after, after,
base` so the two arms bracket each other and thermal/load drift cancels within
the round — with criterion `--warm-up-time 1 --measurement-time 3 --sample-size
20`. Each arm's round score is the mean of its two runs. Apple M4 Pro
(12 cores), rustc 1.97.1, `--release`.

| group | base median | after median | Δ median | paired Δ (mean ± SE) | rounds favouring `after` |
| --- | ---: | ---: | ---: | ---: | ---: |
| `mse_sum_production/production_exact` | 15.566 ms | 15.412 ms | **−0.99%** | −1.12% ± 0.72 | 18 / 24 |
| `scoring/production_exact` | 24.621 ms | 24.061 ms | **−2.28%** | −1.02% ± 0.71 | 17 / 24 |

**Read the sign, not the magnitude.** The host was **not quiet** — an unrelated
process held the load average near 15 on a 12-core machine, so round-to-round
noise is ~3.5% and neither group's mean clears its own standard error. What does
clear is the direction: **35 of 48** paired rounds favour `after`, a two-sided
sign test p ≈ 0.002, and symmetric noise cannot produce that. The honest reading
is a real gain of roughly **1–2%** — at the low end of the issue's ≥1–2% bar,
not the 3–8% it hoped for.

**Why the upside shrank.** The issue's L1-residency argument was written against
the pre-#530 world: 21,513 synapses × 8 B = 168 KB against an M4 core's 128 KB
L1D, with an 8-lane `mse_inter` of 132 KB, so 6 B/synapse would have flipped the
array into L1. At the shipped `MSE_TILE_LANES = 32` that framing no longer
holds — `mse_inter` is ~528 KB and never L1-resident, and each synapse drives
`R = 32` lanes (128 B of gather traffic) against its own 8 B, so trimming 2 B
removes ~1.5% of the loop's bytes rather than crossing a capacity threshold. The
8-lane `scoring` group, where the ratio is 8 B against 32 B, is the
better-placed of the two and shows the larger median — which is why both groups
were measured rather than just the one the issue names.

> **Scope caveat** (same as `pr-summary-530.md`). The issue's acceptance gate
> names the *production* fixture in NEAT-AI-scorer — N ≈ 50 distinct creature
> variants over the ≈22 GiB multi-file corpus in directory mode. Neither the
> 3 MB production `network.json` nor the corpus is available in this repo
> (`BASELINE.md`, "Bench-only baseline"), so that end-to-end A/B cannot run
> here. What is measured above is the exact kernel the issue targets, at
> production record volume, on the closest reproducible proxy this repo has.
> The scorer-side confirmation on the full corpus remains the human-run gate
> before the wall-clock claim is made there — and given the measured margin sits
> at the bar rather than above it, that confirmation matters more than usual.

### Memory

`hot_weights` + `hot_from` cost **+6 B per synapse per compiled network** —
~126 KB on the production creature, ~6 MB across a 50-strong population, since
`CompiledNetwork: Clone` means directory-mode scoring clones them once per
worker. Documented in `README.md` and `benches/BASELINE.md`.

### No UI to screenshot

This is a library-internal performance change with no web interface. The
evidence is the benchmark table above plus the test results below.

### Mutation evidence — the tests can fail

Per AGENTS.md rule 2, each mutation was applied alone and reverted afterwards.
Suites: `hot_synapse_soa`, `mse_batch_interleaved_parity`,
`interleaved_scoring_parity`.

| # | mutation | result |
| --- | --- | --- |
| M1 | `hot_synapse_soa` builds the arrays in reverse order | **5 of 7 red** |
| M2 | `compile_creature` builds the SoA from an empty slice | **3 of 7 red** |
| M3 | `CompiledNetwork::new` drops the last synapse from the SoA | **3 of 7 red** |
| M4 | NEON kernel reads `hot_from[start]` for every synapse (source slip) | **1 of 7 red** (`interleaved_scoring_matches_the_single_record_reference`) |
| M5 | drop `debug_assert_hot_soa` from the MSE interleaved entry point | **1 of 7 red** (the fail-loud guard test) |
| — | all mutations reverted | **all suites green** |

M4 is caught only by the parity test, which is correct — a source slip does not
change the SoA arrays themselves, only the numbers they produce, which is
exactly why the suite carries an independent oracle as well as the structural
assertions.

The oracle is independent per AGENTS.md rule 1:
`interleaved_scoring_matches_the_single_record_reference` scores each record on
its own through the scalar `CompiledNetwork::activate` forward pass, which never
reads `hot_weights` or `hot_from`, so a fault in the gather moves only one side
of the assertion.

### Architecture

```mermaid
flowchart LR
    C["compile_creature / CompiledNetwork::new"] --> S["synapses: Vec&lt;SynapseData&gt;<br/>weight + from_index + synapse_type"]
    S --> H["hot_synapse_soa<br/>single home of the rule"]
    H --> W["hot_weights: Vec&lt;f32&gt;"]
    H --> F["hot_from: Vec&lt;u16&gt;"]
    W --> G["weighted_sum_interleaved::&lt;R&gt;<br/>6 B per synapse"]
    F --> G
    S --> A["aggregate / IF / single-record paths<br/>unchanged, 8 B per synapse"]
    G --> D{"debug_assert_hot_soa<br/>at every entry point"}
    D -- "drifted" --> P["panic in debug — fail loud"]
    D -- "consistent" --> O["bit-identical results"]
```

## Test Plan

New suite `neat-core/tests/hot_synapse_soa.rs` (7 tests):

- `compile_creature_builds_a_hot_view_matching_every_synapse` — the JSON
  construction path, asserted element-for-element **and** against the fixture's
  actual asymmetric weights/sources, so a zeroed or sorted copy fails.
- `binary_deserialiser_builds_a_hot_view_matching_every_synapse` — the same for
  `CompiledNetwork::new` over a hand-serialised `.bin` buffer.
- `cloning_a_network_preserves_the_hot_view` — `Clone` is on the directory-mode
  path, one network per worker.
- `both_construction_paths_agree_on_the_hot_view` — the JSON and binary routes
  describe one topology and must produce one hot view; this is what stops the
  two construction paths drifting apart.
- `hot_synapse_soa_preserves_order_and_handles_an_empty_array` — empty input,
  plus repeated sources and a repeated weight that a de-duplicating or sorting
  implementation would collapse.
- `interleaved_scoring_matches_the_single_record_reference` — the independent
  oracle, over record counts 1 / 5 / 8 / 33 / 70 straddling the scalar, 4-way,
  8-record and 32-record interleaved tiers.
- `a_drifted_hot_view_fails_loud_instead_of_scoring_wrong_numbers` — mutating
  `synapses[0].weight` without rebuilding the view must panic, not score.

Existing suites carried through unchanged (fixtures updated to supply the two
new fields via `hot_synapse_soa`): `mse_batch_interleaved_parity`,
`interleaved_scoring_parity`, `flat_record_scoring_parity`,
`score_squash_simd_parity`, `mse_squash_simd_parity`, `simd_weighted_sums`,
`aggregate_squash_set`, `aggregate_squash_tail_parity`,
`batch_record_skeleton`, `packed_record_scan`, `inline_squash_dispatch`,
`network_activate_trace_batch`, `short_input_zero_fill`. No test was commented
out, skipped, or weakened.

`./quality.sh` passes (fmt, clippy `-D warnings`, `cargo deny`, full workspace
tests, doc build, release build). `cargo check -p neat-core --target
wasm32-unknown-unknown` passes — required by AGENTS.md because no PR gate
compiles the wasm half of `simd.rs`, which this change edits.

### Security self-check

- No new external input surface: `hot_synapse_soa` reads an in-memory slice the
  loader has already validated.
- The load-time `from_index < num_neurons` guard in `CompiledNetwork::new`
  (Issue #207) is unchanged and still the soundness precondition for the
  kernels' `get_unchecked`; the new `unsafe` reads of `hot_weights` / `hot_from`
  are bounded by the same `start..end` span as the `synapses` reads they
  replace, and carry `SAFETY:` notes saying so.
- No secrets, no new dependencies, no shell/SQL/HTTP surface.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msh9r6hr-25546f`<!-- vibe-worker-issue-533 -->