### PR TITLE
Add canonical decision-tree / IF graft fixture and construction helpers (Issue #555)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,35 @@ this you **must**:
 - **Add a state-leak regression test** asserting the reused-buffer path is
   byte-identical to the fresh-allocation path across differently-sized inputs.
 
+## One IF decision-tree construction rule (Issue #555)
+
+`neat-core/src/if_graft.rs` is the single home of the rule that builds an `IF`
+node: which synapse carries which [`SynapseType`] role, that all three roles
+must be present, that the node's own constants come first, and where the node
+may sit so every edge still points forwards. `graft_if_node`,
+`graft_if_tree` and `graft_if_correction` all route through it, and every
+rejection is a typed `GraftError` with **no creature produced** — a caller never
+hand-edits neuron/synapse JSON to add a decision node, and NEAT-AI-Forests reads
+its interpretation of the roles from here rather than inventing one.
+
+`validate_creature_topology` is the gate at both ends. It **reuses**
+`validate_creature_width`, `validate_topology` and
+`validate_structural_integrity` — do not restate their rules here. The ordering
+gate runs only for `forwardOnly` creatures; a recurrent creature legitimately
+carries backward edges, which that gate rejects by design. The post-build check
+is deliberate defence in depth: it is unreachable while the pre-checks are
+complete, so it is exercised directly against synthetic creatures
+(`neat-core/tests/if_graft.rs`, AGENTS.md oracle rule 5) rather than through a
+graft.
+
+`neat-core/src/decision_tree.rs` holds the canonical fixtures and their
+documented expected outputs. `graft_if_correction` on `linear_base_creature()`
+must reproduce `residual_correction_creature()` exactly — that equality is what
+stops the helper and the fixture drifting apart, so change them together.
+`neat-core/tests/decision_tree_fixture.rs` checks every case against a
+hand-written reference tree (plain `if x > t` Rust, no shared kernel) through
+both the single-record and the batched scoring paths.
+
 ## One width check for creature JSON (Issue #550)
 
 `validate_creature_width` (`neat-core/src/creature.rs`) is the single home of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -434,6 +434,64 @@ flowchart LR
     S -. "input &lt; 1 / output &lt; 1" .-> X
 ```
 
+### Canonical IF decision trees and the graft helper (Issue #555)
+
+`neat-core` owns the fleet's one interpretation of a decision tree built from
+the `IF` aggregate. **NEAT-AI-Forests and every other consumer read it from
+here** rather than inventing their own reading of the synapse roles.
+
+An `IF` neuron sums its `Condition` inputs. When that sum is **strictly**
+greater than zero it emits the sum of its `Positive` inputs, otherwise the sum
+of its `Negative` inputs; the neuron's bias is added either way. So a split test
+`x > t` is a condition sum of `x * 1.0 + 1.0 * (-t)`, with a constant neuron
+supplying the `1.0`. A creature may not carry two synapses between the same
+ordered pair of neurons, so one node cannot take all three roles from a single
+constant — each grafted node brings its own trio of `1.0` constants, leaving the
+threshold and the leaf values in the trainable **weights**.
+
+**Fixtures** — `neat-core/src/decision_tree.rs`, with documented expected
+outputs beside each builder:
+
+| Builder | Shape | Covers |
+|---------|-------|--------|
+| `stump_creature()` | `x > 0.5 ? 3.0 : 0.0` | single split, zero/default branch (`STUMP_CASES`) |
+| `depth2_tree_creature()` | root on `x0 > 0.5`, both children on `x1 > 0.25` | nested depth-2, all four leaves (`DEPTH2_CASES`) |
+| `linear_base_creature()` | `2x`, no `IF` at all | the pre-graft base |
+| `residual_correction_creature()` | `2x + (x > 0.75 ? 1.5 : 0)` | non-zero residual/correction leaf (`RESIDUAL_CASES`) |
+
+**Graft helper** — `neat-core/src/if_graft.rs`. A caller describes the node
+(`IfNodeSpec`, or `IfCorrectionSpec` for the common depth-1 correction) and
+`graft_if_node` / `graft_if_tree` / `graft_if_correction` return a **new**
+validated `CreatureExport`; the source is never mutated. Placement is chosen so
+the node is evaluated after every source and before every target, which is what
+preserves the `forwardOnly` reading order the compiled forward pass relies on.
+Every rejection is a typed `GraftError` and **no creature is produced** —
+unknown or duplicate UUID, a missing `IF` role, no outward edge, an edge to an
+input or a constant, a self edge, a duplicate edge, a non-finite weight or bias,
+or no position that keeps every edge pointing forwards. `graft_if_correction`
+on `linear_base_creature()` reproduces `residual_correction_creature()` exactly,
+which is how the helper and the fixture keep each other honest.
+
+`validate_creature_topology` is the shared gate both ends run: it reuses
+`validate_creature_width`, `validate_topology` and
+`validate_structural_integrity` rather than restating their rules. The ordering
+gate only runs for `forwardOnly` creatures, because a recurrent creature
+legitimately carries backward edges.
+
+```mermaid
+flowchart LR
+    B["base CreatureExport"] --> V["validate_creature_topology"]
+    S["IfNodeSpec / IfCorrectionSpec"] --> K{"names new?<br/>all three roles?<br/>edges resolve?"}
+    V --> K
+    K -- no --> E["Err(GraftError) — no creature"]
+    K -- yes --> P{"position after every source,<br/>before every target?"}
+    P -- none exists --> E
+    P -- yes --> G["build creature"]
+    G --> V2["validate_creature_topology"]
+    V2 -- fails --> E
+    V2 -- passes --> O["Ok(CreatureExport)"]
+```
+
 ## Related Repositories
 
 The NEAT-AI project is split across seven public repositories. Each focuses on one concern and composes with the others as shown below.

--- a/docs/archive/pr-summaries/pr-summary-555.md
+++ b/docs/archive/pr-summaries/pr-summary-555.md
@@ -1,0 +1,182 @@
+# Canonical IF decision-tree fixtures and a safe graft helper
+
+## Summary
+
+Gives the NEAT-AI family one authoritative Rust representation of small
+decision trees built from the existing `IF` aggregate, plus a helper that
+constructs them safely, so NEAT-AI-Forests does not have to invent its own
+reading of the synapse roles or hand-edit neuron/synapse JSON. Closes #555.
+
+Two new modules, both public library surface (Forests consumes them, so they
+cannot be test-only):
+
+- **`neat-core/src/decision_tree.rs`** — the canonical fixtures and their
+  documented expected outputs:
+
+  | Builder | Shape | Covers |
+  |---------|-------|--------|
+  | `stump_creature()` | `x > 0.5 ? 3.0 : 0.0` | single split, zero/default branch (`STUMP_CASES`) |
+  | `depth2_tree_creature()` | root on `x0 > 0.5`, both children on `x1 > 0.25` | nested depth-2, all four leaves (`DEPTH2_CASES`) |
+  | `linear_base_creature()` | `2x`, no `IF` at all | the pre-graft base |
+  | `residual_correction_creature()` | `2x + (x > 0.75 ? 1.5 : 0)` | non-zero residual/correction leaf (`RESIDUAL_CASES`) |
+
+- **`neat-core/src/if_graft.rs`** — `IfNodeSpec` / `IfCorrectionSpec` describe
+  *what* is wanted; `graft_if_node`, `graft_if_tree` and `graft_if_correction`
+  return a **new** validated `CreatureExport` and never mutate the source.
+
+Nothing in the serialisation format, the squash discriminants or the existing
+activation kernels changed — the modules are additive, and `SquashType::If` /
+`SynapseType` are used exactly as they already were.
+
+### Design notes a reviewer needs
+
+- **Why each grafted node brings three constants.** A split test `x > t` needs a
+  constant `1.0` source to carry `-t`, and each leaf value needs one too. A
+  creature may not hold two synapses between the same ordered pair of neurons
+  (`validate_topology`'s `DUPLICATE_CONNECTION`), so one node cannot take all
+  three roles from a single constant. `IfCorrectionSpec` therefore introduces
+  `<uuid>-condition-one`, `<uuid>-positive-one` and `<uuid>-negative-one`, all
+  bias `1.0`, leaving the threshold and leaf values in the trainable **weights**.
+- **Placement is the `forwardOnly` guarantee.** The node is inserted at the
+  earliest position that still sits after every source and before every target;
+  when no such position exists the graft fails with `ForwardOrderViolation`
+  rather than emitting a node that reads a stale activation.
+- **The gate reuses existing single-home rules.** `validate_creature_topology`
+  calls `validate_creature_width`, `validate_topology` and
+  `validate_structural_integrity` rather than restating them. The ordering gate
+  runs only for `forwardOnly` creatures, because a recurrent creature
+  legitimately carries backward edges that gate rejects by design.
+- **Fail closed, and prove it.** Every rejection is a typed `GraftError` and no
+  creature is produced. `graft_if_correction` on `linear_base_creature()`
+  reproduces `residual_correction_creature()` **exactly**, which is what stops
+  the helper and the fixture drifting apart.
+
+```mermaid
+flowchart LR
+    B["base CreatureExport"] --> V["validate_creature_topology"]
+    S["IfNodeSpec / IfCorrectionSpec"] --> K{"names new?<br/>all three roles?<br/>edges resolve?"}
+    V --> K
+    K -- no --> E["Err(GraftError) — no creature"]
+    K -- yes --> P{"position after every source,<br/>before every target?"}
+    P -- none exists --> E
+    P -- yes --> G["build creature"]
+    G --> V2["validate_creature_topology"]
+    V2 -- fails --> E
+    V2 -- passes --> O["Ok(CreatureExport)"]
+```
+
+## Evidence
+
+Backend/library change — there is no web interface to screenshot. The evidence
+is the test suite and the mutation sweep below.
+
+`./quality.sh` passes clean (fmt, clippy `-D warnings`, `cargo check`,
+`cargo test --workspace`, rustdoc `-D warnings`, release build, Mermaid gate,
+`cargo deny`). 39 new tests, all existing tests still green.
+
+### Oracle integrity
+
+Per [AGENTS.md](../../../AGENTS.md#oracles-and-mutation-evidence):
+
+1. **The oracle does not share the code path under test.**
+   `neat-core/tests/decision_tree_fixture.rs` declares the reference trees as
+   plain `if x > t` Rust (`stump_reference`, `depth2_reference`,
+   `residual_reference`) that touch neither `compile_creature` nor
+   `CompiledNetwork::activate`. Each documented `*_CASES` constant is checked
+   against that reference too, so a wrong constant in the library is caught as
+   well as a wrong kernel.
+2. **No vacuous assertions.** Every expected value is the leaf the documented
+   tree produces, derived beside the assertion — no `is_finite()`, no bare
+   magic lengths.
+3. **The gate is tested directly.** The post-build validation inside
+   `graft_if_node` is unreachable while the pre-checks are complete (mutation
+   M6 below), so `validate_creature_topology` is exercised against synthetic
+   creatures instead — oracle rule 5.
+
+### Mutation sweep
+
+Each mutation was applied to one site, the two new suites run, then reverted;
+the working tree is clean of all of them.
+
+| # | Mutation | Result | First tests that went red |
+|---|----------|--------|---------------------------|
+| M1 | `network.rs` `activate`: IF `condition_sum > 0.0` → `>= 0.0` | **RED** | all four fixture/boundary tests |
+| M2 | `build_grafted`: emit `Standard` instead of `Condition` | **RED** | `gate_rejects_an_if_neuron_that_lost_a_role`, 5 more |
+| M3 | drop the `ForwardOrderViolation` check | **RED** | `rejects_a_graft_that_cannot_be_placed_forward_only` |
+| M4 | drop the duplicate-source-edge check | **RED** | `rejects_two_synapses_between_the_same_pair` |
+| M5 | pin placement to position `0` | **RED** | `grafted_node_is_placed_after_its_sources_and_before_its_targets` |
+| M6 | drop the result post-check | GREEN — see note | — |
+| M7 | `GRAFT_CONSTANT_BIAS` `1.0` → `2.0` | **RED** | `residual_fixture_matches_reference_on_every_documented_case` |
+| M8 | stump leaves swapped in `leaf_synapses` | **RED** | `stump_fixture_matches_reference_on_every_documented_case` |
+| M9 | skip base-creature validation | **RED** | `rejects_a_base_creature_that_is_already_malformed` |
+| M10 | drop the target-is-input check | **RED** | `rejects_a_synapse_that_targets_an_input` |
+| M11 | drop the missing-role checks | **RED** | `rejects_a_node_missing_any_if_role` |
+| M12 | drop the duplicate-UUID check | **RED** | `graft_if_correction_reproduces_the_canonical_residual_fixture`, 5 more |
+| M13 | drop the non-finite-weight check | **RED** | `rejects_non_finite_weights_and_biases` |
+| M14 | drop the target-is-constant check | **RED** | `rejects_a_synapse_that_targets_a_constant` |
+| M15 | flip the correction threshold sign | **RED** | `graft_if_correction_fires_only_above_the_threshold` |
+| M16 | depth-2 root leaves swapped | **RED** | `depth2_fixture_matches_reference_on_every_documented_case` |
+| M17 | `batch_scoring.rs` IF `>` → `>=` | **RED** | `batched_scoring_reproduces_the_documented_branch_outputs` |
+| M18 | `batch_scoring.rs` route `Negative` into `positive_sum` | **RED** | `batched_scoring_reproduces_the_documented_branch_outputs` |
+
+**M6 is a deliberate, documented gap.** The post-build
+`validate_creature_topology` call is defence in depth: no specification that
+survives the pre-checks can produce a malformed creature, so nothing reaches it.
+It is kept because it makes "never emit a malformed creature" hold even if a
+future pre-check is weakened, and the gate it calls is covered directly by the
+eight `gate_*` tests — M2 and M12 both turn those red, so those tests are not
+vacuous. This is recorded in `AGENTS.md` so a later reader does not delete the
+check as dead code.
+
+M17/M18 were GREEN on the first sweep — the batched aggregate path was not
+reached at all. `batched_scoring_reproduces_the_documented_branch_outputs` was
+added to close that gap: it packs 13 records (`8 + 4 + 1`, so the 8-record
+group, the 4-record remainder and the scalar tail all run) with the documented
+branch outputs as targets, and asserts the summed MSE is zero.
+
+## Test Plan
+
+**`neat-core/tests/decision_tree_fixture.rs`** (10 tests) — fixture semantics:
+
+- `stump_fixture_matches_reference_on_every_documented_case`,
+  `depth2_fixture_matches_reference_on_every_documented_case`,
+  `residual_fixture_matches_reference_on_every_documented_case` — every
+  documented case through `CreatureExport` → `compile_creature` → `activate`,
+  against the independent reference.
+- `stump_takes_the_zero_default_branch_at_and_below_the_threshold` — pins the
+  strict `>` at the split point and the zero/default branch.
+- `depth2_cases_cover_all_four_leaves` — the case table reaches every leaf.
+- `residual_fixture_adds_a_non_zero_correction_over_the_linear_base` — the
+  non-zero residual leaf, measured as the difference from the linear base.
+- `round_trip_preserves_every_synapse_role`,
+  `round_trip_preserves_branch_semantics` — export → JSON → parse → compile
+  keeps the compiled role histogram and the activations.
+- `stripping_synapse_roles_changes_the_branch_output` — the in-suite guard that
+  the role assertions are not vacuous.
+- `batched_scoring_reproduces_the_documented_branch_outputs` — 8-way, 4-way and
+  scalar-tail agreement (added to close the M17/M18 gap).
+
+**`neat-core/tests/if_graft.rs`** (29 tests) — the helper:
+
+- Happy path: branch added to the target, source creature untouched, placement
+  after sources and before targets, `IF` squash and all three roles present on
+  the compiled network, `graft_if_tree` ordering and all-or-nothing behaviour.
+- `graft_if_correction_reproduces_the_canonical_residual_fixture` — structural
+  equality against the hand-written fixture; the acceptance criterion that a
+  caller can graft a depth-1 correction without duplicating role logic.
+- Thirteen rejection tests, one per `GraftError` variant reachable through the
+  helper: duplicate UUID (node and constant), unknown source, unknown target,
+  target is an input, target is a constant, each missing `IF` role, no outward
+  edge, duplicate edge, self edge, non-finite weight/bias (node and constant),
+  forward-order violation, and an already-malformed base.
+- Eight `gate_*` tests driving `validate_creature_topology` directly with
+  synthetic creatures: every canonical fixture accepted; hidden-with-no-outward,
+  an `IF` node that lost a role, a synapse into an input, a duplicate
+  connection, a backward edge (rejected when `forwardOnly`, accepted when
+  recurrent), an unresolvable UUID, and a widthless creature all rejected with
+  the expected `topology_ops` code.
+
+**Docs:** `README.md` gains a "Canonical IF decision trees and the graft helper"
+section with the role rule, the fixture table and a Mermaid flow of the graft
+gate; `AGENTS.md` gains the matching "One IF decision-tree construction rule"
+entry so the single-home rule and the M6 rationale survive.

--- a/neat-core/src/decision_tree.rs
+++ b/neat-core/src/decision_tree.rs
@@ -1,0 +1,369 @@
+//! Canonical decision-tree creature fixtures built from the `IF` aggregate
+//! (Issue #555).
+//!
+//! These are the fleet's **authoritative** small decision trees: NEAT-AI-Forests
+//! and any other consumer reads its interpretation of `SquashType::If` and the
+//! `Condition` / `Negative` / `Positive` synapse roles from here rather than
+//! inventing its own.
+//!
+//! ## The rule the fixtures encode
+//!
+//! An `IF` neuron sums its `Condition` inputs. When that sum is **strictly**
+//! greater than zero it emits the sum of its `Positive` inputs, otherwise the
+//! sum of its `Negative` inputs; its bias is added either way. So the split test
+//! `x > t` is written as a condition sum of `x * 1.0 + 1.0 * (-t)`, with a
+//! constant neuron supplying the `1.0`.
+//!
+//! A creature may not carry two synapses between the same ordered pair of
+//! neurons, so one `IF` node cannot take all three roles from a single constant.
+//! Each fixture therefore declares three shared constants — `const-condition`,
+//! `const-positive` and `const-negative`, all `1.0` — and every threshold and
+//! leaf value lives in a **weight**, which is what training adjusts.
+//!
+//! ```mermaid
+//! flowchart LR
+//!     X["input-0"] -->|"condition w=1"| N(("IF node"))
+//!     C["const-condition = 1"] -->|"condition w=-t"| N
+//!     P["const-positive = 1"] -->|"positive w=leaf⁺"| N
+//!     G["const-negative = 1"] -->|"negative w=leaf⁻"| N
+//!     N -->|"sum(condition) &gt; 0 ? leaf⁺ : leaf⁻"| O["output"]
+//! ```
+//!
+//! ## Fixtures
+//!
+//! | Builder | Shape | Covers |
+//! | --- | --- | --- |
+//! | [`stump_creature`] | `x > 0.5 ? 3.0 : 0.0` | single split, zero default branch |
+//! | [`depth2_tree_creature`] | root on `x0 > 0.5`, both children on `x1 > 0.25` | nested depth-2, all four leaves |
+//! | [`linear_base_creature`] | `2x`, no `IF` at all | the pre-graft base |
+//! | [`residual_correction_creature`] | `2x + (x > 0.75 ? 1.5 : 0)` | non-zero residual leaf grafted onto the base |
+//!
+//! [`residual_correction_creature`] is exactly what
+//! [`crate::if_graft::graft_if_correction`] produces from
+//! [`linear_base_creature`], which is how the helper and the fixture keep each
+//! other honest.
+
+use crate::creature::{CreatureExport, NeuronExport, SynapseExport, squash_name_from};
+use crate::squash::SquashType;
+use crate::synapse_type::SynapseType;
+
+/// Split point of the [`stump_creature`] fixture.
+pub const STUMP_THRESHOLD: f64 = 0.5;
+/// Leaf value the stump emits above [`STUMP_THRESHOLD`].
+pub const STUMP_POSITIVE_VALUE: f64 = 3.0;
+/// Root split of the [`depth2_tree_creature`] fixture, on `input-0`.
+pub const DEPTH2_ROOT_THRESHOLD: f64 = 0.5;
+/// Child split of the [`depth2_tree_creature`] fixture, on `input-1`.
+pub const DEPTH2_SPLIT_THRESHOLD: f64 = 0.25;
+/// Weight of the linear term in [`linear_base_creature`].
+pub const RESIDUAL_BASE_WEIGHT: f64 = 2.0;
+/// Split point of the correction grafted in [`residual_correction_creature`].
+pub const RESIDUAL_THRESHOLD: f64 = 0.75;
+/// Non-zero residual the correction adds above [`RESIDUAL_THRESHOLD`].
+pub const RESIDUAL_VALUE: f64 = 1.5;
+
+/// UUID of the shared constant feeding every condition offset.
+pub const CONST_CONDITION: &str = "const-condition";
+/// UUID of the shared constant feeding every positive leaf.
+pub const CONST_POSITIVE: &str = "const-positive";
+/// UUID of the shared constant feeding every negative leaf.
+pub const CONST_NEGATIVE: &str = "const-negative";
+
+/// One documented record and the output the fixture must produce for it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DecisionCase {
+    /// Input record, in `input-0`, `input-1`, … order.
+    pub inputs: &'static [f32],
+    /// The single output value the fixture is documented to produce.
+    pub expected: f32,
+    /// Which branch of the tree the record exercises.
+    pub branch: &'static str,
+}
+
+/// Documented outputs of [`stump_creature`].
+///
+/// `x > 0.5` selects the positive leaf `3.0`; everything at or below the split
+/// — the strict `>` includes the threshold itself — takes the zero-valued
+/// default branch.
+pub const STUMP_CASES: &[DecisionCase] = &[
+    DecisionCase {
+        inputs: &[0.75],
+        expected: 3.0,
+        branch: "positive",
+    },
+    DecisionCase {
+        inputs: &[0.25],
+        expected: 0.0,
+        branch: "negative",
+    },
+    DecisionCase {
+        inputs: &[0.5],
+        expected: 0.0,
+        branch: "negative (boundary)",
+    },
+];
+
+/// Documented outputs of [`depth2_tree_creature`].
+///
+/// Root `x0 > 0.5` picks the `high` subtree, otherwise `low`; each child then
+/// splits on `x1 > 0.25`. Leaves are `high/positive = 4.0`,
+/// `high/negative = 0.0` (the zero default), `low/positive = 1.0` and
+/// `low/negative = -2.0` (the non-zero residual leaf).
+pub const DEPTH2_CASES: &[DecisionCase] = &[
+    DecisionCase {
+        inputs: &[0.9, 0.9],
+        expected: 4.0,
+        branch: "high/positive",
+    },
+    DecisionCase {
+        inputs: &[0.9, 0.1],
+        expected: 0.0,
+        branch: "high/negative",
+    },
+    DecisionCase {
+        inputs: &[0.1, 0.9],
+        expected: 1.0,
+        branch: "low/positive",
+    },
+    DecisionCase {
+        inputs: &[0.1, 0.1],
+        expected: -2.0,
+        branch: "low/negative",
+    },
+    DecisionCase {
+        inputs: &[0.5, 0.25],
+        expected: -2.0,
+        branch: "low/negative",
+    },
+];
+
+/// Documented outputs of [`residual_correction_creature`]: `2x`, plus `1.5`
+/// once `x > 0.75`.
+pub const RESIDUAL_CASES: &[DecisionCase] = &[
+    DecisionCase {
+        inputs: &[1.0],
+        expected: 3.5,
+        branch: "corrected",
+    },
+    DecisionCase {
+        inputs: &[0.75],
+        expected: 1.5,
+        branch: "uncorrected (boundary)",
+    },
+    DecisionCase {
+        inputs: &[0.25],
+        expected: 0.5,
+        branch: "uncorrected",
+    },
+    DecisionCase {
+        inputs: &[0.0],
+        expected: 0.0,
+        branch: "uncorrected",
+    },
+];
+
+fn constant_neuron(uuid: &str) -> NeuronExport {
+    NeuronExport {
+        neuron_type: "constant".to_string(),
+        uuid: uuid.to_string(),
+        bias: 1.0,
+        squash: None,
+    }
+}
+
+fn if_neuron(uuid: &str, neuron_type: &str) -> NeuronExport {
+    NeuronExport {
+        neuron_type: neuron_type.to_string(),
+        uuid: uuid.to_string(),
+        bias: 0.0,
+        squash: Some(squash_name_from(SquashType::If).to_string()),
+    }
+}
+
+fn edge(from: &str, to: &str, weight: f64, role: SynapseType) -> SynapseExport {
+    SynapseExport {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: crate::creature::synapse_type_name_from(role).map(str::to_string),
+    }
+}
+
+/// The three shared `1.0` constants every fixture tree stands on.
+fn shared_constants() -> Vec<NeuronExport> {
+    vec![
+        constant_neuron(CONST_CONDITION),
+        constant_neuron(CONST_POSITIVE),
+        constant_neuron(CONST_NEGATIVE),
+    ]
+}
+
+/// Emit the four synapses of one leaf `IF` node: `feature > threshold ?
+/// positive_value : negative_value`.
+fn leaf_synapses(
+    node: &str,
+    feature: &str,
+    threshold: f64,
+    positive_value: f64,
+    negative_value: f64,
+) -> Vec<SynapseExport> {
+    vec![
+        edge(feature, node, 1.0, SynapseType::Condition),
+        edge(CONST_CONDITION, node, -threshold, SynapseType::Condition),
+        edge(CONST_POSITIVE, node, positive_value, SynapseType::Positive),
+        edge(CONST_NEGATIVE, node, negative_value, SynapseType::Negative),
+    ]
+}
+
+/// Single-split decision stump: `input-0 > 0.5 ? 3.0 : 0.0`.
+///
+/// The negative leaf weight is `0.0`, so the default branch is the documented
+/// zero output. Expected outputs are in [`STUMP_CASES`].
+pub fn stump_creature() -> CreatureExport {
+    let mut neurons = shared_constants();
+    neurons.push(if_neuron("output-0", "output"));
+
+    CreatureExport {
+        input: 1,
+        output: 1,
+        neurons,
+        synapses: leaf_synapses(
+            "output-0",
+            "input-0",
+            STUMP_THRESHOLD,
+            STUMP_POSITIVE_VALUE,
+            0.0,
+        ),
+        semantic_version: None,
+        forward_only: true,
+    }
+}
+
+/// Depth-2 binary decision tree over two observations.
+///
+/// The root splits on `input-0 > 0.5` and routes to one of two child `IF`
+/// nodes, each splitting on `input-1 > 0.25`. Leaves cover both a zero default
+/// (`high/negative`) and a non-zero negative residual (`low/negative = -2.0`).
+/// Expected outputs are in [`DEPTH2_CASES`].
+pub fn depth2_tree_creature() -> CreatureExport {
+    let mut neurons = shared_constants();
+    neurons.push(if_neuron("low", "hidden"));
+    neurons.push(if_neuron("high", "hidden"));
+    neurons.push(if_neuron("output-0", "output"));
+
+    let mut synapses = leaf_synapses("low", "input-1", DEPTH2_SPLIT_THRESHOLD, 1.0, -2.0);
+    synapses.extend(leaf_synapses(
+        "high",
+        "input-1",
+        DEPTH2_SPLIT_THRESHOLD,
+        4.0,
+        0.0,
+    ));
+    // The root's leaves are the two child nodes rather than constants.
+    synapses.push(edge("input-0", "output-0", 1.0, SynapseType::Condition));
+    synapses.push(edge(
+        CONST_CONDITION,
+        "output-0",
+        -DEPTH2_ROOT_THRESHOLD,
+        SynapseType::Condition,
+    ));
+    synapses.push(edge("high", "output-0", 1.0, SynapseType::Positive));
+    synapses.push(edge("low", "output-0", 1.0, SynapseType::Negative));
+
+    CreatureExport {
+        input: 2,
+        output: 1,
+        neurons,
+        synapses,
+        semantic_version: None,
+        forward_only: true,
+    }
+}
+
+/// Purely linear creature — `output-0 = 2 * input-0`, no `IF` node at all.
+///
+/// The base that [`residual_correction_creature`] grafts a correction onto.
+pub fn linear_base_creature() -> CreatureExport {
+    CreatureExport {
+        input: 1,
+        output: 1,
+        neurons: vec![NeuronExport {
+            neuron_type: "output".to_string(),
+            uuid: "output-0".to_string(),
+            bias: 0.0,
+            squash: Some("IDENTITY".to_string()),
+        }],
+        synapses: vec![SynapseExport {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: RESIDUAL_BASE_WEIGHT,
+            synapse_type: None,
+        }],
+        semantic_version: None,
+        forward_only: true,
+    }
+}
+
+/// [`linear_base_creature`] with a depth-1 `IF` correction of `+1.5` above
+/// `input-0 > 0.75`.
+///
+/// Written out longhand so it can serve as the expected value for
+/// [`crate::if_graft::graft_if_correction`] — the helper must reproduce this
+/// creature exactly, which is what stops either drifting from the other.
+/// Expected outputs are in [`RESIDUAL_CASES`].
+pub fn residual_correction_creature() -> CreatureExport {
+    let node = "residual-0";
+    let condition_one = format!("{node}-condition-one");
+    let positive_one = format!("{node}-positive-one");
+    let negative_one = format!("{node}-negative-one");
+
+    let mut neurons: Vec<NeuronExport> = [&condition_one, &positive_one, &negative_one]
+        .iter()
+        .map(|uuid| NeuronExport {
+            neuron_type: "constant".to_string(),
+            uuid: (*uuid).clone(),
+            bias: crate::if_graft::GRAFT_CONSTANT_BIAS,
+            squash: None,
+        })
+        .collect();
+    neurons.push(if_neuron(node, "hidden"));
+    neurons.push(NeuronExport {
+        neuron_type: "output".to_string(),
+        uuid: "output-0".to_string(),
+        bias: 0.0,
+        squash: Some("IDENTITY".to_string()),
+    });
+
+    let synapses = vec![
+        SynapseExport {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: RESIDUAL_BASE_WEIGHT,
+            synapse_type: None,
+        },
+        edge("input-0", node, 1.0, SynapseType::Condition),
+        edge(
+            &condition_one,
+            node,
+            -RESIDUAL_THRESHOLD,
+            SynapseType::Condition,
+        ),
+        edge(&positive_one, node, RESIDUAL_VALUE, SynapseType::Positive),
+        edge(&negative_one, node, 0.0, SynapseType::Negative),
+        SynapseExport {
+            from_uuid: node.to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        },
+    ];
+
+    CreatureExport {
+        input: 1,
+        output: 1,
+        neurons,
+        synapses,
+        semantic_version: None,
+        forward_only: true,
+    }
+}

