### PR TITLE
Ship a production wasm64 (Memory64) activation bundle (Issue #541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,8 +580,17 @@ jobs:
         with:
           deno-version: "2.9.3"
 
-      - name: Run Memory64 smoke test
-        run: deno test tests/wasm64_memory64_smoke_test.ts < /dev/null
+      # Issue #541 — the same job also runs the *shipped-bundle* gate unit tests
+      # (memory-type and export-surface checks, and the numeric-parity fixture
+      # and comparator). Those need no nightly build, so they belong on every
+      # PR; the end-to-end check against the real artefact runs in
+      # wasm-bundle.yml, which is the only place a built pkg/ exists.
+      - name: Run Memory64 smoke and bundle-gate tests
+        run: |
+          deno test \
+            tests/wasm64_memory64_smoke_test.ts \
+            tests/wasm64_bundle_gate_test.ts \
+            tests/wasm_arch_parity_test.ts < /dev/null
 
   security:
     uses: ./.github/workflows/security.yml

--- a/.github/workflows/wasm-bundle.yml
+++ b/.github/workflows/wasm-bundle.yml
@@ -2,6 +2,21 @@
 # publish a per-commit GitHub Release so NEAT-AI can pin neatCore.rev to any
 # historical Develop SHA. One Release per commit keeps artefacts immutable
 # and addressable by SHA.
+#
+# Issue #541 — the Release now dual-ships two clearly named bundles:
+#
+#   wasm_activation-wasm64-pkg.tar.gz  a genuine Memory64 `(memory i64 …)`
+#                                      artefact — the pin new NEAT-AI revisions
+#                                      take, and the one with no 4 GiB linear
+#                                      memory ceiling;
+#   wasm_activation-pkg.tar.gz         the wasm32 artefact, unchanged, kept as
+#                                      the rollback window until NEAT-AI's
+#                                      Memory64 loader lands.
+#
+# The July 2026 spike recorded wasm-bindgen as a wasm64 NO-GO. That was CLI
+# skew, not a permanent gap: CLI 0.2.108 stripped the bindings, CLI ≥ 0.2.120
+# ships Memory64 codegen (wasm-bindgen#5004). Re-measured 2026-08-14 against
+# CLI 0.2.127 — see docs/research/wasm64-lane-b-build-lane-feasibility.md.
 
 name: Publish wasm_activation bundle
 
@@ -18,7 +33,7 @@ jobs:
   publish:
     name: Build and publish wasm_activation bundle
     runs-on: ubuntu-latest
-    timeout-minutes: 45 # wasm-pack release build + bundle publish
+    timeout-minutes: 60 # two wasm-pack/cargo release builds + bundle publish
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2
@@ -36,6 +51,27 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: wasm32-unknown-unknown
+
+      # Issue #541 — `wasm64-unknown-unknown` is a Rust **Tier 3** target: rustc
+      # knows the triple but ships no prebuilt `std`, so `rustup target add`
+      # refuses it and the build must rebuild the standard library from source
+      # with `-Z build-std`. That needs a nightly toolchain plus `rust-src`;
+      # no `targets:` is requested here for exactly that reason.
+      - name: Install Rust nightly toolchain (for the wasm64 build-std lane)
+        # dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: nightly
+          components: rust-src
+
+      # Issue #541 — Deno runs the repo-owned bundle gates: the Memory64
+      # memory-type/export-surface check on each built pkg, and the wasm32 vs
+      # wasm64 bit-parity comparison. Same pin as ci.yml.
+      - name: Install Deno
+        # denoland/setup-deno@v2.0.5
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+        with:
+          deno-version: "2.9.3"
 
       # Issue #78 — install wasm-pack from a version-pinned release tarball
       # with SHA-256 verification instead of `curl … | sh`. The previous
@@ -63,37 +99,114 @@ jobs:
           rm -rf "$asset" "wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
           wasm-pack --version
 
-      - name: Build wasm_activation bundle
+      # Issue #541 — wasm-pack 0.15.0 still hard-codes `wasm32-unknown-unknown`
+      # as the cargo target it builds and reads back, so the wasm64 lane drives
+      # the `wasm-bindgen` CLI itself. Pinned by version + SHA-256 for the same
+      # supply-chain reason as wasm-pack above (Issue #78).
+      #
+      # The CLI must match the `wasm-bindgen` crate version in Cargo.lock: a
+      # skew is precisely what produced the July 2026 NO-GO, so the pins are
+      # compared and a mismatch fails the job rather than producing a bundle
+      # nobody can explain. Bump WASM_BINDGEN_VERSION + WASM_BINDGEN_SHA256
+      # together with the crate.
+      - name: Install wasm-bindgen CLI
+        env:
+          WASM_BINDGEN_VERSION: "0.2.127"
+          # sha256 of wasm-bindgen-0.2.127-x86_64-unknown-linux-musl.tar.gz
+          # from https://github.com/wasm-bindgen/wasm-bindgen/releases/tag/0.2.127
+          WASM_BINDGEN_SHA256: "61d4a7dc85acfa0d2354ccc0b8361928c7e52a746d17f28ebaa795ed3dc1614a"
+        run: |
+          set -euo pipefail
+          locked="$(awk '/^name = "wasm-bindgen"$/ { getline; gsub(/[" ]/, ""); sub(/^version=/, ""); print; exit }' Cargo.lock)"
+          if [[ "$locked" != "$WASM_BINDGEN_VERSION" ]]; then
+            echo "ERROR: wasm-bindgen CLI pinned at ${WASM_BINDGEN_VERSION} but Cargo.lock resolves the crate to ${locked}." >&2
+            echo "       A CLI/crate skew silently strips bindings — bump both together." >&2
+            exit 1
+          fi
+          asset="wasm-bindgen-${WASM_BINDGEN_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          url="https://github.com/wasm-bindgen/wasm-bindgen/releases/download/${WASM_BINDGEN_VERSION}/${asset}"
+          curl --proto '=https' --tlsv1.2 -fsSL -o "$asset" "$url"
+          echo "${WASM_BINDGEN_SHA256}  ${asset}" | sha256sum -c -
+          tar -xzf "$asset"
+          sudo install -m 0755 \
+            "wasm-bindgen-${WASM_BINDGEN_VERSION}-x86_64-unknown-linux-musl/wasm-bindgen" \
+            /usr/local/bin/wasm-bindgen
+          rm -rf "$asset" "wasm-bindgen-${WASM_BINDGEN_VERSION}-x86_64-unknown-linux-musl"
+          wasm-bindgen --version
+
+      # The wasm32 asset keeps its historical name so every existing
+      # neatCore.rev pin resolves unchanged.
+      - name: Build wasm32 wasm_activation bundle
         run: |
           set -euo pipefail
           chmod +x scripts/build-wasm-bundle.sh
           ./scripts/build-wasm-bundle.sh \
+            --arch wasm32 \
             --rev "${GITHUB_SHA}" \
             --out wasm_activation-pkg.tar.gz
 
-      # Issue #438 — publish a per-revision SHA-256 anchor next to the tarball.
+      # Issue #541 — the Memory64 artefact. build-wasm-bundle.sh gates it before
+      # packaging: the module's memory must declare the i64 index type and the
+      # activation/backprop surface must survive into both the `_bg.wasm` and
+      # the generated glue. A CLI that exits 0 with a stub glue fails here.
+      - name: Build wasm64 (Memory64) wasm_activation bundle
+        run: |
+          set -euo pipefail
+          ./scripts/build-wasm-bundle.sh \
+            --arch wasm64 \
+            --rev "${GITHUB_SHA}" \
+            --out wasm_activation-wasm64-pkg.tar.gz
+
+      # Issue #541 — the two bundles share every kernel; only the address size
+      # differs. Unpack the *published bytes* and require bit-identical f32/f64
+      # results across the committed fixture. A tolerance here would hide the
+      # one failure this gate exists to catch — a pointer-width change that
+      # perturbs a gather stride or a remainder.
+      - name: Check wasm32 / wasm64 numeric parity
+        run: |
+          set -euo pipefail
+          rm -rf parity && mkdir -p parity/wasm32 parity/wasm64
+          tar -xzf wasm_activation-pkg.tar.gz -C parity/wasm32
+          tar -xzf wasm_activation-wasm64-pkg.tar.gz -C parity/wasm64
+          deno run --allow-read scripts/check_wasm_arch_parity.ts \
+            parity/wasm32/pkg parity/wasm64/pkg
+          rm -rf parity
+
+      # Issue #438 — publish a per-revision SHA-256 anchor next to each tarball.
       # NEAT-AI's build.sh verifies the downloaded bundle against this sidecar;
       # without it the only hash a consumer holds for a *new* revision is the
       # deno.json pin recorded for the *old* one, so every neatCore.rev bump
       # fails closed (stSoftwareAU/NEAT-AI#3504). Standard `shasum -a 256`
       # format (<64-hex><two spaces><filename>) is what build.sh parses.
-      - name: Generate tarball SHA-256 sidecar
+      # One step per asset: each sidecar must stand alone, and a shared loop
+      # would make a missing tarball fail on whichever arch happened to be
+      # first rather than on the one that is actually absent.
+      - name: Generate wasm32 tarball SHA-256 sidecar
         run: |
           set -euo pipefail
           sha256sum wasm_activation-pkg.tar.gz > wasm_activation-pkg.tar.gz.sha256
           sha256sum -c wasm_activation-pkg.tar.gz.sha256
           cat wasm_activation-pkg.tar.gz.sha256
 
+      - name: Generate wasm64 tarball SHA-256 sidecar
+        run: |
+          set -euo pipefail
+          sha256sum wasm_activation-wasm64-pkg.tar.gz > wasm_activation-wasm64-pkg.tar.gz.sha256
+          sha256sum -c wasm_activation-wasm64-pkg.tar.gz.sha256
+          cat wasm_activation-wasm64-pkg.tar.gz.sha256
+
       # Issue #125 — emit a CycloneDX SBOM from the locked dependency graph and
       # publish it next to the bundle. Because downstream consumers pin
       # wasm_activation by SHA they otherwise receive an opaque blob; an SBOM
       # on the Release lets responders answer "is the vulnerable crate inside a
-      # bundle we shipped?" in seconds when the next advisory drops. The SBOM is
-      # resolved against the wasm32 target (the artefact's actual triple) so it
-      # captures wasm-bindgen and friends, and is exact rather than approximate
-      # because it derives from Cargo.lock. cargo-cyclonedx is version-pinned
-      # and --locked for supply-chain hygiene (mirrors wasm-pack, Issue #78).
-      - name: Generate CycloneDX SBOM
+      # bundle we shipped?" in seconds when the next advisory drops. One SBOM
+      # per shipped arch, each resolved against that artefact's own triple
+      # (Issue #541) — the arch is what selects the wasm target tables, so a
+      # single wasm32 SBOM would be an assertion about a graph we did not
+      # resolve. Both are exact rather than approximate because they derive
+      # from Cargo.lock. cargo-cyclonedx is version-pinned and --locked for
+      # supply-chain hygiene (mirrors wasm-pack, Issue #78).
+      - name: Generate CycloneDX SBOMs
         env:
           CARGO_CYCLONEDX_VERSION: "0.5.7"
         run: |
@@ -103,6 +216,8 @@ jobs:
           # cargo-cyclonedx writes <package>.cdx.json into each crate directory;
           # publish it under a deterministic, bundle-matching asset name.
           cp neat-core/neat-core.cdx.json wasm_activation-pkg.cdx.json
+          cargo cyclonedx --format json --target wasm64-unknown-unknown
+          cp neat-core/neat-core.cdx.json wasm_activation-wasm64-pkg.cdx.json
 
       # Issue #122 — attest build provenance for the published artefacts.
       # Pinning by SHA + post-publish content re-verification proves the
@@ -123,6 +238,9 @@ jobs:
             wasm_activation-pkg.tar.gz
             wasm_activation-pkg.tar.gz.sha256
             wasm_activation-pkg.cdx.json
+            wasm_activation-wasm64-pkg.tar.gz
+            wasm_activation-wasm64-pkg.tar.gz.sha256
+            wasm_activation-wasm64-pkg.cdx.json
 
       - name: Publish per-commit Release
         env:
@@ -134,24 +252,33 @@ jobs:
             wasm_activation-pkg.tar.gz \
             wasm_activation-pkg.tar.gz.sha256 \
             wasm_activation-pkg.cdx.json \
+            wasm_activation-wasm64-pkg.tar.gz \
+            wasm_activation-wasm64-pkg.tar.gz.sha256 \
+            wasm_activation-wasm64-pkg.cdx.json \
             --target "$GITHUB_SHA" \
             --title "wasm_activation bundle for ${GITHUB_SHA::7}" \
-            --notes "Auto-built wasm_activation/pkg for commit ${GITHUB_SHA}. SHA-256 sidecar attached as wasm_activation-pkg.tar.gz.sha256. CycloneDX SBOM attached as wasm_activation-pkg.cdx.json."
+            --notes "Auto-built wasm_activation/pkg for commit ${GITHUB_SHA}.
 
