### PR TITLE
Reject input < 1 / output < 1 on CreatureExport parse, compile and serialise (#550)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,23 @@ this you **must**:
 - **Add a state-leak regression test** asserting the reused-buffer path is
   byte-identical to the fresh-allocation path across differently-sized inputs.
 
+## One width check for creature JSON (Issue #550)
+
+`validate_creature_width` (`neat-core/src/creature.rs`) is the single home of
+the rule that a `CreatureExport` must declare `input >= 1` and `output >= 1`.
+`input` is the authoritative observation count and **cannot be re-derived from
+`neurons`** (input neurons are not listed there), so the rule is enforced at
+every boundary — `parse_creature_json` (after serde), `compile_creature`
+(before any other validation) and `creature_to_json` / `creature_to_json_pretty`
+(a widthless creature is never *written*) — with the typed
+`CreatureError::InvalidInputCount { found }` / `InvalidOutputCount { found }`.
+There is no `#[serde(default)]` on either field and there never will be: a
+missing key is a serde error, not a silent zero. Adding a new entry point that
+accepts or emits creature JSON means calling the helper there; do not re-inline
+the comparison. `neat-core/tests/creature_width_contract.rs` pins the rule at
+all four sites (each was mutation-checked individually — dropping any one call
+fails its own tests).
+
 ## One activation rule for single-record work (Issue #441)
 
 `neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) is the single home

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -351,6 +351,47 @@ cargo bench -p neat-core --features parallel --bench parallel_scoring
 cargo bench -p neat-core --bench hot_paths -- mse_sum_production
 ```
 
+### Creature JSON observation-width contract (Issue #550)
+
+`CreatureExport` (`neat-core/src/creature.rs`) is the Rust mirror of the
+TypeScript `CreatureExport` interface: top-level `input` / `output` integers,
+then `neurons` and `synapses`. The two counts are the **width contract** for
+the whole fleet — `input` is the observation count and `output` the target
+count — and `neurons` deliberately lists only *non-input* neurons, so **`input`
+cannot be re-derived from the neuron list**: lose it and the width is gone.
+
+`input < 1` or `output < 1` is therefore never accepted anywhere in this crate.
+`validate_creature_width` is the single home of the rule and every entry point
+calls it:
+
+| Entry point | `input: 0` / `output: 0` | missing key | `-1` |
+|-------------|--------------------------|-------------|------|
+| `parse_creature_json` | `CreatureError::InvalidInputCount { found }` / `InvalidOutputCount { found }` | `CreatureError::Json` (no `#[serde(default)]`) | `CreatureError::Json` |
+| `compile_creature` | same typed error, checked **before** any other validation | — | — |
+| `creature_to_json` / `creature_to_json_pretty` | same typed error — a widthless creature is never *written* | — | — |
+
+The Display text (`Must have at least one input neurons was: 0`) mirrors
+NEAT-AI `src/architecture/CreatureValidate.ts` so logs line up across the TS
+and Rust stacks. A valid creature round-trips `input` / `output` byte-identically
+through parse → serialise (`neat-core/tests/creature_width_contract.rs`).
+
+Consumers (NEAT-AI-scorer, -Backpropagation, -Lamarck, -Discovery and the
+downstream trainers) read
+the top-level counts and never re-derive them from `neurons`; a hand-built
+`CreatureExport` should go through `validate_creature_width` at the boundary.
+
+```mermaid
+flowchart LR
+    J["creature JSON"] --> P["parse_creature_json<br/>serde → validate_creature_width"]
+    E["CreatureExport (hand-built)"] --> C["compile_creature<br/>validate_creature_width first"]
+    P --> C
+    E --> S["creature_to_json / _pretty<br/>validate_creature_width first"]
+    P --> S
+    P -. "input &lt; 1 / output &lt; 1" .-> X["Err(InvalidInputCount / InvalidOutputCount)"]
+    C -. "input &lt; 1 / output &lt; 1" .-> X
+    S -. "input &lt; 1 / output &lt; 1" .-> X
+```
+
 ## Related Repositories
 
 The NEAT-AI project is split across seven public repositories. Each focuses on one concern and composes with the others as shown below.

--- a/docs/research/ikaruga-neat-ai-comparison.md
+++ b/docs/research/ikaruga-neat-ai-comparison.md
@@ -111,6 +111,8 @@ Ikaruga derives both `Serialize` and `Deserialize` on its `Genome`, enabling ful
 
 That has **landed**: `CreatureExport`, `NeuronExport`, and `SynapseExport` (`neat-core/src/creature.rs`) now derive both `Deserialize` and `Serialize`, so networks round-trip out to JSON as well as in (Issue #30).
 
+Since Issue #550 the round trip also enforces the **observation-width contract**: the top-level `input` (authoritative observation count — not derivable from `neurons`, which lists only non-input neurons) and `output` (target count) must both be `>= 1`. `parse_creature_json`, `compile_creature` and `creature_to_json` all reject `input < 1` / `output < 1` with the typed `CreatureError::InvalidInputCount` / `InvalidOutputCount`, and neither field carries a `#[serde(default)]`.
+
 - **Priority:** medium.
 - **Effort:** small (~150 LOC + tests: round-trip, deterministic field order, numerical precision on f64 weights).
 - **Status:** **done** — shipped via issue [#30](https://github.com/stSoftwareAU/NEAT-AI-core/issues/30) (`neat-core/src/creature.rs`).

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -22,7 +22,20 @@
 //! respectively, for callers constructing `NeuronExport` / `SynapseExport`
 //! values in Rust from enum variants.
 //!
-//! Issues: #1965 (initial deserialisation), #30 (symmetric serialisation).
+//! **Observation-width contract (Issue #550).** The top-level `input` /
+//! `output` counts are the width contract for the whole fleet: `input` is the
+//! observation count and `output` the target count. `neurons` deliberately
+//! lists only *non-input* neurons, so `input` can never be re-derived once it
+//! is lost. [`validate_creature_width`] is the single home of the rule that
+//! `input < 1` or `output < 1` is never accepted — [`parse_creature_json`],
+//! [`compile_creature`], [`creature_to_json`] and [`creature_to_json_pretty`]
+//! all call it and fail with [`CreatureError::InvalidInputCount`] /
+//! [`CreatureError::InvalidOutputCount`]. There is no default and no fallback:
+//! a missing key is a serde error, a zero is a typed error, and neither is
+//! ever written back out.
+//!
+//! Issues: #1965 (initial deserialisation), #30 (symmetric serialisation),
+//! #550 (observation-width contract).
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -35,9 +48,20 @@ use crate::synapse_type::SynapseType;
 /// Top-level creature export format matching the TypeScript `CreatureExport` interface.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CreatureExport {
-    /// Number of input neurons.
+    /// Number of input neurons — the **authoritative observation count**.
+    ///
+    /// Not derivable from [`neurons`](Self::neurons): input neurons are not
+    /// listed there, so if this value is lost the width is gone for good.
+    /// Must be `>= 1` (Issue #550); there is deliberately no `#[serde(default)]`
+    /// — an absent key fails deserialisation and a zero fails
+    /// [`validate_creature_width`] on parse, compile and serialise.
     pub input: usize,
-    /// Number of output neurons.
+    /// Number of output neurons — the **authoritative target count**.
+    ///
+    /// Must be `>= 1` (Issue #550). Although output neurons *are* listed in
+    /// [`neurons`](Self::neurons), this declared value is the contract, and
+    /// [`compile_creature`] additionally checks it against the typed neurons
+    /// ([`CreatureError::OutputCountMismatch`]). No `#[serde(default)]`.
     pub output: usize,
     /// List of non-input neurons (hidden, output, constant).
     pub neurons: Vec<NeuronExport>,
@@ -114,6 +138,25 @@ pub enum CreatureError {
         /// The node count that exceeded [`crate::network::MAX_NODE_COUNT`].
         count: usize,
     },
+    /// `CreatureExport::input` was below the minimum of one (Issue #550).
+    ///
+    /// `input` is the authoritative observation width and cannot be re-derived
+    /// from `neurons` (input neurons are not listed there), so a widthless
+    /// creature is rejected on parse, compile *and* serialise. Display text
+    /// mirrors NEAT-AI `CreatureValidate.ts` so logs line up across stacks.
+    InvalidInputCount {
+        /// The `input` value that was found (always `0` today; `usize` cannot
+        /// go negative, and a negative JSON literal fails in serde first).
+        found: usize,
+    },
+    /// `CreatureExport::output` was below the minimum of one (Issue #550).
+    ///
+    /// Same rule and same three enforcement points as
+    /// [`CreatureError::InvalidInputCount`].
+    InvalidOutputCount {
+        /// The `output` value that was found.
+        found: usize,
+    },
 }
 
 impl std::fmt::Display for CreatureError {
@@ -134,6 +177,12 @@ impl std::fmt::Display for CreatureError {
                      addressable by a u16 source index",
                     crate::network::MAX_NODE_COUNT
                 )
+            }
+            CreatureError::InvalidInputCount { found } => {
+                write!(f, "Must have at least one input neurons was: {found}")
+            }
+            CreatureError::InvalidOutputCount { found } => {
+                write!(f, "Must have at least one output neurons was: {found}")
             }
         }
     }