--- a/neat-core/src/if_graft.rs
+++ b/neat-core/src/if_graft.rs
@@ -379,7 +379,7 @@ impl From<CreatureError> for GraftError {
 ///
 /// Mirrors [`crate::creature::compile_creature`] exactly: inputs take
 /// `0..input` under their `input-N` names, then the listed neurons follow in
-/// order (a listed neuron re-using an `input-N` name wins, as it does there).
+/// order (a listed neuron reusing an `input-N` name wins, as it does there).
 fn index_map(creature: &CreatureExport) -> HashMap<String, usize> {
     let mut map = HashMap::with_capacity(creature.input + creature.neurons.len());
     for i in 0..creature.input {

--- a/neat-core/src/if_graft.rs
+++ b/neat-core/src/if_graft.rs
@@ -1,0 +1,721 @@
+//! Safe construction and grafting of `IF` decision nodes onto a
+//! [`CreatureExport`] (Issue #555).
+//!
+//! A decision-tree node in this fleet is a neuron with [`SquashType::If`] whose
+//! inbound synapses carry the three [`SynapseType`] roles: `Condition` inputs
+//! are summed, and the neuron emits the `Positive` sum when that condition sum
+//! is **strictly** greater than zero, otherwise the `Negative` sum (plus its own
+//! bias in either case). Hand-editing neuron/synapse JSON to build one is
+//! error-prone: a missing role silently turns the node into a constant, and a
+//! source placed after the node reads a stale activation.
+//!
+//! This module is the single home of that construction rule. Callers describe
+//! *what* they want ([`IfNodeSpec`], or [`IfCorrectionSpec`] for the common
+//! depth-1 correction) and the helper resolves placement, emits the role
+//! strings, and refuses anything malformed with a typed [`GraftError`]. The
+//! source creature is never mutated — a graft either returns a new, validated
+//! [`CreatureExport`] or it returns an error.
+//!
+//! ```mermaid
+//! flowchart LR
+//!     A["IfNodeSpec"] --> B{"names new?<br/>roles present?<br/>edges resolve?"}
+//!     B -- no --> E["Err(GraftError)"]
+//!     B -- yes --> C{"placement:<br/>after every source,<br/>before every target"}
+//!     C -- impossible --> E
+//!     C -- ok --> D["build creature"]
+//!     D --> F{"validate_topology +<br/>validate_structural_integrity"}
+//!     F -- fails --> E
+//!     F -- passes --> G["Ok(CreatureExport)"]
+//! ```
+//!
+//! ## Why a grafted node brings its own constant neurons
+//!
+//! An `IF` condition of the form `x > threshold` needs a constant `1.0` source
+//! to carry `-threshold`, and each leaf value needs one too. A creature may not
+//! hold two synapses between the same ordered pair of neurons, so the three
+//! roles cannot share one constant: [`IfCorrectionSpec`] therefore introduces
+//! three (`<uuid>-condition-one`, `<uuid>-positive-one`, `<uuid>-negative-one`),
+//! each with bias [`GRAFT_CONSTANT_BIAS`], leaving the thresholds and leaf
+//! values in the trainable **weights**.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::creature::{
+    CreatureError, CreatureExport, NeuronExport, SynapseExport, parse_squash_name,
+    parse_synapse_type, squash_name_from, synapse_type_name_from, validate_creature_width,
+};
+use crate::squash::SquashType;
+use crate::synapse_type::SynapseType;
+use crate::topology_ops::{
+    STRUCTURAL_VALID, VALID, validate_structural_integrity, validate_topology,
+};
+
+/// Bias of every constant neuron a graft introduces.
+///
+/// Kept at `1.0` so the threshold offset and the leaf values live in the
+/// synapse **weights**, which are what training adjusts.
+pub const GRAFT_CONSTANT_BIAS: f64 = 1.0;
+
+/// One weighted edge of a grafted node.
+///
+/// `uuid` names the **source** neuron for a branch edge
+/// ([`IfNodeSpec::with_condition`] / [`with_positive`](IfNodeSpec::with_positive)
+/// / [`with_negative`](IfNodeSpec::with_negative)) and the **destination**
+/// neuron for an outward edge ([`IfNodeSpec::with_target`]).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraftEdge {
+    /// UUID of the neuron at the other end of the edge.
+    pub uuid: String,
+    /// Connection weight.
+    pub weight: f64,
+}
+
+impl GraftEdge {
+    /// Build an edge from a UUID and a weight.
+    pub fn new(uuid: impl Into<String>, weight: f64) -> Self {
+        Self {
+            uuid: uuid.into(),
+            weight,
+        }
+    }
+}
+
+/// A constant neuron introduced alongside a grafted node.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConstantSpec {
+    /// UUID for the new constant neuron; must not already exist.
+    pub uuid: String,
+    /// The constant's value — a constant neuron activates to its own bias.
+    pub bias: f64,
+}
+
+impl ConstantSpec {
+    /// Build a constant specification from a UUID and a value.
+    pub fn new(uuid: impl Into<String>, bias: f64) -> Self {
+        Self {
+            uuid: uuid.into(),
+            bias,
+        }
+    }
+}
+
+/// Description of one `IF` node to graft onto a creature.
+///
+/// The grafted neuron is always **hidden**: grafting an output would change the
+/// declared output width and move the output block, which the fleet's
+/// structural gate requires to stay last.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfNodeSpec {
+    /// UUID for the new node; must not already exist in the creature.
+    pub uuid: String,
+    /// Bias added to whichever branch the condition selects.
+    pub bias: f64,
+    /// Constant neurons introduced by this graft, placed immediately before the
+    /// node so its own edges may reference them.
+    pub constants: Vec<ConstantSpec>,
+    /// Inbound edges summed to decide the branch (`> 0` selects positive).
+    pub condition: Vec<GraftEdge>,
+    /// Inbound edges summed when the condition sum is strictly positive.
+    pub positive: Vec<GraftEdge>,
+    /// Inbound edges summed when the condition sum is zero or negative.
+    pub negative: Vec<GraftEdge>,
+    /// Outward edges from the new node to existing non-input, non-constant
+    /// neurons.
+    pub targets: Vec<GraftEdge>,
+}
+
+impl IfNodeSpec {
+    /// Start a specification for a node with the given UUID and bias.
+    pub fn new(uuid: impl Into<String>, bias: f64) -> Self {
+        Self {
+            uuid: uuid.into(),
+            bias,
+            constants: Vec::new(),
+            condition: Vec::new(),
+            positive: Vec::new(),
+            negative: Vec::new(),
+            targets: Vec::new(),
+        }
+    }
+
+    /// Introduce a constant neuron alongside the node.
+    #[must_use]
+    pub fn with_constant(mut self, uuid: impl Into<String>, bias: f64) -> Self {
+        self.constants.push(ConstantSpec::new(uuid, bias));
+        self
+    }
+
+    /// Add a condition edge.
+    #[must_use]
+    pub fn with_condition(mut self, uuid: impl Into<String>, weight: f64) -> Self {
+        self.condition.push(GraftEdge::new(uuid, weight));
+        self
+    }
+
+    /// Add a positive-branch edge.
+    #[must_use]
+    pub fn with_positive(mut self, uuid: impl Into<String>, weight: f64) -> Self {
+        self.positive.push(GraftEdge::new(uuid, weight));
+        self
+    }
+
+    /// Add a negative-branch edge.
+    #[must_use]
+    pub fn with_negative(mut self, uuid: impl Into<String>, weight: f64) -> Self {
+        self.negative.push(GraftEdge::new(uuid, weight));
+        self
+    }
+
+    /// Add an outward edge from the node to an existing neuron.
+    #[must_use]
+    pub fn with_target(mut self, uuid: impl Into<String>, weight: f64) -> Self {
+        self.targets.push(GraftEdge::new(uuid, weight));
+        self
+    }
+}
+
+/// The common depth-1 case: `feature > threshold ? positive : negative`, added
+/// into one existing neuron.
+///
+/// Expands into a full [`IfNodeSpec`] via [`IfCorrectionSpec::to_node_spec`], so
+/// a caller adding a residual correction never restates the synapse-role rule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfCorrectionSpec {
+    /// UUID for the new `IF` node; also the prefix of its three constants.
+    pub uuid: String,
+    /// UUID of the neuron whose activation is compared against `threshold`.
+    pub feature_uuid: String,
+    /// Split point — the node fires the positive leaf when the feature is
+    /// **strictly** greater than this.
+    pub threshold: f64,
+    /// Leaf value emitted above the threshold.
+    pub positive_value: f64,
+    /// Leaf value emitted at or below the threshold (often `0.0`).
+    pub negative_value: f64,
+    /// UUID of the neuron the correction is added into.
+    pub target_uuid: String,
+    /// Weight of the edge into `target_uuid`.
+    pub target_weight: f64,
+}
+
+impl IfCorrectionSpec {
+    /// Expand into the equivalent low-level [`IfNodeSpec`].
+    pub fn to_node_spec(&self) -> IfNodeSpec {
+        let condition_one = format!("{}-condition-one", self.uuid);
+        let positive_one = format!("{}-positive-one", self.uuid);
+        let negative_one = format!("{}-negative-one", self.uuid);
+        IfNodeSpec::new(self.uuid.clone(), 0.0)
+            .with_constant(condition_one.clone(), GRAFT_CONSTANT_BIAS)
+            .with_constant(positive_one.clone(), GRAFT_CONSTANT_BIAS)
+            .with_constant(negative_one.clone(), GRAFT_CONSTANT_BIAS)
+            .with_condition(self.feature_uuid.clone(), 1.0)
+            .with_condition(condition_one, -self.threshold)
+            .with_positive(positive_one, self.positive_value)
+            .with_negative(negative_one, self.negative_value)
+            .with_target(self.target_uuid.clone(), self.target_weight)
+    }
+}
+
+/// Reasons a graft was refused, or a creature failed the shared gates.
+///
+/// Every variant means **no creature was produced** — the helper fails closed.
+#[derive(Debug)]
+pub enum GraftError {
+    /// The creature failed a [`crate::creature`] rule, e.g. the observation
+    /// width contract or an unknown squash name.
+    Creature(CreatureError),
+    /// A UUID the graft introduces is already taken, or repeated within the
+    /// same specification.
+    DuplicateUuid(String),
+    /// A branch edge named a source neuron that does not exist.
+    UnknownSourceUuid(String),
+    /// An outward edge named a destination neuron that does not exist.
+    UnknownTargetUuid(String),
+    /// An outward edge targeted an input neuron — inputs take no synapses.
+    TargetIsInput(String),
+    /// An outward edge targeted a constant neuron — constants take no inbound
+    /// connections.
+    TargetIsConstant(String),
+    /// An edge named the grafted node itself.
+    SelfEdge(String),
+    /// No `condition` edge was supplied, so the node could never branch.
+    MissingConditionSynapse,
+    /// No `positive` edge was supplied.
+    MissingPositiveSynapse,
+    /// No `negative` edge was supplied.
+    MissingNegativeSynapse,
+    /// No outward edge was supplied, so the node could not influence anything.
+    NoTargets,
+    /// Two synapses would connect the same ordered pair of neurons.
+    DuplicateEdge {
+        /// Source neuron UUID.
+        from: String,
+        /// Destination neuron UUID.
+        to: String,
+    },
+    /// A weight was `NaN` or infinite.
+    NonFiniteWeight {
+        /// Source neuron UUID.
+        from: String,
+        /// Destination neuron UUID.
+        to: String,
+        /// The offending weight.
+        weight: f64,
+    },
+    /// A bias was `NaN` or infinite.
+    NonFiniteBias {
+        /// UUID of the neuron carrying the offending bias.
+        uuid: String,
+    },
+    /// No position exists that puts the node after every source and before
+    /// every target, so at least one edge would read a stale activation.
+    ForwardOrderViolation {
+        /// The source that forced the latest possible position.
+        source: String,
+        /// The target that forced the earliest possible position.
+        target: String,
+    },
+    /// The creature failed [`validate_topology`]; `code` is one of the
+    /// `topology_ops` topology codes.
+    ///
+    /// The creature synapse list carries no ordering contract (compilation
+    /// groups by destination), so pairs are sorted before the gate runs and
+    /// `index` refers to that sorted order.
+    MalformedTopology {
+        /// `topology_ops` error code.
+        code: i32,
+        /// Index of the offending synapse in sorted order.
+        index: i32,
+    },
+    /// The creature failed [`validate_structural_integrity`]; `code` is one of
+    /// the `topology_ops` `STRUCTURAL_*` codes and `index` the neuron index.
+    MalformedStructure {
+        /// `topology_ops` structural error code.
+        code: i32,
+        /// Index of the offending neuron.
+        index: i32,
+    },
+    /// The graft itself was well formed but the resulting creature failed a
+    /// shared gate — reported instead of returning the malformed creature.
+    MalformedResult {
+        /// `topology_ops` error code.
+        code: i32,
+        /// Index of the offending synapse or neuron.
+        index: i32,
+        /// `true` when the failure came from the structural gate.
+        structural: bool,
+    },
+}
+
+impl std::fmt::Display for GraftError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GraftError::Creature(e) => write!(f, "Creature error: {e}"),
+            GraftError::DuplicateUuid(u) => write!(f, "UUID already in use: {u}"),
+            GraftError::UnknownSourceUuid(u) => write!(f, "Unknown source neuron UUID: {u}"),
+            GraftError::UnknownTargetUuid(u) => write!(f, "Unknown target neuron UUID: {u}"),
+            GraftError::TargetIsInput(u) => write!(f, "Synapse targets an input neuron: {u}"),
+            GraftError::TargetIsConstant(u) => write!(f, "Synapse targets a constant neuron: {u}"),
+            GraftError::SelfEdge(u) => write!(f, "Synapse connects {u} to itself"),
+            GraftError::MissingConditionSynapse => {
+                write!(f, "IF node has no condition synapse")
+            }
+            GraftError::MissingPositiveSynapse => write!(f, "IF node has no positive synapse"),
+            GraftError::MissingNegativeSynapse => write!(f, "IF node has no negative synapse"),
+            GraftError::NoTargets => write!(f, "Grafted node has no outward connection"),
+            GraftError::DuplicateEdge { from, to } => {
+                write!(f, "Duplicate synapse from {from} to {to}")
+            }
+            GraftError::NonFiniteWeight { from, to, weight } => {
+                write!(f, "Non-finite weight {weight} from {from} to {to}")
+            }
+            GraftError::NonFiniteBias { uuid } => write!(f, "Non-finite bias on neuron {uuid}"),
+            GraftError::ForwardOrderViolation { source, target } => write!(
+                f,
+                "No forward-only position: source {source} is evaluated after target {target}"
+            ),
+            GraftError::MalformedTopology { code, index } => {
+                write!(f, "Topology validation failed (code {code}, index {index})")
+            }
+            GraftError::MalformedStructure { code, index } => write!(
+                f,
+                "Structural validation failed (code {code}, index {index})"
+            ),
+            GraftError::MalformedResult {
+                code,
+                index,
+                structural,
+            } => {
+                let gate = if *structural {
+                    "structural"
+                } else {
+                    "topology"
+                };
+                write!(
+                    f,
+                    "Grafted creature failed {gate} validation (code {code}, index {index})"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for GraftError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            GraftError::Creature(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<CreatureError> for GraftError {
+    fn from(e: CreatureError) -> Self {
+        GraftError::Creature(e)
+    }
+}
+
+/// Map every neuron UUID to the index compilation will give it.
+///
+/// Mirrors [`crate::creature::compile_creature`] exactly: inputs take
+/// `0..input` under their `input-N` names, then the listed neurons follow in
+/// order (a listed neuron re-using an `input-N` name wins, as it does there).
+fn index_map(creature: &CreatureExport) -> HashMap<String, usize> {
+    let mut map = HashMap::with_capacity(creature.input + creature.neurons.len());
+    for i in 0..creature.input {
+        map.insert(format!("input-{i}"), i);
+    }
+    for (j, neuron) in creature.neurons.iter().enumerate() {
+        map.insert(neuron.uuid.clone(), creature.input + j);
+    }
+    map
+}
+
+/// Run the fleet's shared width, topology and structural gates over a creature.
+///
+/// Reuses [`validate_creature_width`], [`validate_topology`] and
+/// [`validate_structural_integrity`] rather than restating their rules, so a
+/// creature that passes here is one the compiler and the WASM consumers accept.
+///
+/// The ordering gate only runs for `forwardOnly` creatures: a recurrent creature
+/// legitimately carries backward edges, which that gate rejects by design.
+pub fn validate_creature_topology(creature: &CreatureExport) -> Result<(), GraftError> {
+    validate_creature_width(creature)?;
+
+    let map = index_map(creature);
+    let num_neurons = creature.input + creature.neurons.len();
+
+    let mut biases = vec![0.0f64; num_neurons];
+    let mut is_constant = vec![0u8; num_neurons];
+    let mut squash_types = vec![SquashType::Identity as u8; num_neurons];
+    for (j, neuron) in creature.neurons.iter().enumerate() {
+        let idx = creature.input + j;
+        biases[idx] = neuron.bias;
+        is_constant[idx] = u8::from(neuron.neuron_type == "constant");
+        squash_types[idx] =
+            parse_squash_name(neuron.squash.as_deref().unwrap_or("IDENTITY"))? as u8;
+    }
+
+    let mut edges: Vec<(u32, u32, u8)> = Vec::with_capacity(creature.synapses.len());
+    for synapse in &creature.synapses {
+        let from = *map
+            .get(&synapse.from_uuid)
+            .ok_or_else(|| GraftError::UnknownSourceUuid(synapse.from_uuid.clone()))?;
+        let to = *map
+            .get(&synapse.to_uuid)
+            .ok_or_else(|| GraftError::UnknownTargetUuid(synapse.to_uuid.clone()))?;
+        edges.push((
+            from as u32,
+            to as u32,
+            parse_synapse_type(synapse.synapse_type.as_deref()) as u8,
+        ));
+    }
+    edges.sort_unstable();
+
+    let from_indices: Vec<u32> = edges.iter().map(|e| e.0).collect();
+    let to_indices: Vec<u32> = edges.iter().map(|e| e.1).collect();
+    let synapse_types: Vec<u8> = edges.iter().map(|e| e.2).collect();
+
+    if creature.forward_only {
+        let codes = validate_topology(&from_indices, &to_indices);
+        if codes[0] != VALID {
+            return Err(GraftError::MalformedTopology {
+                code: codes[0],
+                index: codes[1],
+            });
+        }
+    }
+
+    let codes = validate_structural_integrity(
+        &from_indices,
+        &to_indices,
+        &is_constant,
+        &squash_types,
+        &biases,
+        creature.input as u32,
+        creature.output as u32,
+        &synapse_types,
+    );
+    if codes[0] != STRUCTURAL_VALID {
+        return Err(GraftError::MalformedStructure {
+            code: codes[0],
+            index: codes[1],
+        });
+    }
+
+    Ok(())
+}
+
+/// Graft one `IF` node (and any constants it declares) onto a creature.
+///
+/// Returns a **new** creature; the input is never modified. Placement is chosen
+/// so the node is evaluated after every source and before every target, which
+/// preserves the `forwardOnly` reading order the compiled forward pass relies
+/// on. The result is put through [`validate_creature_topology`] before it is
+/// returned, so a malformed creature is never emitted.
+///
+/// # Errors
+///
+/// Returns a [`GraftError`] when the base creature is already malformed, when
+/// the specification names an unknown or duplicate neuron, when any `IF` role
+/// is missing, when a weight or bias is not finite, or when no position exists
+/// that keeps every edge pointing forwards.
+pub fn graft_if_node(
+    creature: &CreatureExport,
+    spec: &IfNodeSpec,
+) -> Result<CreatureExport, GraftError> {
+    validate_creature_topology(creature)?;
+    let map = index_map(creature);
+
+    // Names this graft introduces must be new, and unique among themselves.
+    let mut introduced: HashSet<&str> = HashSet::with_capacity(spec.constants.len() + 1);
+    let new_names =
+        std::iter::once(spec.uuid.as_str()).chain(spec.constants.iter().map(|c| c.uuid.as_str()));
+    for uuid in new_names {
+        if map.contains_key(uuid) || !introduced.insert(uuid) {
+            return Err(GraftError::DuplicateUuid(uuid.to_string()));
+        }
+    }
+
+    if !spec.bias.is_finite() {
+        return Err(GraftError::NonFiniteBias {
+            uuid: spec.uuid.clone(),
+        });
+    }
+    for constant in &spec.constants {
+        if !constant.bias.is_finite() {
+            return Err(GraftError::NonFiniteBias {
+                uuid: constant.uuid.clone(),
+            });
+        }
+    }
+
+    if spec.condition.is_empty() {
+        return Err(GraftError::MissingConditionSynapse);
+    }
+    if spec.positive.is_empty() {
+        return Err(GraftError::MissingPositiveSynapse);
+    }
+    if spec.negative.is_empty() {
+        return Err(GraftError::MissingNegativeSynapse);
+    }
+    if spec.targets.is_empty() {
+        return Err(GraftError::NoTargets);
+    }
+
+    // Earliest position that still leaves every source before the new node.
+    let mut earliest = 0usize;
+    let mut latest_source: Option<&str> = None;
+    let mut seen_sources: HashSet<&str> = HashSet::new();
+    for edges in [&spec.condition, &spec.positive, &spec.negative] {
+        for edge in edges {
+            if edge.uuid == spec.uuid {
+                return Err(GraftError::SelfEdge(spec.uuid.clone()));
+            }
+            if !edge.weight.is_finite() {
+                return Err(GraftError::NonFiniteWeight {
+                    from: edge.uuid.clone(),
+                    to: spec.uuid.clone(),
+                    weight: edge.weight,
+                });
+            }
+            if !seen_sources.insert(edge.uuid.as_str()) {
+                return Err(GraftError::DuplicateEdge {
+                    from: edge.uuid.clone(),
+                    to: spec.uuid.clone(),
+                });
+            }
+            if introduced.contains(edge.uuid.as_str()) {
+                // A constant this graft introduces is placed before the node.
+                continue;
+            }
+            let index = *map
+                .get(edge.uuid.as_str())
+                .ok_or_else(|| GraftError::UnknownSourceUuid(edge.uuid.clone()))?;
+            if index >= creature.input && index - creature.input + 1 > earliest {
+                earliest = index - creature.input + 1;
+                latest_source = Some(edge.uuid.as_str());
+            }
+        }
+    }
+
+    // Latest position that still leaves every target after the new node.
+    let mut latest = creature.neurons.len();
+    let mut earliest_target: Option<&str> = None;
+    let mut seen_targets: HashSet<&str> = HashSet::new();
+    for edge in &spec.targets {
+        if edge.uuid == spec.uuid {
+            return Err(GraftError::SelfEdge(spec.uuid.clone()));
+        }
+        if !edge.weight.is_finite() {
+            return Err(GraftError::NonFiniteWeight {
+                from: spec.uuid.clone(),
+                to: edge.uuid.clone(),
+                weight: edge.weight,
+            });
+        }
+        if !seen_targets.insert(edge.uuid.as_str()) {
+            return Err(GraftError::DuplicateEdge {
+                from: spec.uuid.clone(),
+                to: edge.uuid.clone(),
+            });
+        }
+        if introduced.contains(edge.uuid.as_str()) {
+            return Err(GraftError::TargetIsConstant(edge.uuid.clone()));
+        }
+        let index = *map
+            .get(edge.uuid.as_str())
+            .ok_or_else(|| GraftError::UnknownTargetUuid(edge.uuid.clone()))?;
+        if index < creature.input {
+            return Err(GraftError::TargetIsInput(edge.uuid.clone()));
+        }
+        let position = index - creature.input;
+        if creature.neurons[position].neuron_type == "constant" {
+            return Err(GraftError::TargetIsConstant(edge.uuid.clone()));
+        }
+        if position < latest {
+            latest = position;
+            earliest_target = Some(edge.uuid.as_str());
+        }
+    }
+
+    if earliest > latest {
+        return Err(GraftError::ForwardOrderViolation {
+            source: latest_source.unwrap_or_default().to_string(),
+            target: earliest_target.unwrap_or_default().to_string(),
+        });
+    }
+
+    let grafted = build_grafted(creature, spec, earliest);
+    match validate_creature_topology(&grafted) {
+        Ok(()) => Ok(grafted),
+        Err(GraftError::MalformedTopology { code, index }) => Err(GraftError::MalformedResult {
+            code,
+            index,
+            structural: false,
+        }),
+        Err(GraftError::MalformedStructure { code, index }) => Err(GraftError::MalformedResult {
+            code,
+            index,
+            structural: true,
+        }),
+        Err(other) => Err(other),
+    }
+}
+
+/// Assemble the grafted creature: constants then the node at `position`, with
+/// the branch synapses (condition, positive, negative) and outward edges
+/// appended in that order.
+fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) -> CreatureExport {
+    let mut neurons = Vec::with_capacity(creature.neurons.len() + spec.constants.len() + 1);
+    neurons.extend_from_slice(&creature.neurons[..position]);
+    for constant in &spec.constants {
+        neurons.push(NeuronExport {
+            neuron_type: "constant".to_string(),
+            uuid: constant.uuid.clone(),
+            bias: constant.bias,
+            squash: None,
+        });
+    }
+    neurons.push(NeuronExport {
+        neuron_type: "hidden".to_string(),
+        uuid: spec.uuid.clone(),
+        bias: spec.bias,
+        squash: Some(squash_name_from(SquashType::If).to_string()),
+    });
+    neurons.extend_from_slice(&creature.neurons[position..]);
+
+    let mut synapses = creature.synapses.clone();
+    synapses.reserve(
+        spec.condition.len() + spec.positive.len() + spec.negative.len() + spec.targets.len(),
+    );
+    for (role, edges) in [
+        (SynapseType::Condition, &spec.condition),
+        (SynapseType::Positive, &spec.positive),
+        (SynapseType::Negative, &spec.negative),
+    ] {
+        for edge in edges {
+            synapses.push(SynapseExport {
+                from_uuid: edge.uuid.clone(),
+                to_uuid: spec.uuid.clone(),
+                weight: edge.weight,
+                synapse_type: synapse_type_name_from(role).map(str::to_string),
+            });
+        }
+    }
+    for edge in &spec.targets {
+        synapses.push(SynapseExport {
+            from_uuid: spec.uuid.clone(),
+            to_uuid: edge.uuid.clone(),
+            weight: edge.weight,
+            synapse_type: None,
+        });
+    }
+
+    CreatureExport {
+        input: creature.input,
+        output: creature.output,
+        neurons,
+        synapses,
+        semantic_version: creature.semantic_version.clone(),
+        forward_only: creature.forward_only,
+    }
+}
+
+/// Graft a sequence of `IF` nodes, each able to reference the ones before it.
+///
+/// All or nothing: the first failure returns its [`GraftError`] and no partial
+/// creature escapes, because each step builds on the previous step's result and
+/// only the final creature is returned.
+///
+/// # Errors
+///
+/// Returns the first [`GraftError`] any node produces, or the base creature's
+/// own validation error when `specs` is empty.
+pub fn graft_if_tree(
+    creature: &CreatureExport,
+    specs: &[IfNodeSpec],
+) -> Result<CreatureExport, GraftError> {
+    validate_creature_topology(creature)?;
+    let mut current = creature.clone();
+    for spec in specs {
+        current = graft_if_node(&current, spec)?;
+    }
+    Ok(current)
+}
+
+/// Graft a depth-1 `IF` correction — `feature > threshold ? positive : negative`
+/// added into one existing neuron.
+///
+/// Thin wrapper over [`graft_if_node`] and [`IfCorrectionSpec::to_node_spec`],
+/// so callers adding a residual correction do not restate the synapse-role rule.
+///
+/// # Errors
+///
+/// Same conditions as [`graft_if_node`].
+pub fn graft_if_correction(
+    creature: &CreatureExport,
+    spec: &IfCorrectionSpec,
+) -> Result<CreatureExport, GraftError> {
+    graft_if_node(creature, &spec.to_node_spec())
+}

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -20,10 +20,12 @@
 pub mod accumulate;
 pub mod batch_scoring;
 pub mod creature;
+pub mod decision_tree;
 pub mod derivative;
 pub mod elastic_distribution;
 pub mod error;
 pub mod fused_error;
+pub mod if_graft;
 pub mod loss;
 pub mod network;
 pub mod parallel_scoring;
@@ -59,6 +61,15 @@ pub use creature::{
     CreatureError, CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
     creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
     squash_name_from, synapse_type_name_from, validate_creature_width,
+};
+// Issue #555 — canonical IF decision-tree fixtures and the graft helper.
+pub use decision_tree::{
+    DecisionCase, depth2_tree_creature, linear_base_creature, residual_correction_creature,
+    stump_creature,
+};
+pub use if_graft::{
+    GraftError, IfCorrectionSpec, IfNodeSpec, graft_if_correction, graft_if_node, graft_if_tree,
+    validate_creature_topology,
 };
 pub use network::{CompiledNetwork, NetworkError, NeuronData, SynapseData, hot_synapse_soa};
 pub use squash::SquashType;

--- a/neat-core/src/loss.rs
+++ b/neat-core/src/loss.rs
@@ -1478,8 +1478,11 @@ pub fn mse_mean_record(
 fn append_le_f32(bytes: &[u8], out: &mut Vec<f32>) {
     out.extend(
         bytes
-            .chunks_exact(4)
-            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])),
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .copied()
+            .map(f32::from_le_bytes),
     );
 }
 