-      # Issue #48 — re-download the asset we just published and prove it
-      # extracts cleanly with all four files NEAT-AI's build.sh checks for
+          Dual-ship (Issue #541):
+          - wasm_activation-wasm64-pkg.tar.gz — Memory64 \`(memory i64 …)\` build; the pin new NEAT-AI revisions should take.
+          - wasm_activation-pkg.tar.gz — wasm32 build, retained as the rollback window.
+
+          Each tarball has a SHA-256 sidecar (.sha256) and a CycloneDX SBOM (.cdx.json) resolved against its own target triple."
+
+      # Issue #48 — re-download the assets we just published and prove they
+      # extract cleanly with all four files NEAT-AI's build.sh checks for
       # and a wasm blob above the 128 KiB stub-detection threshold. Catches
       # silent `gh release create` upload regressions in NEAT-AI-core CI
       # rather than leaving downstream NEAT-AI bump-deps PRs to fail.
-      - name: Verify published bundle
+      - name: Verify published bundle (wasm32)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           tag="wasm-bundle-${GITHUB_SHA}"
           verify_dir="$(mktemp -d)"
-          # The glob pulls down both the tarball and its .sha256 sidecar; the
-          # CycloneDX SBOM does not match it.
+          # The glob pulls down the wasm32 tarball and its .sha256 sidecar; the
+          # CycloneDX SBOM and the wasm64 assets do not match it.
           gh release download "$tag" \
             --pattern 'wasm_activation-pkg.tar.gz*' \
             --dir "$verify_dir"
@@ -165,4 +292,24 @@ jobs:
           chmod +x scripts/verify-wasm-bundle.sh
           ./scripts/verify-wasm-bundle.sh \
             --archive "$verify_dir/wasm_activation-pkg.tar.gz" \
+            --rev "${GITHUB_SHA}"
+
+      - name: Verify published bundle (wasm64)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="wasm-bundle-${GITHUB_SHA}"
+          verify_dir="$(mktemp -d)"
+          gh release download "$tag" \
+            --pattern 'wasm_activation-wasm64-pkg.tar.gz*' \
+            --dir "$verify_dir"
+          if [[ ! -s "$verify_dir/wasm_activation-wasm64-pkg.tar.gz.sha256" ]]; then
+            echo "ERROR: release $tag is missing wasm_activation-wasm64-pkg.tar.gz.sha256" >&2
+            exit 1
+          fi
+          ( cd "$verify_dir" && sha256sum -c wasm_activation-wasm64-pkg.tar.gz.sha256 )
+          chmod +x scripts/verify-wasm-bundle.sh
+          ./scripts/verify-wasm-bundle.sh \
+            --archive "$verify_dir/wasm_activation-wasm64-pkg.tar.gz" \
             --rev "${GITHUB_SHA}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ expressible, and the synthetic tests catch header-overrun and undercover cases.
 ## Repository layout
 
 - **`neat-core/`** — shared native library; **WASM** stays in **NEAT-AI** (`wasm_activation`).
-- **`training_bin_stream`** (`neat-core/src/training_bin_stream.rs`) — **one** chunked `.bin` scan API: pipelined double-buffer reads on native hosts, sequential `File::read` chunks on `wasm32` (same `for_each_read_chunk` callback). Used by **NEAT-AI-scorer** for production-sized forward-only scoring.
+- **`training_bin_stream`** (`neat-core/src/training_bin_stream.rs`) — **one** chunked `.bin` scan API: pipelined double-buffer reads on native hosts, sequential `File::read` chunks on the wasm family (same `for_each_read_chunk` callback). Used by **NEAT-AI-scorer** for production-sized forward-only scoring.
 - Root **`Cargo.toml`** is a **virtual workspace**; **`[workspace.package].version`** is what the PR **auto-bump** job edits; **`neat-core`** uses `version.workspace = true`.
 
 ## Unsafe & SIMD invariants
@@ -121,7 +121,7 @@ soundness rules. They are load-bearing — an edit that ignores one either fails
 the build or ships undefined behaviour. Absorbed from the SIMD/`unsafe`/
 buffer-reuse campaign (PRs #11, #112, #154, #155, #165, #207).
 
-The `wasm32` half of this hot path is **not** compiled by any PR gate — run
+The wasm half of this hot path is **not** compiled by any PR gate — run
 `cargo check -p neat-core --target wasm32-unknown-unknown` before you merge a
 change to it, per [CI / secrets](#ci--secrets).
 
@@ -138,7 +138,7 @@ sound and the hot path stays branch-free. **Never remove or bypass that check as
 "redundant" — doing so reintroduces UB behind `get_unchecked`.** (See also the
 memory-safety note in [`SECURITY.md`](SECURITY.md#memory-safety-of-compiled-network-loading).)
 
-The `wasm32` `gather4` scaffold helper (`simd.rs`) rests on the same invariant
+The wasm `gather4` scaffold helper (`simd.rs`) rests on the same invariant
 since Issue #509 — it reads four `SynapseData` entries and four indirect
 activations unchecked. `checked-gather4` restores the bounds-checked control if
 a build ever needs it; the numbers behind that default are in
@@ -367,7 +367,7 @@ flowchart LR
 `neat-core/src/simd/scalar.rs` is the single home of the rule that says what a
 weighted-sum kernel *means*: the reference scalar semantics of each kernel and
 the small-count guard in front of it — the thing every SIMD path must agree with
-bit-for-bit. It carries no intrinsics and no `cfg`, so the `wasm32` kernels in
+bit-for-bit. It carries no intrinsics and no `cfg`, so the wasm kernels in
 `simd.rs` and the x86/aarch64 kernels in `simd_native.rs` share one copy.
 
 Two layers, deliberately distinct:
@@ -399,7 +399,7 @@ reference.
 
 ```mermaid
 flowchart LR
-    W["simd.rs (wasm32)"] --> S["simd::scalar"]
+    W["simd.rs (wasm32 + wasm64)"] --> S["simd::scalar"]
     N["simd_native.rs — x86"] --> S
     A["simd_native.rs — NEON"] --> S
     S --> G["synapse_count / SINGLE_RECORD_SIMD_MIN"]
@@ -411,7 +411,7 @@ flowchart LR
 
 The scaffold helpers at the top of `neat-core/src/simd.rs` — `gather4`,
 `gather4_products`, `reduce4` — are the single home of the rule that says *how a
-`wasm32` kernel walks a synapse span*: chunk into fours, gather weights and
+wasm kernel walks a synapse span*: chunk into fours, gather weights and
 activations into `f32x4` lanes, fold, reduce the lanes, then finish the 0..3
 remainder from the **running** accumulator through the `scalar::tail_*` helpers
 (Issue #447). All four single-record kernels — `weighted_sum_simd`,
@@ -459,6 +459,65 @@ flowchart LR
     R --> T["scalar::tail_* — seed-taking remainder"]
 ```
 
+## One wasm cfg for both address sizes (Issue #541)
+
+The crate builds for **two** wasm targets — `wasm32-unknown-unknown` and
+`wasm64-unknown-unknown` (Memory64) — and every wasm gate is keyed to
+`cfg(target_family = "wasm")`, never `cfg(target_arch = "wasm32")`. On a wasm64
+build `target_arch` is `"wasm64"`, so an arch-keyed gate fails **silently and
+asymmetrically**: `Cargo.toml`'s dependency tables would drop `wasm-bindgen`
+(no bindings) *and* pull in `rayon` (native-only) at the same time, while every
+`#[cfg_attr(…, wasm_bindgen)]` export quietly vanished. Widen the family, do
+not add a second arch arm.
+
+`wasm_arch` (`neat-core/src/wasm_arch.rs`) is the one exception and the single
+home of the split that genuinely is arch-shaped: `core::arch::wasm32` exists
+only on wasm32, and the identical SIMD128 intrinsics live at
+`core::arch::wasm64` on wasm64 (unstable `simd_wasm64`, enabled from the crate
+root for that arch only). Both wasm kernels — `simd.rs` and
+`elastic_distribution.rs` — import through it. A second copy is how a wasm64
+build comes to compile one kernel and fail the other.
+
+The shipped bundle is **dual-ship**, built and gated by
+`scripts/build-wasm-bundle.sh --arch <wasm32|wasm64>`:
+
+- **wasm32** goes through `wasm-pack`, as before.
+- **wasm64** cannot: wasm-pack 0.15.0 still hard-codes `wasm32-unknown-unknown`
+  as the cargo target it builds and reads back, so the lane drives
+  `cargo +nightly … -Z build-std=std,panic_abort` and then the `wasm-bindgen`
+  CLI itself. That is the *same* post-processing step wasm-pack would run — the
+  July 2026 NO-GO was CLI **skew** (0.2.108 stripped the bindings), not a
+  permanent gap, and the workflow now fails loud if the pinned CLI version and
+  the `Cargo.lock` crate version disagree.
+
+Three gates stand between a build and a published asset, and each exists
+because the corresponding failure is otherwise silent:
+
+1. `scripts/check_wasm64_bundle.ts` — the module's memory index type must match
+   `--arch` (an i64 build that regressed to i32 still validates and still
+   scores, right up to the 4 GiB wall the port exists to remove), and the
+   activation/backprop surface must survive into **both** the `_bg.wasm` and
+   the generated glue. A byte-size threshold cannot see a stripped glue.
+2. `scripts/check_wasm_arch_parity.ts` — the two bundles share every kernel, so
+   the committed fixture (`tests/wasm_arch_parity_fixture.ts`) must produce
+   **bit-identical** `f32`/`f64` results across both. No tolerance: a tolerance
+   would hide exactly the pointer-width slip this gate is for.
+3. `verify-wasm-bundle.sh` — re-downloads each published asset and re-checks it.
+
+This issue does **not** claim to fix V8 exit-133 JS-heap aborts; that ceiling is
+the JS heap, and `--max-old-space-size` remains its lever (lane (a), #296).
+
+```mermaid
+flowchart TD
+    S["neat-core sources<br/>cfg(target_family = &quot;wasm&quot;)"] --> A["wasm-pack<br/>wasm32-unknown-unknown"]
+    S --> B["cargo +nightly -Z build-std<br/>wasm64-unknown-unknown"]
+    B --> C["wasm-bindgen CLI<br/>(pinned = Cargo.lock)"]
+    A --> G1["check_wasm64_bundle.ts<br/>memory type + export surface"]
+    C --> G1
+    G1 --> G2["check_wasm_arch_parity.ts<br/>bit-identical f32/f64"]
+    G2 --> R["per-commit Release<br/>wasm64 = the pin, wasm32 = rollback"]
+```
+
 ## CI / secrets
 
 - PR pipeline: version bump + **`./bump-deps.sh --quarantine-hours … --skip-build`** (a `cargo update` under the **`VIBE_BUMP_QUARANTINE_HOURS`** release-age quarantine, Issue #76), **`cargo audit`**, dependency review, rustfmt bot, then fmt/clippy/deny/tests/doc. Pushes need **`ACTIONS_PUSH`** (**org-level** PAT with **contents:write**).
@@ -466,5 +525,6 @@ flowchart LR
 - **`ACTIONS_PUSH` is supplied just-in-time** (Issue #483): the `version-increment` / `auto-format` checkouts run with **`persist-credentials: false`** and no `token:`, and the PAT reaches only the one step that pushes, through an explicit `https://x-access-token:…` remote URL. Never hand it to a checkout — those jobs execute PR-authored code (`bump-deps.sh`, `cargo fmt`) that would then be able to read an org-wide credential off `.git/config`.
 - **Versioning/release policy:** **`RELEASING.md`** is the single source of truth (Issue #251) — semver, what counts as breaking, and how to signal it. In CI the `version-increment` job bumps minor on a break (patch otherwise); the `version-gate` job **fails** a break shipped on a patch-only bump; `release.yml` cuts a **`v<version>`** tag + GitHub release on `Develop`, decoupled from `wasm-bundle-<sha>`.
 - **`clippy::uninlined_format_args`** is not denied in CI until the test corpus is cleaned up; workspace lints still deny **`filter_next`** / **`collapsible_if`**.
-- **`wasm32` is not gated on PRs — check it yourself before touching wasm-only code.** Neither `quality.sh` nor any `ci.yml` job builds for `wasm32-unknown-unknown` (the `wasm64-memory64-smoke` job is a Deno Memory64 runtime test, not a wasm32 build); the target compiles only *after* merge — on **push to `Develop`** through `wasm-bundle.yml`, and on the scheduled `upgrade-dependencies.yml` run, whose `bump-deps.sh` dual build the PR lane skips with `--skip-build`. The load-bearing manual check is **`cargo check -p neat-core --target wasm32-unknown-unknown`**. What it catches: deleting the last consumer of a `#[cfg(target_arch = "wasm32")]` block leaves an orphaned `use core::arch::wasm32::{…}` that every host gate compiles right past and only the bundle build rejects (Issues #422, #423). For **numeric** wasm changes go further, as Issue #448 did — compile to `wasm32-wasip1`, run under Node's WASI with `-C target-feature=+simd128,+relaxed-simd`, and diff the raw `f32` bit patterns before against after.
+- **`wasm32` is not gated on PRs — check it yourself before touching wasm-only code.** Neither `quality.sh` nor any `ci.yml` job builds for `wasm32-unknown-unknown` (the `wasm64-memory64-smoke` job is a Deno Memory64 runtime test plus the shipped-bundle gate unit tests, not a wasm32 build); the target compiles only *after* merge — on **push to `Develop`** through `wasm-bundle.yml`, and on the scheduled `upgrade-dependencies.yml` run, whose `bump-deps.sh` dual build the PR lane skips with `--skip-build`. The load-bearing manual check is **`cargo check -p neat-core --target wasm32-unknown-unknown`**. What it catches: deleting the last consumer of a `#[cfg(target_family = "wasm")]` block leaves an orphaned `use crate::wasm_arch::{…}` that every host gate compiles right past and only the bundle build rejects (Issues #422, #423). For **numeric** wasm changes go further, as Issue #448 did — compile to `wasm32-wasip1`, run under Node's WASI with `-C target-feature=+simd128,+relaxed-simd`, and diff the raw `f32` bit patterns before against after.
+- **`wasm64` is ungated on PRs for the same reason, and costs more to check.** `wasm64-unknown-unknown` is a Rust **Tier 3** target: no prebuilt `std`, so it needs a nightly toolchain, the `rust-src` component and `-Z build-std` — `rustup target add` refuses it outright. The local check is **`cargo +nightly build -p neat-core --target wasm64-unknown-unknown --release -Z build-std=std,panic_abort`**. Both bundles are built and gated on push to `Develop` (see the wasm64 section below).
 - **CI gates must be repo-owned and unconditional.** Never `if:`-gate a step on a file another repository owns: the Mermaid check was conditioned on a path that never exists here, so it skipped **every** run and a broken diagram merged (Issue #379). Its replacement, `scripts/check_mermaid.ts`, is owned by this repo and runs unconditionally from both `quality.sh` and `markdown-lint.yml`. Related budget rule: **GitHub rejects `timeout-minutes:` on a reusable-workflow *caller* job** — put it on the called workflow's own job instead (`ci.yml`'s `security` job calls `security.yml`, whose job carries `timeout-minutes: 30`; Issue #333).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,57 @@ Development in this repository follows **TDD**: do not merge behaviour changes u
 
 **`wasm_activation`** and **`pkg/`** remain in the **NEAT-AI** repo on `Develop` — not in this repository.
 
+### wasm64 (Memory64) bundle — dual-ship, Issue #541
+
+Every push to `Develop` publishes **two** bundles on the per-commit
+`wasm-bundle-<sha>` Release:
+
+| Asset | Target | Role |
+|-------|--------|------|
+| `wasm_activation-wasm64-pkg.tar.gz` | `wasm64-unknown-unknown` | Genuine Memory64 `(memory i64 …)` build — **the pin new `neatCore.rev` revisions take**. Linear memory grows past the wasm32 65536-page (4 GiB) ceiling. |
+| `wasm_activation-pkg.tar.gz` | `wasm32-unknown-unknown` | Unchanged wasm32 build, retained as the rollback window until NEAT-AI's Memory64 loader lands. |
+
+Each carries its own `.sha256` sidecar and a CycloneDX SBOM resolved against
+its own target triple, and both are covered by the build-provenance attestation.
+
+The July 2026 spike recorded the production `wasm-bindgen` path as a wasm64
+**NO-GO**. That was **CLI skew, not a permanent gap**: CLI `0.2.108` exited 0
+while stripping the bindings, and CLI ≥ `0.2.120` ships Memory64 codegen
+([wasm-bindgen#5004](https://github.com/wasm-bindgen/wasm-bindgen/pull/5004)).
+Re-measured **2026-08-14** against CLI `0.2.127` — the production path emits the
+full activation/backprop surface. See
+[`docs/research/wasm64-lane-b-build-lane-feasibility.md`](docs/research/wasm64-lane-b-build-lane-feasibility.md).
+
+This does **not** fix V8 exit-133 JS-heap aborts: that ceiling is the JS heap,
+not WASM linear memory, and `--max-old-space-size` remains its lever (lane (a),
+Issue #296).
+
+```mermaid
+flowchart TD
+    S["neat-core sources<br/>cfg(target_family = &quot;wasm&quot;)"] --> A["wasm-pack<br/>wasm32"]
+    S --> B["cargo +nightly -Z build-std<br/>wasm64 (Tier 3)"]
+    B --> C["wasm-bindgen CLI<br/>pinned = Cargo.lock"]
+    A --> G1["check_wasm64_bundle.ts<br/>memory type + export surface"]
+    C --> G1
+    G1 --> G2["check_wasm_arch_parity.ts<br/>bit-identical f32/f64"]
+    G2 --> R["Release wasm-bundle-&lt;sha&gt;<br/>wasm64 = pin · wasm32 = rollback"]
+```
+
+Building locally:
+
+```bash
+# wasm32 (needs wasm-pack)
+./scripts/build-wasm-bundle.sh --arch wasm32 --rev "$(git rev-parse HEAD)"
+
+# wasm64 (needs nightly + rust-src + the wasm-bindgen CLI matching Cargo.lock)
+rustup toolchain install nightly --profile minimal --component rust-src
+./scripts/build-wasm-bundle.sh --arch wasm64 --rev "$(git rev-parse HEAD)" \
+  --out wasm_activation-wasm64-pkg.tar.gz
+```
+
+Both invocations gate the built `pkg/` before packaging, so a stripped glue or
+a wrong-arch memory type fails the build instead of shipping.
+
 ## Training-data offload (WASM linear memory) — removed, Issue #415
 
 wasm64 milestone #295, lane (c) — Issue #298 — shipped a `wasm_dataset` module

--- a/docs/archive/pr-summaries/pr-summary-541.md
+++ b/docs/archive/pr-summaries/pr-summary-541.md
@@ -1,0 +1,165 @@
+# Ship a production wasm64 (Memory64) activation bundle
+
+## Summary
+
+`neat-core` now builds, gates and **ships** a genuine Memory64
+(`(memory i64 …)`) `wasm_activation` bundle through the production
+`wasm-bindgen` path — no raw `extern "C"` fallback. Closes #541.
+
+The July 2026 lane (b) NO-GO was **CLI skew, not a permanent gap**: the spike
+measured `wasm-bindgen` CLI **0.2.108**, and **0.2.120** added Memory64 codegen
+([wasm-bindgen#5004](https://github.com/wasm-bindgen/wasm-bindgen/pull/5004)).
+Re-measured **2026-08-14** against CLI **0.2.127** (the version this crate
+depends on): the CLI emits the full activation/backprop surface.
+
+What changed:
+
+1. **Every wasm `cfg` widened to the family.** `cfg(target_arch = "wasm32")` →
+   `cfg(target_family = "wasm")` across `neat-core/src` and `Cargo.toml`. The
+   arch-keyed tables failed in *both* directions on wasm64 at once — dropping
+   `wasm-bindgen` (no bindings) while pulling in the native-only `rayon`.
+   `neat-core/src/wasm_arch.rs` is the single home of the one genuinely
+   arch-shaped split (`core::arch::wasm32` vs `core::arch::wasm64`, the latter
+   behind the unstable `simd_wasm64` feature enabled for that arch only).
+2. **A wasm64 build lane.** `build-wasm-bundle.sh --arch wasm64` runs
+   `cargo +nightly … --target wasm64-unknown-unknown -Z build-std=std,panic_abort`
+   then the `wasm-bindgen` CLI. wasm-pack cannot do this: 0.15.0 still hard-codes
+   `wasm32-unknown-unknown` as the cargo target it builds and reads back.
+3. **Three fail-loud gates.** `scripts/check_wasm64_bundle.ts` (memory index type
+   must match `--arch`; the activation/backprop surface must survive into **both**
+   the `_bg.wasm` and the glue), `scripts/check_wasm_arch_parity.ts` (bit-exact
+   wasm32/wasm64 agreement over a committed fixture), and the existing
+   `verify-wasm-bundle.sh` post-publish check, now run per asset.
+4. **Dual-ship.** The per-commit Release carries
+   `wasm_activation-wasm64-pkg.tar.gz` (the pin new `neatCore.rev` revisions take)
+   alongside the unchanged `wasm_activation-pkg.tar.gz` (rollback window until
+   NEAT-AI's Memory64 loader lands). Each has its own `.sha256` sidecar and a
+   CycloneDX SBOM resolved against **its own** target triple; both are attested.
+5. **The skew that caused the NO-GO cannot recur silently.** The pinned CLI
+   version is compared against `Cargo.lock` — on the PR (bats) and again in the
+   workflow (fails the publish).
+
+**This does not fix V8 exit-133 JS-heap aborts.** That ceiling is the JS heap,
+not WASM linear memory; `--max-old-space-size` remains its lever (lane (a),
+#296). Downstream adoption (Memory64 glue, workers, `build.sh`) is a separate
+NEAT-AI issue, and `wasm_dataset` is **not** re-introduced here.
+
+## Evidence
+
+Backend/WASM only — no web interface to screenshot. Evidence is measured output.
+
+```mermaid
+flowchart TD
+    S["neat-core sources<br/>cfg(target_family = &quot;wasm&quot;)"] --> A["wasm-pack<br/>wasm32"]
+    S --> B["cargo +nightly -Z build-std<br/>wasm64 (Tier 3)"]
+    B --> C["wasm-bindgen CLI 0.2.127<br/>pinned = Cargo.lock"]
+    A --> G1["check_wasm64_bundle.ts<br/>memory type + export surface"]
+    C --> G1
+    G1 --> G2["check_wasm_arch_parity.ts<br/>bit-identical f32/f64"]
+    G2 --> R["Release wasm-bundle-&lt;sha&gt;<br/>wasm64 = pin · wasm32 = rollback"]
+```
+
+### The artefact is genuinely Memory64, with the surface intact
+
+```text
+$ ./scripts/build-wasm-bundle.sh --arch wasm64 --rev "$(git rev-parse HEAD)" ...
+🛠️  Building neat-core for wasm64-unknown-unknown (nightly + -Z build-std)
+🔗  Running wasm-bindgen (target=web, out-name=wasm_activation)
+🚦 Gating the built bundle (arch=wasm64)
+✅ neat-core/wasm_activation/pkg/wasm_activation_bg.wasm validates (525546 bytes)
+✅ linear memory declares the i64 index type
+✅ activation/backprop export surface present in module and glue
+✅ grew linear memory to 65552 pages (> 65536 = 4 GiB)
+✅ neat-core/wasm_activation/pkg passes the wasm64 bundle gate
+✅ Built bundle: /tmp/wasm_activation-wasm64-pkg.tar.gz (172694 bytes, rev=2103f56…)
+
+$ wasm-objdump -x -j Memory .../wasm_activation_bg.wasm
+ - memory[0] pages: initial=17 i64
+```
+
+The generated glue is **68 KB with 50 exported bindings** and the module carries
+**192 exports** — not the `initSync`/`init`-only stub CLI 0.2.108 produced.
+`CompiledNetwork`, `propagate_topological`, `compilednetwork_activate*`,
+`__wbindgen_malloc` and `__wbindgen_free` are all present. Driven from Deno,
+slice marshalling round-trips:
+`compute_score_components([0.5,-1.5,2.0],[0.25,0.75])` → `[5, 5, 2, 1.5]`.
+
+### Numeric parity: bit-identical, no tolerance
+
+```text
+$ deno run --allow-read scripts/check_wasm_arch_parity.ts parity/wasm32/pkg parity/wasm64/pkg
+✅ wasm32 and wasm64 agree bit-for-bit on 485 values
+```
+
+### Throughput: no measurable regression
+
+`mse_sum_batch_packed` over the 11-record fixture, 200 000 calls × 3 runs
+(Deno 2.9.5 / V8 15.0, aarch64-apple-darwin), identical checksums:
+
+| Target | µs/call (3 runs) |
+| --- | --- |
+| wasm32 | 3.116 · 3.088 · 3.252 |
+| wasm64 | 2.985 · 3.226 · 2.976 |
+
+Within run-to-run noise — recorded, not hidden.
+
+### Mutation evidence
+
+A green gate is not evidence; each was made to go red.
+
+| Mutation | Gate | Result |
+| --- | --- | --- |
+| `inline_squash` ReLU `sum.max(0.0)` → `sum.max(0.1)`, wasm64 rebuilt only | `check_wasm_arch_parity.ts` | **red** — 165/485 values differ |
+| `reduce4` lane 3 scaled by `1.000001` (wasm-only SIMD kernel), wasm64 rebuilt only | `check_wasm_arch_parity.ts` | **red** — 209/485 differ, at **one ulp** (`0xbf877560` vs `0xbf877561`); a tolerance comparison would have passed |
+| Glue replaced with the `initSync`-only stub 0.2.108 emitted | `check_wasm64_bundle.ts` | **red** — names all six missing bindings |
+| wasm32 pkg gated as `--arch wasm64` | `check_wasm64_bundle.ts` | **red** — "linear memory declares a 32-bit (i32) index type (flags 0x00)" |
+| Workflow pin skewed to `0.2.126` | `wasm_bundle_wasm64_dual_ship.bats` | **red** — names both versions |
+| Gate stubbed to exit 1 | `build_wasm_bundle_wasm64.bats` | **red** — no tarball produced |
+
+Every mutation was reverted; `git status` is clean and `./quality.sh` passes.
+
+### Local gates
+
+- `./quality.sh` — ✅ all checks passed (shellcheck, 370 bats, deno check,
+  Mermaid, cargo deny, clippy `-D warnings`, tests, doc, release build).
+- `cargo check -p neat-core --target wasm32-unknown-unknown` — ✅ (AGENTS.md
+  manual wasm gate; the widened `cfg` did not regress wasm32).
+- `./scripts/verify-wasm-bundle.sh --archive wasm_activation-wasm64-pkg.tar.gz`
+  — ✅ the wasm64 tarball satisfies the same downstream contract NEAT-AI's
+  `build.sh` checks.
+
+## Test Plan
+
+New:
+
+- `tests/wasm64_bundle_gate_test.ts` (11 tests) — memory-section parsing for i32
+  and i64 modules, `assertMemory64` rejection by name, module/glue export
+  extraction, and `assertBundleExportSurface` failing loud on both a stripped
+  glue and a dropped `.wasm` export. Runs against synthetic modules, so no
+  nightly build is needed.
+- `tests/wasm_arch_parity_test.ts` (13 tests) — the committed fixture serialises
+  to exactly the bytes it declares, every `from_index` is in range for the
+  unchecked gather, and it genuinely reaches the 8-chunk walk, a 0..3 remainder,
+  both inline-squash tiers and all four aggregate squashes; plus the comparator
+  reporting a single differing bit pattern, a one-sided observation and a length
+  mismatch. `bitPatterns` is shown to separate `+0`/`-0` and one-ulp neighbours.
+- `tests/scripts/build_wasm_bundle_wasm64.bats` (11 tests) — the wasm64 lane
+  builds through `cargo +nightly -Z build-std` and `wasm-bindgen` (not
+  wasm-pack), wasm32 still goes through wasm-pack, the arch reaches the gate, a
+  failing gate and a missing `deno` both block the tarball, and the wasm64
+  archive still unpacks to a top-level `pkg/`.
+- `tests/scripts/wasm_bundle_wasm64_dual_ship.bats` (14 tests) — both bundles
+  built and published under distinct names, wasm64 sidecar, parity gate ordered
+  before `gh release create`, nightly + `rust-src`, pinned/checksummed
+  wasm-bindgen CLI, the CLI/`Cargo.lock` agreement (asserted directly *and*
+  executed against a skewed lockfile), per-arch SBOM triples, attestation
+  coverage, and post-publish re-verification.
+
+Modified:
+
+- `tests/wasm64_memory64_smoke.ts` — the page/ceiling constants and
+  `parseMemoryLimits` now re-export from `scripts/wasm64_bundle_gate.ts` instead
+  of holding a second copy. No test was changed, removed or disabled; the
+  existing smoke suite passes unmodified.
+- `.github/workflows/ci.yml` — the `wasm64-memory64-smoke` job also runs the two
+  new Deno suites, so both are gated on every PR.

--- a/docs/research/wasm64-lane-b-build-lane-feasibility.md
+++ b/docs/research/wasm64-lane-b-build-lane-feasibility.md
@@ -9,6 +9,14 @@ This lane answers the gating engineering question for lane (b): *if* a wasm64
 Deno 2.9.3 today?** Method-first per the performance workflow (#177/#1428):
 measure, don't guess.
 
+> **Superseded in part — re-measured 2026-08-14 (Issue #541).** The production
+> `wasm-bindgen` NO-GO recorded below was **CLI skew, not a permanent gap**. See
+> [Re-measurement, 2026-08-14](#re-measurement-2026-08-14-issue-541) at the foot
+> of this document: with CLI **0.2.127** the production path emits the full
+> activation/backprop surface, and `neat-core` now **ships** a Memory64 bundle.
+> Everything else here — the Tier 3 build requirements, the runtime findings,
+> and lane (a)'s V8-heap attribution — still stands.
+
 ## Go / no-go finding
 
 **Qualified GO.** A working wasm64 (Memory64) neat-core artefact **is** buildable
@@ -16,16 +24,17 @@ and loadable in Deno 2.9.3 today — but **only** via the raw `extern "C"` +
 hand-rolled `BigInt` bindings path on a Rust **nightly** toolchain with
 `-Z build-std`. The production binding path this repo actually ships
 (`wasm-bindgen` / `wasm-pack`, see
-[`scripts/build-wasm-bundle.sh`](../../scripts/build-wasm-bundle.sh)) is a
-**NO-GO** today: the `wasm-bindgen` CLI silently strips the exported bindings
-from a Memory64 module.
+[`scripts/build-wasm-bundle.sh`](../../scripts/build-wasm-bundle.sh)) was a
+**NO-GO** *at the CLI version measured here* (0.2.108): the `wasm-bindgen` CLI
+silently strips the exported bindings from a Memory64 module. **That row is
+superseded** — see the 2026-08-14 re-measurement.
 
 | Spike axis | Verdict | Evidence (this host) |
 | --- | --- | --- |
 | **Runtime** — Deno 2.9.3 / V8 14.9 instantiates Memory64 & grows past 4 GiB | **GO** | grows to the V8 impl limit of **262144 pages = 16 GiB**; committed smoke test |
 | **Build (raw)** — `cargo build --target wasm64-unknown-unknown -Z build-std` | **GO (nightly only)** | produces a genuine `(memory i64 …)` module exporting `accumulate` |
 | **Bindings (raw)** — 64-bit (`BigInt`) pointers across JS↔WASM | **GO** | `accumulate(BigInt ptr, BigInt len)` returns the correct sum |
-| **Build (production)** — `wasm-bindgen` / `wasm-pack` on wasm64 | **NO-GO** | CLI exits 0 but strips `accumulate` + `__wbindgen_malloc` from the output |
+| **Build (production)** — `wasm-bindgen` / `wasm-pack` on wasm64 | ~~**NO-GO**~~ → **GO on CLI ≥ 0.2.120** | CLI **0.2.108** exits 0 but strips `accumulate` + `__wbindgen_malloc`; CLI **0.2.127** does not (2026-08-14) |
 | **Perf** — wasm64 vs wasm32 on a 4 GiB-fitting job | **no measurable regression** | scalar accumulate within **±2 %** (measurement noise) |
 
 ## Exact toolchain versions (reproduction baseline)
@@ -161,18 +170,20 @@ flowchart TD
     B -- "WASM linear memory" --> D["wasm64 (Memory64) required"]
     D --> E{"Binding path?"}
     E -- "raw extern C + BigInt" --> F["GO: nightly + -Z build-std, callable today"]
-    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO: CLI silently strips exports on wasm64"]
-    G --> H["Blocker: wait for wasm-bindgen wasm64 support, or use raw path"]
+    E -- "wasm-bindgen / wasm-pack" --> G["NO-GO on CLI 0.2.108: exports stripped"]
+    G --> H["Superseded 2026-08-14: GO on CLI 0.2.127"]
 ```
 
 - **Do not adopt wasm64 yet** — consistent with lane (a): the current production
   ceiling is the V8 heap, liftable with `--max-old-space-size`. wasm64 becomes
   necessary only if the real Learn.ts job attributes its peak to WASM linear
   memory (lane (d), #299).
-- **When/if wasm64 is adopted**, the viable path today is **raw `extern "C"`
-  exports with hand-rolled `BigInt` bindings** on nightly + `-Z build-std`, not
-  `wasm-pack`. A wasm-bindgen-based port is blocked until the toolchain ships
-  working wasm64 post-processing.
+- **When/if wasm64 is adopted**, the viable path *at the CLI version measured
+  here* is **raw `extern "C"` exports with hand-rolled `BigInt` bindings** on
+  nightly + `-Z build-std`, not `wasm-pack`. A wasm-bindgen-based port is
+  blocked until the toolchain ships working wasm64 post-processing. **Resolved
+  2026-08-14:** it does, from CLI 0.2.120, and the shipped bundle takes the
+  wasm-bindgen path — the raw fallback was not needed.
 - **The runtime side is proven and guarded.** The committed smoke test locks in
   the Memory64 runtime capability so a future regression is caught in CI.
 
@@ -193,7 +204,90 @@ wasm-bindgen <wasm64 .wasm> --target web --out-dir pkg64   # exits 0, no accumul
 ```
 
 The wasm64 build requires a network-fetched nightly toolchain + `rust-src`, so
-it is **not** wired into default CI as a build step (unlike the runtime smoke
-test); it is documented here for reproduction and for the lane (d) / planning
-decision. If wasm64 is adopted, the exact `cargo … -Z build-std` invocation above
-becomes the CI build step per this issue's Failure Detection.
+it was **not** wired into default CI as a build step at the time of this spike
+(unlike the runtime smoke test). It is now — see below.
+
+## Re-measurement, 2026-08-14 (Issue #541)
+
+**The production `wasm-bindgen` NO-GO above does not hold.** It was **CLI skew**:
+`wasm-bindgen` **0.2.120** added `wasm64-unknown-unknown` / Memory64 codegen
+([wasm-bindgen#5004](https://github.com/wasm-bindgen/wasm-bindgen/pull/5004)),
+and the spike measured **0.2.108**. Re-run on the *whole* `neat-core` crate — not
+a trivial kernel — with the CLI pinned to the crate version this repo depends on.
+
+### Toolchain (this measurement)
+
+| Tool | Version |
+| --- | --- |
+| Deno | `2.9.5 (stable, release, aarch64-apple-darwin)` |
+| V8 | `15.0.245.2-rusty` |
+| rustc (build) | `1.95.0-nightly (6efa357bf 2026-02-08)` + `rust-src` |
+| rustc (stable) | `1.97.1 (8bab26f4f 2026-07-14)` |
+| wasm-pack | `0.15.0` |
+| wasm-bindgen CLI | `0.2.127` |
+| wasm-bindgen crate | `0.2.127` (Cargo.lock; CLI pinned to match) |
+
+### Findings
+
+| Axis | Verdict | Evidence |
+| --- | --- | --- |
+| **Crate builds for wasm64** | **GO** | `cargo +nightly build -p neat-core --release --target wasm64-unknown-unknown -Z build-std=std,panic_abort` — clean, once the `cfg` gates were widened to `target_family = "wasm"` |
+| **wasm-bindgen on the real crate** | **GO** | 68 KB glue, **50** `export`ed bindings, **192** module exports; `memory[0] pages: initial=17 i64` survives post-processing |
+| **Activation/backprop surface** | **GO** | `CompiledNetwork`, `propagate_topological`, `compilednetwork_activate*`, `__wbindgen_malloc`/`__wbindgen_free` all present in both the `_bg.wasm` and the glue |
+| **Runs in Deno** | **GO** | slice marshalling through `__wbindgen_malloc` round-trips: `compute_score_components([0.5,-1.5,2.0],[0.25,0.75])` → `[5, 5, 2, 1.5]` |
+| **Grows past 4 GiB** | **GO** | the artefact's own memory grows **17 → 65552 pages** (4 GiB + 1 MiB); `grow` takes and returns a `BigInt` |
+| **Numeric parity vs wasm32** | **bit-identical** | **485** observed `f32`/`f64` values agree bit-for-bit across the committed fixture |
+| **Throughput** | **no measurable regression** | `mse_sum_batch_packed` over the 11-record fixture, 200 k calls × 3 runs: wasm32 **3.09–3.25 µs/call**, wasm64 **2.98–3.23 µs/call** — within run-to-run noise, identical checksums |
+
+Artefact sizes: wasm32 `_bg.wasm` **482 771 B** (wasm-opt'd by wasm-pack) vs
+wasm64 **525 546 B**. The wasm64 lane skips `wasm-opt`; both are far above the
+128 KiB stub-detection threshold.
+
+### The `Cargo.toml` gap, closed
+
+The spike recorded that `cfg(target_arch = "wasm32")` misses wasm64. It did, and
+in **both** directions at once: the dependency tables dropped `wasm-bindgen`
+*and* pulled in the native-only `rayon`. Every gate is now keyed to
+`cfg(target_family = "wasm")`, with `neat-core/src/wasm_arch.rs` as the single
+home of the one genuinely arch-shaped split (`core::arch::wasm32` vs
+`core::arch::wasm64`).
+
+### What ships, and what is guarded
+
+`wasm-pack` still cannot reach the target — 0.15.0 hard-codes
+`wasm32-unknown-unknown` as its cargo target — so the wasm64 lane drives
+`cargo … -Z build-std` and the `wasm-bindgen` CLI directly. That is the same
+post-processing step, not the raw `extern "C"` fallback: **no hand-rolled
+`BigInt` bindings were needed.**
+
+`wasm-bundle.yml` now dual-ships `wasm_activation-wasm64-pkg.tar.gz` (the pin)
+and `wasm_activation-pkg.tar.gz` (rollback), gated on the memory index type, the
+export surface, and wasm32/wasm64 bit-parity. The CLI pin is compared against
+`Cargo.lock` so the skew that produced the original NO-GO fails the job.
+
+Lane (a)'s attribution is **unchanged**: today's ~4 GB `learn` abort is the V8 JS
+heap (exit 133), and `--max-old-space-size` remains its lever. Nothing here
+claims otherwise.
+
+```mermaid
+flowchart LR
+    A["Spike, 2026-07<br/>wasm-bindgen CLI 0.2.108"] --> B["NO-GO: glue stripped"]
+    C["Re-measure, 2026-08-14<br/>wasm-bindgen CLI 0.2.127"] --> D["GO: 50 bindings, 192 exports"]
+    D --> E["Ship: dual-ship Release<br/>wasm64 = pin"]
+```
+
+### Reproducing the re-measurement
+
+```text
+rustup toolchain install nightly --profile minimal --component rust-src
+# wasm-bindgen CLI must match the wasm-bindgen crate version in Cargo.lock.
+./scripts/build-wasm-bundle.sh --arch wasm64 --rev "$(git rev-parse HEAD)" \
+  --out wasm_activation-wasm64-pkg.tar.gz
+./scripts/build-wasm-bundle.sh --arch wasm32 --rev "$(git rev-parse HEAD)"
+
+mkdir -p parity/wasm32 parity/wasm64
+tar -xzf wasm_activation-pkg.tar.gz -C parity/wasm32
+tar -xzf wasm_activation-wasm64-pkg.tar.gz -C parity/wasm64
+deno run --allow-read scripts/check_wasm_arch_parity.ts \
+  parity/wasm32/pkg parity/wasm64/pkg
+```

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -34,10 +34,14 @@ parallel = ["dep:rayon"]
 # back out.
 checked-gather4 = []
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Issue #541 - keyed on the wasm *family*, not `wasm32`. A
+# `wasm64-unknown-unknown` build reports `target_arch = "wasm64"`, so the
+# previous `wasm32` tables silently dropped wasm-bindgen and silently pulled
+# rayon into a wasm64 build.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 rayon = { version = "1.12", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = "0.2.127"
 
 [dev-dependencies]

--- a/neat-core/src/accumulate.rs
+++ b/neat-core/src/accumulate.rs
@@ -22,7 +22,7 @@
 //! Output array (3 f64s per item):
 //!   [count, total_bias, total_adjusted_bias]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Apply L1/L2 weight regularisation (weight decay).
@@ -302,7 +302,7 @@ pub(crate) fn accumulate_weight_single(
 ///   [count, totalPositiveActivation, totalNegativeActivation,
 ///    countPositiveActivations, countNegativeActivations,
 ///    totalPositiveAdjustedValue, totalNegativeAdjustedValue] × 4
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_weight_batch_4way(
     current_weights: &[f64],
     target_values: &[f64],
@@ -342,7 +342,7 @@ pub fn accumulate_weight_batch_4way(
 /// Issue #1518 - Batch weight accumulation for 8 synapses.
 ///
 /// Same as 4-way but processes 8 synapses. Returns 56 f64 values.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_weight_batch_8way(
     current_weights: &[f64],
     target_values: &[f64],
@@ -432,7 +432,7 @@ pub(crate) fn accumulate_bias_single(
 /// # Returns
 /// Float64Array with 12 values (3 per neuron):
 ///   [count, totalBias, totalAdjustedBias] × 4
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_bias_batch_4way(
     target_pre_activations: &[f64],
     pre_activations: &[f64],
@@ -467,7 +467,7 @@ pub fn accumulate_bias_batch_4way(
 /// Issue #1518 - Batch bias accumulation for 8 neurons.
 ///
 /// Same as 4-way but processes 8 neurons. Returns 24 f64 values.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_bias_batch_8way(
     target_pre_activations: &[f64],
     pre_activations: &[f64],
@@ -524,7 +524,7 @@ pub fn accumulate_bias_batch_8way(
 ///
 /// # Returns
 /// The calculated average weight
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn calculate_weight(
     count: f64,
     total_positive_activation: f64,
@@ -615,7 +615,7 @@ pub fn calculate_weight(
 ///
 /// # Returns
 /// The calculated bias
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn calculate_bias(
     count: f64,
     total_adjusted_bias: f64,
@@ -671,7 +671,7 @@ pub fn calculate_bias(
 ///
 /// # Returns
 /// Float64Array with 4 calculated weights
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn calculate_weight_batch_4way(
     packed_state: &[f64],
     generations: f64,
@@ -729,7 +729,7 @@ pub fn calculate_weight_batch_4way(
 ///
 /// # Returns
 /// Float64Array with 4 calculated biases
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn calculate_bias_batch_4way(
     packed_state: &[f64],
     no_change_flags: &[u8],

--- a/neat-core/src/elastic_distribution.rs
+++ b/neat-core/src/elastic_distribution.rs
@@ -9,18 +9,18 @@
 /// Planck constant for floating-point comparisons (matches TypeScript default).
 const PLANK_CONSTANT: f32 = 1e-12;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 /// SIMD-accelerated scoring pass: computes activation² × clamped safeZoneFactor.
 ///
 /// Uses WASM SIMD128 to process 4 elements at a time for the squaring and
 /// multiplication, with a scalar fallback for non-WASM targets.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 fn score_pass_simd(activations: &[f32], safe_zone_factors: &[f32], scores: &mut [f32]) -> f32 {
-    use core::arch::wasm32::{
+    use crate::wasm_arch::{
         f32x4, f32x4_add, f32x4_extract_lane, f32x4_max, f32x4_min, f32x4_mul, f32x4_splat,
     };
 
@@ -115,7 +115,7 @@ fn score_pass_simd(activations: &[f32], safe_zone_factors: &[f32], scores: &mut 
 }
 
 /// Scalar fallback scoring pass for non-WASM targets (testing).
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[inline]
 fn score_pass_simd(activations: &[f32], safe_zone_factors: &[f32], scores: &mut [f32]) -> f32 {
     let count = activations.len();
@@ -248,7 +248,7 @@ pub fn apply_distribute_elastic_error(
 ///
 /// # Returns
 /// `Vec<f32>` of error shares, one per link. Sum equals `error`.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn distribute_elastic_error(
     error: f32,
     activations: &[f32],

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -1,11 +1,20 @@
 //! Shared computation library for NEAT-AI neural network operations.
 //!
 //! This crate contains the core neural network logic extracted from the
-//! `wasm_activation` crate. Native targets omit `wasm-bindgen`; on
-//! `wasm32-unknown-unknown`, `accumulate` exports use `wasm-bindgen` behind
-//! `cfg_attr` so the same sources build for CLI tools and WASM.
+//! `wasm_activation` crate. Native targets omit `wasm-bindgen`; on the
+//! **wasm target family** (`wasm32-unknown-unknown` *and*
+//! `wasm64-unknown-unknown`, Issue #541), `accumulate` exports use
+//! `wasm-bindgen` behind `cfg_attr` so the same sources build for CLI tools and
+//! both WASM address sizes.
 //!
 //! Issue #1964 - Extract shared Rust library crate from wasm_activation.
+
+// Issue #541 - `core::arch::wasm64` is unstable (`simd_wasm64`,
+// rust-lang/rust#90599). `wasm64-unknown-unknown` is a Tier 3 target that
+// already requires nightly + `-Z build-std`, so enabling the feature there
+// costs the stable wasm32 and native builds nothing: the attribute is inert
+// unless `target_arch = "wasm64"`.
+#![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 
 // Core computation modules
 pub mod accumulate;
@@ -37,8 +46,13 @@ pub mod unsquash;
 // Issue #36 — WASM-only `#[wasm_bindgen]` shims that wrap apply_* helpers,
 // tuple returns, and the byte-packed `propagate_topological` ABI. Native
 // targets do not see this module.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub mod wasm_exports;
+
+// Issue #541 — one home for the `core::arch::wasm32` / `core::arch::wasm64`
+// split, so both wasm SIMD kernels reach the SIMD128 intrinsics by one path.
+#[cfg(target_family = "wasm")]
+pub mod wasm_arch;
 
 // Re-export key types for convenience
 pub use creature::{

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -18,7 +18,7 @@ use crate::training_bin_stream::{for_each_read_chunk_with_mode, training_read_tu
 use crate::training_data::find_bin_files;
 use std::path::{Path, PathBuf};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Issue #1209 - Shared 8-way activation helper macro to reduce code duplication.
@@ -405,7 +405,7 @@ pub fn mse_record(targets: &[f32], outputs: &[f32]) -> f64 {
 ///
 /// Issue #118x - Fuse activate + MSE for scoring performance.
 /// Issue #1202 - Use 4-record SIMD batching for forward-only networks.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn mse_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],
@@ -1062,7 +1062,7 @@ fn hinge_sum_batch_8way(
 ///
 /// # Returns
 /// Sum of per-record MAE errors (divide by record count for mean)
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn mae_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],
@@ -1123,7 +1123,7 @@ pub fn mae_sum_batch_packed(
 ///
 /// # Returns
 /// Sum of per-record Cross Entropy errors (divide by record count for mean)
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn cross_entropy_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],
@@ -1188,7 +1188,7 @@ pub fn cross_entropy_sum_batch_packed(
 ///
 /// # Returns
 /// Sum of per-record MAPE errors (divide by record count for mean)
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn mape_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],
@@ -1252,7 +1252,7 @@ pub fn mape_sum_batch_packed(
 ///
 /// # Returns
 /// Sum of per-record MSLE errors (divide by record count for mean)
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn msle_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],
@@ -1312,7 +1312,7 @@ pub fn msle_sum_batch_packed(
 ///
 /// # Returns
 /// Sum of per-record Hinge errors (divide by record count for mean)
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn hinge_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],
@@ -1384,7 +1384,7 @@ pub fn hinge_sum_batch_packed(
 ///
 /// Issue stSoftwareAU/NEAT-AI-core#88 — extend native scorer with the last
 /// remaining built-in NEAT-AI cost function.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn categorical_error_sum_batch_packed(
     network: &mut CompiledNetwork,
     records: &[f32],

--- a/neat-core/src/network.rs
+++ b/neat-core/src/network.rs
@@ -19,7 +19,7 @@ use crate::squash::SquashType;
 use crate::squash_simd::squash_x4;
 use crate::synapse_type::SynapseType;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Errors that can occur when constructing a [`CompiledNetwork`] from serialised bytes.
@@ -91,7 +91,7 @@ impl std::error::Error for NetworkError {}
 
 // On `wasm32`, `CompiledNetwork::new` is a `#[wasm_bindgen(constructor)]`, which
 // requires the error type to convert into a `JsValue`.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 impl From<NetworkError> for wasm_bindgen::JsValue {
     fn from(err: NetworkError) -> Self {
         wasm_bindgen::JsValue::from_str(&err.to_string())
@@ -185,57 +185,57 @@ pub fn hot_synapse_soa(synapses: &[SynapseData]) -> (Vec<f32>, Vec<u16>) {
 ///
 /// This compact format minimises memory access and enables efficient iteration.
 /// Issue #1175 - Uses typed structs for better cache locality and compiler optimisation.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 #[derive(Clone)]
 pub struct CompiledNetwork {
     /// Total number of neurons (including input)
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub num_neurons: usize,
     /// Number of input neurons
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub num_inputs: usize,
     /// Neuron metadata using typed struct for cache efficiency
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub neurons: Vec<NeuronData>,
     /// Synapse data using typed struct for cache efficiency
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub synapses: Vec<SynapseData>,
     /// Hot-path weights, struct-of-arrays view of `synapses[i].weight`
     /// (Issue #533). Built by [`hot_synapse_soa`] at every construction path;
     /// read only by the record-interleaved gather.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub hot_weights: Vec<f32>,
     /// Hot-path source indices, struct-of-arrays view of
     /// `synapses[i].from_index` (Issue #533). Same order and length as
     /// [`Self::synapses`] and [`Self::hot_weights`].
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub hot_from: Vec<u16>,
     /// Activation buffer - reused across calls
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub activations: Vec<f32>,
     /// Pre-allocated buffer for hint values in activate_and_trace
     /// Issue #1173 - Pre-allocate `Vec<f32>` buffers in CompiledNetwork struct
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub hint_values_buffer: Vec<f32>,
     /// Pre-allocated buffer for trace data in activate_and_trace
     /// Issue #1173 - Eliminates heap allocation per call
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub trace_data_buffer: Vec<f32>,
     /// Pre-allocated per-record activation buffers for the 4-way batch path.
     /// Issue #155 - Extends the #1173 buffer-reuse precedent to
     /// `activate_and_trace_batch_4way` so the 4 activation buffers are reused
     /// across calls instead of re-allocated each invocation.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub batch_activations: [Vec<f32>; 4],
     /// Pre-allocated per-record hint-value buffers for the 4-way batch path.
     /// Issue #155 - Reused across calls (zeroed per call), mirroring
     /// `hint_values_buffer`.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub batch_hints: [Vec<f32>; 4],
     /// Pre-allocated per-record trace-data buffers for the 4-way batch path.
     /// Issue #155 - Reused across calls (cleared per call), mirroring
     /// `trace_data_buffer`.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub batch_traces: [Vec<f32>; 4],
     /// Record-interleaved scratch for the fused MSE path
     /// (`inter[n * MSE_TILE_LANES + l]`). Sized
@@ -243,7 +243,7 @@ pub struct CompiledNetwork {
     /// `mse_sum_batch_packed` calls instead of allocating per chunk
     /// (NEAT-AI-scorer#531). The 4-way remainder of that path reuses
     /// [`Self::batch_activations`].
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(skip))]
     pub mse_inter: Vec<f32>,
 }
 
@@ -285,7 +285,7 @@ impl CompiledNetwork {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 impl CompiledNetwork {
     /// Reset non-input activations to 0.0.
     ///
@@ -314,7 +314,7 @@ impl CompiledNetwork {
     ///     - u8: synapse_type
     ///     - u8: padding
     ///     - f64: weight
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(constructor))]
     pub fn new(data: &[u8]) -> Result<CompiledNetwork, NetworkError> {
         if data.len() < 8 {
             return Err(NetworkError::TruncatedData { section: "header" });
@@ -762,19 +762,19 @@ impl CompiledNetwork {
     }
 
     /// Get the number of neurons in the network
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(getter))]
     pub fn num_neurons(&self) -> usize {
         self.num_neurons
     }
 
     /// Get the number of input neurons
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(getter))]
     pub fn num_inputs(&self) -> usize {
         self.num_inputs
     }
 
     /// Get the number of synapses in the network
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(getter))]
     pub fn num_synapses(&self) -> usize {
         self.synapses.len()
     }

--- a/neat-core/src/parallel_scoring.rs
+++ b/neat-core/src/parallel_scoring.rs
@@ -67,7 +67,7 @@ use crate::network::CompiledNetwork;
 /// interior runs full 8-record SIMD batches (only the final task's tail can be
 /// short), and small enough that a 2048-record batch splits into many chunks for
 /// work-stealing balance across cores.
-#[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "parallel", not(target_family = "wasm")))]
 const PARALLEL_CHUNK_RECORDS: usize = 64;
 
 impl CompiledNetwork {
@@ -153,7 +153,7 @@ impl CompiledNetwork {
     ///
     /// Panics on a malformed `inputs`/`stride` pair (see
     /// [`CompiledNetwork::score_records_flat`]).
-    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    #[cfg(all(feature = "parallel", not(target_family = "wasm")))]
     pub fn score_records_parallel_flat(
         &self,
         inputs: &[f32],
@@ -189,7 +189,7 @@ impl CompiledNetwork {
     ///
     /// Panics on a malformed `inputs`/`stride` pair (see
     /// [`CompiledNetwork::score_records_flat`]).
-    #[cfg(not(all(feature = "parallel", not(target_arch = "wasm32"))))]
+    #[cfg(not(all(feature = "parallel", not(target_family = "wasm"))))]
     pub fn score_records_parallel_flat(
         &self,
         inputs: &[f32],

--- a/neat-core/src/simd.rs
+++ b/neat-core/src/simd.rs
@@ -31,14 +31,14 @@ pub mod scalar;
 
 // Native single-record/multi-record kernels live in `simd_native.rs`; only the
 // wasm32 implementations below reference `SynapseData` directly.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use crate::network::SynapseData;
 
 // Issue #1178 - WASM SIMD support
 // SIMD intrinsics for vectorised synapse weight summation
 // Issue #1197 - Added f32x4_relaxed_madd for FMA optimisation
-#[cfg(target_arch = "wasm32")]
-use core::arch::wasm32::{
+#[cfg(target_family = "wasm")]
+use crate::wasm_arch::{
     f32x4, f32x4_add, f32x4_extract_lane, f32x4_mul, f32x4_relaxed_madd, f32x4_splat, v128,
 };
 
@@ -77,7 +77,7 @@ use core::arch::wasm32::{
 /// same order), so it is the reference the Issue #509 A/B harness measures
 /// against and the one-flag way back if the unchecked reads ever need to be
 /// taken out of a build.
-#[cfg(all(target_arch = "wasm32", feature = "checked-gather4"))]
+#[cfg(all(target_family = "wasm", feature = "checked-gather4"))]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 fn gather4(synapses: &[SynapseData], activations: &[f32], base: usize) -> (v128, v128) {
@@ -119,7 +119,7 @@ fn gather4(synapses: &[SynapseData], activations: &[f32], base: usize) -> (v128,
 ///    `activations` is sized to exactly `num_neurons`. That is the same
 ///    load-time invariant the `scalar::tail_*` helpers already rely on
 ///    (`AGENTS.md`, "Unsafe & SIMD invariants").
-#[cfg(all(target_arch = "wasm32", not(feature = "checked-gather4")))]
+#[cfg(all(target_family = "wasm", not(feature = "checked-gather4")))]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 fn gather4(synapses: &[SynapseData], activations: &[f32], base: usize) -> (v128, v128) {
@@ -151,7 +151,7 @@ fn gather4(synapses: &[SynapseData], activations: &[f32], base: usize) -> (v128,
 ///
 /// Bit-identical to computing each product scalar-wise and packing the lanes:
 /// `f32x4_mul` is a plain IEEE-754 multiply per lane, not a relaxed operation.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 fn gather4_products(synapses: &[SynapseData], activations: &[f32], base: usize) -> v128 {
@@ -160,7 +160,7 @@ fn gather4_products(synapses: &[SynapseData], activations: &[f32], base: usize) 
 }
 
 /// Horizontal sum of the four lanes, in lane order.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 fn reduce4(acc: v128) -> f32 {
@@ -186,7 +186,7 @@ fn reduce4(acc: v128) -> f32 {
 /// (`NetworkError::InvalidSynapseIndex`), so callers holding a loaded network
 /// already satisfy the precondition.
 ///
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_simd(
@@ -251,7 +251,7 @@ pub fn weighted_sum_simd(
 /// accumulator over chunks of four. Same index precondition as
 /// [`weighted_sum_simd`].
 ///
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_of_squares_simd(
@@ -293,7 +293,7 @@ pub fn weighted_sum_of_squares_simd(
 /// on [`weighted_sum_simd`] only. Same index precondition as
 /// [`weighted_sum_simd`].
 ///
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_no_bias_simd(
@@ -333,7 +333,7 @@ pub fn weighted_sum_no_bias_simd(
 /// accumulator over chunks of four. Same index precondition as
 /// [`weighted_sum_simd`].
 ///
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_of_squares_v2_simd(
@@ -381,7 +381,7 @@ pub fn weighted_sum_of_squares_v2_simd(
 /// Processes the same neuron for 4 different records in parallel using SIMD.
 /// Each record has its own activation buffer, but weights are shared.
 ///
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_simd_4records(
@@ -433,7 +433,7 @@ pub fn weighted_sum_simd_4records(
 /// This extends the 4-record approach (Issue #1202) by stacking two v128 operations
 /// for better cache utilisation and amortised overhead.
 ///
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 #[allow(clippy::too_many_arguments)]
@@ -492,12 +492,12 @@ pub fn weighted_sum_simd_8records(
 
 /// Widest record-interleaved tile the generic gather kernel supports
 /// (Issue #530). Mirrors `simd_native::MAX_INTERLEAVED_LANES`.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub const MAX_INTERLEAVED_LANES: usize = 64;
 
 /// Compile-time guard on a record-interleaved tile width (Issue #530): `R` must
 /// be a non-zero multiple of 8 and no wider than [`MAX_INTERLEAVED_LANES`].
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[inline]
 pub(crate) const fn assert_interleaved_tile<const R: usize>() {
     assert!(
@@ -510,7 +510,7 @@ pub(crate) const fn assert_interleaved_tile<const R: usize>() {
 ///
 /// Lane extraction needs a *const* index, so a generic tile width cannot index
 /// the accumulator array element-wise — the quad is unpacked whole instead.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 fn store_quad(out: &mut [f32], acc: v128) {
@@ -535,7 +535,7 @@ fn store_quad(out: &mut [f32], acc: v128) {
 /// is re-read once per tile rather than once per eight records. Numerically
 /// identical to [`weighted_sum_simd_8records`]: same per-synapse FMA order,
 /// bias seeded into every lane, each lane summed independently.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_interleaved<const R: usize>(
@@ -581,7 +581,7 @@ pub fn weighted_sum_interleaved<const R: usize>(
 
 /// The 8-lane tile of [`weighted_sum_interleaved`], kept as the name the
 /// batched **scoring** path (`BatchScratch::inter`) and its tests use.
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[target_feature(enable = "simd128", enable = "relaxed-simd")]
 #[inline]
 pub fn weighted_sum_interleaved_8(
@@ -597,7 +597,7 @@ pub fn weighted_sum_interleaved_8(
 
 // Native (non-wasm32) multi-record helpers now live in `simd_native.rs` and use
 // AVX2/FMA on x86_64, NEON on aarch64, falling back to scalar elsewhere.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[path = "simd_native.rs"]
 mod simd_native;
 
@@ -605,7 +605,7 @@ mod simd_native;
 // (AVX2/FMA on x86_64, NEON on aarch64, scalar fallback elsewhere and for the
 // 0..3 synapse tail). They live in `simd_native.rs` alongside the multi-record
 // kernels and run on the primary `activate()` forward-pass hot path.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub use simd_native::{
     MAX_INTERLEAVED_LANES, weighted_sum_interleaved, weighted_sum_interleaved_8,
     weighted_sum_no_bias_simd, weighted_sum_of_squares_simd, weighted_sum_of_squares_v2_simd,

--- a/neat-core/src/topology_export.rs
+++ b/neat-core/src/topology_export.rs
@@ -40,7 +40,7 @@ use std::fmt::Write;
 
 use serde::Serialize;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use crate::network::CompiledNetwork;
@@ -317,7 +317,7 @@ pub fn to_dot(network: &CompiledNetwork, num_outputs: usize) -> String {
 // mirroring the pattern used for `activate` / `activate_view` / `reset_state`
 // in `network.rs`. NEAT-AI's TypeScript wrapper depends on these exports.
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 impl CompiledNetwork {
     /// Export this network as a DOT (Graphviz) string.
     ///

--- a/neat-core/src/topology_ops.rs
+++ b/neat-core/src/topology_ops.rs
@@ -6,7 +6,7 @@
 //! single implementation.
 //!
 //! Functions are exported as ordinary `pub fn` items, with
-//! `#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]` on each export so the
+//! `#[cfg_attr(target_family = "wasm", wasm_bindgen)]` on each export so the
 //! same source compiles for native and WASM targets — matching the
 //! pre-existing pattern used by `accumulate`.
 //!
@@ -15,7 +15,7 @@
 //! - NEAT-AI #1960 — batch API design.
 //! - NEAT-AI #1961 — structural integrity + cycle detection.
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use crate::squash::SquashType;
@@ -96,7 +96,7 @@ const SYN_POSITIVE: u8 = SynapseType::Positive as u8;
 ///
 /// # Returns
 /// A two-element vector `[error_code, synapse_index]`.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn validate_topology(from_indices: &[u32], to_indices: &[u32]) -> Vec<i32> {
     let len = from_indices.len();
     if len != to_indices.len() {
@@ -187,7 +187,7 @@ fn scan_is_constant(is_constant: &[u8], to_idx: usize) -> bool {
 /// malformed input — mismatched `from`/`to` lengths, an implausibly large
 /// `num_neurons`, or a candidate count whose result vector could not be
 /// addressed — rather than panicking (which would trap under WASM).
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn scan_available_connections(
     from_indices: &[u32],
     to_indices: &[u32],
@@ -338,7 +338,7 @@ pub fn scan_available_connections(
 /// indices ordered with output neurons first, then hidden neurons after
 /// their downstream consumers. Input neurons are excluded. Neurons remaining
 /// in cycles are appended at the end.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn compute_reverse_topological_order(
     from_indices: &[u32],
     to_indices: &[u32],
@@ -475,7 +475,7 @@ pub fn compute_reverse_topological_order(
 ///
 /// # Returns
 /// `[error_code_0, synapse_index_0, error_code_1, synapse_index_1, ...]`.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn validate_topology_batch(
     all_from_indices: &[u32],
     all_to_indices: &[u32],
@@ -518,7 +518,7 @@ pub fn validate_topology_batch(
 /// - Non-input neuron biases are finite.
 /// - IF neurons have at least 3 inward connections with condition,
 ///   positive (or standard), and negative synapse types.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn validate_structural_integrity(
     from_indices: &[u32],
     to_indices: &[u32],
@@ -646,7 +646,7 @@ pub fn validate_structural_integrity(
 ///
 /// # Returns
 /// `0` if acyclic, `1` if a cycle is detected.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn detect_cycles(
     from_indices: &[u32],
     to_indices: &[u32],

--- a/neat-core/src/training_bin_stream.rs
+++ b/neat-core/src/training_bin_stream.rs
@@ -109,12 +109,12 @@ pub fn training_read_tuning_from_env(record_bytes: usize) -> (TrainingReadMode, 
 /// On `wasm32` the returned label is always `"sequential_chunked_file_read"`
 /// regardless of the input mode (there is only one backend on that target).
 pub fn io_backend_label(mode: TrainingReadMode) -> &'static str {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     {
         let _ = mode;
         "sequential_chunked_file_read"
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     {
         match mode {
             TrainingReadMode::PipelinedDoubleBuffer => "pipelined_double_buffer",
@@ -139,7 +139,7 @@ pub fn for_each_read_chunk<F>(
 where
     F: FnMut(&[u8]) -> Result<(), String>,
 {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     {
         let mode = if sequential_env_requested() {
             TrainingReadMode::SingleBufferSequential
@@ -149,7 +149,7 @@ where
         for_each_read_chunk_with_mode(bin_files, read_buf_len, mode, on_chunk)
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     {
         for_each_read_chunk_with_mode(
             bin_files,
@@ -182,7 +182,7 @@ where
         return Err("read_buf_len must be positive".to_string());
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     {
         match mode {
             TrainingReadMode::PipelinedDoubleBuffer => {
@@ -194,7 +194,7 @@ where
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     {
         let _ = mode;
         for_each_read_chunk_sequential(bin_files, read_buf_len, on_chunk)
@@ -202,7 +202,7 @@ where
 }
 
 /// Returns true if the legacy sequential escape hatch is selected via env var.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 fn sequential_env_requested() -> bool {
     match std::env::var(SEQUENTIAL_ENV) {
         Ok(v) => {
@@ -248,7 +248,7 @@ where
     Ok(())
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 fn for_each_read_chunk_native_double<F>(
     bin_files: &[PathBuf],
     read_buf_len: usize,
@@ -384,7 +384,7 @@ where
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use super::*;
     use std::fs;

--- a/neat-core/src/training_state.rs
+++ b/neat-core/src/training_state.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 
 use crate::accumulate::{accumulate_bias_single, accumulate_weight_single};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Number of f64 fields per synapse in the training state.
@@ -51,7 +51,7 @@ thread_local! {
 /// # Arguments
 /// * `num_synapses` - Number of synapses in the network
 /// * `num_neurons` - Number of neurons in the network
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn init_training_state(num_synapses: usize, num_neurons: usize) {
     SYNAPSE_STATE.with(|s| {
         let mut state = s.borrow_mut();
@@ -73,7 +73,7 @@ pub fn init_training_state(num_synapses: usize, num_neurons: usize) {
 ///
 /// More efficient than `init_training_state` when the network size
 /// hasn't changed — avoids reallocation.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn reset_training_state() {
     SYNAPSE_STATE.with(|s| s.borrow_mut().fill(0.0));
     NEURON_STATE.with(|s| s.borrow_mut().fill(0.0));
@@ -82,7 +82,7 @@ pub fn reset_training_state() {
 /// Free all training state memory.
 ///
 /// Call this when training is complete to release WASM linear memory.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn free_training_state() {
     SYNAPSE_STATE.with(|s| {
         let mut state = s.borrow_mut();
@@ -102,7 +102,7 @@ pub fn free_training_state() {
 ///   [count, totalPositiveActivation, totalNegativeActivation,
 ///    countPositiveActivations, countNegativeActivations,
 ///    totalPositiveAdjustedValue, totalNegativeAdjustedValue]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn read_synapse_state(index: usize) -> Vec<f64> {
     SYNAPSE_STATE.with(|s| {
         let state = s.borrow();
@@ -119,7 +119,7 @@ pub fn read_synapse_state(index: usize) -> Vec<f64> {
 ///
 /// Returns a packed f64 array with 3 values:
 ///   [count, totalBias, totalAdjustedBias]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn read_neuron_state(index: usize) -> Vec<f64> {
     NEURON_STATE.with(|s| {
         let state = s.borrow();
@@ -136,7 +136,7 @@ pub fn read_neuron_state(index: usize) -> Vec<f64> {
 ///
 /// Returns the entire synapse state buffer (num_synapses × 7 values).
 /// More efficient than calling `read_synapse_state` per synapse.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn read_all_synapse_state() -> Vec<f64> {
     SYNAPSE_STATE.with(|s| s.borrow().clone())
 }
@@ -145,7 +145,7 @@ pub fn read_all_synapse_state() -> Vec<f64> {
 ///
 /// Returns the entire neuron state buffer (num_neurons × 3 values).
 /// More efficient than calling `read_neuron_state` per neuron.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn read_all_neuron_state() -> Vec<f64> {
     NEURON_STATE.with(|s| s.borrow().clone())
 }
@@ -165,7 +165,7 @@ pub fn read_all_neuron_state() -> Vec<f64> {
 /// * `learning_rate` - Learning rate for weight adjustment
 /// * `max_weight_adj_scale` - Maximum weight adjustment scale
 /// * `limit_weight_scale` - Global weight scale limit
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_weight_persistent_4way(
     start_index: usize,
     current_weights: &[f64],
@@ -208,7 +208,7 @@ pub fn accumulate_weight_persistent_4way(
 }
 
 /// Accumulate weight adjustments for 8 synapses into persistent state.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_weight_persistent_8way(
     start_index: usize,
     current_weights: &[f64],
@@ -264,7 +264,7 @@ pub fn accumulate_weight_persistent_8way(
 /// * `learning_rate` - Learning rate for bias adjustment
 /// * `max_bias_adj_scale` - Maximum bias adjustment scale
 /// * `limit_bias_scale` - Global bias scale limit
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_bias_persistent_4way(
     start_index: usize,
     target_pre_activations: &[f64],
@@ -302,7 +302,7 @@ pub fn accumulate_bias_persistent_4way(
 }
 
 /// Accumulate bias adjustments for 8 neurons into persistent state.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn accumulate_bias_persistent_8way(
     start_index: usize,
     target_pre_activations: &[f64],

--- a/neat-core/src/wasm_arch.rs
+++ b/neat-core/src/wasm_arch.rs
@@ -1,0 +1,22 @@
+//! One home for the wasm SIMD intrinsic path (Issue #541).
+//!
+//! `core::arch::wasm32` exists only when `target_arch = "wasm32"`; a
+//! `wasm64-unknown-unknown` build reaches the *same* SIMD128 intrinsics through
+//! `core::arch::wasm64`. Both wasm kernels ([`crate::simd`],
+//! [`crate::elastic_distribution`]) import from here so the arch split is
+//! written once — a second copy is how a wasm64 build comes to compile on one
+//! kernel and fail on the other.
+//!
+//! The module is gated on `target_family = "wasm"`, so native builds never see
+//! it.
+
+#![cfg(target_family = "wasm")]
+
+#[cfg(target_arch = "wasm32")]
+pub use core::arch::wasm32::*;
+
+// `core::arch::wasm64` is unstable (`simd_wasm64`, rust-lang/rust#90599); the
+// crate root enables the feature for `target_arch = "wasm64"` only, which is
+// already a nightly-plus-`-Z build-std` target.
+#[cfg(target_arch = "wasm64")]
+pub use core::arch::wasm64::*;

--- a/neat-core/src/wasm_exports.rs
+++ b/neat-core/src/wasm_exports.rs
@@ -11,10 +11,10 @@
 //!
 //! All exports use `js_name` to match the canonical
 //! `wasm_activation/pkg/wasm_activation.d.ts` surface that NEAT-AI consumes.
-//! This module is gated entirely behind `cfg(target_arch = "wasm32")` so
+//! This module is gated entirely behind `cfg(target_family = "wasm")` so
 //! native consumers (`rust_scorer`, CLI, native tests) never see it.
 
-#![cfg(target_arch = "wasm32")]
+#![cfg(target_family = "wasm")]
 
 use wasm_bindgen::prelude::*;
 

--- a/scripts/build-wasm-bundle.sh
+++ b/scripts/build-wasm-bundle.sh
@@ -1,30 +1,47 @@
 #!/usr/bin/env bash
-# build-wasm-bundle.sh — Build wasm_activation/pkg via wasm-pack and tarball
-# it for per-commit publication (Issue #37).
+# build-wasm-bundle.sh — Build wasm_activation/pkg and tarball it for
+# per-commit publication (Issue #37; wasm64 lane, Issue #541).
 #
 # Used by .github/workflows/wasm-bundle.yml. Kept as a standalone script so
 # the build/packaging contract is unit-testable via bats without spinning up
 # a runner.
 #
 # Behaviour:
-#   1. Run `wasm-pack build neat-core --target web --out-name wasm_activation
-#      --out-dir wasm_activation/pkg` (skipped when --pkg-dir is supplied).
-#   2. Verify `wasm_activation_bg.wasm` exceeds the configured byte threshold
+#   1. Build the bundle for --arch (skipped when --pkg-dir is supplied):
+#        wasm32 — `wasm-pack build neat-core --target web …`
+#        wasm64 — `cargo +nightly build --target wasm64-unknown-unknown
+#                  -Z build-std=…` followed by the `wasm-bindgen` CLI, because
+#                  wasm-pack hard-codes `wasm32-unknown-unknown` as its cargo
+#                  target and cannot emit a Memory64 module.
+#   2. Gate what was just built: `scripts/check_wasm64_bundle.ts` proves the
+#      memory index type matches --arch and the activation/backprop surface
+#      survived into both the module and the generated glue. wasm-bindgen
+#      0.2.108 exited 0 while stripping that glue on wasm64, so "the CLI
+#      returned 0" is not evidence of a usable bundle.
+#   3. Verify `wasm_activation_bg.wasm` exceeds the configured byte threshold
 #      (defaults to 100 KB) so a stub build does not get published.
-#   3. Embed the commit SHA in `pkg/neat_core_rev.txt` for downstream
+#   4. Embed the commit SHA in `pkg/neat_core_rev.txt` for downstream
 #      integrity checks (NEAT-AI's `build.sh`).
-#   4. Tar+gzip the `pkg/` directory so the resulting archive unpacks to a
+#   5. Tar+gzip the `pkg/` directory so the resulting archive unpacks to a
 #      `pkg/` subfolder, matching NEAT-AI's existing import paths.
 #
 # Exits non-zero (without producing a tarball) on any failure so the workflow
-# never publishes an incomplete or undersized bundle.
+# never publishes an incomplete, undersized or wrong-arch bundle.
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 DEFAULT_MIN_WASM_BYTES=102400
+DEFAULT_ARCH="wasm32"
+# `wasm64-unknown-unknown` is a Rust Tier 3 target: no prebuilt `std`, so the
+# build needs a nightly toolchain plus `rust-src` and `-Z build-std`.
+WASM64_TOOLCHAIN="${WASM64_TOOLCHAIN:-nightly}"
+WASM64_TARGET="wasm64-unknown-unknown"
 REV="${GITHUB_SHA:-}"
 OUT_TAR="wasm_activation-pkg.tar.gz"
 MIN_WASM_BYTES="$DEFAULT_MIN_WASM_BYTES"
+ARCH="$DEFAULT_ARCH"
 PKG_DIR=""
 SKIP_BUILD=0
 
@@ -35,6 +52,10 @@ Usage: build-wasm-bundle.sh [options]
 Builds the wasm_activation bundle and packages pkg/ as a tarball.
 
 Options:
+  --arch <wasm32|wasm64>   Address size to build and gate against
+                           (default: ${DEFAULT_ARCH}). wasm64 emits a Memory64
+                           module and needs the ${WASM64_TOOLCHAIN} toolchain,
+                           the rust-src component and the wasm-bindgen CLI.
   --rev <SHA>              Commit SHA to embed in neat_core_rev.txt.
                            Defaults to \$GITHUB_SHA if set.
   --out <path>             Output tarball path
@@ -50,6 +71,11 @@ EOF
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --arch)
+      [[ $# -ge 2 ]] || { echo "error: --arch requires a value" >&2; exit 2; }
+      ARCH="$2"
+      shift 2
+      ;;
     --rev)
       [[ $# -ge 2 ]] || { echo "error: --rev requires a value" >&2; exit 2; }
       REV="$2"
@@ -97,23 +123,67 @@ if ! [[ "$MIN_WASM_BYTES" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+if [[ "$ARCH" != "wasm32" && "$ARCH" != "wasm64" ]]; then
+  echo "error: --arch must be wasm32 or wasm64 (got '$ARCH')" >&2
+  exit 2
+fi
+
 if [[ "$SKIP_BUILD" -eq 1 && -z "$PKG_DIR" ]]; then
   echo "error: --skip-build requires --pkg-dir" >&2
   exit 2
 fi
 
-if [[ "$SKIP_BUILD" -eq 0 ]]; then
-  if ! command -v wasm-pack >/dev/null 2>&1; then
-    echo "error: wasm-pack is required on PATH" >&2
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: $1 is required on PATH$2" >&2
     exit 1
   fi
+}
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
   PKG_DIR="neat-core/wasm_activation/pkg"
   rm -rf "neat-core/wasm_activation"
-  echo "🛠️  Running wasm-pack build (target=web, out-name=wasm_activation)"
-  wasm-pack build neat-core \
-    --target web \
-    --out-name wasm_activation \
-    --out-dir wasm_activation/pkg
+
+  if [[ "$ARCH" == "wasm32" ]]; then
+    require_cmd wasm-pack ""
+    echo "🛠️  Running wasm-pack build (target=web, out-name=wasm_activation)"
+    wasm-pack build neat-core \
+      --target web \
+      --out-name wasm_activation \
+      --out-dir wasm_activation/pkg
+  else
+    # wasm-pack cannot reach this target: 0.15.0 still hard-codes
+    # `wasm32-unknown-unknown` as the cargo target it builds and reads back.
+    # Driving cargo + the wasm-bindgen CLI by hand is the documented
+    # equivalent, and it is the *same* wasm-bindgen post-processing step
+    # wasm-pack would run — no raw `extern "C"` fallback needed since CLI
+    # 0.2.120 landed Memory64 codegen.
+    require_cmd cargo ""
+    require_cmd wasm-bindgen " (cargo install wasm-bindgen-cli --version <crate version>)"
+    target_dir="${CARGO_TARGET_DIR:-target}"
+    raw_wasm="${target_dir}/${WASM64_TARGET}/release/neat_core.wasm"
+    echo "🛠️  Building neat-core for ${WASM64_TARGET} (${WASM64_TOOLCHAIN} + -Z build-std)"
+    cargo "+${WASM64_TOOLCHAIN}" build \
+      --package neat-core \
+      --release \
+      --target "$WASM64_TARGET" \
+      -Z build-std=std,panic_abort
+    if [[ ! -f "$raw_wasm" ]]; then
+      echo "error: cargo produced no ${WASM64_TARGET} artefact at ${raw_wasm}" >&2
+      exit 1
+    fi
+    echo "🔗  Running wasm-bindgen (target=web, out-name=wasm_activation)"
+    wasm-bindgen "$raw_wasm" \
+      --target web \
+      --out-name wasm_activation \
+      --out-dir "$PKG_DIR"
+  fi
+
+  # Gate what was just built, before anything is packaged. A CLI that exits 0
+  # while stripping the bindings is a silent failure, not a pass.
+  require_cmd deno " (needed to gate the built bundle)"
+  echo "🚦 Gating the built bundle (arch=${ARCH})"
+  deno run --allow-read "${SCRIPT_DIR}/check_wasm64_bundle.ts" "$PKG_DIR" --arch "$ARCH"
 fi
 
 if [[ ! -d "$PKG_DIR" ]]; then

--- a/scripts/check_wasm64_bundle.ts
+++ b/scripts/check_wasm64_bundle.ts
@@ -1,0 +1,141 @@
+// check_wasm64_bundle.ts — CI/build gate over a *built* wasm_activation pkg/
+// directory (Issue #541).
+//
+// Usage:
+//   deno run --allow-read scripts/check_wasm64_bundle.ts <pkg-dir> --arch wasm64
+//   deno run --allow-read scripts/check_wasm64_bundle.ts <pkg-dir> --arch wasm32
+//
+// What it proves, against the real artefact rather than a hand-assembled
+// fixture:
+//
+//   * the module validates in this runtime;
+//   * its linear memory carries the index type the arch demands — i64 for
+//     wasm64, i32 for the wasm32 rollback asset. A wasm64 build that silently
+//     regressed to i32 still validates and still scores, and would still hit
+//     the 4 GiB wall the port exists to remove;
+//   * the activation/backprop surface survives on **both** sides of the
+//     boundary (module exports and generated glue) — wasm-bindgen 0.2.108
+//     exited 0 while stripping the glue on wasm64;
+//   * for wasm64 only: the artefact's own `WebAssembly.Memory` grows past
+//     65536 pages, using the `BigInt` delta a 64-bit index type requires.
+//
+// Exits non-zero with a diagnostic on any failure — never "no failure marker,
+// therefore a pass".
+
+import {
+  assertBundleExportSurface,
+  assertMemory64,
+  parseMemoryLimits,
+  WASM32_MAX_PAGES,
+  WASM_PAGE_BYTES,
+} from "./wasm64_bundle_gate.ts";
+
+/** One page past the wasm32 ceiling: the smallest growth wasm32 cannot do. */
+const GROW_TARGET_PAGES = WASM32_MAX_PAGES + 16;
+
+interface Args {
+  pkgDir: string;
+  arch: "wasm32" | "wasm64";
+}
+
+function parseArgs(argv: string[]): Args {
+  let pkgDir = "";
+  let arch: "wasm32" | "wasm64" | "" = "";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--arch") {
+      const value = argv[++i];
+      if (value !== "wasm32" && value !== "wasm64") {
+        throw new Error(`--arch must be wasm32 or wasm64 (got ${value ?? "nothing"})`);
+      }
+      arch = value;
+    } else if (argv[i].startsWith("-")) {
+      throw new Error(`unknown option: ${argv[i]}`);
+    } else if (pkgDir === "") {
+      pkgDir = argv[i];
+    } else {
+      throw new Error(`unexpected extra argument: ${argv[i]}`);
+    }
+  }
+  if (pkgDir === "") throw new Error("usage: check_wasm64_bundle.ts <pkg-dir> --arch <wasm32|wasm64>");
+  if (arch === "") throw new Error("--arch <wasm32|wasm64> is required");
+  return { pkgDir, arch };
+}
+
+/**
+ * Grow the artefact's own linear memory one page past the wasm32 ceiling.
+ * V8 reserves pages lazily, so this costs address space, not RAM.
+ */
+async function assertGrowsPastWasm32Ceiling(pkgDir: string, wasmBytes: Uint8Array): Promise<void> {
+  const glueUrl = new URL(`file://${await Deno.realPath(`${pkgDir}/wasm_activation.js`)}`);
+  const mod = await import(glueUrl.href);
+  const exports = await mod.default({ module_or_path: wasmBytes });
+  const memory: WebAssembly.Memory = exports.memory ?? mod.memory;
+  if (!(memory instanceof WebAssembly.Memory)) {
+    throw new Error("initialised bundle exposes no WebAssembly.Memory export");
+  }
+
+  const currentPages = BigInt(memory.buffer.byteLength / WASM_PAGE_BYTES);
+  const delta = BigInt(GROW_TARGET_PAGES) - currentPages;
+  // A 64-bit memory demands a BigInt delta and answers with a BigInt; a Number
+  // throws. That signature *is* the observable proof of the i64 index type.
+  const previous = memory.grow(delta as unknown as number);
+  if (typeof previous !== "bigint") {
+    throw new Error(
+      `WebAssembly.Memory.grow returned ${typeof previous}, not bigint — ` +
+        `this memory is not 64-bit indexed`,
+    );
+  }
+  const pagesNow = memory.buffer.byteLength / WASM_PAGE_BYTES;
+  if (pagesNow <= WASM32_MAX_PAGES) {
+    throw new Error(
+      `linear memory grew to ${pagesNow} pages, which does not pass the wasm32 ` +
+        `ceiling of ${WASM32_MAX_PAGES} pages (4 GiB)`,
+    );
+  }
+  console.log(`✅ grew linear memory to ${pagesNow} pages (> ${WASM32_MAX_PAGES} = 4 GiB)`);
+}
+
+async function main(): Promise<void> {
+  const { pkgDir, arch } = parseArgs(Deno.args);
+  const wasmPath = `${pkgDir}/wasm_activation_bg.wasm`;
+  const gluePath = `${pkgDir}/wasm_activation.js`;
+
+  const wasmBytes = await Deno.readFile(wasmPath);
+  const glueSource = await Deno.readTextFile(gluePath);
+
+  if (!WebAssembly.validate(wasmBytes)) {
+    throw new Error(`${wasmPath}: WebAssembly.validate rejected the module`);
+  }
+  console.log(`✅ ${wasmPath} validates (${wasmBytes.length} bytes)`);
+
+  if (arch === "wasm64") {
+    assertMemory64(wasmBytes, wasmPath);
+    console.log("✅ linear memory declares the i64 index type");
+  } else {
+    const limits = parseMemoryLimits(wasmBytes);
+    if (limits.isMemory64) {
+      throw new Error(
+        `${wasmPath}: --arch wasm32 was requested but the module declares a ` +
+          `64-bit memory (flags 0x${limits.flags.toString(16)}); the dual-ship ` +
+          `rollback asset must stay wasm32`,
+      );
+    }
+    console.log("✅ linear memory declares the i32 index type (wasm32 rollback asset)");
+  }
+
+  assertBundleExportSurface(wasmBytes, glueSource);
+  console.log("✅ activation/backprop export surface present in module and glue");
+
+  if (arch === "wasm64") await assertGrowsPastWasm32Ceiling(pkgDir, wasmBytes);
+
+  console.log(`✅ ${pkgDir} passes the ${arch} bundle gate`);
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`check_wasm64_bundle: ${error instanceof Error ? error.message : error}`);
+    Deno.exit(1);
+  }
+}

--- a/scripts/check_wasm_arch_parity.ts
+++ b/scripts/check_wasm_arch_parity.ts
@@ -1,0 +1,143 @@
+// check_wasm_arch_parity.ts — bit-exact numeric parity between the wasm32 and
+// wasm64 wasm_activation bundles (Issue #541).
+//
+// Usage:
+//   deno run --allow-read scripts/check_wasm_arch_parity.ts <wasm32-pkg> <wasm64-pkg>
+//
+// Widening `cfg(target_arch = "wasm32")` to the wasm family recompiles the
+// SIMD128 kernels for a second address size. The kernels themselves are
+// unchanged, so every overlapping result must be **bit-identical** — not close.
+// A tolerance here would hide exactly the failure this gate exists to catch: a
+// pointer-width change that silently perturbs a gather stride or a remainder.
+//
+// Both bundles are driven through the committed fixture in
+// `tests/wasm_arch_parity_fixture.ts`, and the comparison is on raw IEEE-754
+// bit patterns, so a sign-of-zero or last-ulp difference fails loudly instead of
+// comparing equal.
+
+import {
+  bitPatterns,
+  buildParityInput,
+  buildParityNetwork,
+  buildParityRecords,
+  NUM_INPUTS,
+  NUM_OUTPUTS,
+  NUM_RECORDS,
+  scalarBitPattern,
+} from "../tests/wasm_arch_parity_fixture.ts";
+
+/** Named observations taken from one bundle, keyed identically across arches. */
+export type Observations = Map<string, string[]>;
+
+/** Loss entry points compared as f64 sums over the packed record batch. */
+const LOSS_ENTRY_POINTS = [
+  "mse_sum_batch_packed",
+  "mae_sum_batch_packed",
+  "msle_sum_batch_packed",
+  "hinge_sum_batch_packed",
+  "cross_entropy_sum_batch_packed",
+  "categorical_error_sum_batch_packed",
+] as const;
+
+// deno-lint-ignore no-explicit-any
+async function loadBundle(pkgDir: string): Promise<any> {
+  const gluePath = await Deno.realPath(`${pkgDir}/wasm_activation.js`);
+  const wasmBytes = await Deno.readFile(`${pkgDir}/wasm_activation_bg.wasm`);
+  const mod = await import(new URL(`file://${gluePath}`).href);
+  await mod.default({ module_or_path: wasmBytes });
+  return mod;
+}
+
+async function observe(pkgDir: string): Promise<Observations> {
+  const api = await loadBundle(pkgDir);
+  const out: Observations = new Map();
+
+  const network = new api.CompiledNetwork(buildParityNetwork());
+  out.set("shape", [
+    String(network.num_neurons),
+    String(network.num_inputs),
+    String(network.num_synapses),
+  ]);
+
+  for (let r = 0; r < NUM_RECORDS; r++) {
+    const input = buildParityInput(r);
+    out.set(`activate[${r}]`, bitPatterns(network.activate(input, NUM_OUTPUTS)));
+    out.set(`activate_view[${r}]`, bitPatterns(network.activate_view(input, NUM_OUTPUTS)));
+    out.set(`activate_and_trace[${r}]`, bitPatterns(network.activate_and_trace(input, NUM_OUTPUTS)));
+  }
+
+  const records = buildParityRecords();
+  for (const name of LOSS_ENTRY_POINTS) {
+    const sum = api[name](network, records, NUM_INPUTS, NUM_OUTPUTS, true);
+    out.set(name, [scalarBitPattern(sum)]);
+  }
+
+  // Squash/derivative tables: cheap, and they cover the scalar fall-through the
+  // aggregate neurons above do not reach.
+  const squashSweep: string[] = [];
+  for (const squashType of [0, 1, 6, 7, 13, 18, 27, 29]) {
+    for (const x of [-2.5, -0.125, 0, 0.125, 2.5]) {
+      squashSweep.push(scalarBitPattern(api.squash(squashType, x)));
+      squashSweep.push(scalarBitPattern(api.derivative(squashType, x)));
+    }
+  }
+  out.set("squash_derivative_sweep", squashSweep);
+
+  return out;
+}
+
+/**
+ * Every place the two arches disagree, as human-readable lines. An empty list
+ * means bit-for-bit agreement across every observation taken.
+ */
+export function compare(left: Observations, right: Observations): string[] {
+  const failures: string[] = [];
+  const keys = new Set([...left.keys(), ...right.keys()]);
+  for (const key of [...keys].sort()) {
+    const a = left.get(key);
+    const b = right.get(key);
+    if (a === undefined || b === undefined) {
+      failures.push(`${key}: observed on only one arch`);
+      continue;
+    }
+    if (a.length !== b.length) {
+      failures.push(`${key}: length ${a.length} vs ${b.length}`);
+      continue;
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) failures.push(`${key}[${i}]: 0x${a[i]} vs 0x${b[i]}`);
+    }
+  }
+  return failures;
+}
+
+async function main(): Promise<void> {
+  const [pkg32, pkg64] = Deno.args;
+  if (!pkg32 || !pkg64) {
+    throw new Error("usage: check_wasm_arch_parity.ts <wasm32-pkg> <wasm64-pkg>");
+  }
+
+  const left = await observe(pkg32);
+  const right = await observe(pkg64);
+  const failures = compare(left, right);
+
+  const compared = [...left.values()].reduce((acc, v) => acc + v.length, 0);
+  if (failures.length > 0) {
+    throw new Error(
+      `wasm32/wasm64 numeric parity broken on ${failures.length} of ${compared} ` +
+        `compared values:\n  ${failures.slice(0, 40).join("\n  ")}`,
+    );
+  }
+  console.log(`✅ wasm32 and wasm64 agree bit-for-bit on ${compared} values`);
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(
+      `check_wasm_arch_parity: ${error instanceof Error ? error.message : error}`,
+    );
+    Deno.exit(1);
+  }
+}

--- a/scripts/wasm64_bundle_gate.ts
+++ b/scripts/wasm64_bundle_gate.ts
@@ -1,0 +1,218 @@
+// wasm64_bundle_gate.ts — the checks that decide whether a built
+// wasm_activation bundle is shippable (Issue #541).
+//
+// Two failure modes this repo has actually hit, both silent:
+//
+//   1. `wasm-bindgen` 0.2.108 exited 0 on a `wasm64-unknown-unknown` module
+//      while stripping every binding out of the generated glue — the packaging
+//      step tarred a bundle whose JS surface was `initSync`/`init` and nothing
+//      else (docs/research/wasm64-lane-b-build-lane-feasibility.md).
+//   2. A wasm64 build that silently regressed to a 32-bit memory would still
+//      validate, instantiate and score — and would still hit the 4 GiB wall the
+//      Memory64 port exists to remove.
+//
+// Every function here fails **loud**: it throws with the artefact name and the
+// exact symbols or flags that are wrong, so the build script exits non-zero
+// instead of publishing a broken bundle. This module holds no I/O so it can be
+// unit-tested against synthetic modules; `scripts/check_wasm64_bundle.ts` is
+// the CLI that reads a real `pkg/` directory and calls it.
+
+/** Bytes in one WASM page (64 KiB). */
+export const WASM_PAGE_BYTES = 64 * 1024;
+
+/** wasm32 linear memory is capped at 65536 pages = exactly 4 GiB. */
+export const WASM32_MAX_PAGES = 65536;
+
+/** The hard wasm32 address-space ceiling in bytes (4 GiB). */
+export const WASM32_MAX_BYTES = WASM32_MAX_PAGES * WASM_PAGE_BYTES;
+
+/**
+ * Memory-type flag bit that marks a 64-bit (i64) index type. A wasm32 memory
+ * has this bit clear; a Memory64 memory has it set. (Bit 0 = has-maximum.)
+ */
+export const MEMORY64_INDEX_FLAG = 0x04;
+
+/**
+ * Exports the `_bg.wasm` must declare for NEAT-AI to drive the bundle: the
+ * allocator pair the glue marshals slices through, the `CompiledNetwork`
+ * lifecycle and activation surface, the backprop entry points, and the squash
+ * helpers. A bundle missing any of these is unusable regardless of how large
+ * the `.wasm` blob is, which is what the byte-size threshold alone cannot see.
+ */
+export const REQUIRED_WASM_EXPORTS: string[] = [
+  "memory",
+  "__wbindgen_malloc",
+  "__wbindgen_free",
+  "__wbg_compilednetwork_free",
+  "compilednetwork_new",
+  "compilednetwork_activate",
+  "compilednetwork_activate_into",
+  "compilednetwork_activate_and_trace",
+  "propagate_topological",
+  "mse_sum_batch_packed",
+  "squash",
+  "unsquash",
+  "derivative",
+];
+
+/** Bindings the generated glue must re-export for the same surface. */
+export const REQUIRED_GLUE_EXPORTS: string[] = [
+  "CompiledNetwork",
+  "propagate_topological",
+  "mse_sum_batch_packed",
+  "squash",
+  "unsquash",
+  "derivative",
+];
+
+/** Parsed limits of the first memory declared in a module. */
+export interface MemoryLimits {
+  count: number;
+  flags: number;
+  /** True when the memory declares a 64-bit (i64) index type. */
+  isMemory64: boolean;
+}
+
+/** Result of a successful export-surface check. */
+export interface ExportSurfaceReport {
+  missingWasm: string[];
+  missingGlue: string[];
+}
+
+/** Read one unsigned LEB128 integer starting at `cursor.p`, advancing it. */
+function readLeb(bytes: Uint8Array, cursor: { p: number }): number {
+  let result = 0;
+  let shift = 0;
+  let byte: number;
+  do {
+    byte = bytes[cursor.p++];
+    if (byte === undefined) throw new Error("truncated LEB128: ran off the end of the module");
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+  } while (byte & 0x80);
+  return result >>> 0;
+}
+
+/** Read a length-prefixed UTF-8 name starting at `cursor.p`, advancing it. */
+function readName(bytes: Uint8Array, cursor: { p: number }): string {
+  const len = readLeb(bytes, cursor);
+  const start = cursor.p;
+  cursor.p += len;
+  return new TextDecoder().decode(bytes.subarray(start, start + len));
+}
+
+/**
+ * Parse the memory section (id 0x05) of a module and report its flags, so a
+ * caller can assert the index type **without** instantiating.
+ *
+ * @throws when the module declares no memory section.
+ */
+export function parseMemoryLimits(bytes: Uint8Array): MemoryLimits {
+  const cursor = { p: 8 }; // skip magic + version
+  while (cursor.p < bytes.length) {
+    const id = bytes[cursor.p++];
+    const len = readLeb(bytes, cursor);
+    const start = cursor.p;
+    if (id === 0x05) {
+      const count = readLeb(bytes, cursor);
+      const flags = bytes[cursor.p];
+      return { count, flags, isMemory64: (flags & MEMORY64_INDEX_FLAG) !== 0 };
+    }
+    cursor.p = start + len;
+  }
+  throw new Error("no memory section (0x05) found in module");
+}
+
+/**
+ * Every name in the module's export section (id 0x07), in declaration order.
+ * Returns an empty list when the module declares no exports.
+ */
+export function wasmExportNames(bytes: Uint8Array): string[] {
+  const cursor = { p: 8 };
+  while (cursor.p < bytes.length) {
+    const id = bytes[cursor.p++];
+    const len = readLeb(bytes, cursor);
+    const start = cursor.p;
+    if (id === 0x07) {
+      const count = readLeb(bytes, cursor);
+      const names: string[] = [];
+      for (let i = 0; i < count; i++) {
+        names.push(readName(bytes, cursor));
+        cursor.p++; // export kind
+        readLeb(bytes, cursor); // export index
+      }
+      return names;
+    }
+    cursor.p = start + len;
+  }
+  return [];
+}
+
+/**
+ * Names bound by `export function` / `export class` declarations in generated
+ * glue. `initSync` and `init` are wasm-bindgen's own bootstrap and are counted
+ * like any other binding — the caller decides which names are load-bearing.
+ */
+export function glueExportNames(source: string): string[] {
+  const names: string[] = [];
+  const pattern = /^export\s+(?:async\s+)?(?:function|class)\s+([A-Za-z_$][\w$]*)/gm;
+  for (const match of source.matchAll(pattern)) names.push(match[1]);
+  return names;
+}
+
+/**
+ * Assert the artefact declares a 64-bit linear memory.
+ *
+ * @param artefact path or file name, quoted back in the failure so a CI log
+ *   names the file that is wrong.
+ * @throws when the memory is 32-bit — the exact regression the Memory64 port
+ *   exists to prevent, and one that is otherwise invisible (an i32 bundle
+ *   validates, instantiates and scores correctly right up to 4 GiB).
+ */
+export function assertMemory64(bytes: Uint8Array, artefact: string): MemoryLimits {
+  const limits = parseMemoryLimits(bytes);
+  if (!limits.isMemory64) {
+    throw new Error(
+      `${artefact}: linear memory declares a 32-bit (i32) index type ` +
+        `(flags 0x${limits.flags.toString(16).padStart(2, "0")}); ` +
+        `a Memory64 bundle must set the i64 bit 0x${MEMORY64_INDEX_FLAG.toString(16)} ` +
+        `and is capped at ${WASM32_MAX_PAGES} pages (4 GiB) without it`,
+    );
+  }
+  return limits;
+}
+
+/**
+ * Assert the built bundle exposes the activation/backprop surface on both
+ * sides of the boundary: the compiled module's exports and the generated glue.
+ *
+ * Checking both is the point. A stripped glue with an intact `.wasm` is exactly
+ * what wasm-bindgen 0.2.108 produced on wasm64 — and it is invisible to a
+ * byte-size threshold, because the `.wasm` blob is full-sized.
+ *
+ * @throws listing every missing symbol, so one CI run reports the whole gap.
+ */
+export function assertBundleExportSurface(
+  wasmBytes: Uint8Array,
+  glueSource: string,
+): ExportSurfaceReport {
+  const wasmNames = new Set(wasmExportNames(wasmBytes));
+  const glueNames = new Set(glueExportNames(glueSource));
+  const missingWasm = REQUIRED_WASM_EXPORTS.filter((n) => !wasmNames.has(n));
+  const missingGlue = REQUIRED_GLUE_EXPORTS.filter((n) => !glueNames.has(n));
+
+  if (missingWasm.length > 0 || missingGlue.length > 0) {
+    const parts: string[] = [];
+    if (missingWasm.length > 0) {
+      parts.push(`wasm module is missing exports: ${missingWasm.join(", ")}`);
+    }
+    if (missingGlue.length > 0) {
+      parts.push(`generated glue is missing bindings: ${missingGlue.join(", ")}`);
+    }
+    throw new Error(
+      `wasm_activation bundle export surface incomplete — ${parts.join("; ")}. ` +
+        `A CLI that exits 0 while stripping bindings is a silent failure, not a pass.`,
+    );
+  }
+  return { missingWasm, missingGlue };
+}

--- a/tests/scripts/build_wasm_bundle_wasm64.bats
+++ b/tests/scripts/build_wasm_bundle_wasm64.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# Tests for the wasm64 (Memory64) build lane of scripts/build-wasm-bundle.sh
+# (Issue #541).
+#
+# The wasm32 lane goes through wasm-pack; wasm64 cannot — wasm-pack 0.15.0
+# hard-codes `wasm32-unknown-unknown` as its cargo target, so the wasm64 bundle
+# is built with `cargo +nightly … -Z build-std` and the `wasm-bindgen` CLI
+# directly. These tests drive the script against stub toolchain binaries on
+# PATH, so they assert on what it *invokes* and what it *produces* without a
+# 70-second nightly build.
+#
+# They also pin the fail-loud contract the July 2026 spike recorded: a CLI that
+# exits 0 while stripping the bindings must not yield a published tarball.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/build-wasm-bundle.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_DIR="$(mktemp -d)"
+  STUB_BIN="$TMP_DIR/bin"
+  WORK_DIR="$TMP_DIR/work"
+  mkdir -p "$STUB_BIN" "$WORK_DIR/neat-core"
+  export REPO_ROOT SCRIPT_UNDER_TEST TMP_DIR STUB_BIN WORK_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Write a stub that appends its argv to $TMP_DIR/<name>.log and exits 0.
+stub() {
+  local name="$1"
+  shift
+  {
+    echo '#!/usr/bin/env bash'
+    echo "printf '%s\n' \"\$*\" >> \"$TMP_DIR/${name}.log\""
+    printf '%s\n' "$@"
+    echo 'exit 0'
+  } >"$STUB_BIN/$name"
+  chmod +x "$STUB_BIN/$name"
+}
+
+# Materialise a plausible pkg/ at the --out-dir in argv, prefixed by $1 (empty
+# for wasm-bindgen, which takes a path; "neat-core/" for wasm-pack, which
+# resolves --out-dir relative to the crate directory).
+emit_pkg_body() {
+  cat <<BODY
+out_dir=""
+prev=""
+for arg in "\$@"; do
+  if [ "\$prev" = "--out-dir" ]; then out_dir="${1}\$arg"; fi
+  prev="\$arg"
+done
+[ -n "\$out_dir" ] || { echo "stub: no --out-dir in argv" >&2; exit 3; }
+mkdir -p "\$out_dir"
+: >"\$out_dir/wasm_activation.js"
+: >"\$out_dir/wasm_activation.d.ts"
+: >"\$out_dir/wasm_activation_bg.wasm.d.ts"
+dd if=/dev/zero of="\$out_dir/wasm_activation_bg.wasm" bs=1024 count=200 status=none
+BODY
+}
+
+# A cargo stub that leaves the raw Tier 3 artefact where the real one lands.
+emit_cargo_body() {
+  cat <<'BODY'
+mkdir -p target/wasm64-unknown-unknown/release
+dd if=/dev/zero of=target/wasm64-unknown-unknown/release/neat_core.wasm \
+  bs=1024 count=600 status=none
+BODY
+}
+
+# Install a full stub toolchain: cargo, wasm-bindgen, wasm-pack and deno.
+stub_toolchain() {
+  stub cargo "$(emit_cargo_body)"
+  stub wasm-bindgen "$(emit_pkg_body '')"
+  stub wasm-pack "$(emit_pkg_body 'neat-core/')"
+  stub deno
+}
+
+run_build() {
+  cd "$WORK_DIR" || return 1
+  PATH="$STUB_BIN:$PATH" run "$SCRIPT_UNDER_TEST" "$@"
+}
+
+@test "--help documents the --arch selector and both wasm targets" {
+  run "$SCRIPT_UNDER_TEST" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--arch"* ]]
+  [[ "$output" == *"wasm64"* ]]
+  [[ "$output" == *"wasm32"* ]]
+}
+
+@test "rejects an --arch value that is neither wasm32 nor wasm64" {
+  run "$SCRIPT_UNDER_TEST" --rev deadbeef --arch wasm128
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--arch"* ]]
+  [[ "$output" == *"wasm128"* ]]
+}
+
+@test "--arch wasm64 builds through cargo nightly with -Z build-std" {
+  stub_toolchain
+  run_build --rev cafe1234 --arch wasm64 --out "$TMP_DIR/out64.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/cargo.log" ]
+  grep -q -- "--target wasm64-unknown-unknown" "$TMP_DIR/cargo.log"
+  grep -q -- "-Z build-std" "$TMP_DIR/cargo.log"
+  grep -q -- "+nightly" "$TMP_DIR/cargo.log"
+}
+
+@test "--arch wasm64 runs wasm-bindgen directly, not wasm-pack" {
+  stub_toolchain
+  run_build --rev cafe1234 --arch wasm64 --out "$TMP_DIR/out64.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/wasm-bindgen.log" ]
+  grep -q -- "--target web" "$TMP_DIR/wasm-bindgen.log"
+  grep -q -- "--out-name wasm_activation" "$TMP_DIR/wasm-bindgen.log"
+  [ ! -f "$TMP_DIR/wasm-pack.log" ]
+}
+
+@test "--arch wasm32 still builds through wasm-pack" {
+  stub_toolchain
+  run_build --rev cafe1234 --arch wasm32 --out "$TMP_DIR/out32.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/wasm-pack.log" ]
+  grep -q -- "--target web" "$TMP_DIR/wasm-pack.log"
+  [ ! -f "$TMP_DIR/cargo.log" ]
+}
+
+@test "a built bundle is gated before it is packaged" {
+  stub_toolchain
+  run_build --rev cafe1234 --arch wasm64 --out "$TMP_DIR/out64.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/deno.log" ]
+  grep -q "check_wasm64_bundle.ts" "$TMP_DIR/deno.log"
+  grep -q -- "--arch wasm64" "$TMP_DIR/deno.log"
+}
+
+@test "the arch reaches the gate, so a wasm32 build cannot be gated as wasm64" {
+  stub_toolchain
+  run_build --rev cafe1234 --arch wasm32 --out "$TMP_DIR/out32.tar.gz"
+  [ "$status" -eq 0 ]
+  grep -q -- "--arch wasm32" "$TMP_DIR/deno.log"
+}
+
+@test "a failing gate blocks the tarball — no silent publish" {
+  stub_toolchain
+  # Re-stub deno to fail the way check_wasm64_bundle.ts does on a stripped glue.
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'echo "check_wasm64_bundle: generated glue is missing bindings" >&2'
+    echo 'exit 1'
+  } >"$STUB_BIN/deno"
+  chmod +x "$STUB_BIN/deno"
+
+  run_build --rev cafe1234 --arch wasm64 --out "$TMP_DIR/out64.tar.gz"
+  [ "$status" -ne 0 ]
+  [ ! -f "$TMP_DIR/out64.tar.gz" ]
+}
+
+@test "a missing deno fails loud rather than skipping the gate" {
+  stub cargo "$(emit_cargo_body)"
+  stub wasm-bindgen "$(emit_pkg_body '')"
+  # No deno stub, and a PATH that cannot reach a real one: the gate genuinely
+  # cannot run. Absence of a failure marker must not be reconciled as a pass.
+  cd "$WORK_DIR" || return 1
+  PATH="$STUB_BIN:/usr/bin:/bin" run "$SCRIPT_UNDER_TEST" \
+    --rev cafe1234 --arch wasm64 --out "$TMP_DIR/out64.tar.gz"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"deno"* ]]
+  [ ! -f "$TMP_DIR/out64.tar.gz" ]
+}
+
+@test "the wasm64 tarball still unpacks to a top-level pkg/" {
+  stub_toolchain
+  run_build --rev cafe1234 --arch wasm64 --out "$TMP_DIR/out64.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/out64.tar.gz" ]
+  run tar -tzf "$TMP_DIR/out64.tar.gz"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pkg/wasm_activation_bg.wasm"* ]]
+  [[ "$output" == *"pkg/neat_core_rev.txt"* ]]
+}
+
+@test "--pkg-dir packages a pre-gated directory without invoking a toolchain" {
+  stub_toolchain
+  pkg="$TMP_DIR/prebuilt/pkg"
+  mkdir -p "$pkg"
+  : >"$pkg/wasm_activation.js"
+  : >"$pkg/wasm_activation.d.ts"
+  dd if=/dev/zero of="$pkg/wasm_activation_bg.wasm" bs=1024 count=200 status=none
+
+  run_build --rev cafe1234 --arch wasm64 --pkg-dir "$pkg" --out "$TMP_DIR/pre.tar.gz"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/pre.tar.gz" ]
+  [ ! -f "$TMP_DIR/cargo.log" ]
+  [ ! -f "$TMP_DIR/wasm-bindgen.log" ]
+}

--- a/tests/scripts/wasm_bundle_wasm64_dual_ship.bats
+++ b/tests/scripts/wasm_bundle_wasm64_dual_ship.bats
@@ -131,6 +131,35 @@ LOCK
   rm -rf "$tmp"
 }
 
+@test "the pinned wasm-bindgen CLI version already agrees with Cargo.lock" {
+  # The workflow guard fails the publish on a skew; this catches the same skew
+  # one step earlier, on the PR that bumps the crate, so Develop never breaks.
+  run python3 - "$WF" "${REPO_ROOT}/Cargo.lock" <<'PY'
+import re
+import sys
+
+import yaml
+
+workflow, lockfile = sys.argv[1], sys.argv[2]
+steps = yaml.safe_load(open(workflow))["jobs"]["publish"]["steps"]
+pinned = next(
+    s["env"]["WASM_BINDGEN_VERSION"]
+    for s in steps
+    if "WASM_BINDGEN_VERSION" in (s.get("env") or {})
+)
+lock = open(lockfile, encoding="utf-8").read()
+match = re.search(r'name = "wasm-bindgen"\nversion = "([^"]+)"', lock)
+assert match, "Cargo.lock has no wasm-bindgen entry"
+assert pinned == match.group(1), (
+    f"workflow pins wasm-bindgen CLI {pinned} but Cargo.lock resolves the "
+    f"crate to {match.group(1)} — bump WASM_BINDGEN_VERSION and "
+    f"WASM_BINDGEN_SHA256 together with the crate"
+)
+PY
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
 @test "the CycloneDX SBOM is resolved against the arch it describes" {
   run publish_runs
   [ "$status" -eq 0 ]

--- a/tests/scripts/wasm_bundle_wasm64_dual_ship.bats
+++ b/tests/scripts/wasm_bundle_wasm64_dual_ship.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+# Tests for the wasm64 (Memory64) dual-ship lane of wasm-bundle.yml — Issue #541.
+#
+# The published Release must carry a genuine Memory64 artefact NEAT-AI can pin,
+# alongside the wasm32 asset that remains the rollback window. These are "what"
+# tests: they assert on the YAML the runner will execute, and they execute the
+# real gate scripts where a shell step is what is under test — never on prose.
+#
+# The pinned-install assertion is shared with wasm_pack_pinned_install.bats via
+# helpers.bash (Issue #477).
+
+load helpers
+
+setup() {
+  require_python3
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  WF="${REPO_ROOT}/.github/workflows/wasm-bundle.yml"
+  [ -f "$WF" ]
+  export REPO_ROOT WF
+}
+
+# Every `run:` body in the publish job, newline-joined.
+publish_runs() {
+  python3 - "$WF" <<'PY'
+import sys
+
+import yaml
+
+data = yaml.safe_load(open(sys.argv[1]))
+steps = data["jobs"]["publish"]["steps"]
+print("\n".join(s.get("run", "") for s in steps))
+PY
+}
+
+@test "the publish job builds a wasm64 bundle" {
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--arch wasm64"* ]]
+}
+
+@test "the publish job still builds the wasm32 rollback bundle" {
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--arch wasm32"* ]]
+}
+
+@test "both bundles are published as distinctly named Release assets" {
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"wasm_activation-pkg.tar.gz"* ]]
+  [[ "$output" == *"wasm_activation-wasm64-pkg.tar.gz"* ]]
+}
+
+@test "the wasm64 asset carries its own SHA-256 sidecar" {
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"wasm_activation-wasm64-pkg.tar.gz.sha256"* ]]
+}
+
+@test "numeric parity between the two arches gates the publish" {
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"check_wasm_arch_parity.ts"* ]]
+}
+
+@test "the parity check runs before the Release is created" {
+  run python3 - "$WF" <<'PY'
+import sys
+
+import yaml
+
+steps = yaml.safe_load(open(sys.argv[1]))["jobs"]["publish"]["steps"]
+runs = [s.get("run", "") for s in steps]
+parity = next(i for i, r in enumerate(runs) if "check_wasm_arch_parity.ts" in r)
+release = next(i for i, r in enumerate(runs) if "gh release create" in r)
+assert parity < release, f"parity runs after publish: {parity} > {release}"
+PY
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "the wasm64 build installs a nightly toolchain with rust-src" {
+  run python3 - "$WF" <<'PY'
+import sys
+
+import yaml
+
+steps = yaml.safe_load(open(sys.argv[1]))["jobs"]["publish"]["steps"]
+blob = yaml.safe_dump(steps)
+# wasm64-unknown-unknown is Tier 3: no prebuilt std, so -Z build-std needs the
+# rust-src component on a nightly toolchain.
+assert "rust-src" in blob, "no rust-src component requested"
+assert "nightly" in blob, "no nightly toolchain requested"
+PY
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "wasm-bindgen CLI is installed from a version- and checksum-pinned release" {
+  run assert_pinned_cli_install "$WF" WASM_BINDGEN \
+    'github\.com/(rustwasm|wasm-bindgen)/wasm-bindgen/releases/download/(\$\{?WASM_BINDGEN_VERSION\}?|[0-9]+\.[0-9]+\.[0-9]+)/'
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "the pinned wasm-bindgen CLI version is checked against Cargo.lock" {
+  # A CLI/crate skew is what produced the July 2026 NO-GO. The workflow must
+  # compare the two and fail, not proceed on a hopeful match.
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Cargo.lock"* ]]
+  [[ "$output" == *"WASM_BINDGEN_VERSION"* ]]
+}
+
+@test "the CLI/Cargo.lock version check fails loud on a skew" {
+  tmp="$(mktemp -d)"
+  extract_step "$WF" "Install wasm-bindgen" "$tmp"
+  # Replay only the version-agreement guard from the real step, against a
+  # deliberately skewed Cargo.lock.
+  cat >"$tmp/Cargo.lock" <<'LOCK'
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+LOCK
+  guard="$(grep -n 'locked=' -A 8 "$tmp/step.sh" | sed 's/^[0-9]*[-:]//')"
+  [ -n "$guard" ]
+  cd "$tmp"
+  WASM_BINDGEN_VERSION="0.2.127" run bash -euo pipefail -c "$guard"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"0.2.108"* ]]
+  rm -rf "$tmp"
+}
+
+@test "the CycloneDX SBOM is resolved against the arch it describes" {
+  run publish_runs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--target wasm32-unknown-unknown"* ]]
+  [[ "$output" == *"--target wasm64-unknown-unknown"* ]]
+}
+
+@test "provenance is attested for the wasm64 assets too" {
+  run python3 - "$WF" <<'PY'
+import sys
+
+import yaml
+
+steps = yaml.safe_load(open(sys.argv[1]))["jobs"]["publish"]["steps"]
+attest = [
+    s for s in steps
+    if str(s.get("uses", "")).startswith("actions/attest-build-provenance@")
+]
+assert attest, "no attest-build-provenance step"
+subjects = "\n".join(s.get("with", {}).get("subject-path", "") for s in attest)
+for asset in (
+    "wasm_activation-pkg.tar.gz",
+    "wasm_activation-wasm64-pkg.tar.gz",
+    "wasm_activation-wasm64-pkg.tar.gz.sha256",
+):
+    assert asset in subjects, f"{asset} is not attested: {subjects!r}"
+PY
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "the published wasm64 asset is re-verified after upload" {
+  run python3 - "$WF" <<'PY'
+import sys
+
+import yaml
+
+steps = yaml.safe_load(open(sys.argv[1]))["jobs"]["publish"]["steps"]
+runs = [s.get("run", "") for s in steps]
+release = next(i for i, r in enumerate(runs) if "gh release create" in r)
+after = "\n".join(runs[release + 1:])
+assert "wasm_activation-wasm64-pkg.tar.gz" in after, (
+    "the wasm64 asset is never re-downloaded and verified after publish"
+)
+assert "verify-wasm-bundle.sh" in after, "verify-wasm-bundle.sh is not re-run"
+PY
+  echo "$output"
+  [ "$status" -eq 0 ]
+}

--- a/tests/wasm64_bundle_gate_test.ts
+++ b/tests/wasm64_bundle_gate_test.ts
@@ -1,0 +1,169 @@
+// Gate tests for the shipped wasm_activation bundle — Issue #541.
+//
+// The July 2026 spike recorded a *silent* failure mode: `wasm-bindgen` 0.2.108
+// exited 0 on a wasm64 module while stripping every binding out of the
+// generated glue, so the packaging step happily tarred an artefact with no
+// working API. These tests pin the checks that turn that class of failure into
+// a loud one, and they run against synthetic modules/glue so they need no
+// nightly build.
+//
+// "What" tests (AGENTS.md): every case calls the real gate function with real
+// bytes and asserts on the observable outcome — the returned report, or the
+// thrown error.
+//
+// Run: deno test tests/wasm64_bundle_gate_test.ts
+
+import { assert, assertEquals, assertThrows } from "jsr:@std/assert@1";
+import {
+  assertBundleExportSurface,
+  assertMemory64,
+  glueExportNames,
+  MEMORY64_INDEX_FLAG,
+  parseMemoryLimits,
+  REQUIRED_GLUE_EXPORTS,
+  REQUIRED_WASM_EXPORTS,
+  wasmExportNames,
+} from "../scripts/wasm64_bundle_gate.ts";
+import { buildMemory64Module, WASM32_MAX_PAGES } from "./wasm64_memory64_smoke.ts";
+
+/** Assemble a module carrying a 32-bit memory and the named function exports. */
+function buildWasm32Module(exportNames: string[]): Uint8Array<ArrayBuffer> {
+  const leb = (n: number): number[] => {
+    const out: number[] = [];
+    let v = n;
+    do {
+      let b = v & 0x7f;
+      v = Math.floor(v / 128);
+      if (v !== 0) b |= 0x80;
+      out.push(b);
+    } while (v !== 0);
+    return out;
+  };
+  const section = (id: number, body: number[]) => [id, ...leb(body.length), ...body];
+  const name = (s: string) => [s.length, ...[...s].map((c) => c.charCodeAt(0))];
+
+  // One type: () -> (), one function using it, one 32-bit memory.
+  const types = section(0x01, [0x01, 0x60, 0x00, 0x00]);
+  const funcs = section(0x03, [0x01, 0x00]);
+  const mem = section(0x05, [0x01, 0x00, ...leb(1)]); // flags 0x00 => i32 memory
+  const exportBody: number[] = [...leb(exportNames.length + 1), ...name("memory"), 0x02, 0x00];
+  for (const n of exportNames) exportBody.push(...name(n), 0x00, 0x00);
+  const exportSec = section(0x07, exportBody);
+  const body = [0x00, 0x0b];
+  const code = section(0x0a, [0x01, ...leb(body.length), ...body]);
+
+  const parts = [
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    ...types,
+    ...funcs,
+    ...mem,
+    ...exportSec,
+    ...code,
+  ];
+  const out = new Uint8Array(new ArrayBuffer(parts.length));
+  out.set(parts);
+  return out;
+}
+
+/** Glue text that declares every symbol wasm-bindgen would emit for the bundle. */
+function completeGlue(): string {
+  const lines = REQUIRED_GLUE_EXPORTS.map((sym) =>
+    sym[0] === sym[0].toUpperCase()
+      ? `export class ${sym} {}`
+      : `export function ${sym}() {}`
+  );
+  return ["export function initSync() {}", ...lines].join("\n");
+}
+
+Deno.test("parseMemoryLimits reports the i64 index bit for a Memory64 module", () => {
+  const limits = parseMemoryLimits(buildMemory64Module(WASM32_MAX_PAGES + 128));
+  assertEquals(limits.count, 1);
+  assert(limits.isMemory64);
+  assertEquals(limits.flags & MEMORY64_INDEX_FLAG, MEMORY64_INDEX_FLAG);
+});
+
+Deno.test("parseMemoryLimits reports a plain wasm32 memory as not Memory64", () => {
+  const limits = parseMemoryLimits(buildWasm32Module([]));
+  assertEquals(limits.count, 1);
+  assertEquals(limits.isMemory64, false);
+  assertEquals(limits.flags & MEMORY64_INDEX_FLAG, 0);
+});
+
+Deno.test("assertMemory64 rejects an i32-memory artefact by name", () => {
+  const err = assertThrows(
+    () => assertMemory64(buildWasm32Module([]), "wasm_activation_bg.wasm"),
+    Error,
+  );
+  assert(
+    err.message.includes("wasm_activation_bg.wasm"),
+    `error must name the artefact: ${err.message}`,
+  );
+  assert(/i32|32-bit/.test(err.message), `error must say the memory is 32-bit: ${err.message}`);
+});
+
+Deno.test("assertMemory64 accepts a genuine (memory i64 ...) artefact", () => {
+  const limits = assertMemory64(buildMemory64Module(WASM32_MAX_PAGES + 128), "fixture.wasm");
+  assert(limits.isMemory64);
+});
+
+Deno.test("wasmExportNames lists every export declared by the module", () => {
+  const names = wasmExportNames(buildWasm32Module(["propagate_topological", "__wbindgen_malloc"]));
+  assertEquals(names.includes("memory"), true);
+  assertEquals(names.includes("propagate_topological"), true);
+  assertEquals(names.includes("__wbindgen_malloc"), true);
+  assertEquals(names.includes("compilednetwork_activate"), false);
+});
+
+Deno.test("glueExportNames picks up both function and class bindings", () => {
+  const names = glueExportNames(
+    "export function propagate_topological(d) {}\nexport class CompiledNetwork {}\n",
+  );
+  assertEquals(names.sort(), ["CompiledNetwork", "propagate_topological"]);
+});
+
+Deno.test("glueExportNames sees only the bootstrap in the glue wasm-bindgen 0.2.108 emitted", () => {
+  // The recorded silent failure: the CLI exits 0 and writes initSync/init only,
+  // so the bootstrap is present and not one binding of the real API is.
+  const names = glueExportNames("export function initSync(module) {}\nexport default init;\n");
+  assertEquals(names, ["initSync"]);
+  for (const sym of REQUIRED_GLUE_EXPORTS) assertEquals(names.includes(sym), false);
+});
+
+Deno.test("assertBundleExportSurface passes a bundle carrying the full surface", () => {
+  const report = assertBundleExportSurface(buildWasm32Module(REQUIRED_WASM_EXPORTS), completeGlue());
+  assertEquals(report.missingWasm, []);
+  assertEquals(report.missingGlue, []);
+});
+
+Deno.test("assertBundleExportSurface fails loud when the glue is a silent stub", () => {
+  const err = assertThrows(
+    () =>
+      assertBundleExportSurface(
+        buildWasm32Module(REQUIRED_WASM_EXPORTS),
+        "export function initSync(module) {}\n",
+      ),
+    Error,
+  );
+  assert(/glue/i.test(err.message), `error must blame the glue: ${err.message}`);
+  for (const sym of REQUIRED_GLUE_EXPORTS) {
+    assert(err.message.includes(sym), `error must list the missing binding ${sym}`);
+  }
+});
+
+Deno.test("assertBundleExportSurface fails loud when the wasm drops a required export", () => {
+  const kept = REQUIRED_WASM_EXPORTS.filter((n) => n !== "__wbindgen_malloc");
+  const err = assertThrows(
+    () => assertBundleExportSurface(buildWasm32Module(kept), completeGlue()),
+    Error,
+  );
+  assert(err.message.includes("__wbindgen_malloc"), `error must name the export: ${err.message}`);
+});
+
+Deno.test("the required surface covers the activation and backprop entry points", () => {
+  // Guards the list itself: dropping the network or propagate entry points
+  // would leave the gate green on a bundle NEAT-AI cannot use.
+  for (const sym of ["compilednetwork_new", "compilednetwork_activate", "propagate_topological"]) {
+    assert(REQUIRED_WASM_EXPORTS.includes(sym), `${sym} must be gated`);
+  }
+  assert(REQUIRED_GLUE_EXPORTS.includes("CompiledNetwork"));
+});

--- a/tests/wasm64_memory64_smoke.ts
+++ b/tests/wasm64_memory64_smoke.ts
@@ -10,20 +10,24 @@
 // Every value below is a plain byte constant — the module is small enough to
 // audit by hand against the WebAssembly binary format.
 
-/** Bytes in one WASM page (64 KiB). */
-export const WASM_PAGE_BYTES = 64 * 1024;
+// Issue #541 — the page/ceiling constants and the memory-section parser are
+// shared with the shipped-bundle gate (`scripts/wasm64_bundle_gate.ts`). One
+// home: a second copy of "which flag bit means i64" is exactly the drift that
+// would let a wasm32 regression pass one check and fail the other.
+export {
+  MEMORY64_INDEX_FLAG,
+  type MemoryLimits,
+  parseMemoryLimits,
+  WASM32_MAX_BYTES,
+  WASM32_MAX_PAGES,
+  WASM_PAGE_BYTES,
+} from "../scripts/wasm64_bundle_gate.ts";
 
-/** wasm32 linear memory is capped at 65536 pages = exactly 4 GiB. */
-export const WASM32_MAX_PAGES = 65536;
-
-/** The hard wasm32 address-space ceiling in bytes (4 GiB). */
-export const WASM32_MAX_BYTES = WASM32_MAX_PAGES * WASM_PAGE_BYTES;
-
-/**
- * Memory-type flag bit that marks a 64-bit (i64) index type. A wasm32 memory
- * has this bit clear; a Memory64 memory has it set. (Bit 0 = has-maximum.)
- */
-export const MEMORY64_INDEX_FLAG = 0x04;
+import {
+  MEMORY64_INDEX_FLAG,
+  WASM32_MAX_PAGES,
+  WASM_PAGE_BYTES,
+} from "../scripts/wasm64_bundle_gate.ts";
 
 /** Unsigned LEB128 encoding of a non-negative integer. */
 export function unsignedLeb128(value: number): number[] {
@@ -106,44 +110,6 @@ export function buildMemory64Module(maxPages: number): Uint8Array<ArrayBuffer> {
   const out = new Uint8Array(new ArrayBuffer(parts.length));
   out.set(parts);
   return out;
-}
-
-/** Parsed limits of the first memory declared in a module. */
-export interface MemoryLimits {
-  count: number;
-  flags: number;
-  /** True when the memory declares a 64-bit (i64) index type. */
-  isMemory64: boolean;
-}
-
-/**
- * Parse the memory section (id 0x05) of a module and report its flags. Used to
- * assert — without instantiating — that the module we built really carries the
- * i64 index type.
- */
-export function parseMemoryLimits(bytes: Uint8Array<ArrayBuffer>): MemoryLimits {
-  let p = 8; // skip magic + version
-  const readLeb = (): number => {
-    let result = 0, shift = 0, byte: number;
-    do {
-      byte = bytes[p++];
-      result |= (byte & 0x7f) << shift;
-      shift += 7;
-    } while (byte & 0x80);
-    return result >>> 0;
-  };
-  while (p < bytes.length) {
-    const id = bytes[p++];
-    const len = readLeb();
-    const start = p;
-    if (id === 0x05) {
-      const count = readLeb();
-      const flags = bytes[p];
-      return { count, flags, isMemory64: (flags & MEMORY64_INDEX_FLAG) !== 0 };
-    }
-    p = start + len;
-  }
-  throw new Error("no memory section (0x05) found in module");
 }
 
 /** Handles bound to an instantiated Memory64 store/load module. */

--- a/tests/wasm_arch_parity_fixture.ts
+++ b/tests/wasm_arch_parity_fixture.ts
@@ -1,0 +1,193 @@
+// Committed numeric-parity fixture for the wasm32 / wasm64 bundles — Issue #541.
+//
+// The fixture is *code*, not a checked-in binary: the network buffer and the
+// record batch are assembled here from named constants, so a reviewer can see
+// exactly which kernels the parity check exercises and a diff shows a changed
+// weight instead of a changed blob.
+//
+// Coverage is deliberate. Widening `cfg(target_arch = "wasm32")` to the wasm
+// family means the SIMD kernels in `simd.rs` now compile for a second address
+// size, so the fixture has to reach them:
+//
+//   * synapse spans of 4, 8 and 12 — the 4-wide gather, the dual-accumulator
+//     8-chunk walk, and a 0..3 remainder that must continue (not restart) the
+//     running accumulator;
+//   * both inline-squash tiers: Identity/ReLU/Logistic/Tanh (branched inline)
+//     and Gelu (deferred to `apply_squash`);
+//   * the aggregate squashes that bypass the lane-vectorised path entirely —
+//     Minimum, Maximum, Hypotenuse and Mean;
+//   * a mixed-sign input distribution, so a lane or stride slip cannot cancel.
+
+/** Squash-type ids, mirroring `SquashType::from_u8` in `neat-core/src/squash.rs`. */
+export const SQUASH = {
+  IDENTITY: 0,
+  RELU: 1,
+  LOGISTIC: 6,
+  TANH: 7,
+  GELU: 13,
+  MINIMUM: 32,
+  MAXIMUM: 33,
+  HYPOTENUSE: 35,
+  MEAN: 37,
+} as const;
+
+/** Inputs consumed by the fixture network. */
+export const NUM_INPUTS = 12;
+
+/** Outputs produced by the fixture network. */
+export const NUM_OUTPUTS = 3;
+
+/** Records in the packed batch built by {@link buildParityRecords}. */
+export const NUM_RECORDS = 11;
+
+interface Synapse {
+  from: number;
+  weight: number;
+}
+
+interface Neuron {
+  bias: number;
+  squash: number;
+  synapses: Synapse[];
+}
+
+/**
+ * Deterministic pseudo-random weight in [-1, 1). A tiny LCG keeps the fixture
+ * reproducible across runtimes without committing a table of magic numbers.
+ */
+function lcgWeight(seed: number): number {
+  const next = (seed * 1103515245 + 12345) % 2147483648;
+  return (next / 2147483648) * 2 - 1;
+}
+
+function span(from: number, count: number, seed: number): Synapse[] {
+  return Array.from({ length: count }, (_, i) => ({
+    from: from + i,
+    weight: lcgWeight(seed + i * 7919),
+  }));
+}
+
+/** The fixture topology: 12 inputs, 6 hidden neurons, 3 outputs. */
+function fixtureNeurons(): Neuron[] {
+  const hidden: Neuron[] = [
+    // 12 synapses: two full 4-lane chunks plus a third — the dual-accumulator walk.
+    { bias: 0.25, squash: SQUASH.RELU, synapses: span(0, 12, 1) },
+    // 8 synapses: exactly two chunks, no remainder.
+    { bias: -0.5, squash: SQUASH.TANH, synapses: span(0, 8, 2) },
+    // 7 synapses: one chunk plus a 3-wide remainder that must continue the sum.
+    { bias: 0.125, squash: SQUASH.LOGISTIC, synapses: span(2, 7, 3) },
+    // 5 synapses under an aggregate squash — bypasses the lane-vectorised path.
+    { bias: 0.0, squash: SQUASH.MINIMUM, synapses: span(0, 5, 4) },
+    { bias: 0.0, squash: SQUASH.MAXIMUM, synapses: span(4, 6, 5) },
+    // Hypotenuse reads the sum-of-squares kernel; Mean reads the no-bias kernel.
+    { bias: 0.75, squash: SQUASH.HYPOTENUSE, synapses: span(1, 9, 6) },
+  ];
+  const hiddenBase = NUM_INPUTS;
+  const outputs: Neuron[] = [
+    {
+      bias: 0.05,
+      squash: SQUASH.IDENTITY,
+      synapses: span(hiddenBase, hidden.length, 7),
+    },
+    {
+      bias: -0.2,
+      squash: SQUASH.GELU,
+      synapses: span(hiddenBase, hidden.length, 8),
+    },
+    {
+      bias: 0.4,
+      squash: SQUASH.MEAN,
+      synapses: span(hiddenBase, hidden.length, 9),
+    },
+  ];
+  return [...hidden, ...outputs];
+}
+
+/**
+ * Serialise the fixture into the `CompiledNetwork::new` wire format:
+ * `u32 num_neurons`, `u32 num_inputs`, then per non-input neuron
+ * `f64 bias`, `u8 squash`, `u8 is_constant`, `u16 num_synapses`, and per
+ * synapse `u16 from_index`, `u8 synapse_type`, `u8 padding`, `f64 weight`.
+ */
+export function buildParityNetwork(): Uint8Array<ArrayBuffer> {
+  const neurons = fixtureNeurons();
+  const numNeurons = NUM_INPUTS + neurons.length;
+  const size = 8 +
+    neurons.reduce((acc, n) => acc + 12 + n.synapses.length * 12, 0);
+  const buffer = new ArrayBuffer(size);
+  const view = new DataView(buffer);
+  let o = 0;
+  view.setUint32(o, numNeurons, true);
+  o += 4;
+  view.setUint32(o, NUM_INPUTS, true);
+  o += 4;
+  for (const neuron of neurons) {
+    view.setFloat64(o, neuron.bias, true);
+    o += 8;
+    view.setUint8(o++, neuron.squash);
+    view.setUint8(o++, 0); // is_constant
+    view.setUint16(o, neuron.synapses.length, true);
+    o += 2;
+    for (const s of neuron.synapses) {
+      view.setUint16(o, s.from, true);
+      o += 2;
+      view.setUint8(o++, 0); // synapse_type CONDITION/NORMAL
+      view.setUint8(o++, 0); // padding
+      view.setFloat64(o, s.weight, true);
+      o += 8;
+    }
+  }
+  return new Uint8Array(buffer);
+}
+
+/** Input values for record `index`, spanning both signs and a zero. */
+export function buildParityInput(index: number): Float32Array {
+  const input = new Float32Array(NUM_INPUTS);
+  for (let i = 0; i < NUM_INPUTS; i++) {
+    // Alternating signs with a per-record offset: a lane swap changes the sum.
+    input[i] = ((i % 2 === 0) ? 1 : -1) * ((i + 1) * 0.125 + index * 0.0625);
+  }
+  input[index % NUM_INPUTS] = 0; // one exact zero, rotated per record
+  return input;
+}
+
+/**
+ * The packed `[inputs…, targets…]` batch the `*_sum_batch_packed` loss entry
+ * points scan. Stride is `NUM_INPUTS + NUM_OUTPUTS`; {@link NUM_RECORDS} is odd
+ * and above 8 so the 8-record group, the 4-record group and the scalar tail all
+ * run in one call.
+ */
+export function buildParityRecords(): Float32Array {
+  const stride = NUM_INPUTS + NUM_OUTPUTS;
+  const records = new Float32Array(NUM_RECORDS * stride);
+  for (let r = 0; r < NUM_RECORDS; r++) {
+    records.set(buildParityInput(r), r * stride);
+    for (let t = 0; t < NUM_OUTPUTS; t++) {
+      records[r * stride + NUM_INPUTS + t] = ((t % 2 === 0) ? 0.75 : -0.25) + r * 0.03125;
+    }
+  }
+  return records;
+}
+
+/** The raw IEEE-754 bit patterns behind a float array, as hex words. */
+export function bitPatterns(values: Float32Array | Float64Array): string[] {
+  const view = new DataView(values.buffer, values.byteOffset, values.byteLength);
+  const out: string[] = [];
+  if (values instanceof Float32Array) {
+    for (let i = 0; i < values.length; i++) {
+      out.push(view.getUint32(i * 4, true).toString(16).padStart(8, "0"));
+    }
+  } else {
+    for (let i = 0; i < values.length; i++) {
+      out.push(view.getBigUint64(i * 8, true).toString(16).padStart(16, "0"));
+    }
+  }
+  return out;
+}
+
+/** A single f64 scalar's bit pattern, for the loss-sum comparisons. */
+export function scalarBitPattern(value: number): string {
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, value, true);
+  return view.getBigUint64(0, true).toString(16).padStart(16, "0");
+}

--- a/tests/wasm_arch_parity_test.ts
+++ b/tests/wasm_arch_parity_test.ts
@@ -1,0 +1,160 @@
+// Tests for the wasm32/wasm64 numeric-parity fixture and comparator — Issue #541.
+//
+// The end-to-end parity gate needs two *built* bundles, so it runs in CI
+// (`wasm-bundle.yml`) rather than here. What these tests pin is the part that
+// can silently go vacuous: a fixture that stops reaching the SIMD kernels, or a
+// comparator that reports agreement it never checked.
+//
+// Run: deno test tests/wasm_arch_parity_test.ts
+
+import { assert, assertEquals } from "jsr:@std/assert@1";
+import { compare, type Observations } from "../scripts/check_wasm_arch_parity.ts";
+import {
+  bitPatterns,
+  buildParityInput,
+  buildParityNetwork,
+  buildParityRecords,
+  NUM_INPUTS,
+  NUM_OUTPUTS,
+  NUM_RECORDS,
+  scalarBitPattern,
+  SQUASH,
+} from "./wasm_arch_parity_fixture.ts";
+
+/** Decode the fixture buffer back into the shape `CompiledNetwork::new` reads. */
+function decodeNetwork(bytes: Uint8Array) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const numNeurons = view.getUint32(0, true);
+  const numInputs = view.getUint32(4, true);
+  let o = 8;
+  const neurons: { bias: number; squash: number; synapses: { from: number; weight: number }[] }[] =
+    [];
+  for (let n = numInputs; n < numNeurons; n++) {
+    const bias = view.getFloat64(o, true);
+    const squash = view.getUint8(o + 8);
+    const count = view.getUint16(o + 10, true);
+    o += 12;
+    const synapses = [];
+    for (let s = 0; s < count; s++) {
+      synapses.push({ from: view.getUint16(o, true), weight: view.getFloat64(o + 4, true) });
+      o += 12;
+    }
+    neurons.push({ bias, squash, synapses });
+  }
+  return { numNeurons, numInputs, neurons, consumed: o };
+}
+
+Deno.test("the fixture network serialises to exactly the bytes it declares", () => {
+  const bytes = buildParityNetwork();
+  const net = decodeNetwork(bytes);
+  assertEquals(net.numInputs, NUM_INPUTS);
+  assertEquals(net.numNeurons, NUM_INPUTS + net.neurons.length);
+  // No trailing slack: a mis-sized buffer would leave `CompiledNetwork::new`
+  // parsing padding as a synapse.
+  assertEquals(net.consumed, bytes.length);
+});
+
+Deno.test("every source index in the fixture is in range for the unchecked gather", () => {
+  const net = decodeNetwork(buildParityNetwork());
+  for (const neuron of net.neurons) {
+    for (const s of neuron.synapses) {
+      assert(
+        s.from < net.numNeurons,
+        `from_index ${s.from} must be < num_neurons ${net.numNeurons}`,
+      );
+    }
+  }
+});
+
+Deno.test("the fixture reaches the full chunk-walk: 8-chunk, remainder and below-threshold spans", () => {
+  const counts = decodeNetwork(buildParityNetwork()).neurons.map((n) => n.synapses.length);
+  assert(counts.some((c) => c >= 8), `no span reaches the 8-chunk walk: ${counts}`);
+  assert(counts.some((c) => c % 4 !== 0), `no span leaves a 0..3 remainder: ${counts}`);
+  assert(counts.some((c) => c >= 4 && c < 8), `no span sits in the single-chunk tier: ${counts}`);
+});
+
+Deno.test("the fixture exercises both inline-squash tiers and the aggregate set", () => {
+  const squashes = new Set(decodeNetwork(buildParityNetwork()).neurons.map((n) => n.squash));
+  for (const inline of [SQUASH.IDENTITY, SQUASH.RELU, SQUASH.LOGISTIC, SQUASH.TANH]) {
+    assert(squashes.has(inline), `inline squash ${inline} missing from the fixture`);
+  }
+  assert(squashes.has(SQUASH.GELU), "no squash outside the inline set");
+  for (const aggregate of [SQUASH.MINIMUM, SQUASH.MAXIMUM, SQUASH.HYPOTENUSE, SQUASH.MEAN]) {
+    assert(squashes.has(aggregate), `aggregate squash ${aggregate} missing from the fixture`);
+  }
+});
+
+Deno.test("fixture weights are non-degenerate and mixed-sign", () => {
+  const weights = decodeNetwork(buildParityNetwork()).neurons.flatMap((n) =>
+    n.synapses.map((s) => s.weight)
+  );
+  assert(weights.some((w) => w > 0), "no positive weight");
+  assert(weights.some((w) => w < 0), "no negative weight");
+  // A constant-weight fixture would let a lane swap cancel; require spread.
+  assert(new Set(weights).size > weights.length / 2, "weights are too repetitive to catch a slip");
+});
+
+Deno.test("packed records carry the declared stride and record count", () => {
+  const records = buildParityRecords();
+  const stride = NUM_INPUTS + NUM_OUTPUTS;
+  assertEquals(records.length, NUM_RECORDS * stride);
+  // Records above 8 with an odd count means the 8-group, the 4-group and the
+  // scalar tail all run in one call.
+  assert(NUM_RECORDS > 8 && NUM_RECORDS % 8 !== 0, `NUM_RECORDS ${NUM_RECORDS} skips a tier`);
+  for (let r = 0; r < NUM_RECORDS; r++) {
+    const inputs = records.subarray(r * stride, r * stride + NUM_INPUTS);
+    assertEquals([...inputs], [...buildParityInput(r)]);
+  }
+});
+
+Deno.test("each record has a distinct input vector", () => {
+  const seen = new Set(
+    Array.from({ length: NUM_RECORDS }, (_, r) => bitPatterns(buildParityInput(r)).join(",")),
+  );
+  assertEquals(seen.size, NUM_RECORDS);
+});
+
+Deno.test("bitPatterns separates values a tolerance comparison would merge", () => {
+  // +0 vs -0 compare equal with ===; their bit patterns do not.
+  assertEquals(bitPatterns(new Float32Array([0])), ["00000000"]);
+  assertEquals(bitPatterns(new Float32Array([-0])), ["80000000"]);
+  // Adjacent floats one ulp apart must not collapse.
+  const one = bitPatterns(new Float32Array([1]))[0];
+  const nextUp = bitPatterns(new Float32Array([1 + 2 ** -23]))[0];
+  assert(one !== nextUp, "one-ulp neighbours must differ");
+});
+
+Deno.test("scalarBitPattern distinguishes a last-ulp f64 difference", () => {
+  assert(scalarBitPattern(0.1) !== scalarBitPattern(0.1 + Number.EPSILON / 8));
+  assertEquals(scalarBitPattern(1), "3ff0000000000000");
+});
+
+Deno.test("compare reports nothing when both arches agree", () => {
+  const left: Observations = new Map([["activate[0]", ["3f800000", "bf000000"]]]);
+  const right: Observations = new Map([["activate[0]", ["3f800000", "bf000000"]]]);
+  assertEquals(compare(left, right), []);
+});
+
+Deno.test("compare names the observation and index of a single differing bit pattern", () => {
+  const left: Observations = new Map([["activate[3]", ["3f800000", "bf000000"]]]);
+  const right: Observations = new Map([["activate[3]", ["3f800000", "bf000001"]]]);
+  const failures = compare(left, right);
+  assertEquals(failures.length, 1);
+  assert(failures[0].includes("activate[3][1]"), failures[0]);
+  assert(failures[0].includes("bf000000") && failures[0].includes("bf000001"), failures[0]);
+});
+
+Deno.test("compare fails when an observation exists on only one arch", () => {
+  const left: Observations = new Map([["mse_sum_batch_packed", ["3ff0000000000000"]]]);
+  const failures = compare(left, new Map());
+  assertEquals(failures.length, 1);
+  assert(failures[0].includes("mse_sum_batch_packed"), failures[0]);
+});
+
+Deno.test("compare fails on a length mismatch instead of comparing the shared prefix", () => {
+  const left: Observations = new Map([["activate[0]", ["3f800000", "bf000000"]]]);
+  const right: Observations = new Map([["activate[0]", ["3f800000"]]]);
+  const failures = compare(left, right);
+  assertEquals(failures.length, 1);
+  assert(failures[0].includes("length 2 vs 1"), failures[0]);
+});


### PR DESCRIPTION
# Ship a production wasm64 (Memory64) activation bundle

## Summary

`neat-core` now builds, gates and **ships** a genuine Memory64
(`(memory i64 …)`) `wasm_activation` bundle through the production
`wasm-bindgen` path — no raw `extern "C"` fallback. Closes #541.

The July 2026 lane (b) NO-GO was **CLI skew, not a permanent gap**: the spike
measured `wasm-bindgen` CLI **0.2.108**, and **0.2.120** added Memory64 codegen
([wasm-bindgen#5004](https://github.com/wasm-bindgen/wasm-bindgen/pull/5004)).
Re-measured **2026-08-14** against CLI **0.2.127** (the version this crate
depends on): the CLI emits the full activation/backprop surface.

What changed:

1. **Every wasm `cfg` widened to the family.** `cfg(target_arch = "wasm32")` →
   `cfg(target_family = "wasm")` across `neat-core/src` and `Cargo.toml`. The
   arch-keyed tables failed in *both* directions on wasm64 at once — dropping
   `wasm-bindgen` (no bindings) while pulling in the native-only `rayon`.
   `neat-core/src/wasm_arch.rs` is the single home of the one genuinely
   arch-shaped split (`core::arch::wasm32` vs `core::arch::wasm64`, the latter
   behind the unstable `simd_wasm64` feature enabled for that arch only).
2. **A wasm64 build lane.** `build-wasm-bundle.sh --arch wasm64` runs
   `cargo +nightly … --target wasm64-unknown-unknown -Z build-std=std,panic_abort`
   then the `wasm-bindgen` CLI. wasm-pack cannot do this: 0.15.0 still hard-codes
   `wasm32-unknown-unknown` as the cargo target it builds and reads back.
3. **Three fail-loud gates.** `scripts/check_wasm64_bundle.ts` (memory index type
   must match `--arch`; the activation/backprop surface must survive into **both**
   the `_bg.wasm` and the glue), `scripts/check_wasm_arch_parity.ts` (bit-exact
   wasm32/wasm64 agreement over a committed fixture), and the existing
   `verify-wasm-bundle.sh` post-publish check, now run per asset.
4. **Dual-ship.** The per-commit Release carries
   `wasm_activation-wasm64-pkg.tar.gz` (the pin new `neatCore.rev` revisions take)
   alongside the unchanged `wasm_activation-pkg.tar.gz` (rollback window until
   NEAT-AI's Memory64 loader lands). Each has its own `.sha256` sidecar and a
   CycloneDX SBOM resolved against **its own** target triple; both are attested.
5. **The skew that caused the NO-GO cannot recur silently.** The pinned CLI
   version is compared against `Cargo.lock` — on the PR (bats) and again in the
   workflow (fails the publish).

**This does not fix V8 exit-133 JS-heap aborts.** That ceiling is the JS heap,
not WASM linear memory; `--max-old-space-size` remains its lever (lane (a),
#296). Downstream adoption (Memory64 glue, workers, `build.sh`) is a separate
NEAT-AI issue, and `wasm_dataset` is **not** re-introduced here.

## Evidence

Backend/WASM only — no web interface to screenshot. Evidence is measured output.

```mermaid
flowchart TD
    S["neat-core sources<br/>cfg(target_family = &quot;wasm&quot;)"] --> A["wasm-pack<br/>wasm32"]
    S --> B["cargo +nightly -Z build-std<br/>wasm64 (Tier 3)"]
    B --> C["wasm-bindgen CLI 0.2.127<br/>pinned = Cargo.lock"]
    A --> G1["check_wasm64_bundle.ts<br/>memory type + export surface"]
    C --> G1
    G1 --> G2["check_wasm_arch_parity.ts<br/>bit-identical f32/f64"]
    G2 --> R["Release wasm-bundle-&lt;sha&gt;<br/>wasm64 = pin · wasm32 = rollback"]
```

### The artefact is genuinely Memory64, with the surface intact

```text
$ ./scripts/build-wasm-bundle.sh --arch wasm64 --rev "$(git rev-parse HEAD)" ...
🛠️  Building neat-core for wasm64-unknown-unknown (nightly + -Z build-std)
🔗  Running wasm-bindgen (target=web, out-name=wasm_activation)
🚦 Gating the built bundle (arch=wasm64)
✅ neat-core/wasm_activation/pkg/wasm_activation_bg.wasm validates (525546 bytes)
✅ linear memory declares the i64 index type
✅ activation/backprop export surface present in module and glue
✅ grew linear memory to 65552 pages (> 65536 = 4 GiB)
✅ neat-core/wasm_activation/pkg passes the wasm64 bundle gate
✅ Built bundle: /tmp/wasm_activation-wasm64-pkg.tar.gz (172694 bytes, rev=2103f56…)

$ wasm-objdump -x -j Memory .../wasm_activation_bg.wasm
 - memory[0] pages: initial=17 i64
```

The generated glue is **68 KB with 50 exported bindings** and the module carries
**192 exports** — not the `initSync`/`init`-only stub CLI 0.2.108 produced.
`CompiledNetwork`, `propagate_topological`, `compilednetwork_activate*`,
`__wbindgen_malloc` and `__wbindgen_free` are all present. Driven from Deno,
slice marshalling round-trips:
`compute_score_components([0.5,-1.5,2.0],[0.25,0.75])` → `[5, 5, 2, 1.5]`.

### Numeric parity: bit-identical, no tolerance

```text
$ deno run --allow-read scripts/check_wasm_arch_parity.ts parity/wasm32/pkg parity/wasm64/pkg
✅ wasm32 and wasm64 agree bit-for-bit on 485 values
```

### Throughput: no measurable regression

`mse_sum_batch_packed` over the 11-record fixture, 200 000 calls × 3 runs
(Deno 2.9.5 / V8 15.0, aarch64-apple-darwin), identical checksums:

| Target | µs/call (3 runs) |
| --- | --- |
| wasm32 | 3.116 · 3.088 · 3.252 |
| wasm64 | 2.985 · 3.226 · 2.976 |

Within run-to-run noise — recorded, not hidden.

### Mutation evidence

A green gate is not evidence; each was made to go red.

| Mutation | Gate | Result |
| --- | --- | --- |
| `inline_squash` ReLU `sum.max(0.0)` → `sum.max(0.1)`, wasm64 rebuilt only | `check_wasm_arch_parity.ts` | **red** — 165/485 values differ |
| `reduce4` lane 3 scaled by `1.000001` (wasm-only SIMD kernel), wasm64 rebuilt only | `check_wasm_arch_parity.ts` | **red** — 209/485 differ, at **one ulp** (`0xbf877560` vs `0xbf877561`); a tolerance comparison would have passed |
| Glue replaced with the `initSync`-only stub 0.2.108 emitted | `check_wasm64_bundle.ts` | **red** — names all six missing bindings |
| wasm32 pkg gated as `--arch wasm64` | `check_wasm64_bundle.ts` | **red** — "linear memory declares a 32-bit (i32) index type (flags 0x00)" |
| Workflow pin skewed to `0.2.126` | `wasm_bundle_wasm64_dual_ship.bats` | **red** — names both versions |
| Gate stubbed to exit 1 | `build_wasm_bundle_wasm64.bats` | **red** — no tarball produced |

Every mutation was reverted; `git status` is clean and `./quality.sh` passes.

### Local gates

- `./quality.sh` — ✅ all checks passed (shellcheck, 370 bats, deno check,
  Mermaid, cargo deny, clippy `-D warnings`, tests, doc, release build).
- `cargo check -p neat-core --target wasm32-unknown-unknown` — ✅ (AGENTS.md
  manual wasm gate; the widened `cfg` did not regress wasm32).
- `./scripts/verify-wasm-bundle.sh --archive wasm_activation-wasm64-pkg.tar.gz`
  — ✅ the wasm64 tarball satisfies the same downstream contract NEAT-AI's
  `build.sh` checks.

## Test Plan

New:

- `tests/wasm64_bundle_gate_test.ts` (11 tests) — memory-section parsing for i32
  and i64 modules, `assertMemory64` rejection by name, module/glue export
  extraction, and `assertBundleExportSurface` failing loud on both a stripped
  glue and a dropped `.wasm` export. Runs against synthetic modules, so no
  nightly build is needed.
- `tests/wasm_arch_parity_test.ts` (13 tests) — the committed fixture serialises
  to exactly the bytes it declares, every `from_index` is in range for the
  unchecked gather, and it genuinely reaches the 8-chunk walk, a 0..3 remainder,
  both inline-squash tiers and all four aggregate squashes; plus the comparator
  reporting a single differing bit pattern, a one-sided observation and a length
  mismatch. `bitPatterns` is shown to separate `+0`/`-0` and one-ulp neighbours.
- `tests/scripts/build_wasm_bundle_wasm64.bats` (11 tests) — the wasm64 lane
  builds through `cargo +nightly -Z build-std` and `wasm-bindgen` (not
  wasm-pack), wasm32 still goes through wasm-pack, the arch reaches the gate, a
  failing gate and a missing `deno` both block the tarball, and the wasm64
  archive still unpacks to a top-level `pkg/`.
- `tests/scripts/wasm_bundle_wasm64_dual_ship.bats` (14 tests) — both bundles
  built and published under distinct names, wasm64 sidecar, parity gate ordered
  before `gh release create`, nightly + `rust-src`, pinned/checksummed
  wasm-bindgen CLI, the CLI/`Cargo.lock` agreement (asserted directly *and*
  executed against a skewed lockfile), per-arch SBOM triples, attestation
  coverage, and post-publish re-verification.

Modified:

- `tests/wasm64_memory64_smoke.ts` — the page/ceiling constants and
  `parseMemoryLimits` now re-export from `scripts/wasm64_bundle_gate.ts` instead
  of holding a second copy. No test was changed, removed or disabled; the
  existing smoke suite passes unmodified.
- `.github/workflows/ci.yml` — the `wasm64-memory64-smoke` job also runs the two
  new Deno suites, so both are gated on every PR.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msspdyc7-408793`<!-- vibe-worker-issue-541 -->