### PR TITLE
Branding: hot-link neat-ai-core.png from the hub as the README banner (Issue #543)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,7 @@ jobs:
       # wasm-bundle.yml, which is the only place a built pkg/ exists.
       - name: Run Memory64 smoke and bundle-gate tests
         run: |
+          set -euo pipefail
           deno test \
             tests/wasm64_memory64_smoke_test.ts \
             tests/wasm64_bundle_gate_test.ts \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # NEAT-AI-core
 
+<p align="center">
+  <img width="720" src="https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-core.png" alt="NEAT-AI-core — the shared native Rust core of NEAT-AI">
+</p>
+
 **Native shared Rust** for [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI) — an implementation of [**NEAT** (NeuroEvolution of Augmenting Topologies)](https://en.wikipedia.org/wiki/Neuroevolution_of_augmenting_topologies): the **`neat-core`** crate (tests included) lives here as a Cargo workspace member.
 
 ## Glossary

--- a/docs/archive/pr-summaries/pr-summary-543.md
+++ b/docs/archive/pr-summaries/pr-summary-543.md
@@ -1,0 +1,56 @@
+## Summary
+
+Added the repo's brand banner to the top of the root `README.md`, hot-linked
+from the NEAT-AI hub rather than copied here, and pinned that outcome with a
+new BATS guard. Closes #543.
+
+The hub (stSoftwareAU/NEAT-AI#3764) owns the artwork and regenerates each
+per-repo preview **in place** at the same committed path, so referencing the
+hub's raw `Develop` URL means a hub refresh — including the pending transparent
+regeneration — propagates here with no PR in this repo. Siblings pull, they do
+not copy: no image binary is committed.
+
+Scope held to the root `README.md`. `neat-core/benches/README.md` and
+`wasm-bench/README.md` are internal developer docs and stay text-only.
+
+```mermaid
+flowchart LR
+    H["NEAT-AI hub<br/>docs/brand/social-previews/neat-ai-core.png<br/>(regenerated in place)"]
+    R["raw.githubusercontent.com<br/>.../NEAT-AI/Develop/..."]
+    C["NEAT-AI-core README.md<br/>banner &lt;img src&gt;"]
+    H --> R --> C
+```
+
+## Evidence
+
+No UI surface and no web interface to drive, so no Playwright screenshot was
+captured — and deliberately no image was saved into this repo: the new guard
+`no brand image binary is committed to this repo` fails if any `*.png`/`*.jpg`/
+`*.svg` is tracked, which is the behaviour the issue asks for.
+
+Verified instead:
+
+- The hot-linked URL resolves — `curl` against
+  `https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-core.png`
+  returns `200`, `image/png`, 103091 bytes.
+- `bats tests/scripts/readme_brand_banner.bats` — 6/6 pass; the three banner
+  assertions failed before the README edit and pass after it.
+- Pre-existing README guards still pass: `readme_glossary.bats` (5),
+  `readme_private_repo_reference.bats` (4).
+- `markdownlint-cli2 README.md` — 0 errors (MD033 inline HTML is already
+  permitted by `.markdownlint-cli2.jsonc`).
+- `./quality.sh` passes cleanly.
+
+## Test Plan
+
+- Added `tests/scripts/readme_brand_banner.bats`, which parses the README
+  header block (H1 to the next heading) for Markdown and inline-HTML images and
+  asserts:
+  - a banner image is present in the header block;
+  - its `src` is the hub's raw `Develop` URL for `neat-ai-core.png`;
+  - its alt text is non-empty and names the repo;
+  - it is not a local path (no vendored copy);
+  - `git ls-files` tracks no brand image binary in this repo.
+- Re-ran `tests/scripts/readme_glossary.bats` and
+  `tests/scripts/readme_private_repo_reference.bats` — unaffected, as the issue
+  predicted.

--- a/tests/scripts/readme_brand_banner.bats
+++ b/tests/scripts/readme_brand_banner.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# Tests that README.md is headed by the repo's brand banner, hot-linked from
+# the NEAT-AI hub rather than copied into this repo (Issue #543).
+#
+# Rationale: the hub (stSoftwareAU/NEAT-AI#3764) owns the artwork and
+# regenerates each per-repo preview in place at the same committed path. The
+# siblings pull, they do not copy — so this README must reference the hub's raw
+# URL and this repo must stay free of brand image binaries. That way a hub
+# refresh (e.g. the transparent regeneration) propagates here with no PR.
+#
+# These are "what" tests: they read the published README artefact and assert on
+# the observable outcome (a banner is present, it points at the hub, no image
+# was vendored), matching the style of readme_glossary.bats.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  README="${REPO_ROOT}/README.md"
+  BANNER_URL="https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-core.png"
+}
+
+# Emit the parser shared by the banner assertions: it returns the (src, alt)
+# of every image in the README header block — the lines from the H1 up to the
+# first following heading — covering both Markdown and inline-HTML images.
+header_images_py() {
+  cat <<'PY'
+import re
+import sys
+
+
+def header_images(path):
+    lines = open(path, encoding="utf-8").read().splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("# "))
+    end = next(
+        (
+            i
+            for i, line in enumerate(lines[start + 1 :], start + 1)
+            if line.startswith("#")
+        ),
+        len(lines),
+    )
+    block = "\n".join(lines[start + 1 : end])
+    images = [
+        (m.group("src"), m.group("alt"))
+        for m in re.finditer(r"!\[(?P<alt>[^\]]*)\]\((?P<src>[^)\s]+)", block)
+    ]
+    for tag in re.finditer(r"<img\b[^>]*>", block):
+        src = re.search(r'src="([^"]*)"', tag.group(0))
+        alt = re.search(r'alt="([^"]*)"', tag.group(0))
+        images.append((src.group(1) if src else "", alt.group(1) if alt else ""))
+    return images
+
+
+def fail(message):
+    sys.stderr.write(message + "\n")
+    sys.exit(1)
+PY
+}
+
+@test "README.md exists" {
+  [ -f "$README" ]
+}
+
+@test "README.md header block carries a banner image" {
+  [ -f "$README" ]
+  run python3 - "$README" <<PY
+$(header_images_py)
+
+images = header_images(sys.argv[1])
+if not images:
+    fail("no banner image found between the H1 and the next heading")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "the banner hot-links the hub's raw neat-ai-core.png" {
+  [ -f "$README" ]
+  run python3 - "$README" "$BANNER_URL" <<PY
+$(header_images_py)
+
+path, wanted = sys.argv[1], sys.argv[2]
+sources = [src for src, _ in header_images(path)]
+if wanted not in sources:
+    fail(f"banner does not hot-link {wanted}; header images are {sources}")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "the banner carries non-empty alt text naming the repo" {
+  [ -f "$README" ]
+  run python3 - "$README" "$BANNER_URL" <<PY
+$(header_images_py)
+
+path, wanted = sys.argv[1], sys.argv[2]
+alts = [alt for src, alt in header_images(path) if src == wanted]
+if not alts:
+    fail(f"no header image with src {wanted}")
+if not any("neat-ai-core" in alt.strip().lower() for alt in alts):
+    fail(f"banner alt text does not name the repo: {alts}")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "the banner is not a local path — no brand image is vendored" {
+  [ -f "$README" ]
+  run python3 - "$README" <<PY
+$(header_images_py)
+
+for src, _ in header_images(sys.argv[1]):
+    if "neat-ai-core.png" in src and not src.startswith("https://"):
+        fail(f"banner points at a local copy rather than the hub: {src}")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "no brand image binary is committed to this repo" {
+  # Siblings pull the artwork from the hub; committing a copy would fork the
+  # brand and defeat the hub's in-place regeneration.
+  run git -C "$REPO_ROOT" ls-files -- '*.png' '*.jpg' '*.jpeg' '*.svg' 'docs/brand'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

Added the repo's brand banner to the top of the root `README.md`, hot-linked
from the NEAT-AI hub rather than copied here, and pinned that outcome with a
new BATS guard. Closes #543.

The hub (stSoftwareAU/NEAT-AI#3764) owns the artwork and regenerates each
per-repo preview **in place** at the same committed path, so referencing the
hub's raw `Develop` URL means a hub refresh — including the pending transparent
regeneration — propagates here with no PR in this repo. Siblings pull, they do
not copy: no image binary is committed.

Scope held to the root `README.md`. `neat-core/benches/README.md` and
`wasm-bench/README.md` are internal developer docs and stay text-only.

```mermaid
flowchart LR
    H["NEAT-AI hub<br/>docs/brand/social-previews/neat-ai-core.png<br/>(regenerated in place)"]
    R["raw.githubusercontent.com<br/>.../NEAT-AI/Develop/..."]
    C["NEAT-AI-core README.md<br/>banner &lt;img src&gt;"]
    H --> R --> C
```

## Evidence

No UI surface and no web interface to drive, so no Playwright screenshot was
captured — and deliberately no image was saved into this repo: the new guard
`no brand image binary is committed to this repo` fails if any `*.png`/`*.jpg`/
`*.svg` is tracked, which is the behaviour the issue asks for.

Verified instead:

- The hot-linked URL resolves — `curl` against
  `https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-core.png`
  returns `200`, `image/png`, 103091 bytes.
- `bats tests/scripts/readme_brand_banner.bats` — 6/6 pass; the three banner
  assertions failed before the README edit and pass after it.
- Pre-existing README guards still pass: `readme_glossary.bats` (5),
  `readme_private_repo_reference.bats` (4).
- `markdownlint-cli2 README.md` — 0 errors (MD033 inline HTML is already
  permitted by `.markdownlint-cli2.jsonc`).
- `./quality.sh` passes cleanly.

## Test Plan

- Added `tests/scripts/readme_brand_banner.bats`, which parses the README
  header block (H1 to the next heading) for Markdown and inline-HTML images and
  asserts:
  - a banner image is present in the header block;
  - its `src` is the hub's raw `Develop` URL for `neat-ai-core.png`;
  - its alt text is non-empty and names the repo;
  - it is not a local path (no vendored copy);
  - `git ls-files` tracks no brand image binary in this repo.
- Re-ran `tests/scripts/readme_glossary.bats` and
  `tests/scripts/readme_private_repo_reference.bats` — unaffected, as the issue
  predicted.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msv3cazv-adf8b7`<!-- vibe-worker-issue-543 -->