@@ -288,9 +337,41 @@ pub fn synapse_type_name_from(ty: SynapseType) -> Option<&'static str> {
     }
 }
 
+/// Enforce the observation-width contract: `input >= 1` and `output >= 1`.
+///
+/// Single home of the rule (Issue #550) called by [`parse_creature_json`],
+/// [`compile_creature`], [`creature_to_json`] and [`creature_to_json_pretty`].
+/// `input` is checked first because it is the value that can never be
+/// recovered from the rest of the export. Consumers that build a
+/// [`CreatureExport`] by hand, or deserialise one through their own serde
+/// path, should call this at their own boundary before trusting the widths.
+///
+/// Mirrors NEAT-AI (TS) `src/architecture/CreatureValidate.ts`.
+pub fn validate_creature_width(creature: &CreatureExport) -> Result<(), CreatureError> {
+    if creature.input < 1 {
+        return Err(CreatureError::InvalidInputCount {
+            found: creature.input,
+        });
+    }
+    if creature.output < 1 {
+        return Err(CreatureError::InvalidOutputCount {
+            found: creature.output,
+        });
+    }
+    Ok(())
+}
+
 /// Parse a creature JSON string into a `CreatureExport` struct.
+///
+/// After serde deserialisation the result is passed through
+/// [`validate_creature_width`], so `input: 0` / `output: 0` return
+/// [`CreatureError::InvalidInputCount`] / [`CreatureError::InvalidOutputCount`]
+/// rather than a struct with a zero width. A missing `input` / `output` key or
+/// a negative literal is a [`CreatureError::Json`] error (Issue #550).
 pub fn parse_creature_json(json: &str) -> Result<CreatureExport, CreatureError> {
-    Ok(serde_json::from_str(json)?)
+    let creature: CreatureExport = serde_json::from_str(json)?;
+    validate_creature_width(&creature)?;
+    Ok(creature)
 }
 
 /// Serialise a [`CreatureExport`] to canonical JSON text.
