### PR TITLE
creature_validate: define the validation contract (options, stats, structured failure, input format) (Issue #559)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -525,6 +525,69 @@ flowchart LR
     V2 -- passes --> O["Ok(CreatureExport)"]
 ```
 
+### Creature validation contract (Issue #559)
+
+`neat-core/src/creature_validate.rs` is the Rust home of NEAT-AI's
+`src/architecture/CreatureValidate.ts` — the fleet's one definition of a valid
+creature. NEAT-AI-Forests shipped an invalid creature that `Creature.validate()`
+would have caught; the fix is a single definition Rust consumers call natively
+and NEAT-AI calls over the existing WASM boundary.
+
+**This issue lands the contract only** — the types, the error model, the rule
+order and the input format — so the two rule ports can be worked in parallel
+against a fixed interface.
+
+```rust
+pub fn creature_validate(creature: &CreatureExport, options: &ValidateOptions)
+    -> Result<ValidationStats, ValidationFailure>;
+```
+
+| Piece | What it fixes |
+|-------|---------------|
+| `ValidateOptions` | `forward_only` forces `feedback_loop` to `Some(false)`; otherwise only an explicit `Some(false)` rejects `from > to`. `neurons: Some(0)` is **skipped** (TypeScript truthiness) while `connections: Some(0)` **is** checked (`Number.isInteger`) |
+| `ValidationStats` | the `stats` object `creatureValidate` returns: `input`, `constant`, `hidden`, `output`, `connections` |
+| `ValidationFailure` | `class` (`TopologyError` / `ValidationError`), the verbatim `reason`, the human-readable `message`, and the `neuron_index` / `synapse_index` it stopped on |
+| `VALIDATION_REASONS` / `TOPOLOGY_REASONS` | the `ValidationErrorName` and `TopologyErrorReason` unions verbatim, so NEAT-AI rehydrates the right error type with no translation table |
+
+The reason lists are the single home of the permitted `reason` values and are
+checked at **compile time**: each list is internally distinct and the two are
+disjoint, so a name copied into the wrong union fails the build. The failure
+constructors reject a reason outside their class rather than sending NEAT-AI a
+string it cannot rehydrate. Rule evaluation order is part of the contract — the
+numbered table in the module documentation is what both ports implement, first
+failure wins.
+
+**Input format.** A creature arrives as the `CreatureExport` this crate already
+parses, extended by two optional fields — `NeuronExport::id` (signed: output
+neurons carry negative ids, NEAT-AI #1958) and `CreatureExport::memetic`
+(`biases`, `weights`, with every other key preserved verbatim). Both default to
+absent and are skipped on output, so existing `parse_creature_json` callers and
+already-written creature files round trip byte-identically. The export form is
+index-free, so indices are derived exactly as `compile_creature` derives them:
+`0..input` are the implicit input neurons (`input-N`, `id == index`), and
+`input + i` is `neurons[i]`.
+
+**What stays host-side** (NEAT-AI#3802): `neuron.creature !== creature`,
+`neuron.index !== indx`, `neuron.validate()` and the `debugWrite` diagnostics
+dump all depend on JavaScript object identity or the host filesystem. The
+failure's neuron/synapse index is what lets the host run those against the same
+neuron the shared rules stopped on.
+
+Until the rule bodies land, `creature_validate` returns a
+`Validation` / `OTHER` failure saying so rather than an empty `Ok`: an
+unconditional `Ok` would report the very creature this work exists to catch as
+valid.
+
+```mermaid
+flowchart LR
+    C["CreatureExport<br/>+ id, + memetic"] --> V["creature_validate"]
+    O["ValidateOptions<br/>forward_only → feedback_loop = false"] --> V
+    V -->|"no rule broken"| S["Ok(ValidationStats)"]
+    V -->|"first violated rule"| F["Err(ValidationFailure)<br/>class + reason + message + index"]
+    F --> T["NEAT-AI rehydrates<br/>TopologyError / ValidationError"]
+    F --> H["host-only checks<br/>identity, neuron.validate(), debugWrite"]
+```
+
 ## Related Repositories
 
 The NEAT-AI project is split across seven public repositories. Each focuses on one concern and composes with the others as shown below.

--- a/README.md
+++ b/README.md
@@ -567,8 +567,8 @@ index-free, so indices are derived exactly as `compile_creature` derives them:
 `0..input` are the implicit input neurons (`input-N`, `id == index`), and
 `input + i` is `neurons[i]`.
 
-**What stays host-side** (NEAT-AI#3802): `neuron.creature !== creature`,
-`neuron.index !== indx`, `neuron.validate()` and the `debugWrite` diagnostics
+**What stays host-side** (NEAT-AI#3802): `neuron.creature !== creature`, the
+`neuron.index` vs loop-position check, `neuron.validate()` and the `debugWrite` diagnostics
 dump all depend on JavaScript object identity or the host filesystem. The
 failure's neuron/synapse index is what lets the host run those against the same
 neuron the shared rules stopped on.

--- a/docs/archive/pr-summaries/pr-summary-559.md
+++ b/docs/archive/pr-summaries/pr-summary-559.md
@@ -32,8 +32,8 @@ What landed:
   and the order is contract, not implementation detail.
 - **Input format** — the validator reads the existing `CreatureExport`,
   extended by two optional fields.
-- **Host-side-only checks** — `neuron.creature !== creature`,
-  `neuron.index !== indx`, `neuron.validate()` and the `debugWrite` diagnostics
+- **Host-side-only checks** — `neuron.creature !== creature`, the
+  `neuron.index` vs loop-position check, `neuron.validate()` and the `debugWrite` diagnostics
   dump are documented as staying in TypeScript, with the failure's
   neuron/synapse index as the hook that lets the host run them against the same
   neuron.

--- a/docs/archive/pr-summaries/pr-summary-559.md
+++ b/docs/archive/pr-summaries/pr-summary-559.md
@@ -1,0 +1,148 @@
+# creature_validate: define the validation contract (Issue #559)
+
+## Summary
+
+New module `neat-core/src/creature_validate.rs` fixes the contract for the port
+of NEAT-AI's `src/architecture/CreatureValidate.ts` — options, success value,
+structured failure, input format and rule order — so the two rule-porting
+issues can be worked in parallel against a stable interface. Closes #559.
+
+What landed:
+
+- **`ValidateOptions`** — `forward_only` forces `feedback_loop` to
+  `Some(false)` (`resolved_feedback_loop`); otherwise `feedback_loop` passes
+  through and only an explicit `Some(false)` rejects `from > to`
+  (`rejects_recursive_synapses`). The two count options keep the TypeScript's
+  asymmetry: `neurons: Some(0)` is **skipped** (`if (options &&
+  options.neurons)` is a truthiness test) while `connections: Some(0)` **is**
+  checked (`Number.isInteger`). `expected_neurons` / `expected_connections` are
+  the single home of that difference.
+- **`ValidationStats`** — the `stats` object `creatureValidate` returns.
+- **`ValidationFailure` / `FailureClass`** — class, verbatim `reason`,
+  `message`, `neuron_index`, `synapse_index`, with `Display` rendering
+  `ValidationError(NO_INWARD_CONNECTIONS): …` and `std::error::Error`.
+- **`VALIDATION_REASONS` / `TOPOLOGY_REASONS`** — the `ValidationErrorName` and
+  `TopologyErrorReason` unions verbatim, one named constant each, with a doc
+  comment naming `src/errors/ValidationError.ts` / `src/errors/TopologyError.ts`
+  as the source of truth. Three `const _: () = assert!(…)` gates check at
+  **compile time** that each list is internally distinct and the two are
+  disjoint, and the failure constructors reject a reason outside their class.
+- **Rule order** — a numbered 31-row table in the module doc, in TypeScript
+  evaluation order with the class/reason each rule raises. First failure wins,
+  and the order is contract, not implementation detail.
+- **Input format** — the validator reads the existing `CreatureExport`,
+  extended by two optional fields.
+- **Host-side-only checks** — `neuron.creature !== creature`,
+  `neuron.index !== indx`, `neuron.validate()` and the `debugWrite` diagnostics
+  dump are documented as staying in TypeScript, with the failure's
+  neuron/synapse index as the hook that lets the host run them against the same
+  neuron.
+
+### Input format decision, and why it is backward compatible
+
+A creature reaches the validator as the `CreatureExport` this crate already
+parses — no second validator-only struct. Two fields were added:
+
+| Field | Why | Wire compatibility |
+|-------|-----|--------------------|
+| `NeuronExport::id: Option<i64>` | the neuron-id rules and the memetic keys; signed because output neurons carry negative ids (NEAT-AI #1958) | `#[serde(default, skip_serializing_if = "Option::is_none")]` — absent input parses, absent output emitted |
+| `CreatureExport::memetic: Option<MemeticExport>` | the `MEMETIC` rule (`biases`, `weights`) | same attributes; `MemeticExport::extra` is `#[serde(flatten)]` so `generation`, `score` and `ancestry` survive a round trip instead of being dropped |
+
+Both default to absent and are skipped on output, so every existing
+`parse_creature_json` caller and every already-written creature file round trips
+byte-identically. `MemeticWeightExport`'s `to_id` / `weight` are optional on
+purpose: the `MEMETIC` rule must be able to *report* an entry missing them, and
+making them required would turn that failure into a serde error instead.
+
+The export form is index-free (it lists only non-input neurons, wired by UUID),
+so the indices the TypeScript rules use are derived exactly as
+`compile_creature` derives them: `0..input` are the implicit input neurons
+(`input-N`, `id == index`), and `input + i` is `neurons[i]`. An endpoint naming
+no neuron — a failure the in-memory TypeScript form cannot express — maps onto
+the existing `INVALID_SYNAPSE_REFERENCE` reason rather than a new name.
+
+### Deviation from the acceptance criteria, and why
+
+The issue suggests the stub return an empty `ValidationStats`. It returns a
+`Validation` / `OTHER` failure saying the rule bodies are not ported instead: an
+unconditional `Ok` reports **every** creature as valid, including the invalid
+one this work exists to catch, which is exactly the silent-success shape the
+repo forbids. The interface the downstream issues fill in is unchanged, and the
+stub fails loudly for anyone who wires it up early.
+
+## Evidence
+
+Backend library change — no web interface to screenshot. Evidence is the test
+suite plus the mutation sweep below.
+
+`./quality.sh` passes end to end (shellcheck, bats, deno TypeScript gate,
+Mermaid gate, fmt, clippy `-D warnings`, `cargo test --workspace`, doc build,
+release build).
+
+```mermaid
+flowchart LR
+    C["CreatureExport<br/>+ id, + memetic"] --> V["creature_validate"]
+    O["ValidateOptions<br/>forward_only → feedback_loop = false"] --> V
+    V -->|"no rule broken"| S["Ok(ValidationStats)"]
+    V -->|"first violated rule"| F["Err(ValidationFailure)<br/>class + reason + message + index"]
+    F --> T["NEAT-AI rehydrates<br/>TopologyError / ValidationError"]
+    F --> H["host-only checks<br/>identity, neuron.validate(), debugWrite"]
+```
+
+### Mutation evidence (AGENTS.md rules 2 and 3)
+
+Each mutation was applied on its own, the suite run, then reverted. Every one
+was caught:
+
+| # | Mutation | Result |
+|---|----------|--------|
+| 1 | `resolved_feedback_loop` drops the `forward_only` forcing | 1 failure |
+| 2 | `expected_neurons` stops skipping `Some(0)` | 1 failure |
+| 3 | `expected_connections` starts skipping `Some(0)` | 1 failure |
+| 4 | `reason::NEURON_ORDER` drifts to `"NEURON_ORDERING"` | 1 failure |
+| 5 | the fail-loud reason guard in `ValidationFailure::new` is deleted | 2 failures |
+| 6 | the stub returns `Ok(ValidationStats::default())` | 1 failure |
+| 7 | `NeuronExport::id` loses `skip_serializing_if` | 1 failure |
+| 8 | `MemeticExport::extra` stops capturing unknown keys | 1 failure |
+| 9 | `ValidationStats::neurons` drops the constant count | 1 failure |
+| 10 | `FailureClass::permitted_reasons` swaps the two lists | 6 failures |
+| 11 | `CreatureExport::memetic` is skipped by serde | 3 failures |
+| 12 | `MEMETIC` is copied into `TOPOLOGY_REASONS` | **compile error** — `evaluation panicked: assertion failed: disjoint(&VALIDATION_REASONS, &TOPOLOGY_REASONS)` |
+
+## Test Plan
+
+`neat-core/tests/creature_validate_contract.rs` — 16 tests, all against real
+calls and observable results:
+
+- **Options** — `forward_only_overrides_an_explicit_feedback_loop_request`,
+  `only_an_explicit_false_feedback_loop_rejects_recursive_synapses`,
+  `zero_expected_neuron_count_is_skipped_but_zero_connections_is_checked`.
+- **Success value** — `validation_stats_start_at_zero_and_carry_all_five_counters`.
+- **Failure value** — `reason_sets_reproduce_the_typescript_unions_verbatim`
+  (both unions, member by member, in declaration order),
+  `each_class_permits_only_its_own_union`,
+  `failure_carries_class_reason_message_and_the_offending_index`,
+  `failure_display_names_the_typescript_error_class_and_reason`, and two
+  `#[should_panic]` tests pinning the fail-loud constructor guard.
+- **Entry point** —
+  `the_entry_point_refuses_to_certify_a_creature_until_the_rules_are_ported`,
+  run against the Issue #555 `stump_creature()` fixture. The porting issues
+  replace this test with the real rule coverage.
+- **Input format** —
+  `a_creature_without_id_or_memetic_parses_and_serialises_unchanged`
+  (backward compatibility), `negative_output_neuron_ids_round_trip`,
+  `the_memetic_block_round_trips_including_keys_the_validator_does_not_read`,
+  `a_memetic_weight_missing_its_fields_still_parses_so_the_rule_can_report_it`,
+  `a_hand_built_creature_can_carry_the_extension`.
+
+Existing suites are unchanged in behaviour; the `CreatureExport` /
+`NeuronExport` literals across `decision_tree.rs`, `if_graft.rs` and the
+creature tests gained the two new fields as `None`.
+
+## Security self-check
+
+- Input validation: the new fields are optional and typed; a malformed `id` or
+  memetic block fails at the serde boundary, before any rule runs.
+- No secrets, no new dependencies, no new shell/SQL/HTTP surface.
+- Errors carry no host paths or internal state — the message reproduces the
+  TypeScript text and the indices of the offending neuron/synapse.

--- a/docs/research/ikaruga-neat-ai-comparison.md
+++ b/docs/research/ikaruga-neat-ai-comparison.md
@@ -50,7 +50,7 @@ The `mame-neat` sibling crate mirrors this layout against MAME.
 
 The table lists the modules present in `neat-core/src/` today. `pc_inference` / `pc_learning` (the predictive-coding inference engine and learning rule) were in this inventory when the research was written and were **removed in Issue #414**; `wasm_dataset` was likewise **removed in Issue #415**.
 
-Source footprint: **~18,300** LOC across `neat-core/src/`, measured on `Develop` at Issue #498. `tests/scripts/research_docs_removed_modules.bats` fails loud once the tree drifts more than 10% from that figure — refresh the number here when it does. No evolutionary operator code is present — by design.
+Source footprint: **~20,900** LOC across `neat-core/src/`, measured on `Develop` at Issue #559. `tests/scripts/research_docs_removed_modules.bats` fails loud once the tree drifts more than 10% from that figure — refresh the number here when it does. No evolutionary operator code is present — by design.
 
 ## Feature-by-feature comparison
 

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -43,8 +43,15 @@
 //! [`CreatureError::DuplicateSynapse`] rather than producing a number
 //! TypeScript would never agree with.
 //!
+//! **Validator extension (Issue #559).** [`NeuronExport::id`] and
+//! [`CreatureExport::memetic`] carry the two pieces
+//! [`crate::creature_validate::creature_validate`] needs and nothing else in
+//! this crate reads. Both are optional and skipped when absent, so a creature
+//! written before they existed parses and round trips byte-identically.
+//!
 //! Issues: #1965 (initial deserialisation), #30 (symmetric serialisation),
-//! #550 (observation-width contract), #556 (duplicate-synapse rule).
+//! #550 (observation-width contract), #556 (duplicate-synapse rule),
+//! #559 (validation contract input format).
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -47,7 +47,7 @@
 //! #550 (observation-width contract), #556 (duplicate-synapse rule).
 
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::loss::MSE_TILE_LANES;
 use crate::network::{CompiledNetwork, MAX_NODE_COUNT, NeuronData, SynapseData, hot_synapse_soa};
@@ -82,11 +82,30 @@ pub struct CreatureExport {
     /// When true, training rows are independent (no recurrent / feedback state).
     #[serde(rename = "forwardOnly", default)]
     pub forward_only: bool,
+    /// Optional memetic (local fine-tuning) record — Issue #559.
+    ///
+    /// Read by the `MEMETIC` rule of
+    /// [`crate::creature_validate::creature_validate`]; ignored by every other
+    /// entry point in this crate. Absent by default, and skipped on output, so
+    /// creatures written before the field existed round trip byte-identically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memetic: Option<MemeticExport>,
 }
 
 /// Neuron export format matching the TypeScript `NeuronExport` interface.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct NeuronExport {
+    /// Runtime integer neuron id — Issue #559 (NEAT-AI #1958).
+    ///
+    /// Optional, because NEAT-AI omits it from new exports in favour of
+    /// [`uuid`](Self::uuid); absent by default and skipped on output, so a
+    /// creature written without it round trips byte-identically. Signed:
+    /// output neurons carry **negative** ids (`-(outputIndex + 1)`). Read by
+    /// [`crate::creature_validate::creature_validate`], which needs it for the
+    /// neuron-id rules and to resolve the memetic keys; a non-integer id fails
+    /// in serde rather than reaching the validator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
     /// Neuron type: "hidden", "output", or "constant".
     #[serde(rename = "type")]
     pub neuron_type: String,
@@ -113,6 +132,47 @@ pub struct SynapseExport {
     /// Optional synapse type: "positive", "negative", or "condition".
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub synapse_type: Option<String>,
+}
+
+/// Memetic (local fine-tuning) record carried on a creature — Issue #559.
+///
+/// Mirrors NEAT-AI's `MemeticInterface` (`src/blackbox/MemeticInterface.ts`),
+/// but names only the two members
+/// [`crate::creature_validate::creature_validate`] reads. Everything else the
+/// record carries (`generation`, `score`, `ancestry`) is kept verbatim in
+/// [`extra`](Self::extra) rather than dropped, so a creature round trips
+/// through this crate without losing its fine-tuning history.
+///
+/// Both maps are keyed by the **JSON key text**, not by a parsed integer: the
+/// keys are neuron ids written as strings (TypeScript does `Number(neuronId)`
+/// when it reads them), and a key that is not a number at all is a `MEMETIC`
+/// validation failure rather than a parse error.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct MemeticExport {
+    /// Bias delta per neuron id.
+    #[serde(default)]
+    pub biases: BTreeMap<String, f64>,
+    /// Weight deltas per source neuron id.
+    #[serde(default)]
+    pub weights: BTreeMap<String, Vec<MemeticWeightExport>>,
+    /// Every other key on the TypeScript record, preserved verbatim.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// One memetic weight delta — NEAT-AI's `MemeticWeightInterface`.
+///
+/// Both fields are optional because the `MEMETIC` rule must be able to
+/// *report* an entry missing `toId` or `weight`; making them required would
+/// turn that validation failure into a serde error at the parse boundary.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct MemeticWeightExport {
+    /// Destination neuron id.
+    #[serde(rename = "toId", default, skip_serializing_if = "Option::is_none")]
+    pub to_id: Option<i64>,
+    /// The fine-tuned weight.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
 }
 
 /// Errors that can occur when parsing, serialising, or compiling a creature.

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -1,0 +1,506 @@
+//! Creature validation — the shared definition of a valid creature (Issue #559).
+//!
+//! This module is the Rust home of NEAT-AI's
+//! `src/architecture/CreatureValidate.ts`: the invariants a healthy topology
+//! must hold. NEAT-AI-Forests shipped an invalid creature that
+//! `Creature.validate()` would have caught, and the fix is **one** definition
+//! both stacks read — Rust consumers call [`creature_validate`] natively, and
+//! NEAT-AI calls the same code over the existing WASM boundary.
+//!
+//! **This issue lands the contract only.** The types, the error model, the
+//! rule *order* and the input format are fixed here so the two porting issues
+//! (NEAT-AI#3801 / #3802) can be worked in parallel against a stable
+//! interface. [`creature_validate`] therefore evaluates no rule yet — see
+//! [the entry point](creature_validate) for what it returns until they land.
+//!
+//! # Options
+//!
+//! [`ValidateOptions`] mirrors the TypeScript options bag, including two
+//! asymmetries that are easy to lose in a port and are pinned by
+//! `neat-core/tests/creature_validate_contract.rs`:
+//!
+//! - `forwardOnly === true` forces `feedbackLoop` to `false`
+//!   ([`ValidateOptions::resolved_feedback_loop`]); otherwise `feedbackLoop`
+//!   passes through and **only** an explicit `Some(false)` rejects `from > to`
+//!   ([`ValidateOptions::rejects_recursive_synapses`]).
+//! - `if (options && options.neurons)` is a *truthiness* test, so an expected
+//!   neuron count of `0` is **not** checked, while
+//!   `Number.isInteger(options.connections)` checks `0` like any other integer
+//!   ([`ValidateOptions::expected_neurons`] /
+//!   [`ValidateOptions::expected_connections`]).
+//!
+//! # Rule order is part of the contract
+//!
+//! First failure wins: [`creature_validate`] returns on the first violated
+//! rule, matching the TypeScript `throw`. The order below is the order the
+//! ports must evaluate in — a creature breaking two rules must name the same
+//! one in both stacks.
+//!
+//! | # | Rule | Class / `reason` |
+//! |---|------|------------------|
+//! | 1 | expected neuron count (when truthy) | `Validation` / `OTHER` |
+//! | 2 | `input` is an integer `>= 1` | `Validation` / `OTHER` |
+//! | 3 | `output` is an integer `>= 1` | `Validation` / `OTHER` |
+//! | 4 | neuron has an `id` | `Validation` / `OTHER` |
+//! | 5 | `id` is an integer `<=` [`MAX_NEURON_ID`] | `Validation` / `OTHER` |
+//! | 6 | `id` is unique | `Validation` / `OTHER` |
+//! | 7 | input neuron's `id` equals its index | `Validation` / `OTHER` |
+//! | 8 | non-input neuron has a finite bias | `Validation` / `OTHER` |
+//! | 9 | no neuron follows an output neuron | `Validation` / `OTHER` |
+//! | 10 | no input neuron past the declared input width | `Validation` / `OTHER` |
+//! | 11 | in the computational slice, no constant after a hidden | `Validation` / `NEURON_ORDER` |
+//! | 12 | an `IF` neuron has >= 3 inward edges, one of each role | `Validation` / `IF_CONDITIONS` |
+//! | 13 | `input` neuron has no inward edges | `Topology` / `INVALID_CONNECTION` |
+//! | 14 | `constant` neuron has no inward edges | `Topology` / `INVALID_CONNECTION` |
+//! | 15 | `constant` neuron has no squash | `Topology` / `INVALID_SQUASH` |
+//! | 16 | `constant` neuron has an outward edge | `Validation` / `NO_OUTWARD_CONNECTIONS` |
+//! | 17 | `hidden` neuron has an inward edge | `Validation` / `NO_INWARD_CONNECTIONS` |
+//! | 18 | `hidden` neuron has an outward edge | `Validation` / `NO_OUTWARD_CONNECTIONS` |
+//! | 19 | `hidden` neuron has a finite bias | `Topology` / `INVALID_STATE` |
+//! | 20 | declared type is one of the four known types | `Topology` / `INVALID_NEURON_TYPE` |
+//! | 21 | counted inputs match the declared `input` | `Validation` / `OTHER` |
+//! | 22 | counted outputs match the declared `output` | `Topology` / `INVALID_STATE` |
+//! | 23 | no synapse points at an input neuron | `Topology` / `INVALID_CONNECTION` |
+//! | 24 | no self connection (when `forward_only`) | `Validation` / `SELF_CONNECTION` |
+//! | 25 | synapses sorted by `(from, to)` | `Topology` / `SORT_FAILURE` |
+//! | 26 | no duplicate `(from, to)` pair | `Topology` / `INVALID_CONNECTION` |
+//! | 27 | no `from > to` when recursion is disallowed | `Validation` / `RECURSIVE_SYNAPSE` |
+//! | 28 | expected connection count (when set) | `Validation` / `OTHER` |
+//! | 29 | forward-only creatures are sorted, self-loop free and acyclic | `Topology` / `INVALID_CONNECTION` |
+//! | 30 | forward-only structural integrity | `Validation` / `OTHER` |
+//! | 31 | memetic biases / weights resolve to real neurons and synapses | `Validation` / `MEMETIC` |
+//!
+//! Rule 26 is the same notion of "duplicate" as
+//! [`crate::creature::validate_no_duplicate_synapses`] (Issue #556) — one
+//! ordered `(from, to)` pair, at most once — reported here under the
+//! TypeScript's own class and reason (`TopologyError` / `INVALID_CONNECTION`,
+//! *not* `DUPLICATE_SYNAPSE`, which `creatureValidate` never raises).
+//!
+//! # Input format
+//!
+//! A creature reaches the validator as a [`CreatureExport`] — the JSON wire
+//! shape this crate already parses — not as a second, validator-only struct.
+//! Two fields were added for the rules above, both optional and both skipped
+//! when absent, so every existing [`crate::creature::parse_creature_json`]
+//! caller and every already-written creature file is unaffected:
+//!
+//! | Field | Why the validator needs it |
+//! |-------|----------------------------|
+//! | [`crate::creature::NeuronExport::id`] | rules 4–7 and the memetic keys; output neurons carry **negative** ids (NEAT-AI #1958), so it is signed |
+//! | [`crate::creature::CreatureExport::memetic`] | rule 31 (`biases`, `weights`) |
+//!
+//! The export form is **index-free**: it lists only non-input neurons and
+//! wires them by UUID, while the TypeScript validator walks an in-memory
+//! creature indexed from zero. The port derives the indices the same way
+//! [`crate::creature::compile_creature`] does, and that derivation is part of
+//! the contract:
+//!
+//! - indices `0..input` are the implicit input neurons, UUID `input-N`, with
+//!   `id == index` (so rules 7, 10 and 21 hold by construction, and rule 21
+//!   reports `stats.input == creature.input`);
+//! - index `input + i` is `creature.neurons[i]`;
+//! - a synapse's `from` / `to` are those indices, resolved from `fromUUID` /
+//!   `toUUID`. An endpoint naming no neuron is `Topology` /
+//!   `INVALID_SYNAPSE_REFERENCE` — the one failure the in-memory TypeScript
+//!   form cannot express, mapped onto its existing union rather than a new
+//!   name;
+//! - `neurons` may not declare `type: "input"`; input neurons are implicit, so
+//!   an entry claiming to be one is `Topology` / `INVALID_NEURON_TYPE`;
+//! - `creature.neurons.length` in the TypeScript rules (1, 11) means
+//!   `input + neurons.len()` here.
+//!
+//! Two TypeScript checks are unreachable in the Rust shape because serde
+//! rejects the input earlier, and that is deliberate — a malformed file fails
+//! at the parse boundary instead of reaching the validator: a non-integer
+//! neuron `id` (rule 5) and a non-array memetic `weights` entry (rule 31) are
+//! [`crate::creature::CreatureError::Json`].
+//!
+//! # What stays host-side (NEAT-AI#3802)
+//!
+//! These checks depend on JavaScript object identity or on the host
+//! filesystem, so they do **not** move here and stay in
+//! `CreatureValidate.ts`:
+//!
+//! | TypeScript check | Why it stays |
+//! |------------------|--------------|
+//! | `neuron.creature !== creature` | object identity — a `CreatureExport` has no back-reference |
+//! | `neuron.index !== indx` | the export carries no `index`; position *is* the index here |
+//! | `neuron.validate()` | per-neuron host method over the live `Neuron` class |
+//! | `debugWrite(creature)` diagnostics dump | writes `creatureValidate.json` to the host diagnostics dir |
+//!
+//! The Rust failure carries [`ValidationFailure::neuron_index`] /
+//! [`ValidationFailure::synapse_index`] so the host can run its own identity
+//! checks and its diagnostics dump against the same neuron or synapse the
+//! shared rules stopped on.
+
+use std::fmt;
+
+use crate::creature::CreatureExport;
+
+/// Largest neuron id NEAT-AI accepts — `int32` max, mirroring
+/// `MAX_NEURON_ID` in `src/architecture/CreatureValidate.ts`.
+pub const MAX_NEURON_ID: i64 = 2_147_483_647;
+
+/// The permitted [`ValidationFailure::reason`] values, one constant each.
+///
+/// **Source of truth: NEAT-AI `src/errors/ValidationError.ts`
+/// (`ValidationErrorName`) and `src/errors/TopologyError.ts`
+/// (`TopologyErrorReason`).** The strings are the union members verbatim so
+/// NEAT-AI rehydrates the right error type from the wire without a translation
+/// table; a name that drifts from those two files silently loses a failure
+/// mode, so change them together.
+///
+/// [`VALIDATION_REASONS`] and [`TOPOLOGY_REASONS`] are the full lists, and
+/// [`FailureClass::permits`] is what the failure constructors enforce.
+pub mod reason {
+    // src/errors/ValidationError.ts — ValidationErrorName
+    /// Catch-all validation failure.
+    pub const OTHER: &str = "OTHER";
+    /// Neurons are not in `input, constant, hidden, output` order.
+    pub const NEURON_ORDER: &str = "NEURON_ORDER";
+    /// A neuron that must feed something has no outward synapse.
+    pub const NO_OUTWARD_CONNECTIONS: &str = "NO_OUTWARD_CONNECTIONS";
+    /// A hidden neuron has no inward synapse.
+    pub const NO_INWARD_CONNECTIONS: &str = "NO_INWARD_CONNECTIONS";
+    /// An `IF` neuron is missing one of its condition / positive / negative roles.
+    pub const IF_CONDITIONS: &str = "IF_CONDITIONS";
+    /// A backward synapse (`from > to`) where recursion is disallowed.
+    pub const RECURSIVE_SYNAPSE: &str = "RECURSIVE_SYNAPSE";
+    /// A self connection (`from == to`) in a forward-only creature.
+    pub const SELF_CONNECTION: &str = "SELF_CONNECTION";
+    /// Union member kept verbatim; `creatureValidate` reports a repeated
+    /// `(from, to)` pair as [`INVALID_CONNECTION`] instead.
+    pub const DUPLICATE_SYNAPSE: &str = "DUPLICATE_SYNAPSE";
+    /// A memetic bias or weight does not resolve to a neuron or synapse.
+    pub const MEMETIC: &str = "MEMETIC";
+
+    // src/errors/TopologyError.ts — TopologyErrorReason
+    /// A neuron declares a type outside `input | constant | hidden | output`.
+    pub const INVALID_NEURON_TYPE: &str = "INVALID_NEURON_TYPE";
+    /// A neuron's bias is not a finite number.
+    pub const INVALID_NEURON_BIAS: &str = "INVALID_NEURON_BIAS";
+    /// A neuron carries a squash it may not have.
+    pub const INVALID_SQUASH: &str = "INVALID_SQUASH";
+    /// A synapse weight is not a finite number.
+    pub const INVALID_SYNAPSE_WEIGHT: &str = "INVALID_SYNAPSE_WEIGHT";
+    /// A synapse endpoint does not resolve to a neuron.
+    pub const INVALID_SYNAPSE_REFERENCE: &str = "INVALID_SYNAPSE_REFERENCE";
+    /// A neuron that requires a squash has none.
+    pub const MISSING_SQUASH: &str = "MISSING_SQUASH";
+    /// A synapse is wired somewhere it may not be — including a duplicate pair.
+    pub const INVALID_CONNECTION: &str = "INVALID_CONNECTION";
+    /// The creature's own bookkeeping disagrees with its neurons.
+    pub const INVALID_STATE: &str = "INVALID_STATE";
+    /// Two neurons share a UUID.
+    pub const DUPLICATE_UUID: &str = "DUPLICATE_UUID";
+    /// A referenced neuron is absent.
+    pub const MISSING_NEURON: &str = "MISSING_NEURON";
+    /// A neuron has no UUID.
+    pub const MISSING_NEURON_UUID: &str = "MISSING_NEURON_UUID";
+    /// Synapses are not sorted by `(from, to)`.
+    pub const SORT_FAILURE: &str = "SORT_FAILURE";
+    /// Too many errors to keep reporting.
+    pub const EXCESSIVE_ERRORS: &str = "EXCESSIVE_ERRORS";
+}
+
+/// Every `ValidationErrorName`, in `ValidationError.ts` declaration order.
+pub const VALIDATION_REASONS: [&str; 9] = [
+    reason::OTHER,
+    reason::NEURON_ORDER,
+    reason::NO_OUTWARD_CONNECTIONS,
+    reason::NO_INWARD_CONNECTIONS,
+    reason::IF_CONDITIONS,
+    reason::RECURSIVE_SYNAPSE,
+    reason::SELF_CONNECTION,
+    reason::DUPLICATE_SYNAPSE,
+    reason::MEMETIC,
+];
+
+/// Every `TopologyErrorReason`, in `TopologyError.ts` declaration order.
+pub const TOPOLOGY_REASONS: [&str; 13] = [
+    reason::INVALID_NEURON_TYPE,
+    reason::INVALID_NEURON_BIAS,
+    reason::INVALID_SQUASH,
+    reason::INVALID_SYNAPSE_WEIGHT,
+    reason::INVALID_SYNAPSE_REFERENCE,
+    reason::MISSING_SQUASH,
+    reason::INVALID_CONNECTION,
+    reason::INVALID_STATE,
+    reason::DUPLICATE_UUID,
+    reason::MISSING_NEURON,
+    reason::MISSING_NEURON_UUID,
+    reason::SORT_FAILURE,
+    reason::EXCESSIVE_ERRORS,
+];
+
+const fn str_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+const fn all_distinct(list: &[&str]) -> bool {
+    let mut i = 0;
+    while i < list.len() {
+        let mut j = i + 1;
+        while j < list.len() {
+            if str_eq(list[i], list[j]) {
+                return false;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    true
+}
+
+const fn disjoint(left: &[&str], right: &[&str]) -> bool {
+    let mut i = 0;
+    while i < left.len() {
+        let mut j = 0;
+        while j < right.len() {
+            if str_eq(left[i], right[j]) {
+                return false;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    true
+}
+
+// A reason must name exactly one class, or NEAT-AI cannot rehydrate the right
+// error type from it. Checked at compile time so a copy-paste into the wrong
+// list never builds.
+const _: () = assert!(all_distinct(&VALIDATION_REASONS));
+const _: () = assert!(all_distinct(&TOPOLOGY_REASONS));
+const _: () = assert!(disjoint(&VALIDATION_REASONS, &TOPOLOGY_REASONS));
+
+/// Which TypeScript error class a failure rehydrates as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FailureClass {
+    /// NEAT-AI `TopologyError` — reasons from [`TOPOLOGY_REASONS`].
+    Topology,
+    /// NEAT-AI `ValidationError` — reasons from [`VALIDATION_REASONS`].
+    Validation,
+}
+
+impl FailureClass {
+    /// The TypeScript class name (`Error.name`) this class maps to.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            FailureClass::Topology => "TopologyError",
+            FailureClass::Validation => "ValidationError",
+        }
+    }
+
+    /// The reasons this class may carry.
+    pub const fn permitted_reasons(self) -> &'static [&'static str] {
+        match self {
+            FailureClass::Topology => &TOPOLOGY_REASONS,
+            FailureClass::Validation => &VALIDATION_REASONS,
+        }
+    }
+
+    /// Whether `reason` belongs to this class's union.
+    pub fn permits(self, reason: &str) -> bool {
+        self.permitted_reasons().contains(&reason)
+    }
+}
+
+impl fmt::Display for FailureClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What [`creature_validate`] returns for a creature that broke no rule —
+/// the `stats` object `creatureValidate` returns today.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ValidationStats {
+    /// Input neurons counted (always the declared `input`, see the input
+    /// format section: input neurons are implicit in the export form).
+    pub input: u32,
+    /// Constant neurons counted.
+    pub constant: u32,
+    /// Hidden neurons counted.
+    pub hidden: u32,
+    /// Output neurons counted.
+    pub output: u32,
+    /// Synapses counted.
+    pub connections: u32,
+}
+
+impl ValidationStats {
+    /// Total neurons counted — the TypeScript `creature.neurons.length`.
+    pub const fn neurons(&self) -> u32 {
+        self.input + self.constant + self.hidden + self.output
+    }
+}
+
+/// The first violated rule: which class of TypeScript error it raises, the
+/// verbatim `reason`, the human-readable message and where it was found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationFailure {
+    /// Whether NEAT-AI rehydrates this as a `TopologyError` or a `ValidationError`.
+    pub class: FailureClass,
+    /// One of [`FailureClass::permitted_reasons`], verbatim from the
+    /// TypeScript union — see [`reason`].
+    pub reason: &'static str,
+    /// Human-readable text reproducing the TypeScript message.
+    pub message: String,
+    /// Index of the neuron the rule stopped on, if it was a neuron rule.
+    pub neuron_index: Option<u32>,
+    /// Index of the synapse the rule stopped on, if it was a synapse rule.
+    pub synapse_index: Option<u32>,
+}
+
+impl ValidationFailure {
+    /// Build a failure, rejecting a `reason` outside `class`'s union.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `reason` is not one of [`FailureClass::permitted_reasons`].
+    /// Every caller passes a [`reason`] constant, so this can only fire on a
+    /// programming error — and it fires loudly rather than sending NEAT-AI a
+    /// string it cannot rehydrate into a typed error.
+    pub fn new(class: FailureClass, reason: &'static str, message: impl Into<String>) -> Self {
+        assert!(
+            class.permits(reason),
+            "{reason:?} is not a {} reason",
+            class.as_str()
+        );
+        Self {
+            class,
+            reason,
+            message: message.into(),
+            neuron_index: None,
+            synapse_index: None,
+        }
+    }
+
+    /// Build a [`FailureClass::Validation`] failure. See [`Self::new`].
+    pub fn validation(reason: &'static str, message: impl Into<String>) -> Self {
+        Self::new(FailureClass::Validation, reason, message)
+    }
+
+    /// Build a [`FailureClass::Topology`] failure. See [`Self::new`].
+    pub fn topology(reason: &'static str, message: impl Into<String>) -> Self {
+        Self::new(FailureClass::Topology, reason, message)
+    }
+
+    /// Record the neuron index the rule stopped on.
+    #[must_use]
+    pub fn at_neuron(mut self, index: u32) -> Self {
+        self.neuron_index = Some(index);
+        self
+    }
+
+    /// Record the synapse index the rule stopped on.
+    #[must_use]
+    pub fn at_synapse(mut self, index: u32) -> Self {
+        self.synapse_index = Some(index);
+        self
+    }
+}
+
+impl fmt::Display for ValidationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({}): {}", self.class, self.reason, self.message)
+    }
+}
+
+impl std::error::Error for ValidationFailure {}
+
+/// Options the caller may pin, mirroring the TypeScript options bag.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ValidateOptions {
+    /// Expected total neuron count, `input + neurons.len()`.
+    ///
+    /// Read through [`Self::expected_neurons`]: TypeScript tests this for
+    /// *truthiness*, so `Some(0)` is not checked.
+    pub neurons: Option<usize>,
+    /// Expected synapse count, read through [`Self::expected_connections`].
+    /// TypeScript tests this with `Number.isInteger`, so `Some(0)` **is**
+    /// checked.
+    pub connections: Option<usize>,
+    /// `None` = allow recursive synapses (NEAT-AI's `undefined`).
+    /// `Some(false)` rejects them; `Some(true)` allows them explicitly.
+    pub feedback_loop: Option<bool>,
+    /// Production feed-forward validation: forces [`Self::feedback_loop`] to
+    /// `Some(false)` and rejects self connections.
+    pub forward_only: bool,
+}
+
+impl ValidateOptions {
+    /// `const feedbackLoop = forwardOnly ? false : options?.feedbackLoop;`
+    pub const fn resolved_feedback_loop(&self) -> Option<bool> {
+        if self.forward_only {
+            Some(false)
+        } else {
+            self.feedback_loop
+        }
+    }
+
+    /// Whether a backward synapse (`from > to`) is a failure — true only when
+    /// [`Self::resolved_feedback_loop`] is an explicit `Some(false)`.
+    pub const fn rejects_recursive_synapses(&self) -> bool {
+        matches!(self.resolved_feedback_loop(), Some(false))
+    }
+
+    /// The neuron count to check, or `None` when the rule is skipped.
+    ///
+    /// `if (options && options.neurons)` is a truthiness test in TypeScript,
+    /// so `Some(0)` skips the rule rather than demanding an empty creature.
+    pub const fn expected_neurons(&self) -> Option<usize> {
+        match self.neurons {
+            Some(0) | None => None,
+            some => some,
+        }
+    }
+
+    /// The synapse count to check, or `None` when the rule is skipped.
+    ///
+    /// `Number.isInteger(options.connections)` accepts `0`, so a caller can
+    /// demand a creature with no synapses at all.
+    pub const fn expected_connections(&self) -> Option<usize> {
+        self.connections
+    }
+}
+
+/// Validate a creature against the rules in the module documentation.
+///
+/// First failure wins: the first violated rule is returned and no later rule
+/// runs, matching the TypeScript `throw`.
+///
+/// # Contract stub (Issue #559)
+///
+/// The rule bodies are ported by NEAT-AI#3801 / #3802. Until they land this
+/// function checks **nothing**, and it says so: it returns a
+/// [`FailureClass::Validation`] / [`reason::OTHER`] failure rather than an
+/// empty [`ValidationStats`], because an unconditional `Ok` would report every
+/// creature — including the invalid one this work exists to catch — as valid.
+/// A consumer wiring the entry point up early fails loudly instead.
+///
+/// # Errors
+///
+/// Returns the [`ValidationFailure`] for the first violated rule.
+pub fn creature_validate(
+    _creature: &CreatureExport,
+    _options: &ValidateOptions,
+) -> Result<ValidationStats, ValidationFailure> {
+    Err(ValidationFailure::validation(
+        reason::OTHER,
+        "creature_validate rule bodies are not ported yet (Issue #559 landed the \
+         contract only): no creature can be certified valid by this build",
+    ))
+}

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -124,7 +124,7 @@
 //! | TypeScript check | Why it stays |
 //! |------------------|--------------|
 //! | `neuron.creature !== creature` | object identity — a `CreatureExport` has no back-reference |
