### PR TITLE
creature_validate: port the neuron-level rules from CreatureValidate.ts to Rust (Issue #560)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.9"
+version = "0.9.10"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -573,10 +573,54 @@ dump all depend on JavaScript object identity or the host filesystem. The
 failure's neuron/synapse index is what lets the host run those against the same
 neuron the shared rules stopped on.
 
-Until the rule bodies land, `creature_validate` returns a
+Until *all* the rule bodies land, `creature_validate` returns a
 `Validation` / `OTHER` failure saying so rather than an empty `Ok`: an
 unconditional `Ok` would report the very creature this work exists to catch as
 valid.
+
+### Neuron rules ported (Issue #560)
+
+Rules 1–22 — everything `CreatureValidate.ts` evaluates before its synapse walk
+— now run in Rust, in the TypeScript's own order, with the message text
+reproduced verbatim so NEAT-AI's error-message tests keep passing across the
+boundary. Rules 23–31 (synapses, `forwardOnly`, memetic) are Issue #561, so the
+entry point runs the neuron half and then still reports the un-ported half.
+
+Two derivations make the port work on the index-free, id-optional export form:
+
+| Derivation | Rule |
+|------------|------|
+| Indices — `0..input` are the implicit input neurons, `input + i` is `neurons[i]` (as `compile_creature` derives them) | the walk position every rule reads |
+| Ids — input `= index`, output `= -(outputIndex + 1)`, everything else its exported `id` or a deterministic hash of its UUID | rules 4–7, mirroring NEAT-AI's loader, which assigns ids *before* `creatureValidate` runs |
+
+Without the id derivation every modern export — NEAT-AI writes UUIDs, not ids —
+would fail rule 4. Because inputs and outputs take derived ids, rules 7, 10 and
+21 cannot fail for a `CreatureExport`, and rule 19 is unreachable in both stacks
+behind rule 8; all four are ported and covered anyway so the two files stay
+line-for-line comparable.
+
+**One implementation per invariant.** `creature_validate` and
+`validate_structural_integrity` ask the same wiring questions but answer them
+differently — a TypeScript message here, a numeric code and neuron index there —
+so neither can call the other. What they share now lives in
+`neat-core/src/topology_invariants.rs`: `ConnectionIndex` (inward/outward degree
+and the inward synapse list, built once in `O(neurons + synapses)` so no caller
+rescans the synapse list per neuron), `hidden_wiring_fault` and
+`if_neuron_fault`. Mutating any of the three fails tests on **both** sides.
+
+```mermaid
+flowchart TD
+    CE["CreatureExport"] --> D["derive indices + ids"]
+    D --> W["neuron walk<br/>rules 1-22"]
+    D --> CI["ConnectionIndex"]
+    CI --> W
+    CI --> VSI["validate_structural_integrity"]
+    SI["topology_invariants<br/>hidden_wiring_fault / if_neuron_fault"] --> W
+    SI --> VSI
+    W -->|"first violated rule"| F["Err(ValidationFailure)<br/>TypeScript message"]
+    VSI -->|"first violated rule"| C["[code, neuron index]"]
+    W -->|"rules 1-22 pass"| N["Err — rules 23-31 not ported (#561)"]
+```
 
 ```mermaid
 flowchart LR

--- a/docs/archive/pr-summaries/pr-summary-560.md
+++ b/docs/archive/pr-summaries/pr-summary-560.md
@@ -1,0 +1,136 @@
+# creature_validate: port the neuron-level rules from CreatureValidate.ts
+
+## Summary
+
+Fills in the **neuron half** of `creature_validate` — rules 1–22, everything
+NEAT-AI's `src/architecture/CreatureValidate.ts` evaluates before its synapse
+walk — in the TypeScript's own order, first failure wins, with every message
+reproduced verbatim so NEAT-AI's error-message tests keep passing across the
+boundary. Rules 23–31 (synapses, `forwardOnly`, memetic) stay with Issue #561,
+so the entry point runs the neuron half and *then* reports the un-ported half
+rather than returning an `Ok` this build cannot stand behind. Closes #560.
+
+Two derivations make the port work on the index-free, id-optional export form:
+
+| Derivation | Why |
+|------------|-----|
+| Indices — `0..input` are the implicit input neurons, `input + i` is `neurons[i]` | the walk position every rule reads; same derivation as `compile_creature` |
+| Ids — input `= index`, output `= -(outputIndex + 1)`, everything else its exported `id` or a deterministic hash of its UUID | NEAT-AI's loader assigns these *before* `creatureValidate` runs; without it every modern export (UUIDs, no ids) would fail rule 4 |
+
+Four rules cannot fail for a `CreatureExport` and are ported anyway so the two
+files stay line-for-line comparable: rules 7, 10 and 21 hold by construction
+because the input neurons are derived from the declared width, and rule 19 is
+unreachable in **both** stacks behind rule 8 (which rejects a missing or
+non-finite bias on every non-input neuron first). Each is covered against the
+function that implements it rather than left as dead text.
+
+`neuronWireLabelForDiagnostics` (rules 11, 16, 17, 18) is reproduced branch for
+branch from `src/neuron/NeuronSerialization.ts` — `input-N`, `output-N`, the
+wire UUID, then the two no-UUID fallbacks — since NEAT-AI asserts on that text.
+The substitute is documented in the module docs and pinned by
+`the_wire_label_reproduces_the_typescript_diagnostic_label`.
+
+### One implementation per invariant
+
+`creature_validate` and `topology_ops::validate_structural_integrity` ask the
+same wiring questions but answer them differently — a TypeScript message and a
+neuron index here, a numeric `STRUCTURAL_*` code there — and they evaluate in
+different orders, so neither can call the other and the existing codes cannot
+express the messages. What they share is therefore **factored out** rather than
+mapped, into `neat-core/src/topology_invariants.rs`:
+
+- `ConnectionIndex` — inward/outward degree and the inward synapse list, built
+  once in `O(neurons + synapses)`. This also removes the `O(synapses)` rescan
+  `validate_structural_integrity` did *per* `IF` neuron.
+- `hidden_wiring_fault` — inward before outward, the order both raise them in.
+- `if_neuron_fault` / `IfRoles` / `IF_MINIMUM_INWARD` — count, then condition →
+  positive → negative.
+
+Deliberately *not* extracted: the checks that are a single comparison over those
+values (`constant has inward`, `bias is finite`). Wrapping `inward_count(i) > 0`
+in a named function moves no logic and only adds a hop.
+
+The `SYN_*` code constants in `topology_ops` became test-only: the role tally
+now converts through `SynapseType::from` instead of comparing four constants.
+The drift guard they carried is replaced by a round-trip test on that
+conversion.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. `./quality.sh` passes
+end to end (fmt, clippy `-D warnings`, `cargo check`, 51 test binaries,
+rustdoc `-D warnings`, release build).
+
+**Red run.** With `validate_neuron_rules` short-circuited to
+`Ok(ValidationStats::default())` — the pre-port state — **24 of the 31** new
+`creature_validate` tests fail:
+
+```
+test result: FAILED. 7 passed; 24 failed; 0 ignored; 0 measured; 188 filtered out
+```
+
+The 7 survivors are the ones that call `walk_neurons`, `hidden_bias_failure`,
+`derived_neuron_id`, `wire_label` and `number_text` directly — the rules that a
+`CreatureExport` cannot break — so they never reach the stub.
+
+**Mutation evidence for the shared invariants.** Each mutation was applied to
+`topology_invariants.rs` alone and reverted afterwards; every one fails tests on
+**both** sides, which is what proves the two validators genuinely share the
+code rather than each keeping a copy:
+
+| Mutation | Tests killed |
+|----------|--------------|
+| `hidden_wiring_fault`: inward/outward swapped | `creature_validate::a_hidden_neuron_must_be_wired_in_and_out`, `topology_invariants::a_hidden_neuron_needs_an_inward_edge_before_an_outward_one`, `topology_ops::structural_hidden_no_inward`, `topology_ops::structural_hidden_no_outward` |
+| `if_neuron_fault`: minimum inward 3 → 2 | `creature_validate::an_if_neuron_with_fewer_than_three_inward_connections_is_rejected`, `topology_invariants::an_if_neuron_reports_its_count_then_each_missing_role_in_turn`, `topology_ops::structural_if_too_few_inward` |
+| `ConnectionIndex`: outward degree never counted | 8+ `creature_validate` tests, including `a_constant_with_no_outward_connection_is_rejected` and `a_hidden_neuron_must_be_wired_in_and_out` |
+
+```mermaid
+flowchart TD
+    CE["CreatureExport"] --> D["derive indices + ids"]
+    D --> W["neuron walk<br/>rules 1-22"]
+    D --> CI["ConnectionIndex"]
+    CI --> W
+    CI --> VSI["validate_structural_integrity"]
+    SI["topology_invariants<br/>hidden_wiring_fault / if_neuron_fault"] --> W
+    SI --> VSI
+    W -->|"first violated rule"| F["Err(ValidationFailure)<br/>TypeScript message"]
+    VSI -->|"first violated rule"| C["[code, neuron index]"]
+    W -->|"rules 1-22 pass"| N["Err — rules 23-31 not ported (#561)"]
+```
+
+## Test Plan
+
+31 unit tests in `neat-core/src/creature_validate.rs`, each rule with a
+positive and a negative case:
+
+| Rules | Tests |
+|-------|-------|
+| valid creatures | `the_decision_tree_fixtures_pass_every_neuron_rule` (stats per type), `the_entry_point_reports_a_neuron_rule_before_the_unported_half` |
+| 1–3 | `an_expected_neuron_count_that_misses_the_total_is_reported_with_both_counts`, `a_creature_with_no_input_neurons_is_rejected`, `a_creature_with_no_output_neurons_is_rejected` |
+| 4–6 | `a_neuron_with_no_id_and_no_uuid_is_rejected`, `ids_are_derived_from_the_uuid_when_the_export_carries_none`, `an_id_above_int32_max_is_rejected_and_the_boundary_is_accepted`, `a_duplicate_neuron_id_is_rejected`, `distinct_ids_including_the_negative_output_id_are_accepted` |
+| 7, 10 | `an_input_neuron_whose_id_is_not_its_index_is_rejected`, `an_input_neuron_past_the_declared_width_is_rejected` |
+| 8, 9, 11 | `a_non_finite_bias_on_a_non_input_neuron_is_rejected` (NaN / ±Infinity), `a_neuron_after_an_output_neuron_is_rejected`, `a_constant_after_a_hidden_neuron_breaks_the_required_order` |
+| 12 | `an_if_neuron_with_fewer_than_three_inward_connections_is_rejected`, `an_if_neuron_missing_a_role_names_the_role_it_is_missing`, `an_untyped_inward_synapse_fills_the_positive_role`, `the_if_rule_is_skipped_for_the_first_three_neurons` |
+| 13–20 | `a_synapse_into_an_input_neuron_is_rejected`, `a_constant_with_an_inward_connection_is_rejected`, `a_constant_carrying_a_squash_is_rejected`, `a_constant_with_no_outward_connection_is_rejected`, `a_hidden_neuron_must_be_wired_in_and_out`, `a_hidden_neuron_needs_a_present_and_finite_bias`, `an_unknown_neuron_type_is_rejected_and_so_is_a_declared_input` |
+| 21, 22 | `fewer_input_neurons_than_declared_is_rejected`, `fewer_output_neurons_than_declared_is_rejected` |
+| input format | `a_synapse_endpoint_that_names_no_neuron_is_rejected`, `the_wire_label_reproduces_the_typescript_diagnostic_label`, `numbers_render_the_way_javascript_interpolates_them` |
+
+6 unit tests in `neat-core/src/topology_invariants.rs` cover the index
+(degrees, inward list order, ignored out-of-range endpoints, the fail-loud
+length assert) and both fault functions.
+
+Unchanged and still green: `neat-core/tests/creature_validate_contract.rs`
+(Issue #559) and the `validate_structural_integrity` suite in `topology_ops`,
+which is what holds the refactor behaviour-preserving.
+
+## Security self-check
+
+- Input validation: the new code *is* validation — every field it reads
+  (`id`, `type`, `bias`, `squash`, UUIDs) is bounds- and range-checked before
+  use, and an unresolvable synapse endpoint is rejected rather than indexed.
+- No secrets, no new dependencies, no SQL/shell/filesystem/HTTP surface.
+- Messages carry only creature data the caller already holds (ids, UUIDs, type
+  names, counts) — no paths, no internal state.
+- Fail loud: `ConnectionIndex::build` asserts its endpoint lists match rather
+  than validating half a topology, and a fully valid creature still returns an
+  error naming the un-ported half instead of a green `Ok`.

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -7,11 +7,11 @@
 //! both stacks read — Rust consumers call [`creature_validate`] natively, and
 //! NEAT-AI calls the same code over the existing WASM boundary.
 //!
-//! **This issue lands the contract only.** The types, the error model, the
-//! rule *order* and the input format are fixed here so the two porting issues
-//! (NEAT-AI#3801 / #3802) can be worked in parallel against a stable
-//! interface. [`creature_validate`] therefore evaluates no rule yet — see
-//! [the entry point](creature_validate) for what it returns until they land.
+//! **Rules 1–22 — the neuron half — are ported** (Issue #560). The synapse,
+//! forward-only and memetic rules (23–31) are Issue #561, so
+//! [`creature_validate`] still refuses to certify any creature: it runs every
+//! neuron rule and then reports the un-ported half rather than returning an
+//! `Ok` it cannot stand behind. See [the entry point](creature_validate).
 //!
 //! # Options
 //!
@@ -115,6 +115,53 @@
 //! neuron `id` (rule 5) and a non-array memetic `weights` entry (rule 31) are
 //! [`crate::creature::CreatureError::Json`].
 //!
+//! # Runtime ids are derived, not required (Issue #560)
+//!
+//! `NeuronExport::id` is optional because NEAT-AI stopped writing it: the wire
+//! identity is the UUID (NEAT-AI #1958). The rules still read an id, so this
+//! port reproduces the assignment NEAT-AI's loader
+//! (`src/creature/CreatureSerialization.ts`, `src/neuron/NeuronSerialization.ts`)
+//! performs *before* `creatureValidate` ever runs — otherwise every modern
+//! export would fail rule 4:
+//!
+//! | Neuron | Id |
+//! |--------|----|
+//! | implicit input at index `i` | `i` |
+//! | exported `output` | `-(outputIndex + 1)`, overriding any exported id |
+//! | anything else | the exported `id`, else a deterministic hash of the UUID into `[1_000_000, 2_000_000_000)` |
+//!
+//! A neuron with neither an id nor a UUID has no derivable identity —
+//! TypeScript falls back to a process-global counter there, which nothing else
+//! can reproduce — so it reaches the walk with no id and rule 4 reports it.
+//!
+//! Because the ids of inputs and outputs are derived rather than read, rules 7,
+//! 10 and 21 cannot fail for a `CreatureExport`; they are implemented and
+//! covered against the walk itself, so the port stays 1:1 with the TypeScript.
+//! Rule 19 is unreachable in **both** stacks — rule 8 rejects a missing or
+//! non-finite bias on every non-input neuron first — and is ported for the same
+//! reason.
+//!
+//! # Diagnostic labels
+//!
+//! Where the TypeScript interpolates `neuron.ID()` the message carries the
+//! integer id verbatim. Where it interpolates
+//! `neuronWireLabelForDiagnostics(neuron, indx)` — rules 11, 16, 17, 18 — this
+//! port reproduces `src/neuron/NeuronSerialization.ts` branch for branch, since
+//! NEAT-AI's error-message tests assert on that text: `input-N` for an input,
+//! `output-N` for an output carrying its negative id, otherwise the wire UUID,
+//! and `non-output-negative-id-{id}@index-{indx}` /
+//! `missing-uuid@index-{indx}` when there is no UUID to use.
+//!
+//! # Shared invariants
+//!
+//! The wiring questions this module and
+//! [`crate::topology_ops::validate_structural_integrity`] both ask — inward and
+//! outward degree, "is this hidden neuron wired in and out", "does this `IF`
+//! neuron carry all three roles" — have one implementation, in
+//! [`crate::topology_invariants`]. The two report them differently (a numeric
+//! code and a neuron index there, the TypeScript message here), so neither
+//! calls the other; what they share is the logic, not the answer.
+//!
 //! # What stays host-side (NEAT-AI#3802)
 //!
 //! These checks depend on JavaScript object identity or on the host
@@ -133,9 +180,14 @@
 //! checks and its diagnostics dump against the same neuron or synapse the
 //! shared rules stopped on.
 
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use crate::creature::CreatureExport;
+use crate::creature::{CreatureExport, parse_synapse_type};
+use crate::synapse_type::SynapseType;
+use crate::topology_invariants::{
+    ConnectionIndex, IfFault, IfRoles, WiringFault, hidden_wiring_fault, if_neuron_fault,
+};
 
 /// Largest neuron id NEAT-AI accepts — `int32` max, mirroring
 /// `MAX_NEURON_ID` in `src/architecture/CreatureValidate.ts`.
@@ -482,25 +534,1414 @@ impl ValidateOptions {
 /// First failure wins: the first violated rule is returned and no later rule
 /// runs, matching the TypeScript `throw`.
 ///
-/// # Contract stub (Issue #559)
+/// # Half ported (Issue #560)
 ///
-/// The rule bodies are ported by NEAT-AI#3801 / #3802. Until they land this
-/// function checks **nothing**, and it says so: it returns a
-/// [`FailureClass::Validation`] / [`reason::OTHER`] failure rather than an
-/// empty [`ValidationStats`], because an unconditional `Ok` would report every
-/// creature — including the invalid one this work exists to catch — as valid.
-/// A consumer wiring the entry point up early fails loudly instead.
+/// Rules 1–22, the neuron half, run and report exactly as the TypeScript does.
+/// Rules 23–31 — the synapse walk, the forward-only checks and the memetic
+/// block — are Issue #561, so a creature that breaks none of the neuron rules
+/// still comes back as a [`FailureClass::Validation`] / [`reason::OTHER`]
+/// failure saying which half is missing, rather than as an `Ok` this build
+/// cannot stand behind. A consumer wiring the entry point up early fails
+/// loudly instead of certifying the invalid creature this work exists to catch.
 ///
 /// # Errors
 ///
 /// Returns the [`ValidationFailure`] for the first violated rule.
 pub fn creature_validate(
-    _creature: &CreatureExport,
-    _options: &ValidateOptions,
+    creature: &CreatureExport,
+    options: &ValidateOptions,
 ) -> Result<ValidationStats, ValidationFailure> {
+    let _stats = validate_neuron_rules(creature, options)?;
+
     Err(ValidationFailure::validation(
         reason::OTHER,
-        "creature_validate rule bodies are not ported yet (Issue #559 landed the \
-         contract only): no creature can be certified valid by this build",
+        "creature_validate synapse, forward-only and memetic rule bodies are not \
+         ported yet (Issue #561): no creature can be certified valid by this build",
     ))
+}
+
+/// Rules 1–22 — everything the TypeScript evaluates before it reaches
+/// `creature.synapses.forEach` (Issue #560).
+///
+/// `stats.connections` stays `0`: the synapse walk that fills it is Issue #561.
+fn validate_neuron_rules(
+    creature: &CreatureExport,
+    options: &ValidateOptions,
+) -> Result<ValidationStats, ValidationFailure> {
+    let total_neurons = creature.input + creature.neurons.len();
+
+    // Rule 1 — `if (options && options.neurons)`, a truthiness test.
+    if let Some(expected) = options.expected_neurons()
+        && total_neurons != expected
+    {
+        return Err(ValidationFailure::validation(
+            reason::OTHER,
+            format!("Neurons length: {total_neurons} expected: {expected}"),
+        ));
+    }
+
+    // Rules 2 and 3 — a creature with no observations or no targets is not a
+    // creature. `input` / `output` are `usize` here, so the TypeScript
+    // `Number.isInteger` half of each test is unrepresentable.
+    if creature.input < 1 {
+        return Err(ValidationFailure::validation(
+            reason::OTHER,
+            format!(
+                "Must have at least one input neurons was: {}",
+                creature.input
+            ),
+        ));
+    }
+    if creature.output < 1 {
+        return Err(ValidationFailure::validation(
+            reason::OTHER,
+            format!(
+                "Must have at least one output neurons was: {}",
+                creature.output
+            ),
+        ));
+    }
+
+    let views = neuron_views(creature);
+    let (from, to, synapse_types) = resolve_synapse_endpoints(creature)?;
+    let connections = ConnectionIndex::build(&from, &to, total_neurons);
+
+    walk_neurons(
+        &views,
+        creature.input,
+        creature.output,
+        &connections,
+        &synapse_types,
+    )
+}
+
+/// What the walk needs to know about one neuron, inputs included.
+///
+/// The export form lists only non-input neurons and carries no indices, so the
+/// walk runs over this derived view rather than over `creature.neurons`
+/// directly — see the *Input format* section of the module documentation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct NeuronView<'a> {
+    /// Runtime integer id, derived as NEAT-AI's loader derives it
+    /// ([`derived_neuron_id`]). `None` only when no id can be derived at all.
+    id: Option<i64>,
+    /// The four types the rules branch on, plus [`NeuronKind::Invalid`].
+    kind: NeuronKind,
+    /// The `type` string as declared, reproduced verbatim in messages.
+    declared_type: &'a str,
+    /// The wire UUID; `None` for the implicit input neurons, which are labelled
+    /// `input-N` from their index.
+    uuid: Option<&'a str>,
+    /// `None` is TypeScript's `undefined` bias — unreachable from JSON, where
+    /// `bias` is a required number.
+    bias: Option<f64>,
+    /// Activation function name, absent for constants and implicit inputs.
+    squash: Option<&'a str>,
+}
+
+/// A neuron type as the rules read it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NeuronKind {
+    /// One of the implicit `0..input` neurons.
+    Input,
+    /// A `constant` neuron.
+    Constant,
+    /// A `hidden` neuron.
+    Hidden,
+    /// An `output` neuron.
+    Output,
+    /// Anything else — including an entry that declares `type: "input"`, which
+    /// the export form does not permit (input neurons are implicit).
+    Invalid,
+}
+
+impl NeuronKind {
+    /// Read the `type` of an exported (non-input) neuron.
+    fn from_declared(declared_type: &str) -> Self {
+        match declared_type {
+            "constant" => NeuronKind::Constant,
+            "hidden" => NeuronKind::Hidden,
+            "output" => NeuronKind::Output,
+            _ => NeuronKind::Invalid,
+        }
+    }
+}
+
+impl NeuronView<'_> {
+    /// `neuron.ID()` — `String(this.id)`, so a missing id reads `undefined`.
+    fn id_text(&self) -> String {
+        match self.id {
+            Some(id) => id.to_string(),
+            None => "undefined".to_string(),
+        }
+    }
+
+    /// The UUID when it is a usable label — TypeScript tests `neuron.uuid` for
+    /// truthiness, so an empty string is no label at all.
+    fn stable_uuid(&self) -> Option<&str> {
+        self.uuid.filter(|uuid| !uuid.is_empty())
+    }
+
+    /// Rust's `neuronWireLabelForDiagnostics(neuron, indx)`.
+    ///
+    /// NEAT-AI's error-message tests assert on this text, so it reproduces
+    /// `src/neuron/NeuronSerialization.ts` branch for branch: `input-N` for an
+    /// input, `output-N` for an output carrying its negative id, otherwise the
+    /// wire UUID, and the two diagnostic fallbacks when there is no UUID.
+    fn wire_label(&self, index: usize) -> String {
+        if self.kind == NeuronKind::Input {
+            return format!("input-{index}");
+        }
+        let negative_id = self.id.filter(|id| *id < 0);
+        if let (NeuronKind::Output, Some(id)) = (self.kind, negative_id) {
+            return format!("output-{}", -(id + 1));
+        }
+        if let Some(uuid) = self.stable_uuid() {
+            return uuid.to_string();
+        }
+        match negative_id {
+            Some(id) => format!("non-output-negative-id-{id}@index-{index}"),
+            None => format!("missing-uuid@index-{index}"),
+        }
+    }
+}
+
+/// Render a number the way JavaScript's template interpolation does.
+///
+/// Only the non-finite cases are reachable from the rules that call it (a
+/// finite bias breaks none of them), but an integral value must still print as
+/// `3` rather than Rust's `3`-with-no-fraction guarantee slipping to `3.0`.
+fn number_text(value: Option<f64>) -> String {
+    match value {
+        None => "undefined".to_string(),
+        Some(value) if value.is_nan() => "NaN".to_string(),
+        Some(value) if value.is_infinite() => {
+            if value > 0.0 { "Infinity" } else { "-Infinity" }.to_string()
+        }
+        Some(value) if value.fract() == 0.0 && value.abs() < 1e21 => format!("{}", value as i128),
+        Some(value) => format!("{value}"),
+    }
+}
+
+/// The runtime id NEAT-AI's loader gives a neuron that exports none.
+///
+/// `deterministicIdFromUuid` in `src/neuron/NeuronSerialization.ts`: the
+/// 32-bit string hash, folded into `[1_000_000, 2_000_000_000)` so it can
+/// collide with neither an input id (`0..input`) nor an output id (negative).
+/// `None` when there is no UUID to hash — TypeScript falls back to a
+/// process-global counter there, which no other process can reproduce, so the
+/// neuron reaches the walk with no id at all and rule 4 reports it.
+fn derived_neuron_id(uuid: &str) -> Option<i64> {
+    if uuid.is_empty() {
+        return None;
+    }
+    let mut hash: i32 = 0;
+    for unit in uuid.encode_utf16() {
+        // `((hash << 5) - hash + chr) | 0` — int32 arithmetic throughout.
+        hash = hash
+            .wrapping_shl(5)
+            .wrapping_sub(hash)
+            .wrapping_add(i32::from(unit));
+    }
+    Some(1_000_000 + i64::from((hash % 1_999_000_000).unsigned_abs()))
+}
+
+/// Derive the neuron the rules walk over, index by index.
+///
+/// Indices follow [`crate::creature::compile_creature`]: `0..input` are the
+/// implicit input neurons, then `input + i` is `creature.neurons[i]`. Ids
+/// follow NEAT-AI's loader (`src/creature/CreatureSerialization.ts`), which
+/// assigns them *before* `creatureValidate` ever runs: an input is its own
+/// index, an output is `-(outputIndex + 1)` whatever the file says, and
+/// everything else keeps its exported id or takes [`derived_neuron_id`].
+fn neuron_views(creature: &CreatureExport) -> Vec<NeuronView<'_>> {
+    let mut views = Vec::with_capacity(creature.input + creature.neurons.len());
+
+    for index in 0..creature.input {
+        views.push(NeuronView {
+            id: Some(index as i64),
+            kind: NeuronKind::Input,
+            declared_type: "input",
+            uuid: None,
+            bias: Some(0.0),
+            squash: None,
+        });
+    }
+
+    let mut output_index: i64 = 0;
+    for neuron in &creature.neurons {
+        let kind = NeuronKind::from_declared(&neuron.neuron_type);
+        let id = if kind == NeuronKind::Output {
+            let id = -(output_index + 1);
+            output_index += 1;
+            Some(id)
+        } else {
+            neuron.id.or_else(|| derived_neuron_id(&neuron.uuid))
+        };
+
+        views.push(NeuronView {
+            id,
+            kind,
+            declared_type: &neuron.neuron_type,
+            uuid: Some(neuron.uuid.as_str()),
+            bias: Some(neuron.bias),
+            squash: neuron.squash.as_deref(),
+        });
+    }
+
+    views
+}
+
+/// Resolve every synapse's `fromUUID` / `toUUID` to the neuron indices the
+/// rules use, keeping the declared synapse roles alongside.
+///
+/// The in-memory TypeScript creature cannot express a dangling endpoint — its
+/// synapses already hold indices — so this is the one failure with no
+/// TypeScript counterpart, reported as `Topology` / `INVALID_SYNAPSE_REFERENCE`
+/// (module documentation, *Input format*). It runs after rules 1–3 and before
+/// the walk, because the walk needs the connection index it feeds.
+#[allow(clippy::type_complexity)]
+fn resolve_synapse_endpoints(
+    creature: &CreatureExport,
+) -> Result<(Vec<u32>, Vec<u32>, Vec<SynapseType>), ValidationFailure> {
+    let mut uuid_to_index: HashMap<&str, u32> = HashMap::with_capacity(creature.neurons.len());
+    for (i, neuron) in creature.neurons.iter().enumerate() {
+        uuid_to_index.insert(neuron.uuid.as_str(), (creature.input + i) as u32);
+    }
+
+    let resolve = |uuid: &str| -> Option<u32> {
+        if let Some(index) = uuid_to_index.get(uuid) {
+            return Some(*index);
+        }
+        // Implicit input neurons are wired as `input-N`, never listed.
+        let index: usize = uuid.strip_prefix("input-")?.parse().ok()?;
+        (index < creature.input).then_some(index as u32)
+    };
+
+    let mut from = Vec::with_capacity(creature.synapses.len());
+    let mut to = Vec::with_capacity(creature.synapses.len());
+    let mut types = Vec::with_capacity(creature.synapses.len());
+
+    for (indx, synapse) in creature.synapses.iter().enumerate() {
+        let dangling = |endpoint: &str, uuid: &str| {
+            ValidationFailure::topology(
+                reason::INVALID_SYNAPSE_REFERENCE,
+                format!("{indx}) synapse {endpoint} {uuid} does not name a neuron"),
+            )
+            .at_synapse(indx as u32)
+        };
+
+        from.push(resolve(&synapse.from_uuid).ok_or_else(|| dangling("from", &synapse.from_uuid))?);
+        to.push(resolve(&synapse.to_uuid).ok_or_else(|| dangling("to", &synapse.to_uuid))?);
+        types.push(parse_synapse_type(synapse.synapse_type.as_deref()));
+    }
+
+    Ok((from, to, types))
+}
+
+/// Rules 4–22: the per-neuron walk and the two counts checked after it.
+///
+/// Evaluation order is the contract (module documentation), so this reads as
+/// one pass in the same order as the TypeScript `forEach` body — first failure
+/// wins.
+fn walk_neurons(
+    views: &[NeuronView<'_>],
+    input: usize,
+    output: usize,
+    connections: &ConnectionIndex,
+    synapse_types: &[SynapseType],
+) -> Result<ValidationStats, ValidationFailure> {
+    let mut stats = ValidationStats::default();
+    let mut neuron_ids: HashSet<i64> = HashSet::with_capacity(views.len());
+    let mut outputs_seen = 0usize;
+    let mut computational_seen_hidden = false;
+
+    for (indx, neuron) in views.iter().enumerate() {
+        let at = |failure: ValidationFailure| failure.at_neuron(indx as u32);
+
+        // Rule 4 — every neuron has an id.
+        let Some(id) = neuron.id else {
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{}) no id", neuron.id_text()),
+            )));
+        };
+
+        // Rule 5 — ids fit int32. Negative ids are legal: an output neuron's
+        // id is `-(outputIndex + 1)` (NEAT-AI #1958).
+        if id > MAX_NEURON_ID {
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{id}) invalid neuron id: {id}"),
+            )));
+        }
+
+        // Rule 6 — ids are unique.
+        if !neuron_ids.insert(id) {
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{id}) duplicate neuron id: {id}"),
+            )));
+        }
+
+        if neuron.kind == NeuronKind::Input {
+            // Rule 7 — an input neuron is identified by its own index.
+            if id != indx as i64 {
+                return Err(at(ValidationFailure::validation(
+                    reason::OTHER,
+                    format!("{id}) invalid input neuron id: {id}"),
+                )));
+            }
+        } else if !neuron.bias.is_some_and(f64::is_finite) {
+            // Rule 8 — every other neuron carries a finite bias.
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{id}) invalid bias: {}", number_text(neuron.bias)),
+            )));
+        }
+
+        // Rule 9 — outputs come last.
+        if neuron.kind == NeuronKind::Output {
+            outputs_seen += 1;
+        } else if outputs_seen > 0 {
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{id}) type {} after output neuron", neuron.declared_type),
+            )));
+        }
+
+        // Rule 10 — inputs come first.
+        if neuron.kind == NeuronKind::Input && indx > input {
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{id}) input neuron after the maximum input neurons"),
+            )));
+        }
+
+        // Rule 11 — inside the computational slice, constants precede hiddens.
+        if indx >= input && indx < views.len() - output {
+            if neuron.kind == NeuronKind::Constant && computational_seen_hidden {
+                return Err(at(ValidationFailure::validation(
+                    reason::NEURON_ORDER,
+                    format!(
+                        "{}) type constant after hidden neuron; required order is input, constant, hidden, output",
+                        neuron.wire_label(indx)
+                    ),
+                )));
+            }
+            if neuron.kind == NeuronKind::Hidden {
+                computational_seen_hidden = true;
+            }
+        }
+
+        // Rule 12 — an `IF` neuron decides between two branches, so it needs a
+        // condition, a positive and a negative input.
+        if neuron.squash == Some("IF") && indx > 2 {
+            let inward = connections.inward_synapses(indx);
+            let roles = IfRoles::tally(
+                inward
+                    .iter()
+                    .filter_map(|synapse| synapse_types.get(*synapse as usize).copied()),
+            );
+            if let Some(fault) = if_neuron_fault(inward.len(), roles) {
+                let message = match fault {
+                    IfFault::TooFewInward { found } => {
+                        format!("{id}) 'IF' should have at least 3 inward connections was: {found}")
+                    }
+                    IfFault::MissingCondition => format!("{id}) 'IF' should have a condition(s)"),
+                    IfFault::MissingPositive => {
+                        format!("{id}) 'IF' should have a positive connection(s)")
+                    }
+                    IfFault::MissingNegative => {
+                        format!("{id}) 'IF' should have a negative connection(s)")
+                    }
+                };
+                return Err(at(ValidationFailure::validation(
+                    reason::IF_CONDITIONS,
+                    message,
+                )));
+            }
+        }
+
+        let inward = connections.inward_count(indx);
+        let outward = connections.outward_count(indx);
+
+        match neuron.kind {
+            NeuronKind::Input => {
+                stats.input += 1;
+                // Rule 13 — nothing feeds an observation.
+                if inward > 0 {
+                    return Err(at(ValidationFailure::topology(
+                        reason::INVALID_CONNECTION,
+                        format!("'input' neuron {id} has inward connections: {inward}"),
+                    )));
+                }
+            }
+            NeuronKind::Constant => {
+                stats.constant += 1;
+                // Rule 14 — a constant is a source, never a sink.
+                if inward > 0 {
+                    return Err(at(ValidationFailure::topology(
+                        reason::INVALID_CONNECTION,
+                        format!(
+                            "'{}' neuron {id} has inward connections: {inward}",
+                            neuron.declared_type
+                        ),
+                    )));
+                }
+                // Rule 15 — a constant emits its bias; a squash would change it.
+                if let Some(squash) = neuron.squash {
+                    return Err(at(ValidationFailure::topology(
+                        reason::INVALID_SQUASH,
+                        format!("Node {id} '{}' has squash: {squash}", neuron.declared_type),
+                    )));
+                }
+                // Rule 16 — a constant nothing reads is dead weight.
+                if outward == 0 {
+                    return Err(at(ValidationFailure::validation(
+                        reason::NO_OUTWARD_CONNECTIONS,
+                        format!(
+                            "constants neuron {} has no outward connections",
+                            neuron.wire_label(indx)
+                        ),
+                    )));
+                }
+            }
+            NeuronKind::Hidden => {
+                stats.hidden += 1;
+                // Rules 17 and 18 — a hidden neuron is wired in and out.
+                if let Some(fault) = hidden_wiring_fault(inward, outward) {
+                    let direction = match fault {
+                        WiringFault::NoInward => "inward",
+                        WiringFault::NoOutward => "outward",
+                    };
+                    let wiring_reason = match fault {
+                        WiringFault::NoInward => reason::NO_INWARD_CONNECTIONS,
+                        WiringFault::NoOutward => reason::NO_OUTWARD_CONNECTIONS,
+                    };
+                    return Err(at(ValidationFailure::validation(
+                        wiring_reason,
+                        format!(
+                            "hidden neuron {} has no {direction} connections",
+                            neuron.wire_label(indx)
+                        ),
+                    )));
+                }
+                // Rule 19 — kept for the port, unreachable behind rule 8.
+                if let Some(failure) = hidden_bias_failure(id, neuron.bias) {
+                    return Err(at(failure));
+                }
+            }
+            NeuronKind::Output => {
+                stats.output += 1;
+            }
+            // Rule 20 — the type is one of the four, and `input` is not one of
+            // them here: input neurons are implicit, so an entry claiming to be
+            // one is as invalid as a typo.
+            NeuronKind::Invalid => {
+                return Err(at(ValidationFailure::topology(
+                    reason::INVALID_NEURON_TYPE,
+                    format!("{id}) Invalid type: {}", neuron.declared_type),
+                )));
+            }
+        }
+    }
+
+    // Rule 21 — the counted inputs are the declared width.
+    if stats.input as usize != input {
+        return Err(ValidationFailure::validation(
+            reason::OTHER,
+            format!("Expected {input} input neurons found: {}", stats.input),
+        ));
+    }
+
+    // Rule 22 — and so are the counted outputs.
+    if stats.output as usize != output {
+        return Err(ValidationFailure::topology(
+            reason::INVALID_STATE,
+            format!("Expected {output} output neurons found: {}", stats.output),
+        ));
+    }
+
+    Ok(stats)
+}
+
+/// Rule 19 — a hidden neuron's bias must be present and finite.
+///
+/// Both branches are **unreachable** in NEAT-AI and here: rule 8 rejects a
+/// missing or non-finite bias on every non-input neuron before the type switch
+/// is reached. The rule is ported anyway so the two stacks stay line-for-line
+/// comparable, and it is a function so the messages stay under test rather than
+/// being dead text nothing can exercise.
+fn hidden_bias_failure(id: i64, bias: Option<f64>) -> Option<ValidationFailure> {
+    if bias.is_none() {
+        return Some(ValidationFailure::topology(
+            reason::INVALID_STATE,
+            format!("hidden neuron {id} should have a bias was: undefined"),
+        ));
+    }
+    if !bias.is_some_and(f64::is_finite) {
+        return Some(ValidationFailure::topology(
+            reason::INVALID_STATE,
+            format!(
+                "{id}) hidden neuron should have a finite bias was: {}",
+                number_text(bias)
+            ),
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::creature::{NeuronExport, SynapseExport};
+    use crate::decision_tree::{depth2_tree_creature, stump_creature};
+
+    // -----------------------------------------------------------------------
+    // Fixtures — every id that reaches a message is pinned, so the assertions
+    // are on the TypeScript text rather than on a derived hash.
+    // -----------------------------------------------------------------------
+
+    fn neuron(neuron_type: &str, uuid: &str, id: Option<i64>, bias: f64) -> NeuronExport {
+        NeuronExport {
+            id,
+            neuron_type: neuron_type.to_string(),
+            uuid: uuid.to_string(),
+            bias,
+            squash: None,
+        }
+    }
+
+    fn squashed(neuron_type: &str, uuid: &str, id: Option<i64>, squash: &str) -> NeuronExport {
+        NeuronExport {
+            squash: Some(squash.to_string()),
+            ..neuron(neuron_type, uuid, id, 0.0)
+        }
+    }
+
+    fn edge(from: &str, to: &str) -> SynapseExport {
+        SynapseExport {
+            from_uuid: from.to_string(),
+            to_uuid: to.to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }
+    }
+
+    fn typed_edge(from: &str, to: &str, synapse_type: &str) -> SynapseExport {
+        SynapseExport {
+            synapse_type: Some(synapse_type.to_string()),
+            ..edge(from, to)
+        }
+    }
+
+    fn creature(
+        input: usize,
+        output: usize,
+        neurons: Vec<NeuronExport>,
+        synapses: Vec<SynapseExport>,
+    ) -> CreatureExport {
+        CreatureExport {
+            input,
+            output,
+            neurons,
+            synapses,
+            semantic_version: None,
+            forward_only: false,
+            memetic: None,
+        }
+    }
+
+    fn rejects(creature: &CreatureExport) -> ValidationFailure {
+        validate_neuron_rules(creature, &ValidateOptions::default())
+            .expect_err("a neuron rule should have rejected this creature")
+    }
+
+    fn accepts(creature: &CreatureExport) -> ValidationStats {
+        validate_neuron_rules(creature, &ValidateOptions::default())
+            .expect("no neuron rule is broken by this creature")
+    }
+
+    #[track_caller]
+    fn assert_failure(
+        failure: &ValidationFailure,
+        class: FailureClass,
+        reason: &str,
+        message: &str,
+    ) {
+        assert_eq!(
+            (failure.class, failure.reason, failure.message.as_str()),
+            (class, reason, message)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The canonical valid creatures.
+    // -----------------------------------------------------------------------
+
+    /// The decision-tree fixtures break no neuron rule, and the walk counts
+    /// every type it saw. `connections` is left to Issue #561.
+    #[test]
+    fn the_decision_tree_fixtures_pass_every_neuron_rule() {
+        assert_eq!(
+            accepts(&stump_creature()),
+            ValidationStats {
+                input: 1,
+                constant: 3,
+                hidden: 0,
+                output: 1,
+                connections: 0,
+            }
+        );
+        assert_eq!(
+            accepts(&depth2_tree_creature()),
+            ValidationStats {
+                input: 2,
+                constant: 3,
+                hidden: 2,
+                output: 1,
+                connections: 0,
+            }
+        );
+    }
+
+    /// A creature that breaks a neuron rule is reported by the entry point
+    /// itself, not swallowed by the not-yet-ported synapse half.
+    #[test]
+    fn the_entry_point_reports_a_neuron_rule_before_the_unported_half() {
+        let mut broken = stump_creature();
+        broken.neurons[0].squash = Some("TANH".to_string());
+
+        let failure = creature_validate(&broken, &ValidateOptions::default())
+            .expect_err("a constant may not carry a squash");
+
+        assert_eq!(failure.reason, reason::INVALID_SQUASH);
+        assert!(
+            !failure.message.contains("not ported"),
+            "the neuron rules ran: {}",
+            failure.message
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Rules 1-3 — pre-walk.
+    // -----------------------------------------------------------------------
+
+    /// Rule 1: the expected count is the *total*, inputs included.
+    #[test]
+    fn an_expected_neuron_count_that_misses_the_total_is_reported_with_both_counts() {
+        let stump = stump_creature();
+        let options = |neurons: usize| ValidateOptions {
+            neurons: Some(neurons),
+            ..ValidateOptions::default()
+        };
+
+        let failure = validate_neuron_rules(&stump, &options(9)).expect_err("5 neurons, not 9");
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::OTHER,
+            "Neurons length: 5 expected: 9",
+        );
+
+        assert!(
+            validate_neuron_rules(&stump, &options(5)).is_ok(),
+            "1 input + 4 exported neurons"
+        );
+    }
+
+    /// Rule 2: a creature with no observations is not a creature.
+    #[test]
+    fn a_creature_with_no_input_neurons_is_rejected() {
+        let widthless = creature(0, 1, vec![neuron("output", "out-0", None, 0.0)], vec![]);
+
+        assert_failure(
+            &rejects(&widthless),
+            FailureClass::Validation,
+            reason::OTHER,
+            "Must have at least one input neurons was: 0",
+        );
+    }
+
+    /// Rule 3: nor is one with no targets.
+    #[test]
+    fn a_creature_with_no_output_neurons_is_rejected() {
+        let widthless = creature(1, 0, vec![neuron("output", "out-0", None, 0.0)], vec![]);
+
+        assert_failure(
+            &rejects(&widthless),
+            FailureClass::Validation,
+            reason::OTHER,
+            "Must have at least one output neurons was: 0",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Rules 4-6 — neuron ids.
+    // -----------------------------------------------------------------------
+
+    /// Rule 4: a neuron with neither an exported id nor a UUID to derive one
+    /// from has no identity at all. `neuron.ID()` renders that as `undefined`.
+    #[test]
+    fn a_neuron_with_no_id_and_no_uuid_is_rejected() {
+        let anonymous = creature(
+            1,
+            1,
+            vec![
+                neuron("constant", "", None, 1.0),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("input-0", "out-0")],
+        );
+
+        let failure = rejects(&anonymous);
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::OTHER,
+            "undefined) no id",
+        );
+        assert_eq!(failure.neuron_index, Some(1));
+    }
+
+    /// A creature that exports no ids at all still validates: NEAT-AI's loader
+    /// derives them from the UUIDs before `creatureValidate` runs, and so does
+    /// this port.
+    #[test]
+    fn ids_are_derived_from_the_uuid_when_the_export_carries_none() {
+        assert!(stump_creature().neurons.iter().all(|n| n.id.is_none()));
+
+        let derived = derived_neuron_id("uuid-a").expect("a UUID always derives an id");
+        assert!(
+            (1_000_000..2_000_000_000).contains(&derived),
+            "derived ids avoid the input (0..) and output (negative) ranges, was {derived}"
+        );
+        assert_eq!(
+            derived,
+            derived_neuron_id("uuid-a").unwrap(),
+            "the same UUID always derives the same id"
+        );
+        assert_ne!(derived, derived_neuron_id("uuid-b").unwrap());
+        assert_eq!(derived_neuron_id(""), None, "nothing to hash");
+    }
+
+    /// Rule 5: ids fit int32.
+    #[test]
+    fn an_id_above_int32_max_is_rejected_and_the_boundary_is_accepted() {
+        let over = creature(
+            1,
+            1,
+            vec![
+                neuron("constant", "c-0", Some(MAX_NEURON_ID + 1), 1.0),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("c-0", "out-0")],
+        );
+
+        assert_failure(
+            &rejects(&over),
+            FailureClass::Validation,
+            reason::OTHER,
+            "2147483648) invalid neuron id: 2147483648",
+        );
+
+        let mut at_boundary = over.clone();
+        at_boundary.neurons[0].id = Some(MAX_NEURON_ID);
+        assert_eq!(accepts(&at_boundary).constant, 1);
+    }
+
+    /// Rule 6: two neurons may not share an id.
+    #[test]
+    fn a_duplicate_neuron_id_is_rejected() {
+        let duplicated = creature(
+            1,
+            1,
+            vec![
+                neuron("constant", "c-0", Some(7), 1.0),
+                neuron("constant", "c-1", Some(7), 1.0),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("c-0", "out-0"), edge("c-1", "out-0")],
+        );
+
+        let failure = rejects(&duplicated);
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::OTHER,
+            "7) duplicate neuron id: 7",
+        );
+        assert_eq!(failure.neuron_index, Some(2), "the second one to claim it");
+    }
+
+    /// Rule 6 (negative): distinct ids, including the negative output id, pass.
+    #[test]
+    fn distinct_ids_including_the_negative_output_id_are_accepted() {
+        let distinct = creature(
+            1,
+            1,
+            vec![
+                neuron("constant", "c-0", Some(7), 1.0),
+                neuron("constant", "c-1", Some(8), 1.0),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("c-0", "out-0"), edge("c-1", "out-0")],
+        );
+
+        assert_eq!(accepts(&distinct).constant, 2);
+        assert_eq!(
+            neuron_views(&distinct)[3].id,
+            Some(-1),
+            "output ids are -(outputIndex + 1) whatever the file says"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Rules 7 and 10 — input neuron placement. Both hold by construction from
+    // a `CreatureExport` (the walk derives the input neurons itself), so they
+    // are exercised against the walk directly rather than through a creature
+    // that cannot be written.
+    // -----------------------------------------------------------------------
+
+    fn walk(
+        views: &[NeuronView<'_>],
+        input: usize,
+        output: usize,
+    ) -> Result<ValidationStats, ValidationFailure> {
+        walk_neurons(
+            views,
+            input,
+            output,
+            &ConnectionIndex::build(&[], &[], views.len()),
+            &[],
+        )
+    }
+
+    fn input_view(id: i64) -> NeuronView<'static> {
+        NeuronView {
+            id: Some(id),
+            kind: NeuronKind::Input,
+            declared_type: "input",
+            uuid: None,
+            bias: Some(0.0),
+            squash: None,
+        }
+    }
+
+    fn output_view(id: i64) -> NeuronView<'static> {
+        NeuronView {
+            id: Some(id),
+            kind: NeuronKind::Output,
+            declared_type: "output",
+            uuid: Some("out"),
+            bias: Some(0.0),
+            squash: None,
+        }
+    }
+
+    /// Rule 7: an input neuron is identified by its own index.
+    #[test]
+    fn an_input_neuron_whose_id_is_not_its_index_is_rejected() {
+        let failure = walk(&[input_view(5)], 1, 0).expect_err("id 5 at index 0");
+
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::OTHER,
+            "5) invalid input neuron id: 5",
+        );
+        assert!(walk(&[input_view(0)], 1, 0).is_ok(), "id 0 at index 0");
+    }
+
+    /// Rule 10: an input neuron past the declared width is rejected — after
+    /// the index-matching id check, which a stray input at index 1 survives.
+    #[test]
+    fn an_input_neuron_past_the_declared_width_is_rejected() {
+        let stray = [input_view(0), input_view(1), input_view(2)];
+
+        let failure = walk(&stray, 1, 0).expect_err("one input was declared, three were found");
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::OTHER,
+            "2) input neuron after the maximum input neurons",
+        );
+        assert!(
+            walk(&stray[..2], 2, 0).is_ok(),
+            "two inputs declared, two walked"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Rules 8, 9, 11 — bias and ordering.
+    // -----------------------------------------------------------------------
+
+    /// Rule 8: every non-input neuron carries a finite bias, and the message
+    /// renders the value the way JavaScript does.
+    #[test]
+    fn a_non_finite_bias_on_a_non_input_neuron_is_rejected() {
+        let with_bias = |bias: f64| {
+            creature(
+                1,
+                1,
+                vec![
+                    neuron("constant", "c-0", Some(7), bias),
+                    neuron("output", "out-0", None, 0.0),
+                ],
+                vec![edge("c-0", "out-0")],
+            )
+        };
+
+        for (bias, text) in [
+            (f64::NAN, "NaN"),
+            (f64::INFINITY, "Infinity"),
+            (f64::NEG_INFINITY, "-Infinity"),
+        ] {
+            assert_failure(
+                &rejects(&with_bias(bias)),
+                FailureClass::Validation,
+                reason::OTHER,
+                &format!("7) invalid bias: {text}"),
+            );
+        }
+
+        assert_eq!(accepts(&with_bias(-1.5)).constant, 1);
+    }
+
+    /// Rule 9: nothing but an output may follow an output.
+    #[test]
+    fn a_neuron_after_an_output_neuron_is_rejected() {
+        let trailing = creature(
+            1,
+            1,
+            vec![
+                squashed("output", "out-0", None, "IDENTITY"),
+                neuron("hidden", "h-0", Some(7), 0.0),
+            ],
+            vec![edge("input-0", "out-0"), edge("input-0", "h-0")],
+        );
+
+        assert_failure(
+            &rejects(&trailing),
+            FailureClass::Validation,
+            reason::OTHER,
+            "7) type hidden after output neuron",
+        );
+    }
+
+    /// Rule 11: inside the computational slice the order is constant, then
+    /// hidden — the message labels the neuron the way the wire does.
+    #[test]
+    fn a_constant_after_a_hidden_neuron_breaks_the_required_order() {
+        let out_of_order = creature(
+            1,
+            1,
+            vec![
+                neuron("hidden", "h-0", Some(7), 0.0),
+                neuron("constant", "c-late", Some(8), 1.0),
+                squashed("output", "out-0", None, "IDENTITY"),
+            ],
+            vec![
+                edge("input-0", "h-0"),
+                edge("h-0", "out-0"),
+                edge("c-late", "out-0"),
+            ],
+        );
+
+        let failure = rejects(&out_of_order);
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::NEURON_ORDER,
+            "c-late) type constant after hidden neuron; required order is input, constant, hidden, output",
+        );
+        assert_eq!(failure.neuron_index, Some(2));
+
+        let mut ordered = out_of_order.clone();
+        ordered.neurons.swap(0, 1);
+        assert_eq!(accepts(&ordered).hidden, 1, "constant first is fine");
+    }
+
+    // -----------------------------------------------------------------------
+    // Rule 12 — the `IF` squash.
+    // -----------------------------------------------------------------------
+
+    /// Three inputs feeding one `IF` output at index 3, with the roles named.
+    fn if_creature(roles: [&str; 3]) -> CreatureExport {
+        creature(
+            3,
+            1,
+            vec![squashed("output", "out-0", None, "IF")],
+            roles
+                .iter()
+                .enumerate()
+                .map(|(i, role)| typed_edge(&format!("input-{i}"), "out-0", role))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn an_if_neuron_with_fewer_than_three_inward_connections_is_rejected() {
+        let mut starved = if_creature(["condition", "positive", "negative"]);
+        starved.synapses.pop();
+
+        assert_failure(
+            &rejects(&starved),
+            FailureClass::Validation,
+            reason::IF_CONDITIONS,
+            "-1) 'IF' should have at least 3 inward connections was: 2",
+        );
+        assert_eq!(
+            accepts(&if_creature(["condition", "positive", "negative"])).output,
+            1
+        );
+    }
+
+    #[test]
+    fn an_if_neuron_missing_a_role_names_the_role_it_is_missing() {
+        for (roles, message) in [
+            (
+                ["positive", "positive", "negative"],
+                "-1) 'IF' should have a condition(s)",
+            ),
+            (
+                ["condition", "condition", "negative"],
+                "-1) 'IF' should have a positive connection(s)",
+            ),
+            (
+                ["condition", "positive", "positive"],
+                "-1) 'IF' should have a negative connection(s)",
+            ),
+        ] {
+            assert_failure(
+                &rejects(&if_creature(roles)),
+                FailureClass::Validation,
+                reason::IF_CONDITIONS,
+                message,
+            );
+        }
+    }
+
+    /// An untyped synapse is a positive input, so these three roles are
+    /// complete even though only two are declared.
+    #[test]
+    fn an_untyped_inward_synapse_fills_the_positive_role() {
+        let mut untyped = if_creature(["condition", "positive", "negative"]);
+        untyped.synapses[1].synapse_type = None;
+
+        assert_eq!(accepts(&untyped).output, 1);
+    }
+
+    /// The rule only arms past index 2 — an `IF` neuron that early cannot have
+    /// three inward connections in the first place.
+    #[test]
+    fn the_if_rule_is_skipped_for_the_first_three_neurons() {
+        let early = creature(
+            1,
+            1,
+            vec![squashed("output", "out-0", None, "IF")],
+            vec![edge("input-0", "out-0")],
+        );
+
+        assert_eq!(accepts(&early).output, 1, "index 1 is not > 2");
+    }
+
+    // -----------------------------------------------------------------------
+    // Rules 13-20 — the per-type switch.
+    // -----------------------------------------------------------------------
+
+    /// Rule 13: nothing feeds an observation.
+    #[test]
+    fn a_synapse_into_an_input_neuron_is_rejected() {
+        let mut fed_input = stump_creature();
+        fed_input.synapses.push(edge("const-positive", "input-0"));
+
+        let failure = rejects(&fed_input);
+        assert_failure(
+            &failure,
+            FailureClass::Topology,
+            reason::INVALID_CONNECTION,
+            "'input' neuron 0 has inward connections: 1",
+        );
+        assert_eq!(failure.neuron_index, Some(0));
+    }
+
+    /// Rule 14: a constant is a source, never a sink.
+    #[test]
+    fn a_constant_with_an_inward_connection_is_rejected() {
+        let fed_constant = creature(
+            1,
+            1,
+            vec![
+                neuron("constant", "c-0", Some(7), 1.0),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("input-0", "c-0"), edge("c-0", "out-0")],
+        );
+
+        assert_failure(
+            &rejects(&fed_constant),
+            FailureClass::Topology,
+            reason::INVALID_CONNECTION,
+            "'constant' neuron 7 has inward connections: 1",
+        );
+    }
+
+    /// Rule 15: a constant emits its bias, so a squash has nothing to do.
+    #[test]
+    fn a_constant_carrying_a_squash_is_rejected() {
+        let squashed_constant = creature(
+            1,
+            1,
+            vec![
+                squashed("constant", "c-0", Some(7), "TANH"),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("c-0", "out-0")],
+        );
+
+        assert_failure(
+            &rejects(&squashed_constant),
+            FailureClass::Topology,
+            reason::INVALID_SQUASH,
+            "Node 7 'constant' has squash: TANH",
+        );
+    }
+
+    /// Rule 16: a constant nothing reads is dead weight.
+    #[test]
+    fn a_constant_with_no_outward_connection_is_rejected() {
+        let orphaned = creature(
+            1,
+            1,
+            vec![
+                neuron("constant", "c-lonely", Some(7), 1.0),
+                neuron("output", "out-0", None, 0.0),
+            ],
+            vec![edge("input-0", "out-0")],
+        );
+
+        assert_failure(
+            &rejects(&orphaned),
+            FailureClass::Validation,
+            reason::NO_OUTWARD_CONNECTIONS,
+            "constants neuron c-lonely has no outward connections",
+        );
+
+        let mut wired = orphaned.clone();
+        wired.synapses.push(edge("c-lonely", "out-0"));
+        assert_eq!(accepts(&wired).constant, 1);
+    }
+
+    /// Rules 17 and 18: a hidden neuron is wired in *and* out, inward first.
+    #[test]
+    fn a_hidden_neuron_must_be_wired_in_and_out() {
+        let hidden = |synapses: Vec<SynapseExport>| {
+            creature(
+                1,
+                1,
+                vec![
+                    neuron("hidden", "h-0", Some(7), 0.0),
+                    neuron("output", "out-0", None, 0.0),
+                ],
+                synapses,
+            )
+        };
+
+        assert_failure(
+            &rejects(&hidden(vec![edge("h-0", "out-0")])),
+            FailureClass::Validation,
+            reason::NO_INWARD_CONNECTIONS,
+            "hidden neuron h-0 has no inward connections",
+        );
+        assert_failure(
+            &rejects(&hidden(vec![
+                edge("input-0", "h-0"),
+                edge("input-0", "out-0"),
+            ])),
+            FailureClass::Validation,
+            reason::NO_OUTWARD_CONNECTIONS,
+            "hidden neuron h-0 has no outward connections",
+        );
+        assert_eq!(
+            accepts(&hidden(vec![edge("input-0", "h-0"), edge("h-0", "out-0")])).hidden,
+            1
+        );
+    }
+
+    /// Rule 19: ported for completeness, and unreachable — rule 8 rejects both
+    /// biases first, so the messages are exercised against the rule itself.
+    #[test]
+    fn a_hidden_neuron_needs_a_present_and_finite_bias() {
+        assert_eq!(
+            hidden_bias_failure(7, None).map(|f| f.message),
+            Some("hidden neuron 7 should have a bias was: undefined".to_string())
+        );
+        let non_finite = hidden_bias_failure(7, Some(f64::INFINITY)).expect("not finite");
+        assert_failure(
+            &non_finite,
+            FailureClass::Topology,
+            reason::INVALID_STATE,
+            "7) hidden neuron should have a finite bias was: Infinity",
+        );
+        assert!(hidden_bias_failure(7, Some(0.5)).is_none());
+    }
+
+    /// Rule 20: the type is one of the four known ones — and `input` is not one
+    /// of them in the export form, where input neurons are implicit.
+    #[test]
+    fn an_unknown_neuron_type_is_rejected_and_so_is_a_declared_input() {
+        let typed = |neuron_type: &str| {
+            creature(
+                1,
+                1,
+                vec![
+                    neuron(neuron_type, "n-0", Some(7), 0.0),
+                    neuron("output", "out-0", None, 0.0),
+                ],
+                vec![edge("input-0", "out-0")],
+            )
+        };
+
+        assert_failure(
+            &rejects(&typed("mystery")),
+            FailureClass::Topology,
+            reason::INVALID_NEURON_TYPE,
+            "7) Invalid type: mystery",
+        );
+        assert_failure(
+            &rejects(&typed("input")),
+            FailureClass::Topology,
+            reason::INVALID_NEURON_TYPE,
+            "7) Invalid type: input",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Rules 21 and 22 — post-walk counts.
+    // -----------------------------------------------------------------------
+
+    /// Rule 21: the counted inputs are the declared width. Unreachable from a
+    /// `CreatureExport`, whose input neurons are derived from that same width.
+    #[test]
+    fn fewer_input_neurons_than_declared_is_rejected() {
+        let failure = walk(&[output_view(-1), output_view(-2)], 1, 2)
+            .expect_err("one input was declared, none were walked");
+
+        assert_failure(
+            &failure,
+            FailureClass::Validation,
+            reason::OTHER,
+            "Expected 1 input neurons found: 0",
+        );
+        assert!(walk(&[input_view(0), output_view(-1)], 1, 1).is_ok());
+    }
+
+    /// Rule 22: and so are the counted outputs.
+    #[test]
+    fn fewer_output_neurons_than_declared_is_rejected() {
+        let short = creature(
+            1,
+            2,
+            vec![neuron("output", "out-0", None, 0.0)],
+            vec![edge("input-0", "out-0")],
+        );
+
+        assert_failure(
+            &rejects(&short),
+            FailureClass::Topology,
+            reason::INVALID_STATE,
+            "Expected 2 output neurons found: 1",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Input format — the one failure the TypeScript shape cannot express.
+    // -----------------------------------------------------------------------
+
+    /// A synapse endpoint naming no neuron is `INVALID_SYNAPSE_REFERENCE`,
+    /// carrying the synapse index rather than a neuron index.
+    #[test]
+    fn a_synapse_endpoint_that_names_no_neuron_is_rejected() {
+        let mut dangling = stump_creature();
+        dangling.synapses.push(edge("ghost", "output-0"));
+
+        let failure = rejects(&dangling);
+        assert_eq!(failure.class, FailureClass::Topology);
+        assert_eq!(failure.reason, reason::INVALID_SYNAPSE_REFERENCE);
+        assert_eq!(failure.synapse_index, Some(4));
+        assert_eq!(failure.neuron_index, None);
+        assert!(
+            failure.message.contains("ghost"),
+            "names the endpoint: {}",
+            failure.message
+        );
+
+        let mut unknown_target = stump_creature();
+        unknown_target.synapses.push(edge("input-0", "input-9"));
+        assert_eq!(
+            rejects(&unknown_target).reason,
+            reason::INVALID_SYNAPSE_REFERENCE,
+            "an input index past the declared width names no neuron either"
+        );
+    }
+
+    /// The wire label reproduces `neuronWireLabelForDiagnostics` branch for
+    /// branch, including both no-UUID fallbacks.
+    #[test]
+    fn the_wire_label_reproduces_the_typescript_diagnostic_label() {
+        let hidden = NeuronView {
+            kind: NeuronKind::Hidden,
+            declared_type: "hidden",
+            ..output_view(-2)
+        };
+
+        assert_eq!(input_view(0).wire_label(0), "input-0");
+        assert_eq!(
+            output_view(-2).wire_label(4),
+            "output-1",
+            "an output is labelled from its id, -(id + 1), not its UUID"
+        );
+        assert_eq!(
+            NeuronView {
+                id: Some(7),
+                ..output_view(-2)
+            }
+            .wire_label(4),
+            "out",
+            "an output without an output id falls back to the UUID"
+        );
+        assert_eq!(hidden.wire_label(4), "out", "a hidden neuron uses its UUID");
+        assert_eq!(
+            NeuronView {
+                uuid: Some(""),
+                ..hidden
+            }
+            .wire_label(4),
+            "non-output-negative-id--2@index-4",
+            "a stray negative id on a non-output neuron is called out"
+        );
+        assert_eq!(
+            NeuronView {
+                id: Some(7),
+                uuid: None,
+                ..hidden
+            }
+            .wire_label(4),
+            "missing-uuid@index-4"
+        );
+    }
+
+    /// JavaScript renders an integral double without a fraction, and names its
+    /// three non-finite values.
+    #[test]
+    fn numbers_render_the_way_javascript_interpolates_them() {
+        assert_eq!(number_text(Some(3.0)), "3");
+        assert_eq!(number_text(Some(-0.25)), "-0.25");
+        assert_eq!(number_text(Some(f64::NAN)), "NaN");
+        assert_eq!(number_text(Some(f64::INFINITY)), "Infinity");
+        assert_eq!(number_text(Some(f64::NEG_INFINITY)), "-Infinity");
+        assert_eq!(number_text(None), "undefined");
+    }
 }

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -145,12 +145,12 @@
 //!
 //! Where the TypeScript interpolates `neuron.ID()` the message carries the
 //! integer id verbatim. Where it interpolates
-//! `neuronWireLabelForDiagnostics(neuron, indx)` — rules 11, 16, 17, 18 — this
+//! `neuronWireLabelForDiagnostics(neuron, index)` — rules 11, 16, 17, 18 — this
 //! port reproduces `src/neuron/NeuronSerialization.ts` branch for branch, since
 //! NEAT-AI's error-message tests assert on that text: `input-N` for an input,
 //! `output-N` for an output carrying its negative id, otherwise the wire UUID,
-//! and `non-output-negative-id-{id}@index-{indx}` /
-//! `missing-uuid@index-{indx}` when there is no UUID to use.
+//! and `non-output-negative-id-{id}@index-{index}` /
+//! `missing-uuid@index-{index}` when there is no UUID to use.
 //!
 //! # Shared invariants
 //!
@@ -682,7 +682,7 @@ impl NeuronView<'_> {
         self.uuid.filter(|uuid| !uuid.is_empty())
     }
 
-    /// Rust's `neuronWireLabelForDiagnostics(neuron, indx)`.
+    /// Rust's `neuronWireLabelForDiagnostics(neuron, index)`.
     ///
     /// NEAT-AI's error-message tests assert on this text, so it reproduces
     /// `src/neuron/NeuronSerialization.ts` branch for branch: `input-N` for an
@@ -822,13 +822,13 @@ fn resolve_synapse_endpoints(
     let mut to = Vec::with_capacity(creature.synapses.len());
     let mut types = Vec::with_capacity(creature.synapses.len());
 
-    for (indx, synapse) in creature.synapses.iter().enumerate() {
+    for (index, synapse) in creature.synapses.iter().enumerate() {
         let dangling = |endpoint: &str, uuid: &str| {
             ValidationFailure::topology(
                 reason::INVALID_SYNAPSE_REFERENCE,
-                format!("{indx}) synapse {endpoint} {uuid} does not name a neuron"),
+                format!("{index}) synapse {endpoint} {uuid} does not name a neuron"),
             )
-            .at_synapse(indx as u32)
+            .at_synapse(index as u32)
         };
 
         from.push(resolve(&synapse.from_uuid).ok_or_else(|| dangling("from", &synapse.from_uuid))?);
@@ -856,8 +856,8 @@ fn walk_neurons(
     let mut outputs_seen = 0usize;
     let mut computational_seen_hidden = false;
 
-    for (indx, neuron) in views.iter().enumerate() {
-        let at = |failure: ValidationFailure| failure.at_neuron(indx as u32);
+    for (index, neuron) in views.iter().enumerate() {
+        let at = |failure: ValidationFailure| failure.at_neuron(index as u32);
 
         // Rule 4 — every neuron has an id.
         let Some(id) = neuron.id else {
@@ -886,7 +886,7 @@ fn walk_neurons(
 
         if neuron.kind == NeuronKind::Input {
             // Rule 7 — an input neuron is identified by its own index.
-            if id != indx as i64 {
+            if id != index as i64 {
                 return Err(at(ValidationFailure::validation(
                     reason::OTHER,
                     format!("{id}) invalid input neuron id: {id}"),
@@ -911,7 +911,7 @@ fn walk_neurons(
         }
 
         // Rule 10 — inputs come first.
-        if neuron.kind == NeuronKind::Input && indx > input {
+        if neuron.kind == NeuronKind::Input && index > input {
             return Err(at(ValidationFailure::validation(
                 reason::OTHER,
                 format!("{id}) input neuron after the maximum input neurons"),
@@ -919,13 +919,13 @@ fn walk_neurons(
         }
 
         // Rule 11 — inside the computational slice, constants precede hiddens.
-        if indx >= input && indx < views.len() - output {
+        if index >= input && index < views.len() - output {
             if neuron.kind == NeuronKind::Constant && computational_seen_hidden {
                 return Err(at(ValidationFailure::validation(
                     reason::NEURON_ORDER,
                     format!(
                         "{}) type constant after hidden neuron; required order is input, constant, hidden, output",
-                        neuron.wire_label(indx)
+                        neuron.wire_label(index)
                     ),
                 )));
             }
@@ -936,8 +936,8 @@ fn walk_neurons(
 
         // Rule 12 — an `IF` neuron decides between two branches, so it needs a
         // condition, a positive and a negative input.
-        if neuron.squash == Some("IF") && indx > 2 {
-            let inward = connections.inward_synapses(indx);
+        if neuron.squash == Some("IF") && index > 2 {
+            let inward = connections.inward_synapses(index);
             let roles = IfRoles::tally(
                 inward
                     .iter()
@@ -963,8 +963,8 @@ fn walk_neurons(
             }
         }
 
-        let inward = connections.inward_count(indx);
-        let outward = connections.outward_count(indx);
+        let inward = connections.inward_count(index);
+        let outward = connections.outward_count(index);
 
         match neuron.kind {
             NeuronKind::Input => {
@@ -1002,7 +1002,7 @@ fn walk_neurons(
                         reason::NO_OUTWARD_CONNECTIONS,
                         format!(
                             "constants neuron {} has no outward connections",
-                            neuron.wire_label(indx)
+                            neuron.wire_label(index)
                         ),
                     )));
                 }
@@ -1023,7 +1023,7 @@ fn walk_neurons(
                         wiring_reason,
                         format!(
                             "hidden neuron {} has no {direction} connections",
-                            neuron.wire_label(indx)
+                            neuron.wire_label(index)
                         ),
                     )));
                 }

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod squash_simd;
 pub mod synapse_type;
 pub mod topological_backprop;
 pub mod topology_export;
+pub mod topology_invariants;
 pub mod topology_ops;
 pub mod training_bin_stream;
 pub mod training_data;

--- a/neat-core/src/topology_invariants.rs
+++ b/neat-core/src/topology_invariants.rs
@@ -1,0 +1,353 @@
+//! Wiring invariants shared by the topology validators (Issue #560).
+//!
+//! Two validators ask the same structural questions of a creature:
+//! [`crate::topology_ops::validate_structural_integrity`] (flat typed arrays,
+//! answers with a numeric code and a neuron index) and
+//! [`crate::creature_validate::creature_validate`] (a `CreatureExport`, answers
+//! with the TypeScript message NEAT-AI's tests assert on). The *answers* differ,
+//! so neither can call the other — but the questions must not be asked twice, or
+//! the two stacks drift on what "wired in" means.
+//!
+//! This module is the single home of those questions:
+//!
+//! - [`ConnectionIndex`] — inward / outward degree and the inward synapse list,
+//!   built once in `O(neurons + synapses)`, so no caller rescans the synapse
+//!   list per neuron.
+//! - [`hidden_wiring_fault`] — a hidden neuron needs an inward *and* an outward
+//!   edge, inward reported first.
+//! - [`if_neuron_fault`] — an `IF` neuron needs [`IF_MINIMUM_INWARD`] inward
+//!   edges carrying all three roles, reported condition → positive → negative.
+//!
+//! What is deliberately *not* here: the checks that are a single comparison over
+//! the values above (`constant has inward`, `bias is finite`). Wrapping
+//! `inward_count(i) > 0` in a named function moves no logic and only adds a hop
+//! for a reader to follow.
+
+use crate::synapse_type::SynapseType;
+
+/// Inward edges an `IF` neuron must carry — one per role, at minimum.
+pub const IF_MINIMUM_INWARD: usize = 3;
+
+/// Inward / outward adjacency for one topology, built once from its synapse
+/// list.
+///
+/// Out-of-range endpoints are ignored rather than rejected: the callers police
+/// their own index space (`validate_structural_integrity` returns
+/// `STRUCTURAL_MALFORMED_BUFFER`, `creature_validate` resolves every UUID before
+/// building the index), and a WASM export must not trap on a bad buffer.
+pub struct ConnectionIndex {
+    /// `inward_starts[n]..inward_starts[n + 1]` slices [`Self::inward_synapses`].
+    inward_starts: Vec<u32>,
+    /// Synapse indices, grouped by destination neuron.
+    inward_synapses: Vec<u32>,
+    /// Outward degree per neuron.
+    outward_counts: Vec<u32>,
+}
+
+impl ConnectionIndex {
+    /// Build the index for `num_neurons` neurons wired by `from` / `to`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `from` and `to` differ in length — a caller that lost a
+    /// synapse endpoint must fail loudly rather than validate half a topology.
+    pub fn build(from: &[u32], to: &[u32], num_neurons: usize) -> Self {
+        assert_eq!(
+            from.len(),
+            to.len(),
+            "synapse endpoint lists must be the same length"
+        );
+
+        let mut inward_starts = vec![0u32; num_neurons + 1];
+        let mut outward_counts = vec![0u32; num_neurons];
+
+        for i in 0..from.len() {
+            let source = from[i] as usize;
+            let target = to[i] as usize;
+            if source < num_neurons {
+                outward_counts[source] += 1;
+            }
+            if target < num_neurons {
+                // Counting pass: offset by one so the prefix sum below lands
+                // each neuron's start without a second shift.
+                inward_starts[target + 1] += 1;
+            }
+        }
+
+        for n in 0..num_neurons {
+            inward_starts[n + 1] += inward_starts[n];
+        }
+
+        let total_inward = inward_starts[num_neurons] as usize;
+        let mut inward_synapses = vec![0u32; total_inward];
+        let mut cursor = inward_starts.clone();
+        for i in 0..to.len() {
+            let target = to[i] as usize;
+            if target < num_neurons {
+                inward_synapses[cursor[target] as usize] = i as u32;
+                cursor[target] += 1;
+            }
+        }
+
+        Self {
+            inward_starts,
+            inward_synapses,
+            outward_counts,
+        }
+    }
+
+    /// Number of neurons the index covers.
+    pub fn num_neurons(&self) -> usize {
+        self.outward_counts.len()
+    }
+
+    /// How many synapses arrive at `neuron`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `neuron` is outside `0..num_neurons`.
+    pub fn inward_count(&self, neuron: usize) -> usize {
+        self.inward_synapses(neuron).len()
+    }
+
+    /// How many synapses leave `neuron`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `neuron` is outside `0..num_neurons`.
+    pub fn outward_count(&self, neuron: usize) -> usize {
+        self.outward_counts[neuron] as usize
+    }
+
+    /// Indices of the synapses arriving at `neuron`, in declaration order.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `neuron` is outside `0..num_neurons`.
+    pub fn inward_synapses(&self, neuron: usize) -> &[u32] {
+        let start = self.inward_starts[neuron] as usize;
+        let end = self.inward_starts[neuron + 1] as usize;
+        &self.inward_synapses[start..end]
+    }
+}
+
+/// Which of the three `IF` roles a neuron's inward synapses carry.
+///
+/// A synapse with no declared type is a positive input — NEAT-AI's
+/// `c.type ?? "positive"` and this crate's [`SynapseType::Standard`] are the
+/// same case.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IfRoles {
+    /// At least one `condition` input.
+    pub condition: bool,
+    /// At least one `positive` (or untyped) input.
+    pub positive: bool,
+    /// At least one `negative` input.
+    pub negative: bool,
+}
+
+impl IfRoles {
+    /// Tally the roles carried by a neuron's inward synapse types.
+    pub fn tally(types: impl IntoIterator<Item = SynapseType>) -> Self {
+        let mut roles = Self::default();
+        for synapse_type in types {
+            match synapse_type {
+                SynapseType::Condition => roles.condition = true,
+                SynapseType::Negative => roles.negative = true,
+                SynapseType::Positive | SynapseType::Standard => roles.positive = true,
+            }
+        }
+        roles
+    }
+}
+
+/// Why a hidden neuron is not wired into the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WiringFault {
+    /// Nothing feeds the neuron.
+    NoInward,
+    /// The neuron feeds nothing.
+    NoOutward,
+}
+
+/// The first wiring fault of a hidden neuron, or `None` when it is wired in.
+///
+/// Inward is reported before outward, which is the order NEAT-AI's
+/// `CreatureValidate.ts` raises them in.
+pub fn hidden_wiring_fault(inward: usize, outward: usize) -> Option<WiringFault> {
+    if inward == 0 {
+        return Some(WiringFault::NoInward);
+    }
+    if outward == 0 {
+        return Some(WiringFault::NoOutward);
+    }
+    None
+}
+
+/// Why an `IF` neuron cannot make its decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IfFault {
+    /// Fewer than [`IF_MINIMUM_INWARD`] inward synapses.
+    TooFewInward {
+        /// Inward synapses the neuron actually has.
+        found: usize,
+    },
+    /// No `condition` input — nothing to branch on.
+    MissingCondition,
+    /// No `positive` (or untyped) input — the true branch is empty.
+    MissingPositive,
+    /// No `negative` input — the false branch is empty.
+    MissingNegative,
+}
+
+/// The first `IF` fault of a neuron, or `None` when all three roles are present.
+///
+/// Count first, then condition → positive → negative: the order NEAT-AI's
+/// `CreatureValidate.ts` raises them in, and the order
+/// `validate_structural_integrity` returns its `STRUCTURAL_IF_*` codes in.
+pub fn if_neuron_fault(inward: usize, roles: IfRoles) -> Option<IfFault> {
+    if inward < IF_MINIMUM_INWARD {
+        return Some(IfFault::TooFewInward { found: inward });
+    }
+    if !roles.condition {
+        return Some(IfFault::MissingCondition);
+    }
+    if !roles.positive {
+        return Some(IfFault::MissingPositive);
+    }
+    if !roles.negative {
+        return Some(IfFault::MissingNegative);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Degrees and the inward synapse list come from one build pass, and a
+    /// neuron with no edges reads as zero rather than panicking.
+    #[test]
+    fn the_index_reports_degrees_and_inward_synapses_per_neuron() {
+        // 0 -> 2, 1 -> 2, 2 -> 3, and neuron 4 wired to nothing.
+        let from = [0u32, 1, 2];
+        let to = [2u32, 2, 3];
+        let index = ConnectionIndex::build(&from, &to, 5);
+
+        assert_eq!(index.num_neurons(), 5);
+        assert_eq!(index.inward_count(0), 0);
+        assert_eq!(index.outward_count(0), 1);
+        assert_eq!(index.inward_count(2), 2);
+        assert_eq!(index.outward_count(2), 1);
+        assert_eq!(index.inward_synapses(2), &[0, 1], "declaration order");
+        assert_eq!(index.inward_synapses(3), &[2]);
+        assert_eq!(index.inward_count(4), 0);
+        assert_eq!(index.outward_count(4), 0);
+    }
+
+    /// An endpoint outside the neuron range is ignored, so a malformed buffer
+    /// cannot index out of bounds (or trap in WASM).
+    #[test]
+    fn out_of_range_endpoints_are_ignored() {
+        let index = ConnectionIndex::build(&[0, 9], &[1, 9], 2);
+
+        assert_eq!(index.outward_count(0), 1);
+        assert_eq!(index.inward_count(1), 1);
+        assert_eq!(index.inward_synapses(1), &[0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "same length")]
+    fn mismatched_endpoint_lists_fail_loudly() {
+        let _ = ConnectionIndex::build(&[0, 1], &[1], 2);
+    }
+
+    /// An untyped synapse is a positive input, the same reading NEAT-AI's
+    /// `c.type ?? "positive"` gives it.
+    #[test]
+    fn an_untyped_synapse_counts_as_the_positive_role() {
+        let roles = IfRoles::tally([SynapseType::Standard]);
+
+        assert_eq!(
+            roles,
+            IfRoles {
+                condition: false,
+                positive: true,
+                negative: false
+            }
+        );
+    }
+
+    #[test]
+    fn roles_tally_condition_positive_and_negative() {
+        let roles = IfRoles::tally([
+            SynapseType::Condition,
+            SynapseType::Negative,
+            SynapseType::Positive,
+        ]);
+
+        assert_eq!(
+            roles,
+            IfRoles {
+                condition: true,
+                positive: true,
+                negative: true
+            }
+        );
+        assert_eq!(IfRoles::tally([]), IfRoles::default());
+    }
+
+    #[test]
+    fn a_hidden_neuron_needs_an_inward_edge_before_an_outward_one() {
+        assert_eq!(hidden_wiring_fault(0, 0), Some(WiringFault::NoInward));
+        assert_eq!(hidden_wiring_fault(0, 3), Some(WiringFault::NoInward));
+        assert_eq!(hidden_wiring_fault(2, 0), Some(WiringFault::NoOutward));
+        assert_eq!(hidden_wiring_fault(2, 3), None);
+    }
+
+    #[test]
+    fn an_if_neuron_reports_its_count_then_each_missing_role_in_turn() {
+        let all = IfRoles {
+            condition: true,
+            positive: true,
+            negative: true,
+        };
+
+        assert_eq!(
+            if_neuron_fault(2, all),
+            Some(IfFault::TooFewInward { found: 2 }),
+            "the count is checked before the roles"
+        );
+        assert_eq!(if_neuron_fault(IF_MINIMUM_INWARD, all), None);
+        assert_eq!(
+            if_neuron_fault(
+                3,
+                IfRoles {
+                    condition: false,
+                    ..all
+                }
+            ),
+            Some(IfFault::MissingCondition)
+        );
+        assert_eq!(
+            if_neuron_fault(
+                3,
+                IfRoles {
+                    positive: false,
+                    ..all
+                }
+            ),
+            Some(IfFault::MissingPositive)
+        );
+        assert_eq!(
+            if_neuron_fault(
+                3,
+                IfRoles {
+                    negative: false,
+                    ..all
+                }
+            ),
+            Some(IfFault::MissingNegative)
+        );
+    }
+}

--- a/neat-core/src/topology_ops.rs
+++ b/neat-core/src/topology_ops.rs
@@ -20,6 +20,11 @@ use wasm_bindgen::prelude::*;
 
 use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
+// Issue #560 — the wiring invariants this module shares with
+// `creature_validate` have one home; see `topology_invariants`.
+use crate::topology_invariants::{
+    ConnectionIndex, IfFault, IfRoles, WiringFault, hidden_wiring_fault, if_neuron_fault,
+};
 
 // ===========================================================================
 // Topology validation error codes — must match TypeScript constants
@@ -78,10 +83,19 @@ pub const STRUCTURAL_MALFORMED_BUFFER: i32 = 10;
 
 /// Squash-type code for IF neurons — resolved from [`SquashType::If`].
 const IF_SQUASH: u8 = SquashType::If as u8;
+
 /// Synapse-type codes — resolved from [`SynapseType`] discriminants.
+///
+/// Test-only since Issue #560: the IF-role tally reads the wire codes through
+/// [`SynapseType::from`] rather than comparing them one by one, so these names
+/// survive only to keep the fixtures below readable.
+#[cfg(test)]
 const SYN_STANDARD: u8 = SynapseType::Standard as u8;
+#[cfg(test)]
 const SYN_CONDITION: u8 = SynapseType::Condition as u8;
+#[cfg(test)]
 const SYN_NEGATIVE: u8 = SynapseType::Negative as u8;
+#[cfg(test)]
 const SYN_POSITIVE: u8 = SynapseType::Positive as u8;
 
 /// Validate topology synapse ordering and forward-only constraints.
@@ -554,19 +568,7 @@ pub fn validate_structural_integrity(
         }
     }
 
-    let mut inward_count = vec![0u32; num_neurons];
-    let mut outward_count = vec![0u32; num_neurons];
-
-    for i in 0..num_synapses {
-        let from = from_indices[i] as usize;
-        let to = to_indices[i] as usize;
-        if from < num_neurons {
-            outward_count[from] += 1;
-        }
-        if to < num_neurons {
-            inward_count[to] += 1;
-        }
-    }
+    let connections = ConnectionIndex::build(from_indices, to_indices, num_neurons);
 
     let output_start = num_neurons - output_count;
 
@@ -582,56 +584,51 @@ pub fn validate_structural_integrity(
         }
 
         if is_const {
-            if inward_count[i] > 0 {
+            if connections.inward_count(i) > 0 {
                 return vec![STRUCTURAL_CONSTANT_HAS_INWARD, i as i32];
             }
             continue;
         }
 
         if !is_output {
-            if inward_count[i] == 0 {
-                return vec![STRUCTURAL_HIDDEN_NO_INWARD, i as i32];
-            }
-            if outward_count[i] == 0 {
-                return vec![STRUCTURAL_HIDDEN_NO_OUTWARD, i as i32];
+            let fault =
+                hidden_wiring_fault(connections.inward_count(i), connections.outward_count(i));
+            match fault {
+                Some(WiringFault::NoInward) => {
+                    return vec![STRUCTURAL_HIDDEN_NO_INWARD, i as i32];
+                }
+                Some(WiringFault::NoOutward) => {
+                    return vec![STRUCTURAL_HIDDEN_NO_OUTWARD, i as i32];
+                }
+                None => {}
             }
         }
 
         if i < squash_types.len() && squash_types[i] == IF_SQUASH {
-            if inward_count[i] < 3 {
-                return vec![STRUCTURAL_IF_TOO_FEW_INWARD, i as i32];
-            }
+            let inward = connections.inward_synapses(i);
+            // A synapse index past `synapse_types` carries no role at all —
+            // unlike an absent JSON `type`, which reads as positive.
+            let roles = IfRoles::tally(inward.iter().filter_map(|s| {
+                synapse_types
+                    .get(*s as usize)
+                    .copied()
+                    .map(SynapseType::from)
+            }));
 
-            let mut has_condition = false;
-            let mut has_positive = false;
-            let mut has_negative = false;
-
-            for s in 0..num_synapses {
-                if to_indices[s] as usize != i {
-                    continue;
+            match if_neuron_fault(inward.len(), roles) {
+                Some(IfFault::TooFewInward { .. }) => {
+                    return vec![STRUCTURAL_IF_TOO_FEW_INWARD, i as i32];
                 }
-                if s < synapse_types.len() {
-                    let st = synapse_types[s];
-                    if st == SYN_CONDITION {
-                        has_condition = true;
-                    }
-                    if st == SYN_POSITIVE || st == SYN_STANDARD {
-                        has_positive = true;
-                    }
-                    if st == SYN_NEGATIVE {
-                        has_negative = true;
-                    }
+                Some(IfFault::MissingCondition) => {
+                    return vec![STRUCTURAL_IF_MISSING_CONDITION, i as i32];
                 }
-            }
-
-            if !has_condition {
-                return vec![STRUCTURAL_IF_MISSING_CONDITION, i as i32];
-            }
-            if !has_positive {
-                return vec![STRUCTURAL_IF_MISSING_POSITIVE, i as i32];
-            }
-            if !has_negative {
-                return vec![STRUCTURAL_IF_MISSING_NEGATIVE, i as i32];
+                Some(IfFault::MissingPositive) => {
+                    return vec![STRUCTURAL_IF_MISSING_POSITIVE, i as i32];
+                }
+                Some(IfFault::MissingNegative) => {
+                    return vec![STRUCTURAL_IF_MISSING_NEGATIVE, i as i32];
+                }
+                None => {}
             }
         }
     }
@@ -732,12 +729,23 @@ mod tests {
         assert_eq!(IF_SQUASH, 34);
     }
 
+    /// The wire codes and the enum the IF-role tally reads must agree in both
+    /// directions, since the tally now converts rather than compares.
     #[test]
-    fn synapse_type_constants_match_enum() {
-        assert_eq!(SYN_STANDARD, SynapseType::Standard as u8);
-        assert_eq!(SYN_CONDITION, SynapseType::Condition as u8);
-        assert_eq!(SYN_NEGATIVE, SynapseType::Negative as u8);
-        assert_eq!(SYN_POSITIVE, SynapseType::Positive as u8);
+    fn synapse_type_codes_round_trip_through_the_enum() {
+        for expected in [
+            SynapseType::Standard,
+            SynapseType::Condition,
+            SynapseType::Negative,
+            SynapseType::Positive,
+        ] {
+            assert_eq!(SynapseType::from(expected as u8), expected);
+        }
+
+        assert_eq!(SYN_STANDARD, 0);
+        assert_eq!(SYN_CONDITION, 1);
+        assert_eq!(SYN_NEGATIVE, 2);
+        assert_eq!(SYN_POSITIVE, 3);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
# creature_validate: port the neuron-level rules from CreatureValidate.ts

## Summary

Fills in the **neuron half** of `creature_validate` — rules 1–22, everything
NEAT-AI's `src/architecture/CreatureValidate.ts` evaluates before its synapse
walk — in the TypeScript's own order, first failure wins, with every message
reproduced verbatim so NEAT-AI's error-message tests keep passing across the
boundary. Rules 23–31 (synapses, `forwardOnly`, memetic) stay with Issue #561,
so the entry point runs the neuron half and *then* reports the un-ported half
rather than returning an `Ok` this build cannot stand behind. Closes #560.

Two derivations make the port work on the index-free, id-optional export form:

| Derivation | Why |
|------------|-----|
| Indices — `0..input` are the implicit input neurons, `input + i` is `neurons[i]` | the walk position every rule reads; same derivation as `compile_creature` |
| Ids — input `= index`, output `= -(outputIndex + 1)`, everything else its exported `id` or a deterministic hash of its UUID | NEAT-AI's loader assigns these *before* `creatureValidate` runs; without it every modern export (UUIDs, no ids) would fail rule 4 |

Four rules cannot fail for a `CreatureExport` and are ported anyway so the two
files stay line-for-line comparable: rules 7, 10 and 21 hold by construction
because the input neurons are derived from the declared width, and rule 19 is
unreachable in **both** stacks behind rule 8 (which rejects a missing or
non-finite bias on every non-input neuron first). Each is covered against the
function that implements it rather than left as dead text.

`neuronWireLabelForDiagnostics` (rules 11, 16, 17, 18) is reproduced branch for
branch from `src/neuron/NeuronSerialization.ts` — `input-N`, `output-N`, the
wire UUID, then the two no-UUID fallbacks — since NEAT-AI asserts on that text.
The substitute is documented in the module docs and pinned by
`the_wire_label_reproduces_the_typescript_diagnostic_label`.

### One implementation per invariant

`creature_validate` and `topology_ops::validate_structural_integrity` ask the
same wiring questions but answer them differently — a TypeScript message and a
neuron index here, a numeric `STRUCTURAL_*` code there — and they evaluate in
different orders, so neither can call the other and the existing codes cannot
express the messages. What they share is therefore **factored out** rather than
mapped, into `neat-core/src/topology_invariants.rs`:

- `ConnectionIndex` — inward/outward degree and the inward synapse list, built
  once in `O(neurons + synapses)`. This also removes the `O(synapses)` rescan
  `validate_structural_integrity` did *per* `IF` neuron.
- `hidden_wiring_fault` — inward before outward, the order both raise them in.
- `if_neuron_fault` / `IfRoles` / `IF_MINIMUM_INWARD` — count, then condition →
  positive → negative.

Deliberately *not* extracted: the checks that are a single comparison over those
values (`constant has inward`, `bias is finite`). Wrapping `inward_count(i) > 0`
in a named function moves no logic and only adds a hop.

The `SYN_*` code constants in `topology_ops` became test-only: the role tally
now converts through `SynapseType::from` instead of comparing four constants.
The drift guard they carried is replaced by a round-trip test on that
conversion.

## Evidence

Backend/library change — no web interface to screenshot. `./quality.sh` passes
end to end (fmt, clippy `-D warnings`, `cargo check`, 51 test binaries,
rustdoc `-D warnings`, release build).

**Red run.** With `validate_neuron_rules` short-circuited to
`Ok(ValidationStats::default())` — the pre-port state — **24 of the 31** new
`creature_validate` tests fail:

```
test result: FAILED. 7 passed; 24 failed; 0 ignored; 0 measured; 188 filtered out
```

The 7 survivors are the ones that call `walk_neurons`, `hidden_bias_failure`,
`derived_neuron_id`, `wire_label` and `number_text` directly — the rules that a
`CreatureExport` cannot break — so they never reach the stub.

**Mutation evidence for the shared invariants.** Each mutation was applied to
`topology_invariants.rs` alone and reverted afterwards; every one fails tests on
**both** sides, which is what proves the two validators genuinely share the
code rather than each keeping a copy:

| Mutation | Tests killed |
|----------|--------------|
| `hidden_wiring_fault`: inward/outward swapped | `creature_validate::a_hidden_neuron_must_be_wired_in_and_out`, `topology_invariants::a_hidden_neuron_needs_an_inward_edge_before_an_outward_one`, `topology_ops::structural_hidden_no_inward`, `topology_ops::structural_hidden_no_outward` |
| `if_neuron_fault`: minimum inward 3 → 2 | `creature_validate::an_if_neuron_with_fewer_than_three_inward_connections_is_rejected`, `topology_invariants::an_if_neuron_reports_its_count_then_each_missing_role_in_turn`, `topology_ops::structural_if_too_few_inward` |
| `ConnectionIndex`: outward degree never counted | 8+ `creature_validate` tests, including `a_constant_with_no_outward_connection_is_rejected` and `a_hidden_neuron_must_be_wired_in_and_out` |

```mermaid
flowchart TD
    CE["CreatureExport"] --> D["derive indices + ids"]
    D --> W["neuron walk<br/>rules 1-22"]
    D --> CI["ConnectionIndex"]
    CI --> W
    CI --> VSI["validate_structural_integrity"]
    SI["topology_invariants<br/>hidden_wiring_fault / if_neuron_fault"] --> W
    SI --> VSI
    W -->|"first violated rule"| F["Err(ValidationFailure)<br/>TypeScript message"]
    VSI -->|"first violated rule"| C["[code, neuron index]"]
    W -->|"rules 1-22 pass"| N["Err — rules 23-31 not ported (#561)"]
```

## Test Plan

31 unit tests in `neat-core/src/creature_validate.rs`, each rule with a
positive and a negative case:

| Rules | Tests |
|-------|-------|
| valid creatures | `the_decision_tree_fixtures_pass_every_neuron_rule` (stats per type), `the_entry_point_reports_a_neuron_rule_before_the_unported_half` |
| 1–3 | `an_expected_neuron_count_that_misses_the_total_is_reported_with_both_counts`, `a_creature_with_no_input_neurons_is_rejected`, `a_creature_with_no_output_neurons_is_rejected` |
| 4–6 | `a_neuron_with_no_id_and_no_uuid_is_rejected`, `ids_are_derived_from_the_uuid_when_the_export_carries_none`, `an_id_above_int32_max_is_rejected_and_the_boundary_is_accepted`, `a_duplicate_neuron_id_is_rejected`, `distinct_ids_including_the_negative_output_id_are_accepted` |
| 7, 10 | `an_input_neuron_whose_id_is_not_its_index_is_rejected`, `an_input_neuron_past_the_declared_width_is_rejected` |
| 8, 9, 11 | `a_non_finite_bias_on_a_non_input_neuron_is_rejected` (NaN / ±Infinity), `a_neuron_after_an_output_neuron_is_rejected`, `a_constant_after_a_hidden_neuron_breaks_the_required_order` |
| 12 | `an_if_neuron_with_fewer_than_three_inward_connections_is_rejected`, `an_if_neuron_missing_a_role_names_the_role_it_is_missing`, `an_untyped_inward_synapse_fills_the_positive_role`, `the_if_rule_is_skipped_for_the_first_three_neurons` |
| 13–20 | `a_synapse_into_an_input_neuron_is_rejected`, `a_constant_with_an_inward_connection_is_rejected`, `a_constant_carrying_a_squash_is_rejected`, `a_constant_with_no_outward_connection_is_rejected`, `a_hidden_neuron_must_be_wired_in_and_out`, `a_hidden_neuron_needs_a_present_and_finite_bias`, `an_unknown_neuron_type_is_rejected_and_so_is_a_declared_input` |
| 21, 22 | `fewer_input_neurons_than_declared_is_rejected`, `fewer_output_neurons_than_declared_is_rejected` |
| input format | `a_synapse_endpoint_that_names_no_neuron_is_rejected`, `the_wire_label_reproduces_the_typescript_diagnostic_label`, `numbers_render_the_way_javascript_interpolates_them` |

6 unit tests in `neat-core/src/topology_invariants.rs` cover the index
(degrees, inward list order, ignored out-of-range endpoints, the fail-loud
length assert) and both fault functions.

Unchanged and still green: `neat-core/tests/creature_validate_contract.rs`
(Issue #559) and the `validate_structural_integrity` suite in `topology_ops`,
which is what holds the refactor behaviour-preserving.

## Security self-check

- Input validation: the new code *is* validation — every field it reads
  (`id`, `type`, `bias`, `squash`, UUIDs) is bounds- and range-checked before
  use, and an unresolvable synapse endpoint is rejected rather than indexed.
- No secrets, no new dependencies, no SQL/shell/filesystem/HTTP surface.
- Messages carry only creature data the caller already holds (ids, UUIDs, type
  names, counts) — no paths, no internal state.
- Fail loud: `ConnectionIndex::build` asserts its endpoint lists match rather
  than validating half a topology, and a fully valid creature still returns an
  error naming the un-ported half instead of a green `Ok`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt2pld2n-e3e5de`<!-- vibe-worker-issue-560 -->