@@ -298,12 +379,18 @@ pub fn parse_creature_json(json: &str) -> Result<CreatureExport, CreatureError> 
 /// Output is deterministic: fields are emitted in struct declaration order,
 /// so two calls with the same input produce byte-identical output. This is
 /// the symmetric counterpart to [`parse_creature_json`].
+///
+/// Refuses to write a widthless creature: `input < 1` / `output < 1` return
+/// [`CreatureError::InvalidInputCount`] / [`CreatureError::InvalidOutputCount`]
+/// (Issue #550).
 pub fn creature_to_json(creature: &CreatureExport) -> Result<String, CreatureError> {
+    validate_creature_width(creature)?;
     Ok(serde_json::to_string(creature)?)
 }
 
-/// Pretty-printed variant of [`creature_to_json`].
+/// Pretty-printed variant of [`creature_to_json`]; applies the same width check.
 pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, CreatureError> {
+    validate_creature_width(creature)?;
     Ok(serde_json::to_string_pretty(creature)?)
 }
 
@@ -314,7 +401,14 @@ pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, Crea
 /// 2. Maps neuron UUIDs to their indices
 /// 3. Resolves synapse UUID references to index-based connections
 /// 4. Maps squash function names and synapse type strings to enum values
+///
+/// The observation-width contract ([`validate_creature_width`]) is checked
+/// before anything else, so a hand-built `CreatureExport { input: 0, .. }`
+/// fails exactly as loudly as one that came through [`parse_creature_json`]
+/// (Issue #550).
 pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, CreatureError> {
+    validate_creature_width(creature)?;
+
     let num_inputs = creature.input;
     let num_outputs = creature.output;
 

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -58,7 +58,7 @@ pub mod wasm_arch;
 pub use creature::{
     CreatureError, CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
     creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
-    squash_name_from, synapse_type_name_from,
+    squash_name_from, synapse_type_name_from, validate_creature_width,
 };
 pub use network::{CompiledNetwork, NetworkError, NeuronData, SynapseData, hot_synapse_soa};
 pub use squash::SquashType;

--- a/neat-core/tests/creature_compile.rs
+++ b/neat-core/tests/creature_compile.rs
@@ -708,8 +708,10 @@ fn compile_creature_rejects_too_many_nodes() {
     use neat_core::network::MAX_NODE_COUNT;
     use neat_core::{CreatureError, CreatureExport, NeuronExport};
 
-    // One node over the limit, all hidden so the output count stays 0.
-    let neurons = (0..=MAX_NODE_COUNT)
+    // One node over the limit: 1 input + (MAX_NODE_COUNT - 1) hidden + 1 output
+    // = MAX_NODE_COUNT + 1 nodes. Widths are >= 1 so the Issue #550 width
+    // check passes and the only rejection left is the node-count guard.
+    let mut neurons: Vec<NeuronExport> = (0..MAX_NODE_COUNT - 1)
         .map(|i| NeuronExport {
             neuron_type: "hidden".to_string(),
             uuid: format!("n{i}"),
@@ -717,10 +719,16 @@ fn compile_creature_rejects_too_many_nodes() {
             squash: None,
         })
         .collect();
+    neurons.push(NeuronExport {
+        neuron_type: "output".to_string(),
+        uuid: "output-0".to_string(),
+        bias: 0.0,
+        squash: None,
+    });
 
     let creature = CreatureExport {
-        input: 0,
-        output: 0,
+        input: 1,
+        output: 1,
         neurons,
         synapses: Vec::new(),
         semantic_version: None,

--- a/neat-core/tests/creature_width_contract.rs
+++ b/neat-core/tests/creature_width_contract.rs
@@ -1,0 +1,285 @@
+//! Observation-width contract on `CreatureExport` (Issue #550).
+//!
+//! `input` is the authoritative observation count and `output` the target
+//! count. `neurons` lists only non-input neurons, so `input` can never be
+//! re-derived once lost. The rule mirrored from NEAT-AI (TS)
+//! `CreatureValidate.ts`: `input < 1` or `output < 1` is never accepted —
+//! not on parse, not on compile, not on serialise — and fails with a typed
+//! error. No default, no fallback.
+
+use std::error::Error;
+
+use neat_core::{
+    CreatureError, CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
+    creature_to_json_pretty, parse_creature_json,
+};
+
+/// Zero-input creature JSON exactly as written in the issue's acceptance
+/// criterion.
+const ZERO_INPUT_JSON: &str = r#"{"input":0,"output":1,"neurons":[],"synapses":[]}"#;
+const ZERO_OUTPUT_JSON: &str = r#"{"input":1,"output":0,"neurons":[],"synapses":[]}"#;
+
+fn output_neuron() -> NeuronExport {
+    NeuronExport {
+        neuron_type: "output".to_string(),
+        uuid: "output-0".to_string(),
+        bias: 0.0,
+        squash: Some("IDENTITY".to_string()),
+    }
+}
+
+/// A structurally valid creature apart from the declared widths, so any
+/// rejection can only come from the width rule.
+fn creature_with_widths(input: usize, output: usize) -> CreatureExport {
+    CreatureExport {
+        input,
+        output,
+        neurons: vec![output_neuron()],
+        synapses: vec![SynapseExport {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }],
+        semantic_version: None,
+        forward_only: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// parse_creature_json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_rejects_zero_input_with_invalid_input_count() {
+    match parse_creature_json(ZERO_INPUT_JSON) {
+        Err(CreatureError::InvalidInputCount { found }) => assert_eq!(found, 0),
+        Err(other) => panic!("expected InvalidInputCount, got {other:?}"),
+        Ok(c) => panic!("input: 0 must not parse, got {c:?}"),
+    }
+}
+
+#[test]
+fn parse_rejects_zero_output_with_invalid_output_count() {
+    match parse_creature_json(ZERO_OUTPUT_JSON) {
+        Err(CreatureError::InvalidOutputCount { found }) => assert_eq!(found, 0),
+        Err(other) => panic!("expected InvalidOutputCount, got {other:?}"),
+        Ok(c) => panic!("output: 0 must not parse, got {c:?}"),
+    }
+}
+
+#[test]
+fn parse_reports_input_before_output_when_both_are_zero() {
+    // The input width is the one that can never be recovered, so it is
+    // reported first when both are missing.
+    let json = r#"{"input":0,"output":0,"neurons":[],"synapses":[]}"#;
+    match parse_creature_json(json) {
+        Err(CreatureError::InvalidInputCount { found }) => assert_eq!(found, 0),
+        other => panic!("expected InvalidInputCount, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_rejects_missing_input_as_json_error_naming_the_field() {
+    // No `#[serde(default)]`: an absent key is a deserialisation failure, not
+    // a silent zero.
+    let json = r#"{"output":1,"neurons":[],"synapses":[]}"#;
+    match parse_creature_json(json) {
+        Err(CreatureError::Json(e)) => {
+            let text = e.to_string();
+            assert!(
+                text.contains("missing field `input`"),
+                "serde error must name the missing field, got: {text}"
+            );
+        }
+        other => panic!("expected Json error for missing input, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_rejects_missing_output_as_json_error_naming_the_field() {
+    let json = r#"{"input":1,"neurons":[],"synapses":[]}"#;
+    match parse_creature_json(json) {
+        Err(CreatureError::Json(e)) => {
+            let text = e.to_string();
+            assert!(
+                text.contains("missing field `output`"),
+                "serde error must name the missing field, got: {text}"
+            );
+        }
+        other => panic!("expected Json error for missing output, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_rejects_negative_input_as_json_error() {
+    // `input` is `usize`; `-1` cannot deserialise and must not wrap or clamp.
+    let json = r#"{"input":-1,"output":1,"neurons":[],"synapses":[]}"#;
+    match parse_creature_json(json) {
+        Err(CreatureError::Json(e)) => {
+            let text = e.to_string();
+            assert!(
+                text.contains("invalid value: integer `-1`"),
+                "serde error must report the negative literal, got: {text}"
+            );
+        }
+        other => panic!("expected Json error for input: -1, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_rejects_negative_output_as_json_error() {
+    let json = r#"{"input":1,"output":-1,"neurons":[],"synapses":[]}"#;
+    match parse_creature_json(json) {
+        Err(CreatureError::Json(e)) => {
+            let text = e.to_string();
+            assert!(
+                text.contains("invalid value: integer `-1`"),
+                "serde error must report the negative literal, got: {text}"
+            );
+        }
+        other => panic!("expected Json error for output: -1, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// compile_creature — a directly built CreatureExport bypasses parse, so the
+// compiler must fail just as loudly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compile_rejects_directly_built_zero_input_before_any_other_check() {
+    // Deliberately also carries an output-count mismatch (output: 2, one output
+    // neuron) so the test proves the width check runs *first*.
+    let mut creature = creature_with_widths(0, 2);
+    creature.synapses.clear();
+    match compile_creature(&creature) {
+        Err(CreatureError::InvalidInputCount { found }) => assert_eq!(found, 0),
+        Err(other) => panic!("expected InvalidInputCount, got {other:?}"),
+        Ok(_) => panic!("input: 0 must not compile"),
+    }
+}
+
+#[test]
+fn compile_rejects_directly_built_zero_output() {
+    // Zero declared outputs with zero output neurons used to pass the
+    // declared-vs-typed check (`0 == 0`). It must now be a typed rejection.
+    let creature = CreatureExport {
+        input: 1,
+        output: 0,
+        neurons: Vec::new(),
+        synapses: Vec::new(),
+        semantic_version: None,
+        forward_only: false,
+    };
+    match compile_creature(&creature) {
+        Err(CreatureError::InvalidOutputCount { found }) => assert_eq!(found, 0),
+        Err(other) => panic!("expected InvalidOutputCount, got {other:?}"),
+        Ok(_) => panic!("output: 0 must not compile"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// creature_to_json / creature_to_json_pretty — never *write* a widthless
+// creature.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn serialise_refuses_zero_input() {
+    let creature = creature_with_widths(0, 1);
+    match creature_to_json(&creature) {
+        Err(CreatureError::InvalidInputCount { found }) => assert_eq!(found, 0),
+        Err(other) => panic!("expected InvalidInputCount, got {other:?}"),
+        Ok(json) => panic!("input: 0 must not serialise, got {json}"),
+    }
+}
+
+#[test]
+fn serialise_refuses_zero_output() {
+    let creature = creature_with_widths(1, 0);
+    match creature_to_json(&creature) {
+        Err(CreatureError::InvalidOutputCount { found }) => assert_eq!(found, 0),
+        Err(other) => panic!("expected InvalidOutputCount, got {other:?}"),
+        Ok(json) => panic!("output: 0 must not serialise, got {json}"),
+    }
+}
+
+#[test]
+fn pretty_serialise_refuses_zero_input_and_zero_output() {
+    match creature_to_json_pretty(&creature_with_widths(0, 1)) {
+        Err(CreatureError::InvalidInputCount { found }) => assert_eq!(found, 0),
+        other => panic!("expected InvalidInputCount, got {other:?}"),
+    }
+    match creature_to_json_pretty(&creature_with_widths(1, 0)) {
+        Err(CreatureError::InvalidOutputCount { found }) => assert_eq!(found, 0),
+        other => panic!("expected InvalidOutputCount, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error surface
+// ---------------------------------------------------------------------------
+
+#[test]
+fn width_error_display_mirrors_typescript_creature_validate() {
+    // NEAT-AI `src/architecture/CreatureValidate.ts` wording, so logs from the
+    // TS and Rust stacks line up.
+    assert_eq!(
+        CreatureError::InvalidInputCount { found: 0 }.to_string(),
+        "Must have at least one input neurons was: 0"
+    );
+    assert_eq!(
+        CreatureError::InvalidOutputCount { found: 0 }.to_string(),
+        "Must have at least one output neurons was: 0"
+    );
+}
+
+#[test]
+fn width_errors_are_structural_with_no_source_chain() {
+    // Width failures are structural, not JSON failures: no `source()`.
+    assert!(
+        CreatureError::InvalidInputCount { found: 0 }
+            .source()
+            .is_none()
+    );
+    assert!(
+        CreatureError::InvalidOutputCount { found: 0 }
+            .source()
+            .is_none()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Round trip — a valid creature keeps its width byte-for-byte.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn valid_creature_round_trips_input_and_output_byte_identically() {
+    // Production-shaped widths (a real production creature carries `input: 2511,
+    // output: 1`), written in the exact canonical field order and spacing that
+    // `creature_to_json` emits, so the whole document must come back
+    // byte-identical.
+    let canonical = concat!(
+        r#"{"input":2511,"output":1,"#,
+        r#""neurons":[{"type":"output","uuid":"output-0","bias":0.5,"squash":"IDENTITY"}],"#,
+        r#""synapses":[{"fromUUID":"input-2510","toUUID":"output-0","weight":1.5}],"#,
+        r#""forwardOnly":false}"#
+    );
+
+    let creature = parse_creature_json(canonical).expect("valid creature must parse");
+    assert_eq!(creature.input, 2511);
+    assert_eq!(creature.output, 1);
+
+    let network = compile_creature(&creature).expect("valid creature must compile");
+    // 2511 inputs + 1 output neuron.
+    assert_eq!(network.num_inputs, 2511);
+    assert_eq!(network.num_neurons, 2511 + 1);
+
+    let serialised = creature_to_json(&creature).expect("valid creature must serialise");
+    assert_eq!(serialised, canonical);
+
+    let reparsed = parse_creature_json(&serialised).expect("serialised form must parse");
+    assert_eq!(reparsed.input, 2511);
+    assert_eq!(reparsed.output, 1);
+    assert_eq!(reparsed, creature);
+}


### PR DESCRIPTION
Closes #550

## What changed

- `CreatureError::InvalidInputCount { found }` / `CreatureError::InvalidOutputCount { found }` — Display text mirrors NEAT-AI `CreatureValidate.ts` (`Must have at least one input neurons was: 0` / `... output ...`) so logs line up across the TS and Rust stacks. No `source()` chain (structural, not JSON).
- `validate_creature_width(&CreatureExport)` — new public helper, the single home of the `input >= 1 && output >= 1` rule (`input` is checked first because it is the value that can never be recovered). Re-exported from the crate root.
- `parse_creature_json` validates after serde; `compile_creature` validates **before** any other check (a hand-built `CreatureExport { input: 0, .. }` fails as loudly as a parsed one); `creature_to_json` and `creature_to_json_pretty` refuse to write a widthless creature. Return types are unchanged (`Result<_, CreatureError>` already), so no call sites needed adjusting.
- No `#[serde(default)]` on `input` / `output` — a missing key stays a `CreatureError::Json` (`missing field \`input\``), a negative literal is a serde error (`invalid value: integer \`-1\``).
- Doc comments on `CreatureExport::input` / `::output`: authoritative observation / target count; `input` is not derivable from `neurons` (inputs are not listed there). Module doc, README section ("Creature JSON observation-width contract"), AGENTS.md "One width check for creature JSON" rule, and a note in `docs/research/ikaruga-neat-ai-comparison.md` §8.
- Existing fixture `compile_creature_rejects_too_many_nodes` used `input: 0, output: 0`; it now uses `input: 1` + `MAX_NODE_COUNT - 1` hidden + 1 output (still exactly one node over the limit).

## FFI / wasm audit

No wasm-bindgen or FFI export in this crate accepts creature JSON: `neat-core/src/wasm_exports.rs` exports squash/derivative/error/range/score/propagate shims only, `scripts/build-wasm-bundle.sh` bundles that surface, and `wasm-bench` builds fixtures from `benches/common`. The only JSON entry point is `parse_creature_json`, which now validates. Consumers that deserialise `CreatureExport` through their own serde call (it still derives `Deserialize`) can call `validate_creature_width` at their boundary — and both `compile_creature` and `creature_to_json` will refuse a widthless value regardless.

## Why

`input` / `output` are the fleet's observation-width contract; `neurons` lists only non-input neurons, so a lost or zeroed `input` cannot be re-derived. Before this PR `parse_creature_json` and `compile_creature` accepted `input: 0` / `output: 0` (`OutputCountMismatch` passes on `0 == 0`) and `creature_to_json` would write one back out.

## Verification

- Failing-first: with only the enum variants added, `creature_width_contract` ran **7 passed / 8 failed** (every parse / compile / serialise rejection red); after the implementation **15 passed / 0 failed**.
- Mutation evidence — dropping the `validate_creature_width` call at each site individually: `parse_creature_json` → 3 tests fail; `creature_to_json` → 2 fail; `creature_to_json_pretty` → 1 fails; `compile_creature` → 2 fail. All calls restored before commit.
- `./quality.sh`: **All quality checks passed** — shellcheck clean, bats **376 ok / 0 not ok**, deno/mermaid/codespell/cargo-deny green, clippy `-D warnings` clean, `cargo test --workspace --lib --tests --all-features`: **538 passed / 0 failed** across 46 test binaries, `cargo doc -D warnings` and release build green. (The `cargo update` that `quality.sh` performs locally bumped 4 lines of `Cargo.lock`; reverted — the CI `bump-deps.sh` quarantine channel owns that.)
- `cargo check -p neat-core --target wasm32-unknown-unknown`: green.

Semver note: additive API (two enum variants, one helper) plus a rejection of input that the 2026-08-18 audit found nowhere in production or fixtures; shipped as a patch per RELEASING.md's "tightening" reading. Add the `breaking-change` label if you would rather signal it as a minor.

**Rollout: merge AFTER stSoftwareAU/GRQ#4121, NEAT-AI-Backpropagation#92, NEAT-AI-Lamarck#165, NEAT-AI-Discovery#2020, NEAT-AI-scorer#571 — consumers path-depend on this crate's sibling checkout.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
