### PR TITLE
Rust build profiles: add line-tables-only dev profile; document that consumers carry release settings (VibeCoding#4159) (Issue #546)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,20 @@ expressible, and the synthetic tests catch header-overrun and undercover cases.
 - **`training_bin_stream`** (`neat-core/src/training_bin_stream.rs`) — **one** chunked `.bin` scan API: pipelined double-buffer reads on native hosts, sequential `File::read` chunks on the wasm family (same `for_each_read_chunk` callback). Used by **NEAT-AI-scorer** for production-sized forward-only scoring.
 - Root **`Cargo.toml`** is a **virtual workspace**; **`[workspace.package].version`** is what the PR **auto-bump** job edits; **`neat-core`** uses `version.workspace = true`.
 
+## Build profiles (Issue #546)
+
+Root `Cargo.toml` owns both profiles, workspace-wide: `[profile.dev]` carries
+`debug = "line-tables-only"` (fast rebuilds, panic `file:line` kept) and
+`[profile.release]` carries `opt-level = 3`, `lto = "fat"`, `codegen-units = 1`
+(most optimised artefact, compile time irrelevant). Stable Rust only — no
+nightly profile flags. Never add `-C target-cpu=native` to this repo: the
+`wasm32`/`wasm64` bundles and downstream consumers must stay portable, and
+because cargo takes profiles from the **crate being built**, a library's
+`[profile.*]` never reaches a consumer — each binary crate carries its own
+settings and its own target-cpu choice.
+`tests/scripts/rust_build_profiles.bats` is the gate; the rationale and the
+measured dev-build numbers are in [README "Build profiles"](README.md#build-profiles-issue-546).
+
 ## Ownership fence (Issue #544)
 
 Native training is split across two FFI surfaces, and this crate owns exactly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,21 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"
 
+# Issue #546 (fleet decision stSoftwareAU/VibeCoding#4159): dev builds compile
+# as fast as possible. `line-tables-only` keeps panic/backtrace file:line and
+# drops the rest of the DWARF; `opt-level = 0` and incremental stay at cargo's
+# dev defaults. Stable Rust only — no nightly flags.
+[profile.dev]
+debug = "line-tables-only"
+
+# Release builds produce the most optimised artefact possible; compile time is
+# irrelevant. Declared workspace-wide, not scoped to one package. No
+# `target-cpu=native` here: the wasm bundles and downstream consumers must stay
+# portable, and a library's profiles never reach a consumer anyway — each binary
+# crate carries its own (see README "Build profiles").
 [profile.release]
 opt-level = 3
-lto = true
+lto = "fat"
 codegen-units = 1
 
 [profile.release.package."*"]

--- a/README.md
+++ b/README.md
@@ -137,6 +137,48 @@ job on every push and pull request, so a syntax or type error fails the build.
 Basic validity only — it is not a style or lint gate, and it requires
 [Deno](https://docs.deno.com/runtime/getting_started/installation/).
 
+### Build profiles (Issue #546)
+
+Fleet decision (`stSoftwareAU/VibeCoding#4159`): **dev builds compile as fast as
+possible; release builds produce the most optimised artefact possible and
+compile time is irrelevant.** Stable Rust only — no nightly, no `-Zthreads`, no
+Cranelift. The root `Cargo.toml` carries both profiles workspace-wide:
+
+| Profile | Settings | Why |
+|---------|----------|-----|
+| `[profile.dev]` | `debug = "line-tables-only"` (plus cargo's defaults: `opt-level = 0`, incremental on) | Keeps panic and backtrace `file:line`, drops the rest of the DWARF. Measured here: rebuild after a one-line edit **1.87s → 1.50s**, clean `cargo build --workspace --all-targets` **8.37s → 6.72s**, `target/debug` **1.4G → 1.1G**. |
+| `[profile.release]` | `opt-level = 3`, `lto = "fat"`, `codegen-units = 1` | One codegen unit per crate with fat LTO across the whole graph — the most optimised artefact, whatever it costs to compile. |
+
+**Cargo profiles come from the crate being built.** `neat-core` is a library, so
+its `[profile.*]` tables govern only this workspace's own tests, benches and
+`cargo build --release` — they never reach a consumer. Every binary crate
+downstream (the scorer, the Lamarck and backpropagation consumers, the private
+trainer) must carry the same release settings in its own manifest, or it links
+`neat-core` unoptimised no matter what is written here.
+
+```mermaid
+flowchart LR
+    P["root Cargo.toml<br/>[profile.dev] + [profile.release]"] --> W["this workspace's builds<br/>tests, benches, release"]
+    P -. "never inherited" .-> C["consumer binary crate"]
+    C --> O["consumer's own [profile.release]<br/>+ its own target-cpu choice"]
+```
+
+**`-C target-cpu=native` is consumer-owned and deliberately absent here.**
+Recommended for a binary built and run on the same host (the fleet pattern:
+`cargo build --release` on the machine that runs the artefact); never for a
+published crate and never for the `wasm32`/`wasm64` bundles, which must stay
+portable. Stable Cargo has no per-profile rustflags, so a consumer sets it in
+its own `.cargo/config.toml` under a target-scoped key —
+`[target.'cfg(not(target_arch = "wasm32"))'] rustflags = ["-C", "target-cpu=native"]`
+— or in the build invocation's `RUSTFLAGS`; note that an exported `RUSTFLAGS`
+**replaces** config rustflags entirely rather than adding to them.
+
+`tests/scripts/rust_build_profiles.bats` is the gate: it asserts the manifest's
+values and then splices the live `[profile.*]` tables into a throwaway crate to
+check the flags **cargo itself** passes rustc (`-C debuginfo=line-tables-only`;
+`-C opt-level=3 -C lto=fat -C codegen-units=1`), and fails if any build input
+under `.cargo/`, `scripts/` or `.github/workflows/` pins `target-cpu=native`.
+
 ## Cargo features
 
 | Feature | Default | Effect |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -291,3 +291,9 @@ flowchart TD
     G --> H[release.yml:<br/>cut v&lt;version&gt; tag + GitHub release]
     H --> I[Downstream discovers the bump]
 ```
+
+A release ships **source**, not a compiled artefact: this repo's
+`[profile.release]` (`opt-level = 3`, `lto = "fat"`, `codegen-units = 1`) governs
+its own builds only, because cargo takes profiles from the crate being built. A
+consumer that wants the same optimisation must declare it in its own manifest —
+see [Build profiles](README.md#build-profiles-issue-546) in the README.

--- a/docs/archive/pr-summaries/pr-summary-546.md
+++ b/docs/archive/pr-summaries/pr-summary-546.md
@@ -1,0 +1,118 @@
+# Rust build profiles: line-tables-only dev, fat-LTO release, consumer-owned target-cpu
+
+## Summary
+
+Applies the fleet build-profile decision (`stSoftwareAU/VibeCoding#4159`) to this
+repo — **dev builds compile as fast as possible, release builds produce the most
+optimised artefact possible** — on stable Rust only. Closes #546.
+
+- `Cargo.toml`: added `[profile.dev] debug = "line-tables-only"` at the
+  workspace root (panic/backtrace `file:line` kept, the rest of the DWARF
+  dropped; `opt-level = 0` and incremental stay at cargo's dev defaults).
+- `Cargo.toml`: `[profile.release]` now spells `lto = "fat"` instead of
+  `lto = true` — the same LTO mode to cargo, but unambiguous to a reader and to
+  the new gate — alongside the existing workspace-wide `opt-level = 3` and
+  `codegen-units = 1`.
+- **No** `target-cpu=native` added: the `wasm32`/`wasm64` bundles and downstream
+  consumers must stay portable, so that flag stays consumer-owned.
+- New gate `tests/scripts/rust_build_profiles.bats` pins the contract.
+- Docs: README gains a **Build profiles** section (settings, measured dev-build
+  numbers, the consumers-carry-their-own rule, and how a consumer sets
+  `target-cpu=native`); AGENTS.md and RELEASING.md carry the same rule where
+  they describe the manifest and the release.
+
+The redundant-but-harmless `[profile.release.package."*"] opt-level = 3` is left
+as-is; the new gate asserts no package-scoped table can *weaken* the
+workspace-wide settings.
+
+## Evidence
+
+Backend/build-configuration change — no web interface to screenshot. Evidence is
+the measured build times and the gate output below.
+
+### Dev-build measurement (acceptance criterion)
+
+Same machine, same command, a fresh `CARGO_TARGET_DIR` per side; "rebuild" is
+`cargo build --workspace --all-targets` after appending one comment line to
+`neat-core/src/lib.rs` (median of three).
+
+| Measurement | Before (`debug = 2` default) | After (`line-tables-only`) | Change |
+|---|---|---|---|
+| Rebuild after a one-line edit | 1.92 / 1.81 / **1.87** s | 1.50 / 1.49 / **1.50** s | **−20%** |
+| Clean `cargo build --workspace --all-targets` | 8.37 s | 6.72 s | **−20%** |
+| `target/debug` size | 1.4 G | 1.1 G | **−21%** |
+
+Release side: `cargo build --workspace --release` succeeds inside `./quality.sh`,
+and cargo hands rustc `-C opt-level=3 -C lto=fat -C codegen-units=1` (asserted by
+the gate, so one codegen unit per crate with fat LTO).
+
+### Profile ownership
+
+```mermaid
+flowchart LR
+    P["root Cargo.toml<br/>[profile.dev] + [profile.release]"] --> W["this workspace's builds<br/>tests, benches, release"]
+    P -. "never inherited" .-> C["consumer binary crate"]
+    C --> O["consumer's own [profile.release]<br/>+ its own target-cpu choice"]
+```
+
+### Gate output
+
+```text
+$ bats tests/scripts/rust_build_profiles.bats
+ok 1 dev profile keeps panic file:line but drops full DWARF
+ok 2 dev profile stays unoptimised and incremental
+ok 3 release profile is fully optimised workspace-wide, not per package
+ok 4 no build input pins target-cpu=native — consumers own that flag
+ok 5 cargo resolves the dev profile to line-tables-only debuginfo
+ok 6 cargo resolves the release profile to fat LTO in one codegen unit
+```
+
+`./quality.sh` exits 0 (fmt, clippy `-D warnings`, `cargo check --all-targets`,
+tests, rustdoc, `cargo deny`, Mermaid, TypeScript, release build). Two local
+caveats, both pre-existing and environmental: `codespell` is not installed in
+this container (CI still enforces it), and this container's `python3` has no
+`yaml` module, so 107 of the existing workflow-contract bats tests error on
+`ModuleNotFoundError: No module named 'yaml'`. Verified pre-existing by counting
+failures with the change (107) against the same suite on the unmodified
+manifest/docs (111 — the extra 4 being this PR's own red tests before the fix).
+The new suite uses `tomllib` only and needs no `yaml`.
+
+## Test Plan
+
+New suite `tests/scripts/rust_build_profiles.bats` (runs in `./quality.sh` and in
+the CI `quality` job's bats step):
+
+- **TOML contract, read through a real parser** — `[profile.dev] debug` is
+  `line-tables-only`; dev keeps `opt-level = 0` and incremental; `[profile.release]`
+  declares `opt-level = 3`, `lto = "fat"`, `codegen-units = 1` at the workspace
+  level, and no `[profile.release.package.<name>]` table weakens them.
+- **Behavioural** — the live `[profile.*]` tables are spliced into a throwaway
+  crate and built with `cargo build -v`, asserting the flags **cargo itself**
+  passes rustc: `-C debuginfo=line-tables-only` + `-C incremental=` and no
+  `-C opt-level=[1-9]` for dev; `-C opt-level=3 -C lto=fat -C codegen-units=1`
+  for release. A profile key cargo would ignore (misspelling, wrong table depth)
+  therefore fails here rather than silently doing nothing.
+- **Portability** — every build input under `.cargo/`, `scripts/` and
+  `.github/workflows/` is swept for `target-cpu=native` (prose explaining the
+  rule is deliberately not swept).
+
+### Mutation evidence (AGENTS.md rule 2)
+
+Each mutation applied alone to the fixed manifest, suite re-run, mutation
+reverted. Every one is caught:
+
+| Mutation | Tests that went red |
+|---|---|
+| `debug = "line-tables-only"` line removed | #1, #5 |
+| `debug = "full"` | #1, #5 |
+| `opt-level = 1` added to `[profile.dev]` | #2, #5 |
+| `incremental = false` added to `[profile.dev]` | #2, #5 |
+| release `lto = "thin"` | #3, #6 |
+| release `codegen-units = 16` | #3, #6 |
+| release `opt-level = 2` | #3, #6 |
+| `[profile.release.package.neat-core] opt-level = 1` | #3 |
+| `.cargo/config.toml` pinning `-C target-cpu=native` | #4 |
+
+The `codegen-units = 16` row is why #6 anchors its match: a plain `-F` grep for
+`-C codegen-units=1` also accepts `=16`, and that mutation initially survived #6
+until the assertion was anchored.

--- a/tests/scripts/rust_build_profiles.bats
+++ b/tests/scripts/rust_build_profiles.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# Build-profile contract for the workspace root Cargo.toml (Issue #546).
+#
+# Fleet decision (stSoftwareAU/VibeCoding#4159): dev builds compile as fast as
+# possible, release builds produce the most optimised artefact possible and
+# compile time is irrelevant. Stable Rust only.
+#
+# Cargo profiles come from the crate being built, so `neat-core`'s own tables
+# govern only this workspace's tests and benches — the settings are still
+# declared at the workspace root, workspace-wide, because that is what the
+# workspace's own dev/release builds resolve.
+#
+# These are "what" tests: the TOML assertions read the live manifest through a
+# real parser, and the last two splice the live `[profile.*]` tables into a
+# throwaway crate and assert on the flags **cargo itself** hands rustc — so a
+# key that cargo would ignore (a misspelling, a table at the wrong depth) fails
+# here rather than silently doing nothing.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  MANIFEST="${REPO_ROOT}/Cargo.toml"
+  export MANIFEST
+}
+
+# Emit a throwaway crate in $1 carrying the live root manifest's `[profile.*]`
+# tables verbatim, so cargo resolves the real settings.
+probe_crate() {
+  local dir="$1"
+  mkdir -p "${dir}/src"
+  echo 'fn main() {}' >"${dir}/src/main.rs"
+  python3 - "${dir}/Cargo.toml" <<'PY'
+import json
+import os
+import re
+import sys
+import tomllib
+
+BARE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def key(name):
+    return name if BARE.match(name) else json.dumps(name)
+
+
+def value(val):
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, (int, float)):
+        return repr(val)
+    if isinstance(val, str):
+        return json.dumps(val)
+    if isinstance(val, list):
+        return "[" + ", ".join(value(v) for v in val) + "]"
+    raise AssertionError(f"unsupported profile value: {val!r}")
+
+
+def emit(prefix, table):
+    lines = [f"[{prefix}]"]
+    lines += [f"{key(k)} = {value(v)}" for k, v in table.items()
+              if not isinstance(v, dict)]
+    lines.append("")
+    for name, sub in table.items():
+        if isinstance(sub, dict):
+            lines += emit(f"{prefix}.{key(name)}", sub)
+    return lines
+
+
+with open(os.environ["MANIFEST"], "rb") as fh:
+    profiles = tomllib.load(fh).get("profile") or {}
+assert profiles, "root manifest declares no [profile.*] tables"
+
+out = ['[package]', 'name = "profile-probe"', 'version = "0.0.0"',
+       'edition = "2024"', '']
+for name, table in profiles.items():
+    out += emit(f"profile.{key(name)}", table)
+with open(sys.argv[1], "w") as fh:
+    fh.write("\n".join(out) + "\n")
+PY
+}
+
+# Print the rustc invocation cargo builds the probe crate with, for profile $2.
+probe_rustc_flags() {
+  local dir="$1" profile="$2"
+  (
+    cd "$dir" || exit 1
+    CARGO_TARGET_DIR="${dir}/target" cargo build -v --offline \
+      --profile "$profile" 2>&1
+  ) | grep -F -- '--crate-name profile_probe'
+}
+
+@test "dev profile keeps panic file:line but drops full DWARF" {
+  run python3 - <<'PY'
+import os
+import tomllib
+
+with open(os.environ["MANIFEST"], "rb") as fh:
+    dev = (tomllib.load(fh).get("profile") or {}).get("dev")
+assert dev is not None, "no [profile.dev] table in the root manifest"
+assert dev.get("debug") == "line-tables-only", (
+    f'expected debug = "line-tables-only", got {dev.get("debug")!r}'
+)
+PY
+  [ "$status" -eq 0 ] || {
+    echo "$output"
+    false
+  }
+}
+
+@test "dev profile stays unoptimised and incremental" {
+  run python3 - <<'PY'
+import os
+import tomllib
+
+with open(os.environ["MANIFEST"], "rb") as fh:
+    dev = (tomllib.load(fh).get("profile") or {}).get("dev") or {}
+# Absent keys keep cargo's dev defaults (opt-level 0, incremental on); an
+# explicit value must not walk away from them, or dev builds get slower.
+assert dev.get("opt-level", 0) == 0, f'opt-level = {dev["opt-level"]!r}'
+assert dev.get("incremental", True) is True, (
+    f'incremental = {dev["incremental"]!r}'
+)
+PY
+  [ "$status" -eq 0 ] || {
+    echo "$output"
+    false
+  }
+}
+
+@test "release profile is fully optimised workspace-wide, not per package" {
+  run python3 - <<'PY'
+import os
+import tomllib
+
+with open(os.environ["MANIFEST"], "rb") as fh:
+    release = (tomllib.load(fh).get("profile") or {}).get("release")
+assert release is not None, "no [profile.release] table in the root manifest"
+assert release.get("opt-level") == 3, f'opt-level = {release.get("opt-level")!r}'
+# `lto = true` is the same mode (cargo emits a bare `-C lto`); the manifest
+# spells "fat" so the mode is unambiguous to a reader and to the gate below.
+assert release.get("lto") == "fat", f'lto = {release.get("lto")!r}'
+assert release.get("codegen-units") == 1, (
+    f'codegen-units = {release.get("codegen-units")!r}'
+)
+
+# Package-scoped tables may sharpen the workspace-wide settings, never weaken
+# them — a per-package opt-level of 1 would quietly de-optimise that crate.
+for name, override in (release.get("package") or {}).items():
+    assert override.get("opt-level", 3) == 3, (
+        f'profile.release.package.{name} lowers opt-level to '
+        f'{override["opt-level"]!r}'
+    )
+    assert override.get("lto", "fat") in ("fat", True), (
+        f'profile.release.package.{name} disables fat LTO: {override["lto"]!r}'
+    )
+PY
+  [ "$status" -eq 0 ] || {
+    echo "$output"
+    false
+  }
+}
+
+@test "no build input pins target-cpu=native — consumers own that flag" {
+  # The wasm32/wasm64 bundles and every downstream consumer must stay portable,
+  # so the flag belongs in a consumer's own config or build invocation. Prose
+  # explaining the rule is free; build inputs are what is swept.
+  local -a inputs=()
+  while IFS= read -r path; do
+    inputs+=("$path")
+  done < <(
+    cd "$REPO_ROOT" || exit 1
+    find .cargo scripts .github/workflows -type f \
+      \( -name '*.toml' -o -name '*.sh' -o -name '*.yml' \) 2>/dev/null
+  )
+  [ "${#inputs[@]}" -gt 0 ]
+  local failed=0 path
+  for path in "${inputs[@]}"; do
+    if grep -Fq 'target-cpu=native' "${REPO_ROOT}/${path}"; then
+      echo "target-cpu=native pinned by ${path}" >&2
+      failed=1
+    fi
+  done
+  [ "$failed" -eq 0 ]
+}
+
+@test "cargo resolves the dev profile to line-tables-only debuginfo" {
+  probe_crate "$BATS_TEST_TMPDIR"
+  run probe_rustc_flags "$BATS_TEST_TMPDIR" dev
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -Fq -- '-C debuginfo=line-tables-only'
+  # Fast dev builds still need incremental compilation and no optimisation.
+  echo "$output" | grep -Fq -- '-C incremental='
+  ! echo "$output" | grep -Eq -- '-C opt-level=[1-9]'
+}
+
+@test "cargo resolves the release profile to fat LTO in one codegen unit" {
+  probe_crate "$BATS_TEST_TMPDIR"
+  run probe_rustc_flags "$BATS_TEST_TMPDIR" release
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -Fq -- '-C opt-level=3'
+  echo "$output" | grep -Fq -- '-C lto=fat'
+  # Anchored: a bare -F match on "=1" also accepts "=16".
+  echo "$output" | grep -Eq -- '-C codegen-units=1([[:space:]]|$)'
+}


### PR DESCRIPTION
# Rust build profiles: line-tables-only dev, fat-LTO release, consumer-owned target-cpu

## Summary

Applies the fleet build-profile decision (`stSoftwareAU/VibeCoding#4159`) to this
repo — **dev builds compile as fast as possible, release builds produce the most
optimised artefact possible** — on stable Rust only. Closes #546.

- `Cargo.toml`: added `[profile.dev] debug = "line-tables-only"` at the
  workspace root (panic/backtrace `file:line` kept, the rest of the DWARF
  dropped; `opt-level = 0` and incremental stay at cargo's dev defaults).
- `Cargo.toml`: `[profile.release]` now spells `lto = "fat"` instead of
  `lto = true` — the same LTO mode to cargo, but unambiguous to a reader and to
  the new gate — alongside the existing workspace-wide `opt-level = 3` and
  `codegen-units = 1`.
- **No** `target-cpu=native` added: the `wasm32`/`wasm64` bundles and downstream
  consumers must stay portable, so that flag stays consumer-owned.
- New gate `tests/scripts/rust_build_profiles.bats` pins the contract.
- Docs: README gains a **Build profiles** section (settings, measured dev-build
  numbers, the consumers-carry-their-own rule, and how a consumer sets
  `target-cpu=native`); AGENTS.md and RELEASING.md carry the same rule where
  they describe the manifest and the release.

The redundant-but-harmless `[profile.release.package."*"] opt-level = 3` is left
as-is; the new gate asserts no package-scoped table can *weaken* the
workspace-wide settings.

## Evidence

Backend/build-configuration change — no web interface to screenshot. Evidence is
the measured build times and the gate output below.

### Dev-build measurement (acceptance criterion)

Same machine, same command, a fresh `CARGO_TARGET_DIR` per side; "rebuild" is
`cargo build --workspace --all-targets` after appending one comment line to
`neat-core/src/lib.rs` (median of three).

| Measurement | Before (`debug = 2` default) | After (`line-tables-only`) | Change |
|---|---|---|---|
| Rebuild after a one-line edit | 1.92 / 1.81 / **1.87** s | 1.50 / 1.49 / **1.50** s | **−20%** |
| Clean `cargo build --workspace --all-targets` | 8.37 s | 6.72 s | **−20%** |
| `target/debug` size | 1.4 G | 1.1 G | **−21%** |

Release side: `cargo build --workspace --release` succeeds inside `./quality.sh`,
and cargo hands rustc `-C opt-level=3 -C lto=fat -C codegen-units=1` (asserted by
the gate, so one codegen unit per crate with fat LTO).

### Profile ownership

```mermaid
flowchart LR
    P["root Cargo.toml<br/>[profile.dev] + [profile.release]"] --> W["this workspace's builds<br/>tests, benches, release"]
    P -. "never inherited" .-> C["consumer binary crate"]
    C --> O["consumer's own [profile.release]<br/>+ its own target-cpu choice"]
```

### Gate output

```text
$ bats tests/scripts/rust_build_profiles.bats
ok 1 dev profile keeps panic file:line but drops full DWARF
ok 2 dev profile stays unoptimised and incremental
ok 3 release profile is fully optimised workspace-wide, not per package
ok 4 no build input pins target-cpu=native — consumers own that flag
ok 5 cargo resolves the dev profile to line-tables-only debuginfo
ok 6 cargo resolves the release profile to fat LTO in one codegen unit
```

`./quality.sh` exits 0 (fmt, clippy `-D warnings`, `cargo check --all-targets`,
tests, rustdoc, `cargo deny`, Mermaid, TypeScript, release build). Two local
caveats, both pre-existing and environmental: `codespell` is not installed in
this container (CI still enforces it), and this container's `python3` has no
`yaml` module, so 107 of the existing workflow-contract bats tests error on
`ModuleNotFoundError: No module named 'yaml'`. Verified pre-existing by counting
failures with the change (107) against the same suite on the unmodified
manifest/docs (111 — the extra 4 being this PR's own red tests before the fix).
The new suite uses `tomllib` only and needs no `yaml`.

## Test Plan

New suite `tests/scripts/rust_build_profiles.bats` (runs in `./quality.sh` and in
the CI `quality` job's bats step):

- **TOML contract, read through a real parser** — `[profile.dev] debug` is
  `line-tables-only`; dev keeps `opt-level = 0` and incremental; `[profile.release]`
  declares `opt-level = 3`, `lto = "fat"`, `codegen-units = 1` at the workspace
  level, and no `[profile.release.package.<name>]` table weakens them.
- **Behavioural** — the live `[profile.*]` tables are spliced into a throwaway
  crate and built with `cargo build -v`, asserting the flags **cargo itself**
  passes rustc: `-C debuginfo=line-tables-only` + `-C incremental=` and no
  `-C opt-level=[1-9]` for dev; `-C opt-level=3 -C lto=fat -C codegen-units=1`
  for release. A profile key cargo would ignore (misspelling, wrong table depth)
  therefore fails here rather than silently doing nothing.
- **Portability** — every build input under `.cargo/`, `scripts/` and
  `.github/workflows/` is swept for `target-cpu=native` (prose explaining the
  rule is deliberately not swept).

### Mutation evidence (AGENTS.md rule 2)

Each mutation applied alone to the fixed manifest, suite re-run, mutation
reverted. Every one is caught:

| Mutation | Tests that went red |
|---|---|
| `debug = "line-tables-only"` line removed | #1, #5 |
| `debug = "full"` | #1, #5 |
| `opt-level = 1` added to `[profile.dev]` | #2, #5 |
| `incremental = false` added to `[profile.dev]` | #2, #5 |
| release `lto = "thin"` | #3, #6 |
| release `codegen-units = 16` | #3, #6 |
| release `opt-level = 2` | #3, #6 |
| `[profile.release.package.neat-core] opt-level = 1` | #3 |
| `.cargo/config.toml` pinning `-C target-cpu=native` | #4 |

The `codegen-units = 16` row is why #6 anchors its match: a plain `-F` grep for
`-C codegen-units=1` also accepts `=16`, and that mutation initially survived #6
until the assertion was anchored.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msys3hv1-5b9894`<!-- vibe-worker-issue-546 -->