### PR TITLE
Ownership fence: keep per-sample propagate in core, trainDir epochs in Backpropagation (#544)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,63 @@ expressible, and the synthetic tests catch header-overrun and undercover cases.
 - **`training_bin_stream`** (`neat-core/src/training_bin_stream.rs`) — **one** chunked `.bin` scan API: pipelined double-buffer reads on native hosts, sequential `File::read` chunks on the wasm family (same `for_each_read_chunk` callback). Used by **NEAT-AI-scorer** for production-sized forward-only scoring.
 - Root **`Cargo.toml`** is a **virtual workspace**; **`[workspace.package].version`** is what the PR **auto-bump** job edits; **`neat-core`** uses `version.workspace = true`.
 
+## Ownership fence (Issue #544)
+
+Native training is split across two FFI surfaces, and this crate owns exactly
+one of them: the **per-sample** primitives. **NEAT-AI-Backpropagation**
+(`libneat_ai_backpropagation`) owns the **directory epoch** loop — `trainDir`:
+accumulate, apply, MSE accept/rollback, journal — and calls in one sample at a
+time.
+
+**Stays here.** Backpropagation and NEAT-AI-scorer depend on these, so they are
+never deleted or narrowed as "unused":
+
+- `propagate_topological_loop` (`neat-core/src/topological_backprop.rs`) and the
+  byte-packed ABI codec `propagate_codec` — pinned at the out-of-crate boundary
+  by `neat-core/tests/backprop_ffi_surface.rs`, which is what fails if either is
+  narrowed to `pub(crate)`.
+- `mse_mean_streaming` (`neat-core/src/loss.rs`) over `training_bin_stream`
+  (`neat-core/tests/mse_streaming_directory.rs`).
+- The training-data iterators (`training_data`, `training_state`) and the
+  topology helpers (`topology_ops`, `topology_export`).
+
+**Stays in NEAT-AI-Backpropagation.** Do not relocate into `neat-core`:
+
+- the product `train` epoch loop over a directory (`trainDir`) and its
+  `train.rs`-style orchestration;
+- the journal, the CLI apply policy, the `traceStore` layout, and the
+  sample-rate policy for memetic training.
+
+Absorbing the epoch loop would pull journal and CLI apply policy into **every**
+core consumer — the scorer and Discovery included — for a loop only the trainer
+runs. New NEAT-AI scenarios are reached by FFI *to* Backpropagation, not by
+moving host orchestration down here or by removing core primitives.
+
+`tests/scripts/core_ownership_fence.bats` is the gate: it sweeps
+`neat-core/src` for host-orchestration **item definitions** (`fn train_dir_…`,
+`struct EpochJournal`, `mod trace_store`) and for `train.rs`/`journal.rs`-style
+module files, and fails if one lands here. Prose that merely mentions an epoch
+is free — the sweep matches definitions, not comments.
+
+```mermaid
+flowchart LR
+    subgraph host["NEAT-AI-Backpropagation — host orchestration"]
+        T["trainDir epoch loop<br/>accumulate, apply, accept/rollback"]
+        J["journal + CLI apply policy"]
+        S["traceStore layout<br/>memetic sample-rate policy"]
+        T --> J
+        T --> S
+    end
+    subgraph core["neat-core — per-sample primitives"]
+        P["propagate_topological_loop<br/>propagate_codec packed ABI"]
+        M["mse_mean_streaming<br/>training_bin_stream"]
+        O["topology_ops / topology_export"]
+    end
+    T -->|"one sample per call, FFI"| P
+    T -->|"epoch score for accept/rollback"| M
+    T --> O
+```
+
 ## Unsafe & SIMD invariants
 
 The native SIMD hot path (`neat-core/src/simd_native.rs`) carries durable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.5"
+version = "0.9.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ flowchart LR
 
 The NEAT-AI project is split across seven public repositories. Each focuses on one concern and composes with the others as shown below.
 
+`neat-core` keeps the **per-sample** training primitives (`propagate_topological_loop`, the packed propagate ABI, `mse_mean_streaming`, the topology helpers); the `trainDir` **epoch** loop and its journal, CLI apply policy and `traceStore` layout stay in NEAT-AI-Backpropagation. The rule and the gate that enforces it live in [`AGENTS.md`](AGENTS.md#ownership-fence-issue-544) (Issue #544).
+
 | Repository | Role |
 |------------|------|
 | [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI) | Primary Deno/TypeScript neural-network engine (evolution, training, WASM activation). |

--- a/docs/archive/pr-summaries/pr-summary-544.md
+++ b/docs/archive/pr-summaries/pr-summary-544.md
@@ -1,0 +1,142 @@
+# PR Summary — Ownership fence: per-sample propagate here, `trainDir` epochs in Backpropagation (Issue #544)
+
+## Summary
+
+Native training is split across two FFI surfaces: `neat-core` owns the
+**per-sample** primitives, and NEAT-AI-Backpropagation owns the **directory
+epoch** loop (`trainDir`: accumulate → apply → MSE accept/rollback → journal).
+That split was implicit — nothing stopped a future "simplify by putting
+`trainDir` in core" change from pulling journal, CLI apply policy and
+`traceStore` layout into every core consumer, the scorer and Discovery
+included.
+
+This PR writes the fence down and gates it. No API is deleted, moved or
+narrowed; the only Rust change is a new test. Closes #544.
+
+- **`AGENTS.md` — `## Ownership fence (Issue #544)`**: what stays here
+  (`propagate_topological_loop`, the `propagate_codec` packed ABI,
+  `mse_mean_streaming` over `training_bin_stream`, the `training_data` /
+  `training_state` iterators, the `topology_ops` / `topology_export` helpers)
+  and what stays in NEAT-AI-Backpropagation (the `train` epoch loop over a
+  directory, the journal, the CLI apply policy, the `traceStore` layout, the
+  memetic sample-rate policy), with the reasoning and a Mermaid diagram.
+- **`README.md`**: a one-paragraph pointer under *Related Repositories* that
+  links to the AGENTS.md section rather than restating the rule (the
+  single-source convention `docs_single_source.bats` already enforces for other
+  procedures).
+- **`tests/scripts/core_ownership_fence.bats`**: the gate. Sweeps
+  `neat-core/src` for host-orchestration **item definitions** and for
+  `train.rs`/`journal.rs`-style module files, and checks the documented rule is
+  present and complete.
+- **`neat-core/tests/backprop_ffi_surface.rs`**: the "do keep" half — exercises
+  the typed loop and the packed ABI codec from **outside** the crate, so
+  narrowing either to `pub(crate)` (or moving it out) is a compile error here.
+
+## Evidence
+
+Backend/library change with no web interface, so there is no screenshot to
+capture; the evidence is the gate output and the mutation runs below.
+
+```mermaid
+flowchart LR
+    subgraph host["NEAT-AI-Backpropagation — host orchestration"]
+        T["trainDir epoch loop"]
+        J["journal + CLI apply policy"]
+        S["traceStore layout<br/>memetic sample-rate policy"]
+        T --> J
+        T --> S
+    end
+    subgraph core["neat-core — per-sample primitives"]
+        P["propagate_topological_loop<br/>propagate_codec packed ABI"]
+        M["mse_mean_streaming<br/>training_bin_stream"]
+        O["topology_ops / topology_export"]
+    end
+    T -->|"one sample per call, FFI"| P
+    T -->|"epoch score for accept/rollback"| M
+    T --> O
+```
+
+### Gate output
+
+```text
+bats tests/scripts/core_ownership_fence.bats
+1..10
+ok 1 neat-core sources define no trainDir/epoch/journal/traceStore item
+ok 2 neat-core has no train.rs-style epoch orchestration module
+ok 3 the item pattern rejects epoch-orchestration definitions
+ok 4 the item pattern accepts the primitives core keeps
+ok 5 the module pattern rejects train.rs but keeps the training_* primitives
+ok 6 AGENTS.md carries the ownership fence section
+ok 7 the fence names the per-sample primitives core keeps
+ok 8 the fence names the host orchestration Backpropagation owns
+ok 9 the fence points at the gates that pin it
+ok 10 README defers the fence to AGENTS.md via a link
+
+cargo test -p neat-core --test backprop_ffi_surface
+test result: ok. 4 passed; 0 failed
+```
+
+Tests 6–10 were **red before** the AGENTS.md/README edits (`AGENTS.md has no
+body under '## Ownership fence (Issue #544)'`), which is the failing-first run
+for the documentation half.
+
+### Mutation evidence
+
+A green test is not evidence, so each new assertion was shown to be reachable.
+Every mutation below was reverted before commit (`git status` clean).
+
+| Mutation | Expected red | Result |
+|----------|--------------|--------|
+| Append `pub fn train_dir_epoch_loop() {}` to `neat-core/src/training_state.rs` | fence sweep | `not ok 1` ✔ |
+| Create empty `neat-core/src/journal.rs` | module-name sweep | `not ok 2` ✔ |
+| Gut `HOST_ITEM_RE` to `NEVER_MATCHES` | pattern self-test | `not ok 3` ✔ (the live pattern is compiled by both the sweep and the literal checks — AGENTS.md oracle rule 4) |
+| Gut `HOST_MODULE_RE` to `NEVER_MATCHES` | module pattern self-test | `not ok 5` ✔ |
+| `pub mod propagate_codec;` → `pub(crate) mod propagate_codec;` in `lib.rs` | boundary test | `error[E0603]: module propagate_codec is private` ✔ |
+| `encode_propagate_output`: `f64::NEG_INFINITY` → `f64::INFINITY` for the noChange slot | sentinel test | `packed_abi_round_trip_keeps_the_no_change_sentinel ... FAILED` ✔ |
+
+The sweep is deliberately narrow: it matches Rust **item definitions** whose
+name carries an epoch-loop concept, not prose — the existing doc comment
+"Initialise persistent training state for an epoch" in `training_state.rs`, and
+the `training_data` / `training_state` / `training_bin_stream` modules, are all
+explicitly asserted to pass (tests 4 and 5), so the gate cannot be satisfied by
+renaming a core primitive.
+
+### Quality gate
+
+`./quality.sh` passes on the Rust side: `cargo fmt --all` (no diff),
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
+`cargo test --workspace --lib --tests --all-features`, `cargo deny check`,
+`RUSTDOCFLAGS="-D warnings" cargo doc`, release build, `deno` TypeScript gate
+and the Mermaid gate (`check-mermaid: all Mermaid blocks passed`).
+
+The workflow-contract bats suites report 107 failures **in this container only**
+— `python3` has no `yaml` module, which those suites need to parse workflow YAML
+(`ModuleNotFoundError: No module named 'yaml'`, no `pip`/`sudo` available to
+install it). The identical 107 failures occur on the base commit `bbc4b15`
+before any change in this PR, and the new suite contributes none of them.
+
+## Test Plan
+
+- Added `tests/scripts/core_ownership_fence.bats` (10 tests): the source sweep,
+  the module-name sweep, good/bad literal self-tests for both patterns, and the
+  documented-rule assertions against `AGENTS.md` / `README.md`.
+- Added `neat-core/tests/backprop_ffi_surface.rs` (4 tests) at the out-of-crate
+  boundary:
+  - `typed_propagate_loop_drives_an_identity_output_to_its_expected_value` —
+    identity output at 0.5 with expected 1.0 gives
+    `total_error_absolute_delta = |1.0 − 0.5| = 0.5`, `cached_activation = 1.0`,
+    one bias accumulation, and one positive weight accumulation per inward
+    synapse carrying the source activation 0.5.
+  - `typed_propagate_loop_reports_no_change_when_the_output_already_matches` —
+    error below `plank_constant` yields `NoChange` and moves no weight
+    statistics.
+  - `packed_abi_round_trip_encodes_the_standard_outcome_slots` — a buffer packed
+    by an independent mirror of the TypeScript encoder decodes, runs and
+    re-encodes into the documented
+    `neurons × PER_NEURON_OUT_F64S + synapses × PER_SYNAPSE_OUT_F64S` layout,
+    with input-neuron slots NaN and the output slots carrying the values derived
+    above.
+  - `packed_abi_round_trip_keeps_the_no_change_sentinel` — slot 1 is
+    `−Infinity` with the cached activation in the last slot, the contract the
+    TypeScript host decodes.
+- No existing test was modified or removed.

--- a/neat-core/tests/backprop_ffi_surface.rs
+++ b/neat-core/tests/backprop_ffi_surface.rs
@@ -1,0 +1,289 @@
+//! Issue #544 — the per-sample propagate surface an out-of-crate host reaches.
+//!
+//! NEAT-AI-Backpropagation owns the `trainDir` epoch loop and calls into this
+//! crate one sample at a time, either through the typed
+//! `propagate_topological_loop` or through the byte-packed ABI
+//! (`propagate_codec`). Both are exercised from **outside** the crate here, so
+//! narrowing either to `pub(crate)`, or moving them out of `neat-core`, fails
+//! this file at compile time — the "do keep" half of the ownership fence in
+//! AGENTS.md. The in-crate unit tests cover decoder offsets and error paths;
+//! this file covers the boundary and the sentinel contract the host decodes.
+
+use neat_core::propagate_codec::{
+    HEADER_BYTES, NEURON_RECORD_BYTES, PER_NEURON_OUT_F64S, PER_SYNAPSE_OUT_F64S,
+    SYNAPSE_RECORD_BYTES, decode_propagate_buffer, encode_propagate_output,
+};
+use neat_core::topological_backprop::{
+    NEURON_TYPE_INPUT, NEURON_TYPE_OUTPUT, NeuronInput, PropagateInput, PropagateOutcome,
+    PropagateOutput, SynapseInput, propagate_topological_loop,
+};
+
+const PLANK: f32 = 1.0e-7;
+/// Both inputs sit at this activation, so every inward link is a positive one.
+const INPUT_ACTIVATION: f32 = 0.5;
+/// The identity output neuron's own activation before propagation.
+const OUTPUT_ACTIVATION: f32 = 0.5;
+
+fn neuron(neuron_type: u8, adjusted_activation: f32) -> NeuronInput {
+    NeuronInput {
+        squash_type: 0, // Identity — target activation passes through unsquashed.
+        neuron_type,
+        propagate_needed: true,
+        update_needed: true,
+        hint_value: 0.0,
+        range_low: -1.0e6,
+        range_high: 1.0e6,
+        adjusted_activation,
+        adjusted_bias: 0.0,
+    }
+}
+
+/// 2 input neurons (0, 1) → 1 identity output neuron (2), one unit-weight
+/// synapse each. Returns the pieces a [`PropagateInput`] borrows.
+fn fixture() -> (Vec<NeuronInput>, Vec<SynapseInput>) {
+    let neurons = vec![
+        neuron(NEURON_TYPE_INPUT, INPUT_ACTIVATION),
+        neuron(NEURON_TYPE_INPUT, INPUT_ACTIVATION),
+        neuron(NEURON_TYPE_OUTPUT, OUTPUT_ACTIVATION),
+    ];
+    let synapses = vec![
+        SynapseInput {
+            from: 0,
+            to: 2,
+            original_weight: 1.0,
+            adjusted_weight: 1.0,
+            is_self_loop: false,
+        },
+        SynapseInput {
+            from: 1,
+            to: 2,
+            original_weight: 1.0,
+            adjusted_weight: 1.0,
+            is_self_loop: false,
+        },
+    ];
+    (neurons, synapses)
+}
+
+fn run(neurons: &[NeuronInput], synapses: &[SynapseInput], expected: &[f32]) -> PropagateOutput {
+    let inward_starts = [0u32, 0, 0];
+    let inward_counts = [0u32, 0, 2];
+    let inward_indices = [0u32, 1];
+    let order = [2u32];
+    let input = PropagateInput {
+        neurons,
+        synapses,
+        inward_starts: &inward_starts,
+        inward_counts: &inward_counts,
+        inward_synapse_indices: &inward_indices,
+        reverse_topo_order: &order,
+        expected,
+        input_count: 2,
+        output_count: 1,
+        plank_constant: PLANK,
+        normalise_gradients: false,
+    };
+    let output = propagate_topological_loop(&input);
+    assert_eq!(output.neurons.len(), neurons.len());
+    assert_eq!(output.synapses.len(), synapses.len());
+    output
+}
+
+#[test]
+fn typed_propagate_loop_drives_an_identity_output_to_its_expected_value() {
+    let (neurons, synapses) = fixture();
+    // expected − activation = 1.0 − 0.5 = 0.5, an error well above PLANK.
+    let output = run(&neurons, &synapses, &[1.0]);
+
+    // One inward link per input neuron, each accumulated exactly once with the
+    // source activation on the positive side (INPUT_ACTIVATION > 0).
+    for (i, delta) in output.synapses.iter().enumerate() {
+        assert_eq!(delta.count, 1.0, "synapse {i} accumulation count");
+        assert_eq!(
+            delta.total_positive_activation, INPUT_ACTIVATION,
+            "synapse {i} positive activation"
+        );
+        assert_eq!(
+            delta.total_negative_activation, 0.0,
+            "synapse {i} negative activation"
+        );
+        assert_eq!(delta.count_positive, 1.0, "synapse {i} positive count");
+        assert_eq!(delta.count_negative, 0.0, "synapse {i} negative count");
+    }
+
+    match output.neurons[2] {
+        PropagateOutcome::Standard(s) => {
+            assert_eq!(
+                s.total_error_absolute_delta, 0.5,
+                "|expected − adjusted_activation|"
+            );
+            // Identity squash: the clamped target activation (0.5 + 0.5) is the
+            // new cached activation, unchanged by unsquash.
+            assert_eq!(s.cached_activation, 1.0, "identity target activation");
+            assert!(!s.no_change, "update_needed neuron is not flagged noChange");
+            assert_eq!(s.bias_count_delta, 1, "one bias accumulation");
+            assert_eq!(
+                s.trace_activation,
+                Some(1.0),
+                "trace activation is recorded for an update_needed neuron"
+            );
+        }
+        other => panic!("expected a Standard outcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn typed_propagate_loop_reports_no_change_when_the_output_already_matches() {
+    let (neurons, synapses) = fixture();
+    // expected == adjusted_activation ⇒ error 0.0, below PLANK.
+    let output = run(&neurons, &synapses, &[OUTPUT_ACTIVATION]);
+
+    match output.neurons[2] {
+        PropagateOutcome::NoChange { cached_activation } => {
+            assert_eq!(cached_activation, OUTPUT_ACTIVATION);
+        }
+        other => panic!("expected NoChange, got {other:?}"),
+    }
+    // The loop bails before accumulation, so no weight statistics move.
+    for (i, delta) in output.synapses.iter().enumerate() {
+        assert_eq!(delta.count, 0.0, "synapse {i} accumulation count");
+        assert_eq!(
+            delta.total_positive_activation, 0.0,
+            "synapse {i} positive activation"
+        );
+    }
+}
+
+/// Mirror of the TypeScript encoder in NEAT-AI's `WasmTopologicalBackprop.ts`
+/// — the host side of the packed ABI. Built here rather than imported so the
+/// buffer this test decodes is written independently of the decoder.
+struct Packer {
+    bytes: Vec<u8>,
+}
+
+impl Packer {
+    /// Pack the [`fixture`] network with `expected` as the target output.
+    fn fixture_buffer(expected: f32) -> Vec<u8> {
+        let mut p = Packer { bytes: Vec::new() };
+        // Header: neuron/input/output/synapse counts, order length, inward total.
+        p.u32(3);
+        p.u32(2);
+        p.u32(1);
+        p.u32(2);
+        p.u32(1);
+        p.u32(2);
+        p.f64(PLANK as f64);
+        p.u8(0); // normalise_gradients
+        p.u8(0);
+        p.u8(0);
+        p.u8(0);
+        assert_eq!(p.bytes.len(), HEADER_BYTES);
+
+        for (kind, activation) in [
+            (NEURON_TYPE_INPUT, INPUT_ACTIVATION),
+            (NEURON_TYPE_INPUT, INPUT_ACTIVATION),
+            (NEURON_TYPE_OUTPUT, OUTPUT_ACTIVATION),
+        ] {
+            p.u8(0); // squash_type: Identity
+            p.u8(kind);
+            p.u8(1); // propagate_needed
+            p.u8(1); // update_needed
+            p.f32(0.0); // hint_value
+            p.f32(-1.0e6); // range_low
+            p.f32(1.0e6); // range_high
+            p.f32(activation);
+            p.f32(0.0); // adjusted_bias
+        }
+        assert_eq!(p.bytes.len(), HEADER_BYTES + 3 * NEURON_RECORD_BYTES);
+
+        for from in [0u32, 1] {
+            p.u32(from);
+            p.u32(2); // to
+            p.f32(1.0); // original_weight
+            p.f32(1.0); // adjusted_weight
+            p.u8(0); // is_self_loop
+            p.u8(0);
+            p.u8(0);
+            p.u8(0);
+        }
+        assert_eq!(
+            p.bytes.len(),
+            HEADER_BYTES + 3 * NEURON_RECORD_BYTES + 2 * SYNAPSE_RECORD_BYTES
+        );
+
+        for (start, count) in [(0u32, 0u32), (0, 0), (0, 2)] {
+            p.u32(start);
+            p.u32(count);
+        }
+        p.u32(0); // inward indices
+        p.u32(1);
+        p.u32(2); // reverse topological order: the output neuron only
+        p.f32(expected);
+        p.bytes
+    }
+
+    fn u8(&mut self, v: u8) {
+        self.bytes.push(v);
+    }
+    fn u32(&mut self, v: u32) {
+        self.bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    fn f32(&mut self, v: f32) {
+        self.bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    fn f64(&mut self, v: f64) {
+        self.bytes.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
+#[test]
+fn packed_abi_round_trip_encodes_the_standard_outcome_slots() {
+    let buffer = Packer::fixture_buffer(1.0);
+    let decoded = decode_propagate_buffer(&buffer).expect("decode packed buffer");
+    let packed = encode_propagate_output(&propagate_topological_loop(&decoded.as_input()));
+
+    assert_eq!(
+        packed.len(),
+        3 * PER_NEURON_OUT_F64S + 2 * PER_SYNAPSE_OUT_F64S,
+        "3 neuron slots then 2 synapse slots"
+    );
+
+    // Input neurons are never propagated through: every slot is NaN.
+    for slot in &packed[..2 * PER_NEURON_OUT_F64S] {
+        assert!(slot.is_nan(), "input-neuron slots encode as NaN");
+    }
+
+    // Output neuron (index 2) — same values the typed loop reports above, in
+    // the documented slot order.
+    let out = &packed[2 * PER_NEURON_OUT_F64S..3 * PER_NEURON_OUT_F64S];
+    assert_eq!(out[0], 0.5, "total_error_absolute delta");
+    assert_eq!(out[1], 1.0, "cached activation");
+    assert_eq!(out[2], 0.0, "noChange flag clear");
+    assert_eq!(out[3], 1.0, "bias count delta");
+    assert_eq!(out[6], 1.0, "trace activation");
+
+    // Synapse section: count then the positive/negative activation pair.
+    for i in 0..2 {
+        let base = 3 * PER_NEURON_OUT_F64S + i * PER_SYNAPSE_OUT_F64S;
+        assert_eq!(packed[base], 1.0, "synapse {i} count");
+        assert_eq!(
+            packed[base + 1],
+            INPUT_ACTIVATION as f64,
+            "synapse {i} positive activation"
+        );
+        assert_eq!(packed[base + 2], 0.0, "synapse {i} negative activation");
+    }
+}
+
+#[test]
+fn packed_abi_round_trip_keeps_the_no_change_sentinel() {
+    let buffer = Packer::fixture_buffer(OUTPUT_ACTIVATION);
+    let decoded = decode_propagate_buffer(&buffer).expect("decode packed buffer");
+    let packed = encode_propagate_output(&propagate_topological_loop(&decoded.as_input()));
+
+    // The TS↔host contract: slot 1 of a neuron carries −Infinity to select the
+    // noChange path, with the cached activation stashed in the last slot.
+    let out = &packed[2 * PER_NEURON_OUT_F64S..3 * PER_NEURON_OUT_F64S];
+    assert_eq!(out[1], f64::NEG_INFINITY, "noChange sentinel");
+    assert_eq!(out[6], OUTPUT_ACTIVATION as f64, "cached activation");
+}

--- a/tests/scripts/core_ownership_fence.bats
+++ b/tests/scripts/core_ownership_fence.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# Issue #544 — ownership fence between `neat-core` (per-sample primitives) and
+# NEAT-AI-Backpropagation (the `trainDir` epoch loop: accumulate → apply → MSE
+# accept/rollback → journal). Nothing stopped a future "simplify by putting
+# trainDir in core" change from pulling journal, CLI apply policy and
+# `traceStore` layout into every core consumer, so the fence is asserted here:
+# the rule has a documented home, and the sources are swept for the host
+# orchestration items it excludes.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  AGENTS="${REPO_ROOT}/AGENTS.md"
+  README="${REPO_ROOT}/README.md"
+  CORE_SRC="${REPO_ROOT}/neat-core/src"
+
+  # ONE definition of the host-orchestration item pattern (AGENTS.md oracle
+  # rule 4: a gate self-test compiles the live pattern, never a private copy).
+  # The sweep over the real sources and the good/bad literal checks below all
+  # match against this string, so gutting it fails the literal tests.
+  #
+  # It matches a Rust *item definition* whose name carries an epoch-loop
+  # concept — `fn train_dir_epoch`, `struct EpochJournal`, `mod trace_store` —
+  # and deliberately not prose, so a doc comment mentioning "epoch" is free.
+  HOST_ITEM_RE='^[[:space:]]*(pub[[:space:]]*(\([^)]*\)[[:space:]]*)?)?(fn|struct|enum|trait|mod|type|const|static)[[:space:]]+[a-z0-9_]*(train_?dir|epoch|journal|trace_?store)'
+
+  # ONE definition of the module basenames that would mean the epoch loop was
+  # relocated here. `training_data.rs` / `training_state.rs` /
+  # `training_bin_stream.rs` are core primitives and stay.
+  HOST_MODULE_RE='^(train|trainer|train_dir|epoch|journal|trace_store)\.rs$'
+}
+
+# Body of the H2 named $1, up to the next H2. Fails loud on an empty body so a
+# renamed heading cannot make every assertion below pass vacuously.
+section_body() {
+  local heading="$1" body
+  body="$(awk -v h="$heading" '
+    index($0, "## ") == 1 { f = (substr($0, 4) == h) ? 1 : 0; next }
+    f' "$AGENTS")"
+  if [[ -z "${body//[[:space:]]/}" ]]; then
+    echo "AGENTS.md has no body under '## ${heading}'" >&2
+    return 1
+  fi
+  printf '%s\n' "$body"
+}
+
+# assert_states <text> <ERE> <what the rule must say>
+assert_states() {
+  local text="$1" pattern="$2" what="$3"
+  if [[ ! "$text" =~ $pattern ]]; then
+    echo "AGENTS.md does not state ${what} (no /${pattern}/)" >&2
+    return 1
+  fi
+}
+
+# --- The fence itself: neat-core carries no epoch orchestration -------------
+
+@test "neat-core sources define no trainDir/epoch/journal/traceStore item" {
+  run grep -rEni "$HOST_ITEM_RE" "$CORE_SRC"
+  if [ "$status" -eq 0 ]; then
+    echo "host-orchestration items found in neat-core/src:" >&2
+    echo "$output" >&2
+    echo "Those belong in NEAT-AI-Backpropagation — see AGENTS.md 'Ownership fence'." >&2
+  fi
+  [ "$status" -ne 0 ]
+}
+
+@test "neat-core has no train.rs-style epoch orchestration module" {
+  local offenders=""
+  local file
+  for file in "$CORE_SRC"/*.rs "$CORE_SRC"/*/*.rs; do
+    [ -e "$file" ] || continue
+    if [[ "$(basename "$file")" =~ $HOST_MODULE_RE ]]; then
+      offenders+="${file}"$'\n'
+    fi
+  done
+  [ -z "$offenders" ] || {
+    echo "epoch-orchestration modules found: $offenders" >&2
+    false
+  }
+}
+
+# --- The pattern can fail: known-bad and known-good literals ----------------
+
+@test "the item pattern rejects epoch-orchestration definitions" {
+  local bad
+  for bad in \
+    'pub fn train_dir(dir: &Path) -> Result<(), TrainError> {' \
+    'pub fn train_epoch_loop(&mut self) -> EpochResult {' \
+    '    pub(crate) fn apply_epoch(&mut self) {' \
+    'struct EpochJournal {' \
+    'pub struct TrainDirOptions {' \
+    'mod trace_store;' \
+    'const JOURNAL_PATH: &str = ".journal";'
+  do
+    printf '%s\n' "$bad" | grep -Eqi "$HOST_ITEM_RE" || {
+      echo "pattern failed to reject: $bad" >&2
+      false
+    }
+  done
+}
+
+@test "the item pattern accepts the primitives core keeps" {
+  local good
+  for good in \
+    "pub fn propagate_topological_loop(input: &PropagateInput<'_>) -> PropagateOutput {" \
+    'pub fn mse_mean_streaming(' \
+    'pub fn compute_reverse_topological_order(' \
+    'pub struct TrainingDataConfig {' \
+    'pub mod training_bin_stream;' \
+    '/// Initialise persistent training state for an epoch.' \
+    '// The trainDir journal stays in NEAT-AI-Backpropagation.'
+  do
+    printf '%s\n' "$good" | grep -Eqi "$HOST_ITEM_RE" && {
+      echo "pattern wrongly rejected: $good" >&2
+      false
+    }
+  done
+  true
+}
+
+@test "the module pattern rejects train.rs but keeps the training_* primitives" {
+  local bad good
+  for bad in train.rs trainer.rs train_dir.rs epoch.rs journal.rs trace_store.rs; do
+    [[ "$bad" =~ $HOST_MODULE_RE ]] || {
+      echo "module pattern failed to reject: $bad" >&2
+      false
+    }
+  done
+  for good in training_data.rs training_state.rs training_bin_stream.rs topological_backprop.rs; do
+    [[ "$good" =~ $HOST_MODULE_RE ]] && {
+      echo "module pattern wrongly rejected: $good" >&2
+      false
+    }
+  done
+  true
+}
+
+# --- The fence is documented ------------------------------------------------
+
+@test "AGENTS.md carries the ownership fence section" {
+  run grep -c '^## Ownership fence (Issue #544)$' "$AGENTS"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "the fence names the per-sample primitives core keeps" {
+  local body
+  body="$(section_body 'Ownership fence (Issue #544)')"
+  assert_states "$body" 'propagate_topological_loop' 'that the per-sample propagate loop stays'
+  assert_states "$body" 'propagate_codec' 'that the packed ABI codec stays'
+  assert_states "$body" 'mse_mean_streaming' 'that the streaming MSE helper stays'
+  assert_states "$body" 'training_data' 'that the training-data iterators stay'
+  assert_states "$body" 'topology_ops' 'that the topology helpers stay'
+}
+
+@test "the fence names the host orchestration Backpropagation owns" {
+  local body
+  body="$(section_body 'Ownership fence (Issue #544)')"
+  assert_states "$body" 'NEAT-AI-Backpropagation' 'which repository owns the epoch loop'
+  assert_states "$body" 'trainDir' 'that the trainDir epoch loop is out of scope'
+  assert_states "$body" '[Jj]ournal' 'that the journal is out of scope'
+  assert_states "$body" 'traceStore' 'that the traceStore layout is out of scope'
+  assert_states "$body" 'sample-rate' 'that memetic sample-rate policy is out of scope'
+  assert_states "$body" 'CLI apply policy' 'that the CLI apply policy is out of scope'
+}
+
+@test "the fence points at the gates that pin it" {
+  local body
+  body="$(section_body 'Ownership fence (Issue #544)')"
+  assert_states "$body" 'core_ownership_fence\.bats' 'which gate sweeps the sources'
+  assert_states "$body" 'backprop_ffi_surface\.rs' 'which test pins the kept propagate surface'
+}
+
+@test "README defers the fence to AGENTS.md via a link" {
+  run grep -q 'AGENTS.md#ownership-fence-issue-544' "$README"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Ownership fence: per-sample propagate here, `trainDir` epochs in Backpropagation (Issue #544)

## Summary

Native training is split across two FFI surfaces: `neat-core` owns the
**per-sample** primitives, and NEAT-AI-Backpropagation owns the **directory
epoch** loop (`trainDir`: accumulate → apply → MSE accept/rollback → journal).
That split was implicit — nothing stopped a future "simplify by putting
`trainDir` in core" change from pulling journal, CLI apply policy and
`traceStore` layout into every core consumer, the scorer and Discovery
included.

This PR writes the fence down and gates it. No API is deleted, moved or
narrowed; the only Rust change is a new test. Closes #544.

- **`AGENTS.md` — `## Ownership fence (Issue #544)`**: what stays here
  (`propagate_topological_loop`, the `propagate_codec` packed ABI,
  `mse_mean_streaming` over `training_bin_stream`, the `training_data` /
  `training_state` iterators, the `topology_ops` / `topology_export` helpers)
  and what stays in NEAT-AI-Backpropagation (the `train` epoch loop over a
  directory, the journal, the CLI apply policy, the `traceStore` layout, the
  memetic sample-rate policy), with the reasoning and a Mermaid diagram.
- **`README.md`**: a one-paragraph pointer under *Related Repositories* that
  links to the AGENTS.md section rather than restating the rule (the
  single-source convention `docs_single_source.bats` already enforces for other
  procedures).
- **`tests/scripts/core_ownership_fence.bats`**: the gate. Sweeps
  `neat-core/src` for host-orchestration **item definitions** and for
  `train.rs`/`journal.rs`-style module files, and checks the documented rule is
  present and complete.
- **`neat-core/tests/backprop_ffi_surface.rs`**: the "do keep" half — exercises
  the typed loop and the packed ABI codec from **outside** the crate, so
  narrowing either to `pub(crate)` (or moving it out) is a compile error here.

## Evidence

Backend/library change with no web interface, so there is no screenshot to
capture; the evidence is the gate output and the mutation runs below.

```mermaid
flowchart LR
    subgraph host["NEAT-AI-Backpropagation — host orchestration"]
        T["trainDir epoch loop"]
        J["journal + CLI apply policy"]
        S["traceStore layout<br/>memetic sample-rate policy"]
        T --> J
        T --> S
    end
    subgraph core["neat-core — per-sample primitives"]
        P["propagate_topological_loop<br/>propagate_codec packed ABI"]
        M["mse_mean_streaming<br/>training_bin_stream"]
        O["topology_ops / topology_export"]
    end
    T -->|"one sample per call, FFI"| P
    T -->|"epoch score for accept/rollback"| M
    T --> O
```

### Gate output

```text
bats tests/scripts/core_ownership_fence.bats
1..10
ok 1 neat-core sources define no trainDir/epoch/journal/traceStore item
ok 2 neat-core has no train.rs-style epoch orchestration module
ok 3 the item pattern rejects epoch-orchestration definitions
ok 4 the item pattern accepts the primitives core keeps
ok 5 the module pattern rejects train.rs but keeps the training_* primitives
ok 6 AGENTS.md carries the ownership fence section
ok 7 the fence names the per-sample primitives core keeps
ok 8 the fence names the host orchestration Backpropagation owns
ok 9 the fence points at the gates that pin it
ok 10 README defers the fence to AGENTS.md via a link

cargo test -p neat-core --test backprop_ffi_surface
test result: ok. 4 passed; 0 failed
```

Tests 6–10 were **red before** the AGENTS.md/README edits (`AGENTS.md has no
body under '## Ownership fence (Issue #544)'`), which is the failing-first run
for the documentation half.

### Mutation evidence

A green test is not evidence, so each new assertion was shown to be reachable.
Every mutation below was reverted before commit (`git status` clean).

| Mutation | Expected red | Result |
|----------|--------------|--------|
| Append `pub fn train_dir_epoch_loop() {}` to `neat-core/src/training_state.rs` | fence sweep | `not ok 1` ✔ |
| Create empty `neat-core/src/journal.rs` | module-name sweep | `not ok 2` ✔ |
| Gut `HOST_ITEM_RE` to `NEVER_MATCHES` | pattern self-test | `not ok 3` ✔ (the live pattern is compiled by both the sweep and the literal checks — AGENTS.md oracle rule 4) |
| Gut `HOST_MODULE_RE` to `NEVER_MATCHES` | module pattern self-test | `not ok 5` ✔ |
| `pub mod propagate_codec;` → `pub(crate) mod propagate_codec;` in `lib.rs` | boundary test | `error[E0603]: module propagate_codec is private` ✔ |
| `encode_propagate_output`: `f64::NEG_INFINITY` → `f64::INFINITY` for the noChange slot | sentinel test | `packed_abi_round_trip_keeps_the_no_change_sentinel ... FAILED` ✔ |

The sweep is deliberately narrow: it matches Rust **item definitions** whose
name carries an epoch-loop concept, not prose — the existing doc comment
"Initialise persistent training state for an epoch" in `training_state.rs`, and
the `training_data` / `training_state` / `training_bin_stream` modules, are all
explicitly asserted to pass (tests 4 and 5), so the gate cannot be satisfied by
renaming a core primitive.

### Quality gate

`./quality.sh` passes on the Rust side: `cargo fmt --all` (no diff),
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`cargo test --workspace --lib --tests --all-features`, `cargo deny check`,
`RUSTDOCFLAGS="-D warnings" cargo doc`, release build, `deno` TypeScript gate
and the Mermaid gate (`check-mermaid: all Mermaid blocks passed`).

The workflow-contract bats suites report 107 failures **in this container only**
— `python3` has no `yaml` module, which those suites need to parse workflow YAML
(`ModuleNotFoundError: No module named 'yaml'`, no `pip`/`sudo` available to
install it). The identical 107 failures occur on the base commit `bbc4b15`
before any change in this PR, and the new suite contributes none of them.

## Test Plan

- Added `tests/scripts/core_ownership_fence.bats` (10 tests): the source sweep,
  the module-name sweep, good/bad literal self-tests for both patterns, and the
  documented-rule assertions against `AGENTS.md` / `README.md`.
- Added `neat-core/tests/backprop_ffi_surface.rs` (4 tests) at the out-of-crate
  boundary:
  - `typed_propagate_loop_drives_an_identity_output_to_its_expected_value` —
    identity output at 0.5 with expected 1.0 gives
    `total_error_absolute_delta = |1.0 − 0.5| = 0.5`, `cached_activation = 1.0`,
    one bias accumulation, and one positive weight accumulation per inward
    synapse carrying the source activation 0.5.
  - `typed_propagate_loop_reports_no_change_when_the_output_already_matches` —
    error below `plank_constant` yields `NoChange` and moves no weight
    statistics.
  - `packed_abi_round_trip_encodes_the_standard_outcome_slots` — a buffer packed
    by an independent mirror of the TypeScript encoder decodes, runs and
    re-encodes into the documented
    `neurons × PER_NEURON_OUT_F64S + synapses × PER_SYNAPSE_OUT_F64S` layout,
    with input-neuron slots NaN and the output slots carrying the values derived
    above.
  - `packed_abi_round_trip_keeps_the_no_change_sentinel` — slot 1 is
    `−Infinity` with the cached activation in the last slot, the contract the
    TypeScript host decodes.
- No existing test was modified or removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msyk7m6s-2a98fe`<!-- vibe-worker-issue-544 -->