-//! | `neuron.index !== indx` | the export carries no `index`; position *is* the index here |
+//! | `neuron.index` vs its loop position | the export carries no `index`; position *is* the index here |
 //! | `neuron.validate()` | per-neuron host method over the live `Neuron` class |
 //! | `debugWrite(creature)` diagnostics dump | writes `creatureValidate.json` to the host diagnostics dir |
 //!

--- a/neat-core/src/decision_tree.rs
+++ b/neat-core/src/decision_tree.rs
@@ -164,6 +164,7 @@ pub const RESIDUAL_CASES: &[DecisionCase] = &[
 
 fn constant_neuron(uuid: &str) -> NeuronExport {
     NeuronExport {
+        id: None,
         neuron_type: "constant".to_string(),
         uuid: uuid.to_string(),
         bias: 1.0,
@@ -173,6 +174,7 @@ fn constant_neuron(uuid: &str) -> NeuronExport {
 
 fn if_neuron(uuid: &str, neuron_type: &str) -> NeuronExport {
     NeuronExport {
+        id: None,
         neuron_type: neuron_type.to_string(),
         uuid: uuid.to_string(),
         bias: 0.0,
@@ -224,6 +226,7 @@ pub fn stump_creature() -> CreatureExport {
     neurons.push(if_neuron("output-0", "output"));
 
     CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons,
@@ -271,6 +274,7 @@ pub fn depth2_tree_creature() -> CreatureExport {
     synapses.push(edge("low", "output-0", 1.0, SynapseType::Negative));
 
     CreatureExport {
+        memetic: None,
         input: 2,
         output: 1,
         neurons,
@@ -285,9 +289,11 @@ pub fn depth2_tree_creature() -> CreatureExport {
 /// The base that [`residual_correction_creature`] grafts a correction onto.
 pub fn linear_base_creature() -> CreatureExport {
     CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons: vec![NeuronExport {
+            id: None,
             neuron_type: "output".to_string(),
             uuid: "output-0".to_string(),
             bias: 0.0,
@@ -320,6 +326,7 @@ pub fn residual_correction_creature() -> CreatureExport {
     let mut neurons: Vec<NeuronExport> = [&condition_one, &positive_one, &negative_one]
         .iter()
         .map(|uuid| NeuronExport {
+            id: None,
             neuron_type: "constant".to_string(),
             uuid: (*uuid).clone(),
             bias: crate::if_graft::GRAFT_CONSTANT_BIAS,
@@ -328,6 +335,7 @@ pub fn residual_correction_creature() -> CreatureExport {
         .collect();
     neurons.push(if_neuron(node, "hidden"));
     neurons.push(NeuronExport {
+        id: None,
         neuron_type: "output".to_string(),
         uuid: "output-0".to_string(),
         bias: 0.0,
@@ -359,6 +367,7 @@ pub fn residual_correction_creature() -> CreatureExport {
     ];
 
     CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons,

--- a/neat-core/src/if_graft.rs
+++ b/neat-core/src/if_graft.rs
@@ -631,6 +631,7 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
     neurons.extend_from_slice(&creature.neurons[..position]);
     for constant in &spec.constants {
         neurons.push(NeuronExport {
+            id: None,
             neuron_type: "constant".to_string(),
             uuid: constant.uuid.clone(),
             bias: constant.bias,
@@ -638,6 +639,7 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
         });
     }
     neurons.push(NeuronExport {
+        id: None,
         neuron_type: "hidden".to_string(),
         uuid: spec.uuid.clone(),
         bias: spec.bias,
@@ -673,6 +675,7 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
     }
 
     CreatureExport {
+        memetic: None,
         input: creature.input,
         output: creature.output,
         neurons,

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod accumulate;
 pub mod batch_scoring;
 pub mod creature;
+pub mod creature_validate;
 pub mod decision_tree;
 pub mod derivative;
 pub mod elastic_distribution;
@@ -58,10 +59,14 @@ pub mod wasm_arch;
 
 // Re-export key types for convenience
 pub use creature::{
-    CreatureError, CreatureExport, NeuronExport, SynapseExport, compile_creature, creature_to_json,
-    creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
-    squash_name_from, synapse_type_name_from, validate_creature_width,
-    validate_no_duplicate_synapses,
+    CreatureError, CreatureExport, MemeticExport, MemeticWeightExport, NeuronExport, SynapseExport,
+    compile_creature, creature_to_json, creature_to_json_pretty, parse_creature_json,
+    parse_squash_name, parse_synapse_type, squash_name_from, synapse_type_name_from,
+    validate_creature_width, validate_no_duplicate_synapses,
+};
+// Issue #559 — the shared creature-validation contract.
+pub use creature_validate::{
+    FailureClass, ValidateOptions, ValidationFailure, ValidationStats, creature_validate,
 };
 // Issue #555 — canonical IF decision-tree fixtures and the graft helper.
 pub use decision_tree::{

--- a/neat-core/tests/creature/roundtrip.rs
+++ b/neat-core/tests/creature/roundtrip.rs
@@ -139,9 +139,11 @@ fn minimal_one_input_one_output_one_synapse_roundtrips() {
 #[test]
 fn camelcase_field_names_are_symmetric_on_output() {
     let creature = CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons: vec![NeuronExport {
+            id: None,
             neuron_type: "output".to_string(),
             uuid: "output-0".to_string(),
             bias: 0.0,
@@ -201,9 +203,11 @@ fn optional_fields_absent_when_none() {
     // emit those keys at all — matches the TypeScript "optional field"
     // convention and avoids explicit `null` values in the canonical JSON.
     let creature = CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons: vec![NeuronExport {
+            id: None,
             neuron_type: "output".to_string(),
             uuid: "output-0".to_string(),
             bias: 0.0,

--- a/neat-core/tests/creature_compile.rs
+++ b/neat-core/tests/creature_compile.rs
@@ -717,6 +717,7 @@ fn compile_creature_rejects_too_many_nodes() {
     // check passes and the only rejection left is the node-count guard.
     let mut neurons: Vec<NeuronExport> = (0..MAX_NODE_COUNT - 1)
         .map(|i| NeuronExport {
+            id: None,
             neuron_type: "hidden".to_string(),
             uuid: format!("n{i}"),
             bias: 0.0,
@@ -724,6 +725,7 @@ fn compile_creature_rejects_too_many_nodes() {
         })
         .collect();
     neurons.push(NeuronExport {
+        id: None,
         neuron_type: "output".to_string(),
         uuid: "output-0".to_string(),
         bias: 0.0,
@@ -731,6 +733,7 @@ fn compile_creature_rejects_too_many_nodes() {
     });
 
     let creature = CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons,

--- a/neat-core/tests/creature_duplicate_synapses.rs
+++ b/neat-core/tests/creature_duplicate_synapses.rs
@@ -29,6 +29,7 @@ fn synapse(from: &str, to: &str, weight: f64, synapse_type: Option<&str>) -> Syn
 
 fn neuron(neuron_type: &str, uuid: &str, bias: f64, squash: &str) -> NeuronExport {
     NeuronExport {
+        id: None,
         neuron_type: neuron_type.to_string(),
         uuid: uuid.to_string(),
         bias,
@@ -44,6 +45,7 @@ fn neuron(neuron_type: &str, uuid: &str, bias: f64, squash: &str) -> NeuronExpor
 /// trustworthy, so the creature must not compile.
 fn if_triple_from_one_constant() -> CreatureExport {
     CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons: vec![
@@ -179,6 +181,7 @@ fn compile_accepts_an_if_neuron_fed_by_three_distinct_constants() {
     // The canonical IF shape the duplicate repro was a corruption of: one
     // constant per branch, so the three pairs are distinct.
     let creature = CreatureExport {
+        memetic: None,
         input: 1,
         output: 1,
         neurons: vec![

--- a/neat-core/tests/creature_validate_contract.rs
+++ b/neat-core/tests/creature_validate_contract.rs
@@ -212,7 +212,8 @@ fn failure_carries_class_reason_message_and_the_offending_index() {
 /// line reads the same as the TypeScript one it mirrors.
 #[test]
 fn failure_display_names_the_typescript_error_class_and_reason() {
-    let failure = ValidationFailure::validation(reason::NO_INWARD_CONNECTIONS, "hidden-2 is orphaned");
+    let failure =
+        ValidationFailure::validation(reason::NO_INWARD_CONNECTIONS, "hidden-2 is orphaned");
 
     assert_eq!(
         failure.to_string(),
@@ -283,7 +284,10 @@ fn a_creature_without_id_or_memetic_parses_and_serialises_unchanged() {
 
     let json = creature_to_json(&creature).expect("serialises");
     assert!(!json.contains("\"id\""), "no id key was emitted: {json}");
-    assert!(!json.contains("memetic"), "no memetic key was emitted: {json}");
+    assert!(
+        !json.contains("memetic"),
+        "no memetic key was emitted: {json}"
+    );
     assert_eq!(
         parse_creature_json(&json).expect("re-parses"),
         creature,
@@ -309,8 +313,8 @@ fn negative_output_neuron_ids_round_trip() {
     assert_eq!(creature.neurons[0].id, Some(2));
     assert_eq!(creature.neurons[1].id, Some(-1));
 
-    let round_tripped = parse_creature_json(&creature_to_json(&creature).expect("serialises"))
-        .expect("re-parses");
+    let round_tripped =
+        parse_creature_json(&creature_to_json(&creature).expect("serialises")).expect("re-parses");
     assert_eq!(round_tripped, creature);
 }
 
@@ -346,10 +350,13 @@ fn the_memetic_block_round_trips_including_keys_the_validator_does_not_read() {
             .as_slice()
         )
     );
-    assert_eq!(memetic.extra.get("generation").and_then(|v| v.as_i64()), Some(12));
+    assert_eq!(
+        memetic.extra.get("generation").and_then(|v| v.as_i64()),
+        Some(12)
+    );
 
-    let round_tripped = parse_creature_json(&creature_to_json(&creature).expect("serialises"))
-        .expect("re-parses");
+    let round_tripped =
+        parse_creature_json(&creature_to_json(&creature).expect("serialises")).expect("re-parses");
     assert_eq!(round_tripped, creature, "generation and score survive");
 }
 

--- a/neat-core/tests/creature_validate_contract.rs
+++ b/neat-core/tests/creature_validate_contract.rs
@@ -1,0 +1,398 @@
+//! Issue #559 — the `creature_validate` contract: options semantics, the
+//! success value, the structured failure and the input format.
+//!
+//! These are **contract** tests. The rule bodies are ported by the follow-up
+//! issues (NEAT-AI#3801 / #3802); what is pinned here is the interface those
+//! ports must fill in — the option resolution NEAT-AI's TypeScript performs
+//! before any rule runs, the exact `reason` string sets, the fail-loud
+//! constructor guard, and the creature JSON shape the validator reads.
+
+use neat_core::creature::{MemeticExport, MemeticWeightExport};
+use neat_core::creature_validate::{
+    FailureClass, TOPOLOGY_REASONS, VALIDATION_REASONS, ValidateOptions, ValidationFailure,
+    ValidationStats, creature_validate, reason,
+};
+use neat_core::{CreatureExport, NeuronExport, creature_to_json, parse_creature_json};
+
+// ---------------------------------------------------------------------------
+// 1. Options — the resolution TypeScript performs before any rule runs.
+// ---------------------------------------------------------------------------
+
+/// `const feedbackLoop = forwardOnly ? false : options?.feedbackLoop;` — a
+/// caller asking for both gets the forward-only answer, not its own.
+#[test]
+fn forward_only_overrides_an_explicit_feedback_loop_request() {
+    let options = ValidateOptions {
+        forward_only: true,
+        feedback_loop: Some(true),
+        ..ValidateOptions::default()
+    };
+
+    assert_eq!(options.resolved_feedback_loop(), Some(false));
+    assert!(options.rejects_recursive_synapses());
+}
+
+/// Without `forward_only`, `feedback_loop` passes through untouched and only
+/// an explicit `Some(false)` rejects `from > to`.
+#[test]
+fn only_an_explicit_false_feedback_loop_rejects_recursive_synapses() {
+    let allowed_by_default = ValidateOptions::default();
+    assert_eq!(allowed_by_default.resolved_feedback_loop(), None);
+    assert!(!allowed_by_default.rejects_recursive_synapses());
+
+    let allowed_explicitly = ValidateOptions {
+        feedback_loop: Some(true),
+        ..ValidateOptions::default()
+    };
+    assert_eq!(allowed_explicitly.resolved_feedback_loop(), Some(true));
+    assert!(!allowed_explicitly.rejects_recursive_synapses());
+
+    let rejected = ValidateOptions {
+        feedback_loop: Some(false),
+        ..ValidateOptions::default()
+    };
+    assert_eq!(rejected.resolved_feedback_loop(), Some(false));
+    assert!(rejected.rejects_recursive_synapses());
+}
+
+/// The two count options are deliberately asymmetric in TypeScript:
+/// `if (options && options.neurons)` is a **truthiness** test, so a zero
+/// expected neuron count is skipped, while `Number.isInteger(options.connections)`
+/// checks zero like any other integer.
+#[test]
+fn zero_expected_neuron_count_is_skipped_but_zero_connections_is_checked() {
+    let zeros = ValidateOptions {
+        neurons: Some(0),
+        connections: Some(0),
+        ..ValidateOptions::default()
+    };
+
+    assert_eq!(zeros.expected_neurons(), None);
+    assert_eq!(zeros.expected_connections(), Some(0));
+
+    let counted = ValidateOptions {
+        neurons: Some(7),
+        connections: Some(9),
+        ..ValidateOptions::default()
+    };
+    assert_eq!(counted.expected_neurons(), Some(7));
+    assert_eq!(counted.expected_connections(), Some(9));
+
+    let unset = ValidateOptions::default();
+    assert_eq!(unset.expected_neurons(), None);
+    assert_eq!(unset.expected_connections(), None);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Success value.
+// ---------------------------------------------------------------------------
+
+/// `ValidationStats` mirrors the `stats` object `creatureValidate` returns, and
+/// starts at zero for every counter the way the TypeScript literal does.
+#[test]
+fn validation_stats_start_at_zero_and_carry_all_five_counters() {
+    assert_eq!(
+        ValidationStats::default(),
+        ValidationStats {
+            input: 0,
+            constant: 0,
+            hidden: 0,
+            output: 0,
+            connections: 0,
+        }
+    );
+
+    let stats = ValidationStats {
+        input: 2,
+        constant: 1,
+        hidden: 3,
+        output: 1,
+        connections: 8,
+    };
+    assert_eq!(stats.neurons(), 7, "input + constant + hidden + output");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Failure value.
+// ---------------------------------------------------------------------------
+
+/// The permitted `reason` values are the TypeScript unions verbatim, in
+/// declaration order — NEAT-AI rehydrates its own error type from the string,
+/// so a drifted name silently loses the failure mode.
+#[test]
+fn reason_sets_reproduce_the_typescript_unions_verbatim() {
+    assert_eq!(
+        VALIDATION_REASONS,
+        [
+            "OTHER",
+            "NEURON_ORDER",
+            "NO_OUTWARD_CONNECTIONS",
+            "NO_INWARD_CONNECTIONS",
+            "IF_CONDITIONS",
+            "RECURSIVE_SYNAPSE",
+            "SELF_CONNECTION",
+            "DUPLICATE_SYNAPSE",
+            "MEMETIC",
+        ],
+        "src/errors/ValidationError.ts ValidationErrorName"
+    );
+    assert_eq!(
+        TOPOLOGY_REASONS,
+        [
+            "INVALID_NEURON_TYPE",
+            "INVALID_NEURON_BIAS",
+            "INVALID_SQUASH",
+            "INVALID_SYNAPSE_WEIGHT",
+            "INVALID_SYNAPSE_REFERENCE",
+            "MISSING_SQUASH",
+            "INVALID_CONNECTION",
+            "INVALID_STATE",
+            "DUPLICATE_UUID",
+            "MISSING_NEURON",
+            "MISSING_NEURON_UUID",
+            "SORT_FAILURE",
+            "EXCESSIVE_ERRORS",
+        ],
+        "src/errors/TopologyError.ts TopologyErrorReason"
+    );
+
+    assert_eq!(
+        FailureClass::Validation.permitted_reasons(),
+        VALIDATION_REASONS.as_slice()
+    );
+    assert_eq!(
+        FailureClass::Topology.permitted_reasons(),
+        TOPOLOGY_REASONS.as_slice()
+    );
+}
+
+/// Each class accepts only its own union — the named constants are typed by
+/// where they live, so a topology reason never reaches a `ValidationError`.
+#[test]
+fn each_class_permits_only_its_own_union() {
+    assert!(FailureClass::Validation.permits(reason::MEMETIC));
+    assert!(!FailureClass::Validation.permits(reason::SORT_FAILURE));
+
+    assert!(FailureClass::Topology.permits(reason::SORT_FAILURE));
+    assert!(!FailureClass::Topology.permits(reason::MEMETIC));
+
+    assert!(!FailureClass::Validation.permits("NOT_A_REASON"));
+    assert!(!FailureClass::Topology.permits("NOT_A_REASON"));
+}
+
+/// A failure carries the class, the verbatim reason, the human-readable text
+/// and the index of whatever it was looking at.
+#[test]
+fn failure_carries_class_reason_message_and_the_offending_index() {
+    let failure = ValidationFailure::validation(
+        reason::RECURSIVE_SYNAPSE,
+        "3) Recursive synapse hidden-1 -> hidden-0",
+    )
+    .at_synapse(3);
+
+    assert_eq!(failure.class, FailureClass::Validation);
+    assert_eq!(failure.reason, "RECURSIVE_SYNAPSE");
+    assert_eq!(failure.message, "3) Recursive synapse hidden-1 -> hidden-0");
+    assert_eq!(failure.synapse_index, Some(3));
+    assert_eq!(failure.neuron_index, None);
+
+    let neuron_failure = ValidationFailure::topology(
+        reason::INVALID_SQUASH,
+        "Node uuid-c 'constant' has squash: TANH",
+    )
+    .at_neuron(4);
+
+    assert_eq!(neuron_failure.class, FailureClass::Topology);
+    assert_eq!(neuron_failure.reason, "INVALID_SQUASH");
+    assert_eq!(neuron_failure.neuron_index, Some(4));
+    assert_eq!(neuron_failure.synapse_index, None);
+}
+
+/// `Display` names the TypeScript error class and reason so a Rust-side log
+/// line reads the same as the TypeScript one it mirrors.
+#[test]
+fn failure_display_names_the_typescript_error_class_and_reason() {
+    let failure = ValidationFailure::validation(reason::NO_INWARD_CONNECTIONS, "hidden-2 is orphaned");
+
+    assert_eq!(
+        failure.to_string(),
+        "ValidationError(NO_INWARD_CONNECTIONS): hidden-2 is orphaned"
+    );
+    assert_eq!(
+        ValidationFailure::topology(reason::SORT_FAILURE, "5) synapses not sorted").to_string(),
+        "TopologyError(SORT_FAILURE): 5) synapses not sorted"
+    );
+}
+
+/// A reason outside the class's union is a programming error and fails loud
+/// rather than crossing the WASM boundary as a string NEAT-AI cannot rehydrate.
+#[test]
+#[should_panic(expected = "not a ValidationError reason")]
+fn a_topology_reason_on_a_validation_failure_fails_loud() {
+    let _ = ValidationFailure::validation(reason::INVALID_CONNECTION, "wrong union");
+}
+
+#[test]
+#[should_panic(expected = "not a TopologyError reason")]
+fn an_unlisted_reason_on_a_topology_failure_fails_loud() {
+    let _ = ValidationFailure::topology("MADE_UP", "not in either union");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Entry point — contract only; no rule body has been ported yet.
+// ---------------------------------------------------------------------------
+
+/// Until the rule bodies land, `creature_validate` certifies nothing: it
+/// returns a structured `OTHER` failure rather than an empty `Ok`, so a
+/// consumer that wires it up early cannot mistake "not implemented" for
+/// "valid". The porting issues replace this test with the real rule coverage.
+#[test]
+fn the_entry_point_refuses_to_certify_a_creature_until_the_rules_are_ported() {
+    let creature = neat_core::stump_creature();
+    let failure = creature_validate(&creature, &ValidateOptions::default())
+        .expect_err("the contract stub must not report a creature valid");
+
+    assert_eq!(failure.class, FailureClass::Validation);
+    assert_eq!(failure.reason, reason::OTHER);
+    assert!(
+        failure.message.contains("not ported"),
+        "message should say why nothing was checked, was: {}",
+        failure.message
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Input format — the `CreatureExport` extension.
+// ---------------------------------------------------------------------------
+
+const CREATURE_WITHOUT_EXTENSIONS: &str = r#"{
+  "input": 1,
+  "output": 1,
+  "neurons": [{ "type": "output", "uuid": "out-0", "bias": 0.25, "squash": "IDENTITY" }],
+  "synapses": [{ "fromUUID": "input-0", "toUUID": "out-0", "weight": 1.5 }]
+}"#;
+
+/// The extension is opt-in on the wire: a creature written before it existed
+/// parses unchanged and serialises without either new key.
+#[test]
+fn a_creature_without_id_or_memetic_parses_and_serialises_unchanged() {
+    let creature = parse_creature_json(CREATURE_WITHOUT_EXTENSIONS).expect("parses");
+
+    assert_eq!(creature.neurons[0].id, None);
+    assert_eq!(creature.memetic, None);
+
+    let json = creature_to_json(&creature).expect("serialises");
+    assert!(!json.contains("\"id\""), "no id key was emitted: {json}");
+    assert!(!json.contains("memetic"), "no memetic key was emitted: {json}");
+    assert_eq!(
+        parse_creature_json(&json).expect("re-parses"),
+        creature,
+        "round trip is lossless"
+    );
+}
+
+/// Output neurons carry negative ids (NEAT-AI #1958), so the field is signed
+/// and survives a round trip.
+#[test]
+fn negative_output_neuron_ids_round_trip() {
+    let json = r#"{
+      "input": 2,
+      "output": 1,
+      "neurons": [
+        { "type": "constant", "uuid": "c-0", "bias": 1.0, "id": 2 },
+        { "type": "output", "uuid": "out-0", "bias": 0.0, "squash": "IDENTITY", "id": -1 }
+      ],
+      "synapses": [{ "fromUUID": "c-0", "toUUID": "out-0", "weight": 1.0 }]
+    }"#;
+
+    let creature = parse_creature_json(json).expect("parses");
+    assert_eq!(creature.neurons[0].id, Some(2));
+    assert_eq!(creature.neurons[1].id, Some(-1));
+
+    let round_tripped = parse_creature_json(&creature_to_json(&creature).expect("serialises"))
+        .expect("re-parses");
+    assert_eq!(round_tripped, creature);
+}
+
+/// The memetic block reaches the validator with its `biases` and `weights`
+/// intact, and the keys it does not read (`generation`, `score`, `ancestry`)
+/// survive the round trip rather than being dropped on the floor.
+#[test]
+fn the_memetic_block_round_trips_including_keys_the_validator_does_not_read() {
+    let json = r#"{
+      "input": 1,
+      "output": 1,
+      "neurons": [{ "type": "output", "uuid": "out-0", "bias": 0.0, "id": -1 }],
+      "synapses": [{ "fromUUID": "input-0", "toUUID": "out-0", "weight": 1.0 }],
+      "memetic": {
+        "generation": 12,
+        "score": 0.5,
+        "biases": { "-1": 0.75 },
+        "weights": { "0": [{ "toId": -1, "weight": 1.25 }] }
+      }
+    }"#;
+
+    let creature = parse_creature_json(json).expect("parses");
+    let memetic = creature.memetic.as_ref().expect("memetic block present");
+
+    assert_eq!(memetic.biases.get("-1"), Some(&0.75));
+    assert_eq!(
+        memetic.weights.get("0").map(Vec::as_slice),
+        Some(
+            [MemeticWeightExport {
+                to_id: Some(-1),
+                weight: Some(1.25),
+            }]
+            .as_slice()
+        )
+    );
+    assert_eq!(memetic.extra.get("generation").and_then(|v| v.as_i64()), Some(12));
+
+    let round_tripped = parse_creature_json(&creature_to_json(&creature).expect("serialises"))
+        .expect("re-parses");
+    assert_eq!(round_tripped, creature, "generation and score survive");
+}
+
+/// A memetic weight missing `toId` or `weight` is a `MEMETIC` failure the
+/// validator must be able to *report*, so the wire shape has to be able to
+/// carry it rather than failing in serde first.
+#[test]
+fn a_memetic_weight_missing_its_fields_still_parses_so_the_rule_can_report_it() {
+    let json = r#"{
+      "input": 1,
+      "output": 1,
+      "neurons": [{ "type": "output", "uuid": "out-0", "bias": 0.0, "id": -1 }],
+      "synapses": [{ "fromUUID": "input-0", "toUUID": "out-0", "weight": 1.0 }],
+      "memetic": { "biases": {}, "weights": { "0": [{}] } }
+    }"#;
+
+    let creature = parse_creature_json(json).expect("parses");
+    let weights = &creature.memetic.as_ref().expect("memetic").weights["0"];
+
+    assert_eq!(weights[0].to_id, None);
+    assert_eq!(weights[0].weight, None);
+}
+
+/// A hand-built `CreatureExport` reaches the same shape without going through
+/// JSON — the struct fields are public and default to "absent".
+#[test]
+fn a_hand_built_creature_can_carry_the_extension() {
+    let creature = CreatureExport {
+        input: 1,
+        output: 1,
+        neurons: vec![NeuronExport {
+            id: Some(-1),
+            neuron_type: "output".to_string(),
+            uuid: "out-0".to_string(),
+            bias: 0.0,
+            squash: Some("IDENTITY".to_string()),
+        }],
+        synapses: vec![],
+        semantic_version: None,
+        forward_only: true,
+        memetic: Some(MemeticExport::default()),
+    };
+
+    let json = creature_to_json(&creature).expect("serialises");
+    assert_eq!(parse_creature_json(&json).expect("re-parses"), creature);
+}

--- a/neat-core/tests/creature_width_contract.rs
+++ b/neat-core/tests/creature_width_contract.rs
@@ -21,6 +21,7 @@ const ZERO_OUTPUT_JSON: &str = r#"{"input":1,"output":0,"neurons":[],"synapses":
 
 fn output_neuron() -> NeuronExport {
     NeuronExport {
+        id: None,
         neuron_type: "output".to_string(),
         uuid: "output-0".to_string(),
         bias: 0.0,
@@ -32,6 +33,7 @@ fn output_neuron() -> NeuronExport {
 /// rejection can only come from the width rule.
 fn creature_with_widths(input: usize, output: usize) -> CreatureExport {
     CreatureExport {
+        memetic: None,
         input,
         output,
         neurons: vec![output_neuron()],
@@ -165,6 +167,7 @@ fn compile_rejects_directly_built_zero_output() {
     // Zero declared outputs with zero output neurons used to pass the
     // declared-vs-typed check (`0 == 0`). It must now be a typed rejection.
     let creature = CreatureExport {
+        memetic: None,
         input: 1,
         output: 0,
         neurons: Vec::new(),

--- a/neat-core/tests/if_graft.rs
+++ b/neat-core/tests/if_graft.rs
@@ -23,16 +23,19 @@ const TOL: f32 = 1e-6;
 /// IF creature — the graft has to add every role itself.
 fn base_creature() -> CreatureExport {
     CreatureExport {
+        memetic: None,
         input: 2,
         output: 1,
         neurons: vec![
             NeuronExport {
+                id: None,
                 neuron_type: "hidden".to_string(),
                 uuid: "hidden-1".to_string(),
                 bias: 0.0,
                 squash: Some("TANH".to_string()),
             },
             NeuronExport {
+                id: None,
                 neuron_type: "output".to_string(),
                 uuid: "output-0".to_string(),
                 bias: 0.0,


### PR DESCRIPTION
# creature_validate: define the validation contract (Issue #559)

## Summary

New module `neat-core/src/creature_validate.rs` fixes the contract for the port
of NEAT-AI's `src/architecture/CreatureValidate.ts` — options, success value,
structured failure, input format and rule order — so the two rule-porting
issues can be worked in parallel against a stable interface. Closes #559.

What landed:

- **`ValidateOptions`** — `forward_only` forces `feedback_loop` to
  `Some(false)` (`resolved_feedback_loop`); otherwise `feedback_loop` passes
  through and only an explicit `Some(false)` rejects `from > to`
  (`rejects_recursive_synapses`). The two count options keep the TypeScript's
  asymmetry: `neurons: Some(0)` is **skipped** (`if (options &&
  options.neurons)` is a truthiness test) while `connections: Some(0)` **is**
  checked (`Number.isInteger`). `expected_neurons` / `expected_connections` are
  the single home of that difference.
- **`ValidationStats`** — the `stats` object `creatureValidate` returns.
- **`ValidationFailure` / `FailureClass`** — class, verbatim `reason`,
  `message`, `neuron_index`, `synapse_index`, with `Display` rendering
  `ValidationError(NO_INWARD_CONNECTIONS): …` and `std::error::Error`.
- **`VALIDATION_REASONS` / `TOPOLOGY_REASONS`** — the `ValidationErrorName` and
  `TopologyErrorReason` unions verbatim, one named constant each, with a doc
  comment naming `src/errors/ValidationError.ts` / `src/errors/TopologyError.ts`
  as the source of truth. Three `const _: () = assert!(…)` gates check at
  **compile time** that each list is internally distinct and the two are
  disjoint, and the failure constructors reject a reason outside their class.
- **Rule order** — a numbered 31-row table in the module doc, in TypeScript
  evaluation order with the class/reason each rule raises. First failure wins,
  and the order is contract, not implementation detail.
- **Input format** — the validator reads the existing `CreatureExport`,
  extended by two optional fields.
- **Host-side-only checks** — `neuron.creature !== creature`, the
  `neuron.index` vs loop-position check, `neuron.validate()` and the `debugWrite` diagnostics
  dump are documented as staying in TypeScript, with the failure's
  neuron/synapse index as the hook that lets the host run them against the same
  neuron.

### Input format decision, and why it is backward compatible

A creature reaches the validator as the `CreatureExport` this crate already
parses — no second validator-only struct. Two fields were added:

| Field | Why | Wire compatibility |
|-------|-----|--------------------|
| `NeuronExport::id: Option<i64>` | the neuron-id rules and the memetic keys; signed because output neurons carry negative ids (NEAT-AI #1958) | `#[serde(default, skip_serializing_if = "Option::is_none")]` — absent input parses, absent output emitted |
| `CreatureExport::memetic: Option<MemeticExport>` | the `MEMETIC` rule (`biases`, `weights`) | same attributes; `MemeticExport::extra` is `#[serde(flatten)]` so `generation`, `score` and `ancestry` survive a round trip instead of being dropped |

Both default to absent and are skipped on output, so every existing
`parse_creature_json` caller and every already-written creature file round trips
byte-identically. `MemeticWeightExport`'s `to_id` / `weight` are optional on
purpose: the `MEMETIC` rule must be able to *report* an entry missing them, and
making them required would turn that failure into a serde error instead.

The export form is index-free (it lists only non-input neurons, wired by UUID),
so the indices the TypeScript rules use are derived exactly as
`compile_creature` derives them: `0..input` are the implicit input neurons
(`input-N`, `id == index`), and `input + i` is `neurons[i]`. An endpoint naming
no neuron — a failure the in-memory TypeScript form cannot express — maps onto
the existing `INVALID_SYNAPSE_REFERENCE` reason rather than a new name.

### Deviation from the acceptance criteria, and why

The issue suggests the stub return an empty `ValidationStats`. It returns a
`Validation` / `OTHER` failure saying the rule bodies are not ported instead: an
unconditional `Ok` reports **every** creature as valid, including the invalid
one this work exists to catch, which is exactly the silent-success shape the
repo forbids. The interface the downstream issues fill in is unchanged, and the
stub fails loudly for anyone who wires it up early.

## Evidence

Backend library change — no web interface to screenshot. Evidence is the test
suite plus the mutation sweep below.

`./quality.sh` passes end to end (shellcheck, bats, deno TypeScript gate,
Mermaid gate, fmt, clippy `-D warnings`, `cargo test --workspace`, doc build,
release build).

```mermaid
flowchart LR
    C["CreatureExport<br/>+ id, + memetic"] --> V["creature_validate"]
    O["ValidateOptions<br/>forward_only → feedback_loop = false"] --> V
    V -->|"no rule broken"| S["Ok(ValidationStats)"]
    V -->|"first violated rule"| F["Err(ValidationFailure)<br/>class + reason + message + index"]
    F --> T["NEAT-AI rehydrates<br/>TopologyError / ValidationError"]
    F --> H["host-only checks<br/>identity, neuron.validate(), debugWrite"]
```

### Mutation evidence (AGENTS.md rules 2 and 3)

Each mutation was applied on its own, the suite run, then reverted. Every one
was caught:

| # | Mutation | Result |
|---|----------|--------|
| 1 | `resolved_feedback_loop` drops the `forward_only` forcing | 1 failure |
| 2 | `expected_neurons` stops skipping `Some(0)` | 1 failure |
| 3 | `expected_connections` starts skipping `Some(0)` | 1 failure |
| 4 | `reason::NEURON_ORDER` drifts to `"NEURON_ORDERING"` | 1 failure |
| 5 | the fail-loud reason guard in `ValidationFailure::new` is deleted | 2 failures |
| 6 | the stub returns `Ok(ValidationStats::default())` | 1 failure |
| 7 | `NeuronExport::id` loses `skip_serializing_if` | 1 failure |
| 8 | `MemeticExport::extra` stops capturing unknown keys | 1 failure |
| 9 | `ValidationStats::neurons` drops the constant count | 1 failure |
| 10 | `FailureClass::permitted_reasons` swaps the two lists | 6 failures |
| 11 | `CreatureExport::memetic` is skipped by serde | 3 failures |
| 12 | `MEMETIC` is copied into `TOPOLOGY_REASONS` | **compile error** — `evaluation panicked: assertion failed: disjoint(&VALIDATION_REASONS, &TOPOLOGY_REASONS)` |

## Test Plan

`neat-core/tests/creature_validate_contract.rs` — 16 tests, all against real
calls and observable results:

- **Options** — `forward_only_overrides_an_explicit_feedback_loop_request`,
  `only_an_explicit_false_feedback_loop_rejects_recursive_synapses`,
  `zero_expected_neuron_count_is_skipped_but_zero_connections_is_checked`.
- **Success value** — `validation_stats_start_at_zero_and_carry_all_five_counters`.
- **Failure value** — `reason_sets_reproduce_the_typescript_unions_verbatim`
  (both unions, member by member, in declaration order),
  `each_class_permits_only_its_own_union`,
  `failure_carries_class_reason_message_and_the_offending_index`,
  `failure_display_names_the_typescript_error_class_and_reason`, and two
  `#[should_panic]` tests pinning the fail-loud constructor guard.
- **Entry point** —
  `the_entry_point_refuses_to_certify_a_creature_until_the_rules_are_ported`,
  run against the Issue #555 `stump_creature()` fixture. The porting issues
  replace this test with the real rule coverage.
- **Input format** —
  `a_creature_without_id_or_memetic_parses_and_serialises_unchanged`
  (backward compatibility), `negative_output_neuron_ids_round_trip`,
  `the_memetic_block_round_trips_including_keys_the_validator_does_not_read`,
  `a_memetic_weight_missing_its_fields_still_parses_so_the_rule_can_report_it`,
  `a_hand_built_creature_can_carry_the_extension`.

Existing suites are unchanged in behaviour; the `CreatureExport` /
`NeuronExport` literals across `decision_tree.rs`, `if_graft.rs` and the
creature tests gained the two new fields as `None`.

## Security self-check

- Input validation: the new fields are optional and typed; a malformed `id` or
  memetic block fails at the serde boundary, before any rule runs.
- No secrets, no new dependencies, no new shell/SQL/HTTP surface.
- Errors carry no host paths or internal state — the message reproduces the
  TypeScript text and the indices of the offending neuron/synapse.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt2pld2n-e3e5de`<!-- vibe-worker-issue-559 -->