--- a/neat-core/src/training_data.rs
+++ b/neat-core/src/training_data.rs
@@ -194,13 +194,21 @@ fn validate_config(config: &TrainingDataConfig) -> Result<(), TrainingDataError>
 /// into their input/output buffers via [`parse_record_into`] (Issue #385).
 #[cfg(test)]
 fn parse_f32_values(bytes: &[u8]) -> Vec<f32> {
-    bytes.chunks_exact(4).map(f32_from_le_chunk).collect()
+    le_f32_values(bytes).collect()
 }
 
-/// Decode a single little-endian `f32` from a 4-byte chunk.
+/// Iterate the little-endian `f32` values in `bytes`.
+///
+/// A trailing 1..3 bytes cannot form a value and is ignored; callers hand this
+/// helper whole records only.
 #[inline]
-fn f32_from_le_chunk(chunk: &[u8]) -> f32 {
-    f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
+fn le_f32_values(bytes: &[u8]) -> impl Iterator<Item = f32> + '_ {
+    bytes
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .copied()
+        .map(f32::from_le_bytes)
 }
 
 /// Split a record's bytes into its input and output byte sub-slices.
@@ -217,9 +225,9 @@ fn split_record_bytes<'a>(bytes: &'a [u8], config: &TrainingDataConfig) -> (&'a 
 fn parse_record(bytes: &[u8], config: &TrainingDataConfig) -> TrainingRecord {
     let (input_bytes, output_bytes) = split_record_bytes(bytes, config);
     let mut inputs = Vec::with_capacity(config.num_inputs);
-    inputs.extend(input_bytes.chunks_exact(4).map(f32_from_le_chunk));
+    inputs.extend(le_f32_values(input_bytes));
     let mut outputs = Vec::with_capacity(config.num_outputs);
-    outputs.extend(output_bytes.chunks_exact(4).map(f32_from_le_chunk));
+    outputs.extend(le_f32_values(output_bytes));
     TrainingRecord { inputs, outputs }
 }
 
@@ -234,13 +242,9 @@ fn parse_record(bytes: &[u8], config: &TrainingDataConfig) -> TrainingRecord {
 fn parse_record_into(bytes: &[u8], config: &TrainingDataConfig, record: &mut TrainingRecord) {
     let (input_bytes, output_bytes) = split_record_bytes(bytes, config);
     record.inputs.clear();
-    record
-        .inputs
-        .extend(input_bytes.chunks_exact(4).map(f32_from_le_chunk));
+    record.inputs.extend(le_f32_values(input_bytes));
     record.outputs.clear();
-    record
-        .outputs
-        .extend(output_bytes.chunks_exact(4).map(f32_from_le_chunk));
+    record.outputs.extend(le_f32_values(output_bytes));
 }
 
 // ---------------------------------------------------------------------------

--- a/neat-core/tests/decision_tree_fixture.rs
+++ b/neat-core/tests/decision_tree_fixture.rs
@@ -1,0 +1,296 @@
+//! Canonical decision-tree fixture semantics (Issue #555).
+//!
+//! Every expectation here is checked against a **hand-written reference tree**
+//! declared in this file — plain `if x > t` Rust that shares no code with
+//! `compile_creature` / `CompiledNetwork::activate`. A fault in the IF kernel
+//! moves the network side only, so the assertion goes red (AGENTS.md oracle
+//! rule 1). The documented `*_CASES` tables are checked against the same
+//! reference, so a wrong constant in the library is caught too.
+
+use neat_core::decision_tree::{
+    DEPTH2_CASES, DEPTH2_ROOT_THRESHOLD, DEPTH2_SPLIT_THRESHOLD, DecisionCase, RESIDUAL_CASES,
+    RESIDUAL_THRESHOLD, RESIDUAL_VALUE, STUMP_CASES, STUMP_POSITIVE_VALUE, STUMP_THRESHOLD,
+    depth2_tree_creature, linear_base_creature, residual_correction_creature, stump_creature,
+};
+use neat_core::{
+    CreatureExport, SynapseType, compile_creature, creature_to_json, mse_sum_batch_packed,
+    parse_creature_json,
+};
+
+/// f32 tolerance for a handful of adds — the fixtures are exact in f32, but the
+/// assertions stay within "normal f32 tolerance" as the issue specifies.
+const TOL: f32 = 1e-6;
+
+// ---------------------------------------------------------------------------
+// Independent reference trees — no shared code path with the network kernel.
+// ---------------------------------------------------------------------------
+
+/// `x > 0.5 ? 3.0 : 0.0` — the stump the fixture is documented to encode.
+fn stump_reference(x: f32) -> f32 {
+    if x > STUMP_THRESHOLD as f32 {
+        STUMP_POSITIVE_VALUE as f32
+    } else {
+        0.0
+    }
+}
+
+/// Depth-2 tree: root splits on `x0 > 0.5`, both children split on `x1 > 0.25`.
+fn depth2_reference(x0: f32, x1: f32) -> f32 {
+    let root = DEPTH2_ROOT_THRESHOLD as f32;
+    let split = DEPTH2_SPLIT_THRESHOLD as f32;
+    if x0 > root {
+        if x1 > split { 4.0 } else { 0.0 }
+    } else if x1 > split {
+        1.0
+    } else {
+        -2.0
+    }
+}
+
+/// Linear base `2x` plus a depth-1 IF correction of `+1.5` when `x > 0.75`.
+fn residual_reference(x: f32) -> f32 {
+    let correction = if x > RESIDUAL_THRESHOLD as f32 {
+        RESIDUAL_VALUE as f32
+    } else {
+        0.0
+    };
+    2.0 * x + correction
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn activate_once(creature: &CreatureExport, inputs: &[f32]) -> f32 {
+    let mut net = compile_creature(creature).expect("fixture compiles");
+    let out = net.activate(inputs, creature.output);
+    assert_eq!(out.len(), creature.output);
+    out[0]
+}
+
+fn assert_close(actual: f32, expected: f32, what: &str) {
+    assert!(
+        (actual - expected).abs() <= TOL,
+        "{what}: expected {expected}, got {actual}"
+    );
+}
+
+/// Drive every documented case through the compiled network *and* the
+/// independent reference.
+fn check_cases(
+    creature: &CreatureExport,
+    cases: &[DecisionCase],
+    reference: impl Fn(&[f32]) -> f32,
+) {
+    assert!(!cases.is_empty(), "case table must not be empty");
+    for case in cases {
+        let expected = reference(case.inputs);
+        assert_close(
+            case.expected,
+            expected,
+            &format!("documented expected value for branch {}", case.branch),
+        );
+        let actual = activate_once(creature, case.inputs);
+        assert_close(
+            actual,
+            expected,
+            &format!("activation for branch {} at {:?}", case.branch, case.inputs),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stump
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stump_fixture_matches_reference_on_every_documented_case() {
+    check_cases(&stump_creature(), STUMP_CASES, |i| stump_reference(i[0]));
+}
+
+#[test]
+fn stump_takes_the_zero_default_branch_at_and_below_the_threshold() {
+    let creature = stump_creature();
+    // `condition_sum > 0.0` is strict, so the threshold itself is the default.
+    assert_close(
+        activate_once(&creature, &[STUMP_THRESHOLD as f32]),
+        0.0,
+        "x == threshold",
+    );
+    assert_close(activate_once(&creature, &[0.0]), 0.0, "x below threshold");
+    assert_close(
+        activate_once(&creature, &[STUMP_THRESHOLD as f32 + 0.25]),
+        STUMP_POSITIVE_VALUE as f32,
+        "x above threshold",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Depth-2 tree
+// ---------------------------------------------------------------------------
+
+#[test]
+fn depth2_fixture_matches_reference_on_every_documented_case() {
+    check_cases(&depth2_tree_creature(), DEPTH2_CASES, |i| {
+        depth2_reference(i[0], i[1])
+    });
+}
+
+#[test]
+fn depth2_cases_cover_all_four_leaves() {
+    let mut leaves: Vec<&str> = DEPTH2_CASES.iter().map(|c| c.branch).collect();
+    leaves.sort_unstable();
+    leaves.dedup();
+    // Four leaves plus the boundary case that pins the strict `>` comparison.
+    assert!(
+        leaves.len() >= 4,
+        "expected every leaf to be exercised, saw {leaves:?}"
+    );
+    // Every leaf value the reference can produce must appear in the table.
+    for expected in [4.0f32, 0.0, 1.0, -2.0] {
+        assert!(
+            DEPTH2_CASES
+                .iter()
+                .any(|c| (c.expected - expected).abs() <= TOL),
+            "no documented case yields leaf {expected}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Residual / correction leaf
+// ---------------------------------------------------------------------------
+
+#[test]
+fn residual_fixture_matches_reference_on_every_documented_case() {
+    check_cases(&residual_correction_creature(), RESIDUAL_CASES, |i| {
+        residual_reference(i[0])
+    });
+}
+
+#[test]
+fn residual_fixture_adds_a_non_zero_correction_over_the_linear_base() {
+    let base = linear_base_creature();
+    let corrected = residual_correction_creature();
+    let x = RESIDUAL_THRESHOLD as f32 + 0.25;
+
+    let base_out = activate_once(&base, &[x]);
+    let corrected_out = activate_once(&corrected, &[x]);
+    assert_close(base_out, 2.0 * x, "linear base");
+    assert_close(
+        corrected_out - base_out,
+        RESIDUAL_VALUE as f32,
+        "correction above threshold",
+    );
+
+    // Below the threshold the correction leaf contributes nothing.
+    let low = RESIDUAL_THRESHOLD as f32 - 0.25;
+    assert_close(
+        activate_once(&corrected, &[low]) - activate_once(&base, &[low]),
+        0.0,
+        "correction below threshold",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Round trip: export -> JSON -> parse -> compile keeps every synapse role
+// ---------------------------------------------------------------------------
+
+/// Count compiled synapses per role, so the assertion is on the compiled
+/// structure rather than on the JSON text.
+fn role_histogram(creature: &CreatureExport) -> [usize; 4] {
+    let net = compile_creature(creature).expect("compiles");
+    let mut counts = [0usize; 4];
+    for s in &net.synapses {
+        counts[SynapseType::from(s.synapse_type) as usize] += 1;
+    }
+    counts
+}
+
+#[test]
+fn round_trip_preserves_every_synapse_role() {
+    for creature in [
+        stump_creature(),
+        depth2_tree_creature(),
+        residual_correction_creature(),
+    ] {
+        let before = role_histogram(&creature);
+        assert!(
+            before[SynapseType::Condition as usize] > 0
+                && before[SynapseType::Positive as usize] > 0
+                && before[SynapseType::Negative as usize] > 0,
+            "fixture must exercise all three IF roles, saw {before:?}"
+        );
+
+        let json = creature_to_json(&creature).expect("serialise");
+        let reparsed = parse_creature_json(&json).expect("parse");
+        assert_eq!(reparsed, creature, "round trip changed the export");
+        assert_eq!(role_histogram(&reparsed), before, "round trip lost a role");
+    }
+}
+
+#[test]
+fn round_trip_preserves_branch_semantics() {
+    for (creature, cases) in [
+        (stump_creature(), STUMP_CASES),
+        (depth2_tree_creature(), DEPTH2_CASES),
+        (residual_correction_creature(), RESIDUAL_CASES),
+    ] {
+        let json = creature_to_json(&creature).expect("serialise");
+        let reparsed = parse_creature_json(&json).expect("parse");
+        for case in cases {
+            assert_close(
+                activate_once(&reparsed, case.inputs),
+                activate_once(&creature, case.inputs),
+                "round-tripped activation",
+            );
+        }
+    }
+}
+
+/// The batched scoring kernels drop to one record at a time for aggregate
+/// squashes, so a record must not score differently for landing in an 8-record
+/// group, the 4-record remainder or the scalar tail. Thirteen records
+/// (`8 + 4 + 1`) reach all three tiers; the packed targets are the documented
+/// branch outputs, so a disagreeing tier shows up as non-zero MSE.
+#[test]
+fn batched_scoring_reproduces_the_documented_branch_outputs() {
+    for (creature, cases) in [
+        (stump_creature(), STUMP_CASES),
+        (depth2_tree_creature(), DEPTH2_CASES),
+        (residual_correction_creature(), RESIDUAL_CASES),
+    ] {
+        let mut packed: Vec<f32> = Vec::new();
+        for i in 0..13 {
+            let case = &cases[i % cases.len()];
+            packed.extend_from_slice(case.inputs);
+            packed.push(case.expected);
+        }
+        let mut net = compile_creature(&creature).expect("compiles");
+        let sum = mse_sum_batch_packed(&mut net, &packed, creature.input, creature.output, true);
+        assert!(
+            sum.abs() <= 1e-9,
+            "batched scoring disagreed with the documented branches: summed MSE {sum}"
+        );
+    }
+}
+
+/// A dropped `type` key must change the answer — this is the mutation guard
+/// that proves the role assertions above are not vacuous.
+#[test]
+fn stripping_synapse_roles_changes_the_branch_output() {
+    let mut stripped = stump_creature();
+    for s in &mut stripped.synapses {
+        s.synapse_type = None;
+    }
+    // Without roles every inbound synapse becomes "positive", so the condition
+    // sum is zero and the IF neuron always takes the (now empty) negative
+    // branch: the above-threshold case no longer returns the positive leaf.
+    let x = STUMP_THRESHOLD as f32 + 0.25;
+    let intact = activate_once(&stump_creature(), &[x]);
+    let broken = activate_once(&stripped, &[x]);
+    assert!(
+        (intact - broken).abs() > TOL,
+        "dropping synapse roles must change the output ({intact} vs {broken})"
+    );
+}

--- a/neat-core/tests/if_graft.rs
+++ b/neat-core/tests/if_graft.rs
@@ -1,0 +1,544 @@
+//! Safe IF-node grafting onto a `CreatureExport` (Issue #555).
+//!
+//! Every assertion is on an observable outcome — the returned creature, the
+//! compiled network's activations, or the typed error — never on how the helper
+//! got there.
+
+use neat_core::decision_tree::{
+    RESIDUAL_THRESHOLD, RESIDUAL_VALUE, linear_base_creature, residual_correction_creature,
+};
+use neat_core::if_graft::{
+    GraftError, IfCorrectionSpec, IfNodeSpec, graft_if_correction, graft_if_node, graft_if_tree,
+    validate_creature_topology,
+};
+use neat_core::topology_ops::{
+    BACKWARD_CONNECTION, DUPLICATE_CONNECTION, STRUCTURAL_HIDDEN_NO_OUTWARD,
+    STRUCTURAL_IF_MISSING_CONDITION, STRUCTURAL_SYNAPSE_TARGETS_INPUT,
+};
+use neat_core::{CreatureExport, NeuronExport, SynapseExport, SynapseType, compile_creature};
+
+const TOL: f32 = 1e-6;
+
+/// Two inputs, one hidden TANH neuron, one identity output. Deliberately not an
+/// IF creature — the graft has to add every role itself.
+fn base_creature() -> CreatureExport {
+    CreatureExport {
+        input: 2,
+        output: 1,
+        neurons: vec![
+            NeuronExport {
+                neuron_type: "hidden".to_string(),
+                uuid: "hidden-1".to_string(),
+                bias: 0.0,
+                squash: Some("TANH".to_string()),
+            },
+            NeuronExport {
+                neuron_type: "output".to_string(),
+                uuid: "output-0".to_string(),
+                bias: 0.0,
+                squash: Some("IDENTITY".to_string()),
+            },
+        ],
+        synapses: vec![
+            SynapseExport {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-1".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseExport {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "hidden-1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseExport {
+                from_uuid: "hidden-1".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+        ],
+        semantic_version: None,
+        forward_only: true,
+    }
+}
+
+/// A well-formed depth-1 IF node: fires when `input-0 > 0.25`.
+fn valid_spec() -> IfNodeSpec {
+    IfNodeSpec::new("if-1", 0.0)
+        .with_constant("if-1-one", 1.0)
+        .with_constant("if-1-pos", 1.0)
+        .with_constant("if-1-neg", 1.0)
+        .with_condition("input-0", 1.0)
+        .with_condition("if-1-one", -0.25)
+        .with_positive("if-1-pos", 2.0)
+        .with_negative("if-1-neg", 0.0)
+        .with_target("output-0", 1.0)
+}
+
+fn activate(creature: &CreatureExport, inputs: &[f32]) -> f32 {
+    let mut net = compile_creature(creature).expect("grafted creature compiles");
+    net.activate(inputs, creature.output)[0]
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn grafted_if_node_adds_its_branch_to_the_target() {
+    let base = base_creature();
+    let grafted = graft_if_node(&base, &valid_spec()).expect("graft succeeds");
+
+    // Above the split the positive leaf (2.0) is added; at or below it the
+    // zero-valued negative leaf contributes nothing.
+    let above = [0.5f32, 0.0];
+    let below = [0.1f32, 0.0];
+    assert!((activate(&grafted, &above) - (activate(&base, &above) + 2.0)).abs() <= TOL);
+    assert!((activate(&grafted, &below) - activate(&base, &below)).abs() <= TOL);
+}
+
+#[test]
+fn graft_leaves_the_source_creature_untouched() {
+    let base = base_creature();
+    let before = base.clone();
+    let _ = graft_if_node(&base, &valid_spec()).expect("graft succeeds");
+    assert_eq!(base, before);
+}
+
+#[test]
+fn grafted_node_is_placed_after_its_sources_and_before_its_targets() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_constant("if-1-one", 1.0)
+        .with_constant("if-1-pos", 1.0)
+        .with_constant("if-1-neg", 1.0)
+        .with_condition("hidden-1", 1.0)
+        .with_condition("if-1-one", -0.1)
+        .with_positive("if-1-pos", 1.0)
+        .with_negative("if-1-neg", 0.0)
+        .with_target("output-0", 1.0);
+    let grafted = graft_if_node(&base_creature(), &spec).expect("graft succeeds");
+
+    let order: Vec<&str> = grafted
+        .neurons
+        .iter()
+        .map(|n| n.uuid.as_str())
+        .collect::<Vec<_>>();
+    let pos = |u: &str| order.iter().position(|o| *o == u).expect("neuron present");
+    assert!(pos("hidden-1") < pos("if-1"), "order was {order:?}");
+    assert!(pos("if-1") < pos("output-0"), "order was {order:?}");
+    for c in ["if-1-one", "if-1-pos", "if-1-neg"] {
+        assert!(
+            pos(c) < pos("if-1"),
+            "constant {c} after the node: {order:?}"
+        );
+    }
+}
+
+#[test]
+fn grafted_node_carries_the_if_squash_and_all_three_roles() {
+    let grafted = graft_if_node(&base_creature(), &valid_spec()).expect("graft succeeds");
+    let node = grafted
+        .neurons
+        .iter()
+        .find(|n| n.uuid == "if-1")
+        .expect("node present");
+    assert_eq!(node.squash.as_deref(), Some("IF"));
+    assert_eq!(node.neuron_type, "hidden");
+
+    let net = compile_creature(&grafted).expect("compiles");
+    let mut counts = [0usize; 4];
+    for s in &net.synapses {
+        counts[SynapseType::from(s.synapse_type) as usize] += 1;
+    }
+    assert_eq!(counts[SynapseType::Condition as usize], 2);
+    assert_eq!(counts[SynapseType::Positive as usize], 1);
+    assert_eq!(counts[SynapseType::Negative as usize], 1);
+}
+
+#[test]
+fn graft_if_tree_applies_every_node_in_order() {
+    let first = valid_spec();
+    let second = IfNodeSpec::new("if-2", 0.0)
+        .with_constant("if-2-one", 1.0)
+        .with_constant("if-2-pos", 1.0)
+        .with_constant("if-2-neg", 1.0)
+        .with_condition("if-1", 1.0)
+        .with_condition("if-2-one", -1.0)
+        .with_positive("if-2-pos", 5.0)
+        .with_negative("if-2-neg", 0.0)
+        .with_target("output-0", 1.0);
+
+    let grafted = graft_if_tree(&base_creature(), &[first, second]).expect("tree graft succeeds");
+    let order: Vec<&str> = grafted.neurons.iter().map(|n| n.uuid.as_str()).collect();
+    let pos = |u: &str| order.iter().position(|o| *o == u).expect("neuron present");
+    assert!(pos("if-1") < pos("if-2"), "order was {order:?}");
+    assert!(pos("if-2") < pos("output-0"), "order was {order:?}");
+
+    // `if-1` yields 2.0 above its split, which clears `if-2`'s threshold of 1.0
+    // and adds a further 5.0 on top.
+    let base = base_creature();
+    let above = [0.5f32, 0.0];
+    assert!((activate(&grafted, &above) - (activate(&base, &above) + 2.0 + 5.0)).abs() <= TOL);
+}
+
+#[test]
+fn graft_if_tree_is_all_or_nothing() {
+    let good = valid_spec();
+    let bad = IfNodeSpec::new("if-2", 0.0)
+        .with_condition("no-such-neuron", 1.0)
+        .with_positive("hidden-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("output-0", 1.0);
+    let err = graft_if_tree(&base_creature(), &[good, bad]).expect_err("second node is invalid");
+    assert!(matches!(err, GraftError::UnknownSourceUuid(ref u) if u == "no-such-neuron"));
+}
+
+// ---------------------------------------------------------------------------
+// Depth-1 correction convenience — the canonical residual fixture
+// ---------------------------------------------------------------------------
+
+#[test]
+fn graft_if_correction_reproduces_the_canonical_residual_fixture() {
+    let spec = IfCorrectionSpec {
+        uuid: "residual-0".to_string(),
+        feature_uuid: "input-0".to_string(),
+        threshold: RESIDUAL_THRESHOLD,
+        positive_value: RESIDUAL_VALUE,
+        negative_value: 0.0,
+        target_uuid: "output-0".to_string(),
+        target_weight: 1.0,
+    };
+    let grafted = graft_if_correction(&linear_base_creature(), &spec).expect("graft succeeds");
+    assert_eq!(grafted, residual_correction_creature());
+}
+
+#[test]
+fn graft_if_correction_fires_only_above_the_threshold() {
+    let spec = IfCorrectionSpec {
+        uuid: "residual-0".to_string(),
+        feature_uuid: "input-0".to_string(),
+        threshold: 0.75,
+        positive_value: 1.5,
+        negative_value: 0.0,
+        target_uuid: "output-0".to_string(),
+        target_weight: 1.0,
+    };
+    let base = linear_base_creature();
+    let grafted = graft_if_correction(&base, &spec).expect("graft succeeds");
+
+    assert!((activate(&grafted, &[1.0]) - 3.5).abs() <= TOL);
+    // Strict `>`: the threshold itself takes the negative (zero) leaf.
+    assert!((activate(&grafted, &[0.75]) - 1.5).abs() <= TOL);
+    assert!((activate(&grafted, &[0.25]) - 0.5).abs() <= TOL);
+}
+
+// ---------------------------------------------------------------------------
+// Fail closed — every rejection returns a typed error and no creature
+// ---------------------------------------------------------------------------
+
+fn reject(spec: IfNodeSpec) -> GraftError {
+    graft_if_node(&base_creature(), &spec).expect_err("graft must be rejected")
+}
+
+#[test]
+fn rejects_a_uuid_that_already_exists() {
+    let spec = valid_spec();
+    let clashing = IfNodeSpec {
+        uuid: "hidden-1".to_string(),
+        ..spec
+    };
+    assert!(matches!(reject(clashing), GraftError::DuplicateUuid(ref u) if u == "hidden-1"));
+}
+
+#[test]
+fn rejects_a_constant_uuid_that_already_exists() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_constant("output-0", 1.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("output-0", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(reject(spec), GraftError::DuplicateUuid(ref u) if u == "output-0"));
+}
+
+#[test]
+fn rejects_an_unknown_source() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("ghost", 1.0)
+        .with_positive("input-0", 1.0)
+        .with_negative("input-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(reject(spec), GraftError::UnknownSourceUuid(ref u) if u == "ghost"));
+}
+
+#[test]
+fn rejects_an_unknown_target() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("ghost", 1.0);
+    assert!(matches!(reject(spec), GraftError::UnknownTargetUuid(ref u) if u == "ghost"));
+}
+
+#[test]
+fn rejects_a_synapse_that_targets_an_input() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("input-0", 1.0);
+    assert!(matches!(reject(spec), GraftError::TargetIsInput(ref u) if u == "input-0"));
+}
+
+#[test]
+fn rejects_a_synapse_that_targets_a_constant() {
+    let with_constant = graft_if_node(&base_creature(), &valid_spec()).expect("graft succeeds");
+    let spec = IfNodeSpec::new("if-2", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("if-1-one", 1.0);
+    let err = graft_if_node(&with_constant, &spec).expect_err("must be rejected");
+    assert!(matches!(err, GraftError::TargetIsConstant(ref u) if u == "if-1-one"));
+}
+
+#[test]
+fn rejects_a_node_missing_any_if_role() {
+    let missing_condition = IfNodeSpec::new("if-1", 0.0)
+        .with_positive("input-0", 1.0)
+        .with_negative("input-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(missing_condition),
+        GraftError::MissingConditionSynapse
+    ));
+
+    let missing_positive = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_negative("input-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(missing_positive),
+        GraftError::MissingPositiveSynapse
+    ));
+
+    let missing_negative = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(missing_negative),
+        GraftError::MissingNegativeSynapse
+    ));
+}
+
+#[test]
+fn rejects_a_node_with_no_outward_connection() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0);
+    assert!(matches!(reject(spec), GraftError::NoTargets));
+}
+
+#[test]
+fn rejects_two_synapses_between_the_same_pair() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-0", 1.0)
+        .with_negative("input-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(spec),
+        GraftError::DuplicateEdge { ref from, ref to } if from == "input-0" && to == "if-1"
+    ));
+}
+
+#[test]
+fn rejects_a_self_edge() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("if-1", 1.0)
+        .with_positive("input-0", 1.0)
+        .with_negative("input-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(reject(spec), GraftError::SelfEdge(ref u) if u == "if-1"));
+}
+
+#[test]
+fn rejects_non_finite_weights_and_biases() {
+    let bad_weight = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", f64::NAN)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(bad_weight),
+        GraftError::NonFiniteWeight { .. }
+    ));
+
+    let bad_bias = IfNodeSpec::new("if-1", f64::INFINITY)
+        .with_condition("input-0", 1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(bad_bias),
+        GraftError::NonFiniteBias { ref uuid } if uuid == "if-1"
+    ));
+
+    let bad_constant = IfNodeSpec::new("if-1", 0.0)
+        .with_constant("if-1-one", f64::NAN)
+        .with_condition("input-0", 1.0)
+        .with_condition("if-1-one", -1.0)
+        .with_positive("input-1", 1.0)
+        .with_negative("hidden-1", 1.0)
+        .with_target("output-0", 1.0);
+    assert!(matches!(
+        reject(bad_constant),
+        GraftError::NonFiniteBias { ref uuid } if uuid == "if-1-one"
+    ));
+}
+
+#[test]
+fn rejects_a_graft_that_cannot_be_placed_forward_only() {
+    // Source `output-0` sits after target `hidden-1`, so no insertion point
+    // keeps every edge pointing forwards.
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("output-0", 1.0)
+        .with_positive("input-0", 1.0)
+        .with_negative("input-1", 1.0)
+        .with_target("hidden-1", 1.0);
+    assert!(matches!(
+        reject(spec),
+        GraftError::ForwardOrderViolation { ref source, ref target }
+            if source == "output-0" && target == "hidden-1"
+    ));
+}
+
+#[test]
+fn rejects_a_base_creature_that_is_already_malformed() {
+    let mut base = base_creature();
+    // A hidden neuron with no outward connection is structurally invalid.
+    base.synapses.retain(|s| s.from_uuid != "hidden-1");
+    let err = graft_if_node(&base, &valid_spec()).expect_err("malformed base is rejected");
+    assert!(matches!(err, GraftError::MalformedStructure { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// The gate itself — the post-check that stops a malformed creature escaping is
+// unreachable through `graft_if_node` by construction, so it is exercised
+// directly with synthetic creatures (AGENTS.md oracle rule 5).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gate_accepts_every_canonical_fixture() {
+    for creature in [
+        linear_base_creature(),
+        residual_correction_creature(),
+        neat_core::decision_tree::stump_creature(),
+        neat_core::decision_tree::depth2_tree_creature(),
+        base_creature(),
+    ] {
+        validate_creature_topology(&creature).expect("canonical creature passes the gate");
+    }
+}
+
+#[test]
+fn gate_rejects_a_hidden_neuron_with_no_outward_connection() {
+    let mut creature = base_creature();
+    creature.synapses.retain(|s| s.from_uuid != "hidden-1");
+    let err = validate_creature_topology(&creature).expect_err("rejected");
+    assert!(matches!(
+        err,
+        GraftError::MalformedStructure { code, .. } if code == STRUCTURAL_HIDDEN_NO_OUTWARD
+    ));
+}
+
+#[test]
+fn gate_rejects_an_if_neuron_that_lost_a_role() {
+    let mut creature = graft_if_node(&base_creature(), &valid_spec()).expect("graft succeeds");
+    for s in &mut creature.synapses {
+        if s.to_uuid == "if-1" && s.synapse_type.as_deref() == Some("condition") {
+            s.synapse_type = None;
+        }
+    }
+    let err = validate_creature_topology(&creature).expect_err("rejected");
+    assert!(matches!(
+        err,
+        GraftError::MalformedStructure { code, .. } if code == STRUCTURAL_IF_MISSING_CONDITION
+    ));
+}
+
+#[test]
+fn gate_rejects_a_synapse_that_targets_an_input() {
+    let mut creature = base_creature();
+    // Recurrent, so the ordering gate stands aside and the structural gate is
+    // what has to catch a synapse pointing back into an input neuron.
+    creature.forward_only = false;
+    creature.synapses.push(SynapseExport {
+        from_uuid: "hidden-1".to_string(),
+        to_uuid: "input-0".to_string(),
+        weight: 1.0,
+        synapse_type: None,
+    });
+    let err = validate_creature_topology(&creature).expect_err("rejected");
+    assert!(matches!(
+        err,
+        GraftError::MalformedStructure { code, .. } if code == STRUCTURAL_SYNAPSE_TARGETS_INPUT
+    ));
+}
+
+#[test]
+fn gate_rejects_a_duplicate_connection() {
+    let mut creature = base_creature();
+    creature.synapses.push(SynapseExport {
+        from_uuid: "hidden-1".to_string(),
+        to_uuid: "output-0".to_string(),
+        weight: 0.25,
+        synapse_type: None,
+    });
+    let err = validate_creature_topology(&creature).expect_err("rejected");
+    assert!(matches!(
+        err,
+        GraftError::MalformedTopology { code, .. } if code == DUPLICATE_CONNECTION
+    ));
+}
+
+#[test]
+fn gate_rejects_a_backward_edge_only_when_forward_only() {
+    let mut creature = base_creature();
+    creature.synapses.push(SynapseExport {
+        from_uuid: "output-0".to_string(),
+        to_uuid: "hidden-1".to_string(),
+        weight: 0.25,
+        synapse_type: None,
+    });
+    let err = validate_creature_topology(&creature).expect_err("rejected while forward-only");
+    assert!(matches!(
+        err,
+        GraftError::MalformedTopology { code, .. } if code == BACKWARD_CONNECTION
+    ));
+
+    // A recurrent creature legitimately carries the same edge.
+    creature.forward_only = false;
+    validate_creature_topology(&creature).expect("recurrent creature is accepted");
+}
+
+#[test]
+fn gate_rejects_an_unresolvable_synapse_uuid() {
+    let mut creature = base_creature();
+    creature.synapses[0].from_uuid = "ghost".to_string();
+    let err = validate_creature_topology(&creature).expect_err("rejected");
+    assert!(matches!(err, GraftError::UnknownSourceUuid(ref u) if u == "ghost"));
+}
+
+#[test]
+fn gate_rejects_a_widthless_creature() {
+    let mut creature = base_creature();
+    creature.input = 0;
+    let err = validate_creature_topology(&creature).expect_err("rejected");
+    assert!(matches!(err, GraftError::Creature(_)));
+}


### PR DESCRIPTION
# Canonical IF decision-tree fixtures and a safe graft helper

## Summary

Gives the NEAT-AI family one authoritative Rust representation of small
decision trees built from the existing `IF` aggregate, plus a helper that
constructs them safely, so NEAT-AI-Forests does not have to invent its own
reading of the synapse roles or hand-edit neuron/synapse JSON. Closes #555.

Two new modules, both public library surface (Forests consumes them, so they
cannot be test-only):

- **`neat-core/src/decision_tree.rs`** — the canonical fixtures and their
  documented expected outputs:

  | Builder | Shape | Covers |
  |---------|-------|--------|
  | `stump_creature()` | `x > 0.5 ? 3.0 : 0.0` | single split, zero/default branch (`STUMP_CASES`) |
  | `depth2_tree_creature()` | root on `x0 > 0.5`, both children on `x1 > 0.25` | nested depth-2, all four leaves (`DEPTH2_CASES`) |
  | `linear_base_creature()` | `2x`, no `IF` at all | the pre-graft base |
  | `residual_correction_creature()` | `2x + (x > 0.75 ? 1.5 : 0)` | non-zero residual/correction leaf (`RESIDUAL_CASES`) |

- **`neat-core/src/if_graft.rs`** — `IfNodeSpec` / `IfCorrectionSpec` describe
  *what* is wanted; `graft_if_node`, `graft_if_tree` and `graft_if_correction`
  return a **new** validated `CreatureExport` and never mutate the source.

Nothing in the serialisation format, the squash discriminants or the existing
activation kernels changed — the modules are additive, and `SquashType::If` /
`SynapseType` are used exactly as they already were.

### Design notes a reviewer needs

- **Why each grafted node brings three constants.** A split test `x > t` needs a
  constant `1.0` source to carry `-t`, and each leaf value needs one too. A
  creature may not hold two synapses between the same ordered pair of neurons
  (`validate_topology`'s `DUPLICATE_CONNECTION`), so one node cannot take all
  three roles from a single constant. `IfCorrectionSpec` therefore introduces
  `<uuid>-condition-one`, `<uuid>-positive-one` and `<uuid>-negative-one`, all
  bias `1.0`, leaving the threshold and leaf values in the trainable **weights**.
- **Placement is the `forwardOnly` guarantee.** The node is inserted at the
  earliest position that still sits after every source and before every target;
  when no such position exists the graft fails with `ForwardOrderViolation`
  rather than emitting a node that reads a stale activation.
- **The gate reuses existing single-home rules.** `validate_creature_topology`
  calls `validate_creature_width`, `validate_topology` and
  `validate_structural_integrity` rather than restating them. The ordering gate
  runs only for `forwardOnly` creatures, because a recurrent creature
  legitimately carries backward edges that gate rejects by design.
- **Fail closed, and prove it.** Every rejection is a typed `GraftError` and no
  creature is produced. `graft_if_correction` on `linear_base_creature()`
  reproduces `residual_correction_creature()` **exactly**, which is what stops
  the helper and the fixture drifting apart.

```mermaid
flowchart LR
    B["base CreatureExport"] --> V["validate_creature_topology"]
    S["IfNodeSpec / IfCorrectionSpec"] --> K{"names new?<br/>all three roles?<br/>edges resolve?"}
    V --> K
    K -- no --> E["Err(GraftError) — no creature"]
    K -- yes --> P{"position after every source,<br/>before every target?"}
    P -- none exists --> E
    P -- yes --> G["build creature"]
    G --> V2["validate_creature_topology"]
    V2 -- fails --> E
    V2 -- passes --> O["Ok(CreatureExport)"]
```

## Evidence

Backend/library change — there is no web interface to screenshot. The evidence
is the test suite and the mutation sweep below.

`./quality.sh` passes clean (fmt, clippy `-D warnings`, `cargo check`,
`cargo test --workspace`, rustdoc `-D warnings`, release build, Mermaid gate,
`cargo deny`). 39 new tests, all existing tests still green.

### Oracle integrity

Per [AGENTS.md](../../../AGENTS.md#oracles-and-mutation-evidence):

1. **The oracle does not share the code path under test.**
   `neat-core/tests/decision_tree_fixture.rs` declares the reference trees as
   plain `if x > t` Rust (`stump_reference`, `depth2_reference`,
   `residual_reference`) that touch neither `compile_creature` nor
   `CompiledNetwork::activate`. Each documented `*_CASES` constant is checked
   against that reference too, so a wrong constant in the library is caught as
   well as a wrong kernel.
2. **No vacuous assertions.** Every expected value is the leaf the documented
   tree produces, derived beside the assertion — no `is_finite()`, no bare
   magic lengths.
3. **The gate is tested directly.** The post-build validation inside
   `graft_if_node` is unreachable while the pre-checks are complete (mutation
   M6 below), so `validate_creature_topology` is exercised against synthetic
   creatures instead — oracle rule 5.

### Mutation sweep

Each mutation was applied to one site, the two new suites run, then reverted;
the working tree is clean of all of them.

| # | Mutation | Result | First tests that went red |
|---|----------|--------|---------------------------|
| M1 | `network.rs` `activate`: IF `condition_sum > 0.0` → `>= 0.0` | **RED** | all four fixture/boundary tests |
| M2 | `build_grafted`: emit `Standard` instead of `Condition` | **RED** | `gate_rejects_an_if_neuron_that_lost_a_role`, 5 more |
| M3 | drop the `ForwardOrderViolation` check | **RED** | `rejects_a_graft_that_cannot_be_placed_forward_only` |
| M4 | drop the duplicate-source-edge check | **RED** | `rejects_two_synapses_between_the_same_pair` |
| M5 | pin placement to position `0` | **RED** | `grafted_node_is_placed_after_its_sources_and_before_its_targets` |
| M6 | drop the result post-check | GREEN — see note | — |
| M7 | `GRAFT_CONSTANT_BIAS` `1.0` → `2.0` | **RED** | `residual_fixture_matches_reference_on_every_documented_case` |
| M8 | stump leaves swapped in `leaf_synapses` | **RED** | `stump_fixture_matches_reference_on_every_documented_case` |
| M9 | skip base-creature validation | **RED** | `rejects_a_base_creature_that_is_already_malformed` |
| M10 | drop the target-is-input check | **RED** | `rejects_a_synapse_that_targets_an_input` |
| M11 | drop the missing-role checks | **RED** | `rejects_a_node_missing_any_if_role` |
| M12 | drop the duplicate-UUID check | **RED** | `graft_if_correction_reproduces_the_canonical_residual_fixture`, 5 more |
| M13 | drop the non-finite-weight check | **RED** | `rejects_non_finite_weights_and_biases` |
| M14 | drop the target-is-constant check | **RED** | `rejects_a_synapse_that_targets_a_constant` |
| M15 | flip the correction threshold sign | **RED** | `graft_if_correction_fires_only_above_the_threshold` |
| M16 | depth-2 root leaves swapped | **RED** | `depth2_fixture_matches_reference_on_every_documented_case` |
| M17 | `batch_scoring.rs` IF `>` → `>=` | **RED** | `batched_scoring_reproduces_the_documented_branch_outputs` |
| M18 | `batch_scoring.rs` route `Negative` into `positive_sum` | **RED** | `batched_scoring_reproduces_the_documented_branch_outputs` |

**M6 is a deliberate, documented gap.** The post-build
`validate_creature_topology` call is defence in depth: no specification that
survives the pre-checks can produce a malformed creature, so nothing reaches it.
It is kept because it makes "never emit a malformed creature" hold even if a
future pre-check is weakened, and the gate it calls is covered directly by the
eight `gate_*` tests — M2 and M12 both turn those red, so those tests are not
vacuous. This is recorded in `AGENTS.md` so a later reader does not delete the
check as dead code.

M17/M18 were GREEN on the first sweep — the batched aggregate path was not
reached at all. `batched_scoring_reproduces_the_documented_branch_outputs` was
added to close that gap: it packs 13 records (`8 + 4 + 1`, so the 8-record
group, the 4-record remainder and the scalar tail all run) with the documented
branch outputs as targets, and asserts the summed MSE is zero.

## Test Plan

**`neat-core/tests/decision_tree_fixture.rs`** (10 tests) — fixture semantics:

- `stump_fixture_matches_reference_on_every_documented_case`,
  `depth2_fixture_matches_reference_on_every_documented_case`,
  `residual_fixture_matches_reference_on_every_documented_case` — every
  documented case through `CreatureExport` → `compile_creature` → `activate`,
  against the independent reference.
- `stump_takes_the_zero_default_branch_at_and_below_the_threshold` — pins the
  strict `>` at the split point and the zero/default branch.
- `depth2_cases_cover_all_four_leaves` — the case table reaches every leaf.
- `residual_fixture_adds_a_non_zero_correction_over_the_linear_base` — the
  non-zero residual leaf, measured as the difference from the linear base.
- `round_trip_preserves_every_synapse_role`,
  `round_trip_preserves_branch_semantics` — export → JSON → parse → compile
  keeps the compiled role histogram and the activations.
- `stripping_synapse_roles_changes_the_branch_output` — the in-suite guard that
  the role assertions are not vacuous.
- `batched_scoring_reproduces_the_documented_branch_outputs` — 8-way, 4-way and
  scalar-tail agreement (added to close the M17/M18 gap).

**`neat-core/tests/if_graft.rs`** (29 tests) — the helper:

- Happy path: branch added to the target, source creature untouched, placement
  after sources and before targets, `IF` squash and all three roles present on
  the compiled network, `graft_if_tree` ordering and all-or-nothing behaviour.
- `graft_if_correction_reproduces_the_canonical_residual_fixture` — structural
  equality against the hand-written fixture; the acceptance criterion that a
  caller can graft a depth-1 correction without duplicating role logic.
- Thirteen rejection tests, one per `GraftError` variant reachable through the
  helper: duplicate UUID (node and constant), unknown source, unknown target,
  target is an input, target is a constant, each missing `IF` role, no outward
  edge, duplicate edge, self edge, non-finite weight/bias (node and constant),
  forward-order violation, and an already-malformed base.
- Eight `gate_*` tests driving `validate_creature_topology` directly with
  synthetic creatures: every canonical fixture accepted; hidden-with-no-outward,
  an `IF` node that lost a role, a synapse into an input, a duplicate
  connection, a backward edge (rejected when `forwardOnly`, accepted when
  recurrent), an unresolvable UUID, and a widthless creature all rejected with
  the expected `topology_ops` code.

**Docs:** `README.md` gains a "Canonical IF decision trees and the graft helper"
section with the role rule, the fixture table and a Mermaid flow of the graft
gate; `AGENTS.md` gains the matching "One IF decision-tree construction rule"
entry so the single-home rule and the M6 rationale survive.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt2f9deg-2ed0e3`<!-- vibe-worker-issue-555 -->