### PR TITLE
fix: accept SOFTMAX as LOGISTIC alias (#547)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -157,7 +157,7 @@ impl From<serde_json::Error> for CreatureError {
 /// Parse a squash function name string into a `SquashType` enum value.
 ///
 /// Handles all activation function names from the TypeScript codebase,
-/// including aliases (CLIPPED, RELU, INVERSE, SINUSOID).
+/// including aliases (CLIPPED, RELU, INVERSE, SINUSOID, SOFTMAX).
 pub fn parse_squash_name(name: &str) -> Result<SquashType, CreatureError> {
     match name {
         "IDENTITY" => Ok(SquashType::Identity),
@@ -166,7 +166,11 @@ pub fn parse_squash_name(name: &str) -> Result<SquashType, CreatureError> {
         "LeakyReLU" => Ok(SquashType::LeakyRelu),
         "SELU" => Ok(SquashType::Selu),
         "ELU" => Ok(SquashType::Elu),
-        "LOGISTIC" => Ok(SquashType::Logistic),
+        // SOFTMAX: NEAT-AI tags multi-class outputs with this name for
+        // loss/intent (Issue #547 / NEAT-AI #3783 / #2793). Per-neuron forward
+        // pass is the logistic surrogate (`wasmAliasName() → LOGISTIC`), so
+        // creature JSON carrying `squash: "SOFTMAX"` compiles as Logistic.
+        "LOGISTIC" | "SOFTMAX" => Ok(SquashType::Logistic),
         "TANH" => Ok(SquashType::Tanh),
         "HARD_TANH" | "CLIPPED" => Ok(SquashType::HardTanh),
         "SOFTSIGN" => Ok(SquashType::Softsign),

--- a/neat-core/tests/creature_compile.rs
+++ b/neat-core/tests/creature_compile.rs
@@ -87,6 +87,8 @@ fn test_parse_squash_names() {
         SquashType::Complement
     );
     assert_eq!(parse_squash_name("SINUSOID").unwrap(), SquashType::Sine);
+    // NEAT-AI SOFTMAX is a logistic surrogate at compile time (Issue #547).
+    assert_eq!(parse_squash_name("SOFTMAX").unwrap(), SquashType::Logistic);
 }
 
 #[test]
@@ -227,6 +229,27 @@ fn test_compile_creature_no_hidden_neurons() {
     // output-1 = logistic(0.0 * 1.0 + (-0.2)) = logistic(-0.2)
     let expected_logistic = apply_squash(SquashType::Logistic, -0.2);
     assert!((output[1] - expected_logistic).abs() < 1e-5);
+}
+
+#[test]
+fn test_compile_creature_softmax_alias_matches_logistic() {
+    // Issue #547: SOFTMAX is NEAT-AI's multi-class tag; compile as Logistic.
+    let json = r#"{
+            "input": 1,
+            "output": 1,
+            "neurons": [
+                {"type": "output", "uuid": "output-0", "bias": -0.2, "squash": "SOFTMAX"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+            ]
+        }"#;
+
+    let creature = parse_creature_json(json).unwrap();
+    let mut network = compile_creature(&creature).unwrap();
+    let output = network.activate(&[0.0], 1);
+    let expected = apply_squash(SquashType::Logistic, -0.2);
+    assert!((output[0] - expected).abs() < 1e-5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `parse_squash_name("SOFTMAX")` now maps to `SquashType::Logistic`, matching NEAT-AI’s `wasmAliasName() → LOGISTIC` surrogate (NEAT-AI #2793).
- Creature JSON that still carries `squash: "SOFTMAX"` compiles in rust_scorer / native core instead of failing with `Unknown squash function: SOFTMAX`.
- Closes #547 (transferred from [NEAT-AI#3783](https://github.com/stSoftwareAU/NEAT-AI/issues/3783)).

## Test plan
- [x] `cargo test -p neat-core --test creature_compile softmax`
- [x] `cargo test -p neat-core --test creature_compile test_parse_squash_names`
- [x] `./quality.sh`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)