### PR TITLE
Accept SOFTMAX as a LOGISTIC squash alias (Issue #547)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -214,9 +214,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "futures-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -157,7 +157,7 @@ impl From<serde_json::Error> for CreatureError {
 /// Parse a squash function name string into a `SquashType` enum value.
 ///
 /// Handles all activation function names from the TypeScript codebase,
-/// including aliases (CLIPPED, RELU, INVERSE, SINUSOID).
+/// including aliases (CLIPPED, RELU, INVERSE, SINUSOID, SOFTMAX).
 pub fn parse_squash_name(name: &str) -> Result<SquashType, CreatureError> {
     match name {
         "IDENTITY" => Ok(SquashType::Identity),
@@ -166,7 +166,9 @@ pub fn parse_squash_name(name: &str) -> Result<SquashType, CreatureError> {
         "LeakyReLU" => Ok(SquashType::LeakyRelu),
         "SELU" => Ok(SquashType::Selu),
         "ELU" => Ok(SquashType::Elu),
-        "LOGISTIC" => Ok(SquashType::Logistic),
+        // SOFTMAX is a loss/intent tag on output neurons; the per-neuron
+        // forward pass is the logistic surrogate (Issue #547).
+        "LOGISTIC" | "SOFTMAX" => Ok(SquashType::Logistic),
         "TANH" => Ok(SquashType::Tanh),
         "HARD_TANH" | "CLIPPED" => Ok(SquashType::HardTanh),
         "SOFTSIGN" => Ok(SquashType::Softsign),

--- a/neat-core/tests/creature_compile.rs
+++ b/neat-core/tests/creature_compile.rs
@@ -87,6 +87,9 @@ fn test_parse_squash_names() {
         SquashType::Complement
     );
     assert_eq!(parse_squash_name("SINUSOID").unwrap(), SquashType::Sine);
+    // NEAT-AI tags output neurons SOFTMAX for loss/intent; the per-neuron
+    // forward pass is the logistic surrogate (Issue #547).
+    assert_eq!(parse_squash_name("SOFTMAX").unwrap(), SquashType::Logistic);
 }
 
 #[test]
@@ -227,6 +230,35 @@ fn test_compile_creature_no_hidden_neurons() {
     // output-1 = logistic(0.0 * 1.0 + (-0.2)) = logistic(-0.2)
     let expected_logistic = apply_squash(SquashType::Logistic, -0.2);
     assert!((output[1] - expected_logistic).abs() < 1e-5);
+}
+
+#[test]
+fn softmax_tagged_output_compiles_as_logistic() {
+    // Creature JSON still carries squash: "SOFTMAX" for loss/intent tagging.
+    // The TypeScript WASM path aliases that name to LOGISTIC; compile must
+    // do the same or rust_scorer rejects the creature (Issue #547).
+    let json = r#"{
+            "input": 1,
+            "output": 1,
+            "neurons": [
+                {"type": "output", "uuid": "output-0", "bias": -0.2, "squash": "SOFTMAX"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+            ]
+        }"#;
+
+    let creature = parse_creature_json(json).unwrap();
+    let mut network = compile_creature(&creature).unwrap();
+
+    // weighted sum = 0.5 * 1.0 + (-0.2) = 0.3; logistic(0.3) is the oracle.
+    let output = network.activate(&[0.5], 1);
+    let expected = apply_squash(SquashType::Logistic, 0.3);
+    assert!(
+        (output[0] - expected).abs() < 1e-5,
+        "SOFTMAX-tagged output must activate as logistic: got {}, expected {expected}",
+        output[0],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `parse_squash_name` now treats `SOFTMAX` as an alias of `LOGISTIC`, matching the TypeScript WASM `wasmAliasName()` surrogate.
- Creature JSON that tags output neurons `SOFTMAX` for loss/intent compiles instead of failing rust_scorer with `Unknown squash function: SOFTMAX`.
- Canonical emit stays `LOGISTIC` (`squash_name_from` is unchanged).

Closes #547.

## Test plan
- [x] `softmax_tagged_output_compiles_as_logistic` — compile a `SOFTMAX`-tagged output and assert activation equals `apply_squash(Logistic, 0.3)`
- [x] `test_parse_squash_names` — `parse_squash_name("SOFTMAX") == Logistic`
- [x] Mutation: drop the `| "SOFTMAX"` arm → both tests red (`UnknownSquash("SOFTMAX")`); reverted before commit
- [x] `./quality.sh` green (fmt, clippy, deny, workspace tests)


Made with [Cursor](https://cursor.com)