### PR TITLE
creature_validate: expose over the WASM boundary and native API, prove conformance, release (Issue #562)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,11 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --lib --tests --all-features -- --test-threads=2
 
+      # Issue #562 — the public API's doctests (creature_validate) are a gate,
+      # not decoration: `--lib --tests` never compiles them.
+      - name: Run doctests
+        run: cargo test --workspace --doc --all-features
+
       - name: Build documentation
         env:
           RUSTDOCFLAGS: "-D warnings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.10"
+version = "0.9.11"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -574,9 +574,9 @@ failure's neuron/synapse index is what lets the host run those against the same
 neuron the shared rules stopped on.
 
 Both halves of the table are ported, so `creature_validate` evaluates every
-rule and returns `ValidationStats` for a creature that breaks none of them.
-Exposing it over the WASM boundary and replaying the TypeScript conformance
-corpus is Issue #562.
+rule and returns `ValidationStats` for a creature that breaks none of them. It
+is reachable natively and over the WASM boundary, and replayed against the
+TypeScript conformance corpus — Issue #562, below.
 
 ### Neuron rules ported (Issue #560)
 
@@ -674,6 +674,84 @@ flowchart LR
     T --> M
     M --> S["Ok(()) — stats.connections tallied"]
 ```
+
+#### Both consumers, and conformance (Issue #562)
+
+The ported rules are now reachable by both consumer kinds, and proven to agree
+with the TypeScript they replace.
+
+**Rust consumers** call `creature_validate` straight off the crate root
+(NEAT-AI-Forests and friends); the entry point carries worked doctests for a
+valid creature and a rejected one, and `cargo test --doc` is part of the gate.
+
+**NEAT-AI** calls the same code over the WASM boundary as
+`creature_validate(request: string) -> string`. The ABI is **JSON in, JSON
+out** — the existing exports split between packed byte buffers
+(`propagate_topological`) and scalar arguments, and neither fits a whole
+creature in and a structured failure out:
+
+```jsonc
+// in
+{ "creature": { /* CreatureExport */ },
+  "options": { "neurons": 3, "connections": 2, "feedbackLoop": false, "forwardOnly": true } }
+
+// out — one of
+{ "ok": true,  "stats": { "input": 1, "constant": 0, "hidden": 1, "output": 1, "connections": 2 } }
+{ "ok": false, "failure": { "class": "ValidationError", "reason": "NO_INWARD_CONNECTIONS",
+                            "message": "hidden neuron h1 has no inward connections",
+                            "neuronIndex": 1, "synapseIndex": null, "malformed": false } }
+```
+
+Keys the creature carries beyond `CreatureExport` are ignored, but an **unknown
+option key is a failure** — silently ignoring `forwardonly` would validate a
+production creature under the wrong rules and call it healthy. The creature is
+deserialised with serde alone, deliberately not through `parse_creature_json`,
+whose width check would shadow rules 2 and 3.
+
+**Malformed input cannot panic.** A panic in WASM aborts the module and
+`catch_unwind` is unavailable there, so the boundary is built not to panic:
+anything that is not a request comes back as an ordinary structured failure
+carrying `"malformed": true` and a `MALFORMED_REQUEST:` message — the JSON twin
+of `topology_ops`' `MALFORMED_BUFFER`. Two faults are refused before a rule
+runs: a payload serde cannot read, and a creature declaring more than
+`MAX_REQUEST_NEURONS` neurons (the ceiling `compile_creature` already enforces),
+because the walk allocates one entry per neuron before the first rule. The whole
+ABI lives in `neat-core/src/creature_validate_json.rs`, so it is covered by
+`cargo test` rather than only in a browser; `wasm_exports.rs` is a rename over
+it.
+
+```mermaid
+flowchart LR
+    JS["NEAT-AI TypeScript"] -->|request JSON| W["wasm_exports<br/>creature_validate"]
+    RS["Rust consumers"] -->|CreatureExport| V["creature_validate"]
+    W --> J["creature_validate_json"]
+    J -->|"not a request,<br/>or too many neurons"| MF["failure<br/>malformed: true"]
+    J --> V
+    V -->|"Ok(stats)"| OK["ok: true + stats"]
+    V -->|"Err(failure)"| ERR["ok: false + class,<br/>reason, message, indices"]
+```
+
+**Conformance.** NEAT-AI's language-neutral corpus (NEAT-AI#3801) is vendored
+under `neat-core/tests/fixtures/creature_validate/` — bytes, source commit and
+checksums recorded there — and replayed by
+`neat-core/tests/creature_validate_conformance.rs`. Every replayed case must
+produce the same error class, the same `reason` and the same message text; the
+happy paths must produce the same five counters.
+
+Ten of the 47 cases describe something the wire shape cannot express, all of
+them consequences of the input format Issue #559 fixed rather than of a rule
+that was dropped: a non-integer count or id serde rejects at the parse
+boundary, an input neuron carrying its own id (inputs are implicit), an output
+neuron's declared id (ids are derived), and the host-only `neuron.index` check.
+None is skipped — each is declared in the runner with why it diverges *and*
+what this crate does instead, and that behaviour is asserted too, so a stale
+declaration or a changed outcome fails the test.
+
+**What stays host-side** is unchanged: `neuron.creature !== creature`,
+`neuron.index`, `neuron.validate()` and the `debugWrite` diagnostics dump all
+read JavaScript object identity or the host filesystem. The failure's
+`neuronIndex` / `synapseIndex` is what lets NEAT-AI run those against the same
+neuron the shared rules stopped on.
 
 ## Related Repositories
 

--- a/docs/archive/pr-summaries/pr-summary-562.md
+++ b/docs/archive/pr-summaries/pr-summary-562.md
@@ -1,0 +1,172 @@
+# creature_validate: both consumers, proven conformance
+
+## Summary
+
+`creature_validate` was ported (Issues #559–#561) but reachable only from Rust
+and unproven against the TypeScript it replaces. This change makes it reachable
+by both consumer kinds and proves it agrees, case by case, with NEAT-AI's own
+conformance corpus. Closes #562.
+
+- **Native API** — `creature_validate` was already re-exported from `lib.rs`; it
+  now carries worked doctests (a valid creature returning `ValidationStats`, an
+  invalid one returning a `ValidationFailure` naming its `reason`), and
+  `cargo test --doc` was added to `quality.sh` and CI so a doctest that stops
+  compiling fails the gate instead of passing unrun.
+- **WASM export** — `#[wasm_bindgen(js_name = creature_validate)]` in
+  `wasm_exports.rs`, a rename over the new native
+  `neat-core/src/creature_validate_json.rs`. The ABI is **JSON in, JSON out**:
+  the existing exports split between packed byte buffers and scalar arguments,
+  and neither fits a whole creature in and a structured failure out. The whole
+  ABI lives in the native module so it is covered by `cargo test` rather than
+  only in a browser.
+- **Malformed input cannot panic** — a panic in WASM aborts the module and
+  `catch_unwind` is unavailable there, so anything that is not a request comes
+  back as a structured failure carrying `"malformed": true` and a
+  `MALFORMED_REQUEST:` message, the JSON twin of `topology_ops`'
+  `MALFORMED_BUFFER`. A creature declaring more than `MAX_REQUEST_NEURONS`
+  neurons is refused **before** the per-neuron allocation, which would otherwise
+  abort on a payload saying `"input": 17179869180`.
+- **A real panic fixed** — rule 11 computed `neurons.len() - output` on a
+  `usize`. A creature declaring more outputs than it carries neurons underflowed
+  and panicked. It now saturates, which *is* the JavaScript semantics (the
+  comparison against a negative number is false), and rule 22 reports the
+  miscount.
+- **Conformance** — the NEAT-AI#3801 corpus is vendored under
+  `neat-core/tests/fixtures/creature_validate/` with its source commit and
+  checksums recorded, and replayed against `creature_validate`.
+
+### Wire ABI
+
+```jsonc
+// in
+{ "creature": { /* CreatureExport */ },
+  "options": { "neurons": 3, "connections": 2, "feedbackLoop": false, "forwardOnly": true } }
+
+// out — one of
+{ "ok": true,  "stats": { "input": 1, "constant": 0, "hidden": 1, "output": 1, "connections": 2 } }
+{ "ok": false, "failure": { "class": "ValidationError", "reason": "NO_INWARD_CONNECTIONS",
+                            "message": "hidden neuron h1 has no inward connections",
+                            "neuronIndex": 1, "synapseIndex": null, "malformed": false } }
+```
+
+Two decisions worth a reviewer's eye:
+
+- **An unknown option key is a failure**, not a silent default — ignoring
+  `forwardonly` would validate a production creature under the wrong rules and
+  call it healthy. Unknown *creature* keys stay ignored, so NEAT-AI's own extra
+  fields still parse.
+- **The creature is deserialised with serde alone**, deliberately not through
+  `parse_creature_json`, whose width check would shadow rules 2 and 3 and answer
+  `InvalidInputCount` where NEAT-AI expects
+  `Must have at least one input neurons was: 0`.
+
+## Evidence
+
+Backend/WASM change — no web interface to screenshot. The evidence is the gate.
+
+```mermaid
+flowchart LR
+    JS["NEAT-AI TypeScript"] -->|request JSON| W["wasm_exports<br/>creature_validate"]
+    RS["Rust consumers"] -->|CreatureExport| V["creature_validate"]
+    W --> J["creature_validate_json"]
+    J -->|"not a request,<br/>or too many neurons"| MF["failure<br/>malformed: true"]
+    J --> V
+    V -->|"Ok(stats)"| OK["ok: true + stats"]
+    V -->|"Err(failure)"| ERR["ok: false + class,<br/>reason, message, indices"]
+```
+
+**`./quality.sh` passes**, including the new doctest step:
+
+```text
+🧪 Running tests...
+test result: ok. 226 passed  (lib)
+test result: ok. 3 passed    (creature_validate_conformance)
+test result: ok. 11 passed   (creature_validate_json_boundary)
+🧪 Running doctests...
+test neat-core/src/creature_validate.rs - creature_validate::creature_validate (line 580) ... ok
+test neat-core/src/creature_validate.rs - creature_validate::creature_validate (line 607) ... ok
+test neat-core/src/creature_validate_json.rs - creature_validate_json::creature_validate_json (line 236) ... ok
+✅ All quality checks passed!
+```
+
+**The conformance gate bites.** Mutating one message
+(`has no {direction} connections` → `links`) fails it on the offending case:
+
+```text
+forward-only-structural-defect-shadowed: message "hidden neuron h1 has no inward links"
+  does not contain "hidden neuron h1 has no inward connections"
+test result: FAILED. 2 passed; 1 failed
+```
+
+**The rule-11 panic was real** — before the fix, a creature with
+`input: 1, output: 5` and one hidden neuron gave:
+
+```text
+thread 'probe' panicked at neat-core/src/creature_validate.rs:941:38:
+attempt to subtract with overflow
+```
+
+**Corpus result: 37 of 47 cases replay exactly** — same error class, same
+`reason`, same message text; the happy paths match all five counters. The other
+ten describe something the wire shape cannot express, each a consequence of the
+input format Issue #559 fixed rather than of a rule that was dropped:
+
+| Case | Why | What this crate does |
+|------|-----|----------------------|
+| `input-count-not-integer`, `output-count-not-integer`, `neuron-id-not-integer`, `hidden-bias-undefined-shadowed`, `memetic-weights-not-an-array` | the value cannot be written on the wire at all | rejected at the parse boundary |
+| `neuron-missing-id` | an output's id is derived as `-(outputIndex + 1)` whatever the file says (rule 4 unreachable through one) | — |
+| `input-neuron-id-not-index`, `input-neuron-past-input-count` | input neurons are implicit (rules 7 and 10 unreachable) | — |
+| `stats-input-count-mismatch` | the wire form carries exactly `input` implicit inputs (rule 21) | accepts, `stats = 2/0/1/1/2` |
+| `neuron-index-mismatch` | `neuron.index` stays host-side (NEAT-AI#3802) | ignores the key, accepts |
+
+None is skipped: each is declared in `DIVERGENCES` in the runner **with what
+this crate does instead**, and that behaviour is asserted, so a stale
+declaration or a changed Rust outcome fails the test as loudly as a mismatch.
+The full table is on issue #562, and no contract change (#559) is outstanding —
+every divergence is a decision that contract already recorded.
+
+**wasm32 / wasm64 bundles.** The container has no `wasm32-unknown-unknown`
+target installed (`rustup` is absent), so both bundles are built by
+`.github/workflows/wasm-bundle.yml` on merge to `Develop`, which also runs the
+arch parity and export-surface gates. The shim is the same shape as the
+existing `version()` export — `&str` in, `String` out — and carries no
+target-specific code.
+
+**Release.** Additive change, so the `version-increment` job bumps the patch on
+this PR; `release.yml` cuts the `v<version>` tag and `wasm-bundle.yml` publishes
+the bundle carrying the new export on merge, per `RELEASING.md`. No manual
+version edit is needed, and NEAT-AI's `build.sh` picks the bundle up by SHA.
+
+### Security self-check
+
+- Input validation: the boundary accepts only the declared request shape,
+  refuses unknown option keys, and caps the neuron count before allocating.
+- Injection surface: no SQL, shell, filesystem or HTTP call is added; the only
+  parsing is `serde_json` on caller-supplied text.
+- Error handling: failure messages carry the serde diagnostic for the caller's
+  *own* payload and no internal state, paths or stack traces.
+- Secrets and dependencies: none added; no new third-party crate.
+
+## Test Plan
+
+Added:
+
+- `neat-core/tests/creature_validate_conformance.rs` — replays the vendored
+  NEAT-AI#3801 corpus (3 tests): every case matches or is a declared divergence
+  with its Rust outcome pinned; every `coverage.json` site still has a case; the
+  replayed/declared split is asserted so a case cannot quietly move into the
+  divergence table.
+- `neat-core/tests/creature_validate_json_boundary.rs` — 11 tests over the ABI:
+  the five counters, the options bag, `forwardOnly`, the failure indices, 14
+  hostile payloads (empty, non-JSON, truncated, trailing garbage, wrong-typed,
+  negative and non-integer widths), a misspelt option key, an absurd neuron
+  count, 2 000-deep nesting, a creature at the ceiling, and `input: 0` reaching
+  rule 2 in NEAT-AI's own words.
+- `creature_validate_json::tests` — 5 unit tests pinning the exact response text
+  and the options mapping.
+- `creature_validate::tests::declaring_more_outputs_than_neurons_reports_rule_22_rather_than_panicking`
+  — the rule-11 underflow regression.
+- Two doctests on `creature_validate`.
+
+Modified: `quality.sh` and `.github/workflows/ci.yml` gained a
+`cargo test --workspace --doc` step. No existing test was changed or removed.

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -9,10 +9,18 @@
 //!
 //! **Every rule is ported.** Rules 1–22, the neuron half, landed with Issue
 //! #560; rules 23–31 — the synapse walk, the forward-only leg and the memetic
-//! cross-references — land with Issue #561, so [`creature_validate`] now
+//! cross-references — landed with Issue #561, so [`creature_validate`]
 //! evaluates the whole table and returns [`ValidationStats`] for a creature
-//! that breaks none of it. Exposing it over the WASM boundary and proving
-//! conformance against the TypeScript corpus is Issue #562.
+//! that breaks none of it.
+//!
+//! **Both consumers reach it** (Issue #562). Rust callers use this function
+//! directly; NEAT-AI calls it over the WASM boundary through
+//! [`mod@crate::creature_validate_json`], which is where the JSON ABI and its
+//! cannot-panic contract are documented. The rules are replayed against
+//! NEAT-AI's own conformance corpus by
+//! `neat-core/tests/creature_validate_conformance.rs`, which asserts the same
+//! class, `reason` and message text for every case the wire shape can carry —
+//! and pins what this crate does with the ten it cannot.
 //!
 //! # Options
 //!
@@ -565,6 +573,63 @@ impl ValidateOptions {
 /// #560) fill the neuron counters, then the synapse, forward-only and memetic
 /// rules 23–31 (Issue #561) add [`ValidationStats::connections`].
 ///
+/// # Examples
+///
+/// A creature that breaks no rule answers with its counters:
+///
+/// ```
+/// use neat_core::{ValidateOptions, creature_validate, parse_creature_json};
+///
+/// let creature = parse_creature_json(
+///     r#"{
+///         "input": 1,
+///         "output": 1,
+///         "neurons": [
+///             { "type": "hidden", "uuid": "h1", "bias": 0.5, "squash": "IDENTITY" },
+///             { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+///         ],
+///         "synapses": [
+///             { "fromUUID": "input-0", "toUUID": "h1", "weight": 1.0 },
+///             { "fromUUID": "h1", "toUUID": "output-0", "weight": 1.0 }
+///         ]
+///     }"#,
+/// )?;
+///
+/// let stats = creature_validate(&creature, &ValidateOptions::default())?;
+/// assert_eq!((stats.input, stats.hidden, stats.output, stats.connections), (1, 1, 1, 2));
+/// assert_eq!(stats.neurons(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// Drop the hidden neuron's outward synapse and the first violated rule comes
+/// back naming itself — class, `reason`, message and the neuron it stopped on:
+///
+/// ```
+/// use neat_core::{FailureClass, ValidateOptions, creature_validate, parse_creature_json};
+///
+/// let creature = parse_creature_json(
+///     r#"{
+///         "input": 1,
+///         "output": 1,
+///         "neurons": [
+///             { "type": "hidden", "uuid": "h1", "bias": 0.5, "squash": "IDENTITY" },
+///             { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+///         ],
+///         "synapses": [
+///             { "fromUUID": "input-0", "toUUID": "h1", "weight": 1.0 }
+///         ]
+///     }"#,
+/// )?;
+///
+/// let failure = creature_validate(&creature, &ValidateOptions::default())
+///     .expect_err("a hidden neuron nothing reads is invalid");
+/// assert_eq!(failure.class, FailureClass::Validation);
+/// assert_eq!(failure.reason, "NO_OUTWARD_CONNECTIONS");
+/// assert_eq!(failure.message, "hidden neuron h1 has no outward connections");
+/// assert_eq!(failure.neuron_index, Some(1));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
 /// # Errors
 ///
 /// Returns the [`ValidationFailure`] for the first violated rule.
@@ -938,7 +1003,15 @@ fn walk_neurons(
         }
 
         // Rule 11 — inside the computational slice, constants precede hiddens.
-        if index >= input && index < views.len() - output {
+        //
+        // `saturating_sub` is the JavaScript semantics, not a papering over
+        // (Issue #562): a creature declaring more outputs than it carries
+        // neurons makes the TypeScript `index < neurons.length - output`
+        // compare against a negative number, which is always false. In Rust
+        // the same subtraction underflows a `usize` — a panic that aborts the
+        // WASM module — so it saturates to `0` and the comparison is false the
+        // same way. Rule 22 is what reports the miscount.
+        if index >= input && index < views.len().saturating_sub(output) {
             if neuron.kind == NeuronKind::Constant && computational_seen_hidden {
                 return Err(at(ValidationFailure::validation(
                     reason::NEURON_ORDER,
@@ -2187,6 +2260,33 @@ mod tests {
             FailureClass::Topology,
             reason::INVALID_STATE,
             "Expected 2 output neurons found: 1",
+        );
+    }
+
+    /// Rule 11 must not panic when the declared output count exceeds the
+    /// neurons the creature carries (Issue #562).
+    ///
+    /// `neurons.length - output` is negative in JavaScript, so the slice test
+    /// is simply false; the same subtraction underflowed a `usize` here and
+    /// panicked — an abort, not a failure, once the validator is reachable
+    /// from WASM. Rule 22 is what reports the miscount.
+    #[test]
+    fn declaring_more_outputs_than_neurons_reports_rule_22_rather_than_panicking() {
+        let impossible = creature(
+            1,
+            5,
+            vec![
+                neuron("hidden", "h1", Some(7), 0.0),
+                neuron("output", "output-0", None, 0.0),
+            ],
+            vec![edge("input-0", "h1"), edge("h1", "output-0")],
+        );
+
+        assert_failure(
+            &rejects(&impossible),
+            FailureClass::Topology,
+            reason::INVALID_STATE,
+            "Expected 5 output neurons found: 1",
         );
     }
 

--- a/neat-core/src/creature_validate_json.rs
+++ b/neat-core/src/creature_validate_json.rs
@@ -1,0 +1,366 @@
+//! The JSON ABI [`creature_validate`] crosses the WASM boundary on
+//! (Issue #562).
+//!
+//! NEAT-AI calls the validator from TypeScript, so the rules need a wire form.
+//! The existing exports split between packed byte buffers
+//! (`propagate_topological`) and scalar arguments; neither fits a whole
+//! creature in and a structured failure out, so this one is **JSON in, JSON
+//! out** — the creature is already JSON on the host, and the failure is a
+//! record, not a number.
+//!
+//! # Request
+//!
+//! ```json
+//! {
+//!   "creature": { "input": 1, "output": 1, "neurons": [], "synapses": [] },
+//!   "options": { "neurons": 3, "connections": 2, "feedbackLoop": false, "forwardOnly": true }
+//! }
+//! ```
+//!
+//! `creature` is the [`CreatureExport`] wire shape
+//! [`crate::parse_creature_json`] already accepts. Keys it does not name are
+//! ignored, so a creature carrying NEAT-AI's own extra fields still validates.
+//! `options` is optional, every key in it is optional, and an **unknown option
+//! key is a failure** rather than a silent default: a payload saying
+//! `forwardonly` would otherwise validate a production creature under the
+//! wrong rules and call it healthy.
+//!
+//! The creature is deserialised with serde alone — deliberately *not* through
+//! [`crate::parse_creature_json`], whose width check would shadow rules 2 and 3
+//! and answer `InvalidInputCount` where NEAT-AI expects
+//! `Must have at least one input neurons was: 0`.
+//!
+//! # Response
+//!
+//! ```json
+//! { "ok": true,  "stats": { "input": 1, "constant": 0, "hidden": 1, "output": 1, "connections": 2 } }
+//! { "ok": false, "failure": { "class": "ValidationError", "reason": "NO_INWARD_CONNECTIONS",
+//!                             "message": "hidden neuron h1 has no inward connections",
+//!                             "neuronIndex": 1, "synapseIndex": null, "malformed": false } }
+//! ```
+//!
+//! `class` and `reason` are the verbatim NEAT-AI union members, so the host
+//! rehydrates a `TopologyError` or a `ValidationError` without a translation
+//! table. `neuronIndex` / `synapseIndex` are `null` unless the rule stopped on
+//! one, and are what lets the host run its own host-side checks
+//! (`neuron.creature`, `neuron.index`, `neuron.validate()`, `debugWrite`)
+//! against the same neuron.
+//!
+//! # Malformed input cannot panic
+//!
+//! A panic in WASM aborts the module and takes the host's session with it, and
+//! `catch_unwind` is not available there — so the boundary must not be able to
+//! panic in the first place. It mirrors the [`MALFORMED_BUFFER`] convention in
+//! [`crate::topology_ops`]: a payload that is not a request comes back as an
+//! ordinary structured failure carrying `"malformed": true` and a message
+//! leading with [`MALFORMED_REQUEST`], never as a trap.
+//!
+//! Two faults are refused before any rule runs:
+//!
+//! | Fault | Why it cannot reach the rules |
+//! |-------|-------------------------------|
+//! | the payload is not a request | serde reports it; the message names what it read |
+//! | the creature declares more than [`MAX_REQUEST_NEURONS`] neurons | the walk allocates one entry per neuron *before* the first rule, so a declared `"input": 17179869180` would abort on the allocation |
+//!
+//! [`MALFORMED_BUFFER`]: crate::topology_ops::MALFORMED_BUFFER
+
+use serde::{Deserialize, Serialize};
+
+use crate::creature::CreatureExport;
+use crate::creature_validate::{
+    ValidateOptions, ValidationFailure, ValidationStats, creature_validate,
+};
+use crate::network::MAX_NODE_COUNT;
+
+/// Message prefix every boundary fault leads with.
+///
+/// The JSON twin of [`crate::topology_ops::MALFORMED_BUFFER`]: one greppable
+/// marker that says "this payload never reached a rule", so a host cannot read
+/// a boundary fault as a verdict on its creature.
+pub const MALFORMED_REQUEST: &str = "MALFORMED_REQUEST:";
+
+/// Largest creature the boundary will validate, in neurons (implicit inputs
+/// included).
+///
+/// The same ceiling [`crate::compile_creature`] enforces
+/// ([`MAX_NODE_COUNT`]) — a creature past it cannot be compiled or scored, and
+/// the validator's per-neuron allocation happens before the first rule, so the
+/// count is checked at the boundary rather than trusted from the payload.
+pub const MAX_REQUEST_NEURONS: usize = MAX_NODE_COUNT;
+
+/// The `options` half of a request — every key optional, unknown keys refused.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RequestOptions {
+    #[serde(default)]
+    neurons: Option<usize>,
+    #[serde(default)]
+    connections: Option<usize>,
+    #[serde(default)]
+    feedback_loop: Option<bool>,
+    #[serde(default)]
+    forward_only: Option<bool>,
+}
+
+impl From<RequestOptions> for ValidateOptions {
+    fn from(options: RequestOptions) -> Self {
+        Self {
+            neurons: options.neurons,
+            connections: options.connections,
+            feedback_loop: options.feedback_loop,
+            forward_only: options.forward_only.unwrap_or(false),
+        }
+    }
+}
+
+/// A whole request: the creature, and the options to validate it under.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ValidateRequest {
+    creature: CreatureExport,
+    #[serde(default)]
+    options: RequestOptions,
+}
+
+/// The five counters, as the host reads them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ValidationStatsJson {
+    /// Input neurons counted.
+    pub input: u32,
+    /// Constant neurons counted.
+    pub constant: u32,
+    /// Hidden neurons counted.
+    pub hidden: u32,
+    /// Output neurons counted.
+    pub output: u32,
+    /// Synapses counted.
+    pub connections: u32,
+}
+
+impl From<ValidationStats> for ValidationStatsJson {
+    fn from(stats: ValidationStats) -> Self {
+        Self {
+            input: stats.input,
+            constant: stats.constant,
+            hidden: stats.hidden,
+            output: stats.output,
+            connections: stats.connections,
+        }
+    }
+}
+
+/// The first violated rule, or the boundary fault that stopped the request
+/// reaching one.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationFailureJson {
+    /// `"TopologyError"` or `"ValidationError"` — the class the host rehydrates.
+    pub class: String,
+    /// The verbatim NEAT-AI `reason` union member.
+    pub reason: String,
+    /// The human-readable message, reproducing the TypeScript text.
+    pub message: String,
+    /// Index of the neuron the rule stopped on, `null` when it was not a
+    /// neuron rule.
+    pub neuron_index: Option<u32>,
+    /// Index of the synapse the rule stopped on, `null` when it was not a
+    /// synapse rule.
+    pub synapse_index: Option<u32>,
+    /// `true` when the payload never reached a rule — see [`MALFORMED_REQUEST`].
+    pub malformed: bool,
+}
+
+impl From<ValidationFailure> for ValidationFailureJson {
+    fn from(failure: ValidationFailure) -> Self {
+        Self {
+            class: failure.class.as_str().to_string(),
+            reason: failure.reason.to_string(),
+            message: failure.message,
+            neuron_index: failure.neuron_index,
+            synapse_index: failure.synapse_index,
+            malformed: false,
+        }
+    }
+}
+
+/// What [`creature_validate_json`] answers with.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ValidateResponse {
+    /// `true` when the creature broke no rule.
+    pub ok: bool,
+    /// The counters — present only when `ok`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stats: Option<ValidationStatsJson>,
+    /// The first violated rule, or the boundary fault — present only when not
+    /// `ok`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ValidationFailureJson>,
+}
+
+impl ValidateResponse {
+    /// A boundary fault: the payload never reached a rule.
+    ///
+    /// Reported as `ValidationError` / `OTHER` — the payload said nothing about
+    /// the creature's topology, so claiming a `TopologyError` would be a
+    /// verdict this call never reached — with `malformed` set and the message
+    /// led by [`MALFORMED_REQUEST`] so neither the host nor a log reader can
+    /// mistake it for one.
+    fn malformed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            ok: false,
+            stats: None,
+            failure: Some(ValidationFailureJson {
+                class: crate::creature_validate::FailureClass::Validation
+                    .as_str()
+                    .to_string(),
+                reason: crate::creature_validate::reason::OTHER.to_string(),
+                message: format!("{MALFORMED_REQUEST} {detail}"),
+                neuron_index: None,
+                synapse_index: None,
+                malformed: true,
+            }),
+        }
+    }
+}
+
+/// Validate a creature described by a JSON request, answering with JSON.
+///
+/// This is the whole of the WASM export: `wasm_exports::wasm_creature_validate`
+/// is a `#[wasm_bindgen]` rename over it, so the ABI is testable natively.
+/// The request and response shapes, and the malformed-input contract, are in
+/// the module documentation.
+///
+/// Never panics and never returns an error: a payload that is not a request
+/// comes back as a structured failure carrying `"malformed": true`.
+///
+/// ```
+/// use neat_core::creature_validate_json;
+///
+/// let answer = creature_validate_json(r#"{ "creature": "not a creature" }"#);
+/// assert!(answer.contains("MALFORMED_REQUEST"));
+/// ```
+pub fn creature_validate_json(request: &str) -> String {
+    let response = validate_request(request);
+    // The response is derived `Serialize` over owned `String`s and plain
+    // numbers, so this cannot fail — but a fallback that says so beats an
+    // `unwrap` that would abort the module if it ever did.
+    serde_json::to_string(&response).unwrap_or_else(|error| {
+        format!(
+            r#"{{"ok":false,"failure":{{"class":"ValidationError","reason":"OTHER","message":"{MALFORMED_REQUEST} response could not be serialised: {error}","neuronIndex":null,"synapseIndex":null,"malformed":true}}}}"#
+        )
+    })
+}
+
+/// The typed half of [`creature_validate_json`], kept separate so the tests
+/// read the answer as a value rather than as text.
+fn validate_request(request: &str) -> ValidateResponse {
+    let request: ValidateRequest = match serde_json::from_str(request) {
+        Ok(request) => request,
+        Err(error) => return ValidateResponse::malformed(error),
+    };
+
+    let declared = request
+        .creature
+        .input
+        .saturating_add(request.creature.neurons.len());
+    if declared > MAX_REQUEST_NEURONS {
+        return ValidateResponse::malformed(format!(
+            "creature declares {declared} neurons, exceeding the maximum of {MAX_REQUEST_NEURONS}"
+        ));
+    }
+
+    match creature_validate(&request.creature, &request.options.into()) {
+        Ok(stats) => ValidateResponse {
+            ok: true,
+            stats: Some(stats.into()),
+            failure: None,
+        },
+        Err(failure) => ValidateResponse {
+            ok: false,
+            stats: None,
+            failure: Some(failure.into()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_response_shape_is_the_documented_wire_shape() {
+        let answer = creature_validate_json(
+            r#"{ "creature": { "input": 1, "output": 1,
+                 "neurons": [ { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" } ],
+                 "synapses": [ { "fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0 } ] } }"#,
+        );
+
+        assert_eq!(
+            answer,
+            r#"{"ok":true,"stats":{"input":1,"constant":0,"hidden":0,"output":1,"connections":1}}"#
+        );
+    }
+
+    #[test]
+    fn a_failure_names_the_class_reason_message_and_index() {
+        let answer = creature_validate_json(
+            r#"{ "creature": { "input": 1, "output": 1,
+                 "neurons": [ { "type": "banana", "id": 1000001, "uuid": "b1", "bias": 0.0 },
+                              { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" } ],
+                 "synapses": [ { "fromUUID": "input-0", "toUUID": "b1", "weight": 1.0 },
+                               { "fromUUID": "b1", "toUUID": "output-0", "weight": 1.0 } ] } }"#,
+        );
+
+        assert_eq!(
+            answer,
+            r#"{"ok":false,"failure":{"class":"TopologyError","reason":"INVALID_NEURON_TYPE",
+"message":"1000001) Invalid type: banana","neuronIndex":1,"synapseIndex":null,"malformed":false}}"#
+                .replace('\n', "")
+        );
+    }
+
+    #[test]
+    fn unknown_creature_keys_are_ignored_but_unknown_request_keys_are_not() {
+        let with_extra_creature_key = creature_validate_json(
+            r#"{ "creature": { "input": 1, "output": 1, "tags": ["evolved"],
+                 "neurons": [ { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" } ],
+                 "synapses": [ { "fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0 } ] } }"#,
+        );
+        assert!(
+            with_extra_creature_key.contains(r#""ok":true"#),
+            "{with_extra_creature_key}"
+        );
+
+        let with_extra_request_key = creature_validate_json(
+            r#"{ "creature": { "input": 1, "output": 1, "neurons": [], "synapses": [] }, "verbose": true }"#,
+        );
+        assert!(
+            with_extra_request_key.contains(MALFORMED_REQUEST),
+            "{with_extra_request_key}"
+        );
+    }
+
+    #[test]
+    fn the_options_bag_maps_onto_the_validate_options() {
+        let options = RequestOptions {
+            neurons: Some(3),
+            connections: Some(0),
+            feedback_loop: Some(true),
+            forward_only: Some(true),
+        };
+        let mapped: ValidateOptions = options.into();
+
+        assert_eq!(mapped.expected_neurons(), Some(3));
+        assert_eq!(mapped.expected_connections(), Some(0));
+        assert!(mapped.forward_only);
+        // `forward_only` wins over an explicit `feedbackLoop: true`.
+        assert_eq!(mapped.resolved_feedback_loop(), Some(false));
+    }
+
+    #[test]
+    fn an_absent_feedback_loop_stays_absent() {
+        let mapped: ValidateOptions = RequestOptions::default().into();
+        assert_eq!(mapped.resolved_feedback_loop(), None);
+        assert!(!mapped.rejects_recursive_synapses());
+    }
+}

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod accumulate;
 pub mod batch_scoring;
 pub mod creature;
 pub mod creature_validate;
+pub mod creature_validate_json;
 pub mod decision_tree;
 pub mod derivative;
 pub mod elastic_distribution;
@@ -69,6 +70,11 @@ pub use creature::{
 pub use creature_validate::{
     FailureClass, ValidateOptions, ValidationFailure, ValidationStats, creature_validate,
     validate_synapse_and_memetic_rules,
+};
+// Issue #562 — the JSON ABI the same rules cross the WASM boundary on.
+pub use creature_validate_json::{
+    MALFORMED_REQUEST, MAX_REQUEST_NEURONS, ValidateResponse, ValidationFailureJson,
+    ValidationStatsJson, creature_validate_json,
 };
 // Issue #555 — canonical IF decision-tree fixtures and the graft helper.
 pub use decision_tree::{

--- a/neat-core/src/wasm_exports.rs
+++ b/neat-core/src/wasm_exports.rs
@@ -18,6 +18,7 @@
 
 use wasm_bindgen::prelude::*;
 
+use crate::creature_validate_json::creature_validate_json;
 use crate::derivative::apply_derivative;
 use crate::error::apply_calculate_error;
 use crate::fused_error::apply_fused_error_distribution;
@@ -165,6 +166,31 @@ pub fn wasm_scan_max_bias(
 ) -> Vec<f64> {
     let (max, second_max) = scan_max_bias(weights, biases, exclude_idx, new_bias);
     vec![max, second_max]
+}
+
+// ---------------------------------------------------------------------------
+// creature_validate — JSON in, JSON out (Issue #562).
+//
+// The whole ABI, and why it is JSON rather than a packed buffer, is documented
+// on `crate::creature_validate_json`; this shim only renames it for JS. Both
+// halves of the contract live in that native module so the boundary is covered
+// by `cargo test` rather than only in a browser:
+//
+//   In:  { "creature": <CreatureExport>, "options"?: { neurons?, connections?,
+//         feedbackLoop?, forwardOnly? } }
+//   Out: { "ok": true,  "stats": { input, constant, hidden, output, connections } }
+//        { "ok": false, "failure": { class, reason, message, neuronIndex,
+//                                    synapseIndex, malformed } }
+//
+// Malformed input answers with `malformed: true` and a `MALFORMED_REQUEST:`
+// message — the JSON twin of `topology_ops`' `MALFORMED_BUFFER` — because a
+// panic here aborts the module and `catch_unwind` is unavailable on wasm.
+// ---------------------------------------------------------------------------
+
+/// JS `creature_validate(request: string) -> string`.
+#[wasm_bindgen(js_name = creature_validate)]
+pub fn wasm_creature_validate(request: &str) -> String {
+    creature_validate_json(request)
 }
 
 // ---------------------------------------------------------------------------

--- a/neat-core/tests/creature_validate_conformance.rs
+++ b/neat-core/tests/creature_validate_conformance.rs
@@ -1,0 +1,624 @@
+//! Issue #562 — replay NEAT-AI's `creatureValidate` conformance corpus against
+//! the Rust port.
+//!
+//! The corpus (NEAT-AI#3801) is the executable definition of what the
+//! TypeScript does today. It is **vendored**, not fetched: the bytes and the
+//! commit they came from are in
+//! `tests/fixtures/creature_validate/README.md`, so drift between the two
+//! stacks shows up as a diff rather than as a test that quietly changed
+//! meaning.
+//!
+//! # The two shapes
+//!
+//! The corpus describes creatures in NEAT-AI's **runtime** shape — every
+//! neuron listed, inputs included, ids and `from`/`to` as integers. This crate
+//! validates the **wire** shape ([`CreatureExport`]): inputs are implicit,
+//! neurons are named by UUID and ids are derived. [`to_export`] is the one
+//! adapter between them, and it is deliberately dumb — it drops the input
+//! neurons, resolves each synapse index to a UUID, and hands the result
+//! straight to serde.
+//!
+//! # No case is skipped
+//!
+//! Ten cases describe something the wire shape cannot express — a non-integer
+//! id serde rejects before any rule runs, an input neuron carrying its own id,
+//! the host-only `neuron.index` check. They are not dropped: each is declared
+//! in [`DIVERGENCES`] with *why*, and with what this crate does instead, and
+//! the test asserts that behaviour too. A divergent case that starts
+//! converting, or whose Rust outcome changes, fails here just as loudly as a
+//! mismatched one — and an entry that no longer diverges fails as a stale
+//! declaration.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use neat_core::{CreatureExport, ValidateOptions, ValidationStats, creature_validate};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+/// Where the vendored corpus lives.
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/creature_validate")
+}
+
+// ---------------------------------------------------------------------------
+// The corpus, as it is written.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct CorpusFile {
+    #[allow(dead_code)]
+    group: String,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    name: String,
+    rule: String,
+    creature: Value,
+    #[serde(default)]
+    options: Option<CaseOptions>,
+    expect: Expect,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CaseOptions {
+    neurons: Option<usize>,
+    connections: Option<usize>,
+    feedback_loop: Option<bool>,
+    forward_only: Option<bool>,
+}
+
+impl From<&CaseOptions> for ValidateOptions {
+    fn from(options: &CaseOptions) -> Self {
+        Self {
+            neurons: options.neurons,
+            connections: options.connections,
+            feedback_loop: options.feedback_loop,
+            forward_only: options.forward_only.unwrap_or(false),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Expect {
+    outcome: String,
+    error: Option<String>,
+    reason: Option<String>,
+    message_contains: Option<String>,
+    stats: Option<ExpectedStats>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedStats {
+    input: u32,
+    constant: u32,
+    hidden: u32,
+    output: u32,
+    connections: u32,
+}
+
+/// The `coverage.json` manifest: every validation site, in source order.
+#[derive(Debug, Deserialize)]
+struct Coverage {
+    sites: Vec<Site>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Site {
+    id: String,
+    status: String,
+}
+
+fn load_corpus() -> Vec<Case> {
+    let mut files: Vec<PathBuf> = fs::read_dir(fixture_dir())
+        .expect("the vendored corpus directory must exist")
+        .map(|entry| entry.expect("readable directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .filter(|path| path.file_name().is_some_and(|name| name != "coverage.json"))
+        .collect();
+    files.sort();
+    assert!(!files.is_empty(), "the corpus must not be empty");
+
+    let mut cases = Vec::new();
+    for path in files {
+        let text = fs::read_to_string(&path).expect("readable corpus file");
+        let file: CorpusFile = serde_json::from_str(&text)
+            .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+        cases.extend(file.cases);
+    }
+    cases
+}
+
+fn load_coverage() -> Coverage {
+    let text = fs::read_to_string(fixture_dir().join("coverage.json")).expect("readable manifest");
+    serde_json::from_str(&text).expect("coverage.json parses")
+}
+
+// ---------------------------------------------------------------------------
+// Runtime shape -> wire shape.
+// ---------------------------------------------------------------------------
+
+/// Convert one corpus creature into the [`CreatureExport`] this crate validates.
+///
+/// The mapping is the one `compile_creature` already fixes: indices `0..input`
+/// are the implicit input neurons (`input-N`), index `input + i` is
+/// `neurons[i]`, and a synapse's `from` / `to` become those neurons' UUIDs.
+///
+/// `Err` means the wire shape cannot carry the case — the message says what
+/// stopped it, and the case must be declared in [`DIVERGENCES`].
+fn to_export(creature: &Value) -> Result<CreatureExport, String> {
+    let object = creature.as_object().ok_or("creature is not an object")?;
+    let input = object
+        .get("input")
+        .and_then(Value::as_u64)
+        .ok_or("`input` is not a non-negative integer the wire form can hold")?
+        as usize;
+
+    let neurons = object
+        .get("neurons")
+        .and_then(Value::as_array)
+        .ok_or("`neurons` is not an array")?;
+
+    // Every neuron's wire label, indexed as the runtime shape indexes them, so
+    // the synapses can be resolved afterwards.
+    let mut labels: Vec<String> = Vec::with_capacity(neurons.len());
+    let mut exported: Vec<Value> = Vec::new();
+    // Non-finite biases: JSON has no literal for them, so the corpus writes
+    // "NaN" / "Infinity" / "-Infinity" and this patches them back in after
+    // serde has parsed the rest.
+    let mut bias_patches: Vec<(usize, f64)> = Vec::new();
+
+    for (index, neuron) in neurons.iter().enumerate() {
+        let neuron = neuron.as_object().ok_or("a neuron is not an object")?;
+        let declared_type = neuron.get("type").and_then(Value::as_str).unwrap_or("");
+
+        // The leading run of input-typed neurons is what the wire form makes
+        // implicit; it is dropped here and rebuilt from `creature.input`.
+        if declared_type == "input" {
+            if !exported.is_empty() {
+                return Err(format!(
+                    "neuron {index} is an input neuron behind a computational one; \
+                     the wire form lists no input neurons at all"
+                ));
+            }
+            if neuron.get("id").and_then(Value::as_i64) != Some(index as i64) {
+                return Err(format!(
+                    "input neuron {index} declares an id that is not its index; \
+                     implicit input neurons take `id == index` by construction"
+                ));
+            }
+            labels.push(format!("input-{index}"));
+            continue;
+        }
+
+        let uuid = neuron.get("uuid").and_then(Value::as_str).unwrap_or("");
+        labels.push(uuid.to_string());
+
+        let mut wire = Map::new();
+        wire.insert("type".to_string(), json!(declared_type));
+        wire.insert("uuid".to_string(), json!(uuid));
+
+        // Ids: an output's is derived as `-(outputIndex + 1)` and every other
+        // neuron with no id takes a hash of its UUID, so a case that says
+        // otherwise is describing something the wire form overrides.
+        let declared_id = neuron.get("id").unwrap_or(&Value::Null).clone();
+        if declared_type == "output" {
+            let ordinal = exported
+                .iter()
+                .filter(|n| n["type"] == json!("output"))
+                .count() as i64;
+            if declared_id != json!(-(ordinal + 1)) {
+                return Err(format!(
+                    "output neuron {index} declares id {declared_id}, but the wire form \
+                     derives -{} whatever the file says",
+                    ordinal + 1
+                ));
+            }
+        } else if declared_id.is_null() {
+            return Err(format!(
+                "neuron {index} declares no id; the wire form derives one from its UUID, \
+                 so the missing-id rule cannot be reached this way"
+            ));
+        }
+        if !declared_id.is_null() {
+            wire.insert("id".to_string(), declared_id);
+        }
+
+        match neuron.get("bias") {
+            Some(Value::String(text)) => {
+                let value = match text.as_str() {
+                    "NaN" => f64::NAN,
+                    "Infinity" => f64::INFINITY,
+                    "-Infinity" => f64::NEG_INFINITY,
+                    other => return Err(format!("neuron {index} has a bias of {other:?}")),
+                };
+                bias_patches.push((exported.len(), value));
+                wire.insert("bias".to_string(), json!(0.0));
+            }
+            Some(bias) => {
+                wire.insert("bias".to_string(), bias.clone());
+            }
+            None => {
+                wire.insert("bias".to_string(), Value::Null);
+            }
+        }
+
+        if let Some(squash) = neuron.get("squash") {
+            wire.insert("squash".to_string(), squash.clone());
+        }
+
+        exported.push(Value::Object(wire));
+    }
+
+    let mut synapses = Vec::new();
+    for synapse in object
+        .get("synapses")
+        .and_then(Value::as_array)
+        .ok_or("`synapses` is not an array")?
+    {
+        let label = |key: &str| -> Result<String, String> {
+            let index = synapse
+                .get(key)
+                .and_then(Value::as_u64)
+                .ok_or_else(|| format!("synapse `{key}` is not an index"))?
+                as usize;
+            labels
+                .get(index)
+                .cloned()
+                .ok_or_else(|| format!("synapse `{key}` names no neuron: {index}"))
+        };
+
+        let mut wire = Map::new();
+        wire.insert("fromUUID".to_string(), json!(label("from")?));
+        wire.insert("toUUID".to_string(), json!(label("to")?));
+        wire.insert(
+            "weight".to_string(),
+            synapse.get("weight").cloned().unwrap_or(Value::Null),
+        );
+        if let Some(kind) = synapse.get("type") {
+            wire.insert("type".to_string(), kind.clone());
+        }
+        synapses.push(Value::Object(wire));
+    }
+
+    let mut wire = Map::new();
+    wire.insert("input".to_string(), json!(input));
+    wire.insert(
+        "output".to_string(),
+        object.get("output").cloned().unwrap_or(Value::Null),
+    );
+    wire.insert("neurons".to_string(), Value::Array(exported));
+    wire.insert("synapses".to_string(), Value::Array(synapses));
+    if let Some(forward_only) = object.get("forwardOnly") {
+        wire.insert("forwardOnly".to_string(), forward_only.clone());
+    }
+    if let Some(memetic) = object.get("memetic") {
+        wire.insert("memetic".to_string(), memetic.clone());
+    }
+
+    let mut creature: CreatureExport = serde_json::from_value(Value::Object(wire))
+        .map_err(|error| format!("the wire form rejects this creature: {error}"))?;
+
+    for (index, bias) in bias_patches {
+        creature.neurons[index].bias = bias;
+    }
+
+    Ok(creature)
+}
+
+// ---------------------------------------------------------------------------
+// The declared divergences.
+// ---------------------------------------------------------------------------
+
+/// What this crate does with a case the wire shape cannot describe.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum RustOutcome {
+    /// The creature never reaches a rule — serde or the shape adapter stops it.
+    Unrepresentable,
+    /// The creature reaches the rules and breaks none, with these counters:
+    /// `input`, `constant`, `hidden`, `output`, `connections`.
+    Accepted([u32; 5]),
+}
+
+/// One corpus case the Rust port cannot reproduce, and why.
+struct Declared {
+    /// The corpus case name.
+    case: &'static str,
+    /// Why the wire shape cannot carry it.
+    why: &'static str,
+    /// What this crate does instead — pinned so a change here still fails.
+    outcome: RustOutcome,
+}
+
+/// Every case the port does not reproduce.
+///
+/// Each is a consequence of the input format the contract fixed in Issue #559,
+/// not of a rule that was dropped — the rules themselves are all ported. The
+/// four `Unrepresentable` parse-boundary entries are the format working as
+/// designed: a malformed creature fails at the wire boundary instead of
+/// reaching a validator that would have to describe it.
+const DIVERGENCES: [Declared; 10] = [
+    // -- The wire form rejects the creature before any rule runs. -----------
+    Declared {
+        case: "input-count-not-integer",
+        why: "`input` is `usize` on the wire; 1.5 cannot be written, let alone validated",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    Declared {
+        case: "output-count-not-integer",
+        why: "`output` is `usize` on the wire; 2.5 is a serde error, not a rule failure",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    Declared {
+        case: "neuron-id-not-integer",
+        why: "the case states -1.5 on an *output* neuron, whose id the wire form derives \
+              anyway; and `NeuronExport::id` is `i64`, so -1.5 is a serde error either way \
+              (module docs, rule 5)",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    Declared {
+        case: "hidden-bias-undefined-shadowed",
+        why: "`NeuronExport::bias` is a required number; `undefined` cannot be written",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    Declared {
+        case: "memetic-weights-not-an-array",
+        why: "memetic `weights` values are typed arrays; a bare object is a serde error \
+              (module docs, rule 31)",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    // -- Input neurons are implicit, so their identity cannot be misstated. --
+    Declared {
+        case: "input-neuron-id-not-index",
+        why: "implicit input neurons take `id == index` by construction, so rule 7 \
+              cannot fail on the wire",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    Declared {
+        case: "input-neuron-past-input-count",
+        why: "the wire form lists no input neurons, so none can sit past the declared \
+              width (rule 10)",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    Declared {
+        case: "stats-input-count-mismatch",
+        why: "the wire form carries exactly `input` implicit inputs, so the count cannot \
+              disagree with itself (rule 21) — the second input is simply implied",
+        outcome: RustOutcome::Accepted([2, 0, 1, 1, 2]),
+    },
+    // -- Ids are derived by the loader before the rules ever see them. -------
+    Declared {
+        case: "neuron-missing-id",
+        why: "an output's id is derived as -(outputIndex + 1) whatever the file says, so \
+              rule 4 cannot be reached through an output neuron",
+        outcome: RustOutcome::Unrepresentable,
+    },
+    // -- Host-only. ---------------------------------------------------------
+    Declared {
+        case: "neuron-index-mismatch",
+        why: "`neuron.index` is one of the checks that stay host-side (NEAT-AI#3802); the \
+              wire form carries no index, so the key is ignored and the creature is valid",
+        outcome: RustOutcome::Accepted([1, 0, 0, 1, 1]),
+    },
+];
+
+fn declared(case: &str) -> Option<&'static Declared> {
+    DIVERGENCES.iter().find(|entry| entry.case == case)
+}
+
+// ---------------------------------------------------------------------------
+// The replay.
+// ---------------------------------------------------------------------------
+
+fn assert_matches_corpus(
+    case: &Case,
+    result: &Result<ValidationStats, neat_core::ValidationFailure>,
+) {
+    let name = &case.name;
+    match case.expect.outcome.as_str() {
+        "ok" => {
+            let stats = result
+                .as_ref()
+                .unwrap_or_else(|failure| panic!("{name}: expected `ok`, got {failure}"));
+            let expected = case
+                .expect
+                .stats
+                .as_ref()
+                .unwrap_or_else(|| panic!("{name}: an `ok` case must pin its stats"));
+            assert_eq!(
+                (
+                    stats.input,
+                    stats.constant,
+                    stats.hidden,
+                    stats.output,
+                    stats.connections
+                ),
+                (
+                    expected.input,
+                    expected.constant,
+                    expected.hidden,
+                    expected.output,
+                    expected.connections
+                ),
+                "{name}: stats disagree with the TypeScript"
+            );
+        }
+        "throws" => {
+            let failure = match result {
+                Err(failure) => failure,
+                Ok(stats) => panic!("{name}: expected a failure, got {stats:?}"),
+            };
+            let error = case.expect.error.as_deref().unwrap_or_default();
+            let reason = case.expect.reason.as_deref().unwrap_or_default();
+            let message = case.expect.message_contains.as_deref().unwrap_or_default();
+
+            assert_eq!(
+                failure.class.as_str(),
+                error,
+                "{name}: wrong error class ({failure})"
+            );
+            assert_eq!(failure.reason, reason, "{name}: wrong reason ({failure})");
+            assert!(
+                failure.message.contains(message),
+                "{name}: message {:?} does not contain {message:?}",
+                failure.message
+            );
+        }
+        other => panic!("{name}: unknown outcome {other:?}"),
+    }
+}
+
+/// Every corpus case either reproduces the TypeScript, or is a declared
+/// divergence whose Rust behaviour is pinned here instead.
+#[test]
+fn the_corpus_replays_against_creature_validate() {
+    let cases = load_corpus();
+    assert!(
+        cases.len() >= 47,
+        "the vendored corpus shrank to {} cases",
+        cases.len()
+    );
+
+    let mut seen_divergences: BTreeSet<&str> = BTreeSet::new();
+    let mut names: BTreeSet<String> = BTreeSet::new();
+
+    for case in &cases {
+        assert!(
+            names.insert(case.name.clone()),
+            "duplicate case name {}",
+            case.name
+        );
+
+        let options = case
+            .options
+            .as_ref()
+            .map(ValidateOptions::from)
+            .unwrap_or_default();
+
+        match to_export(&case.creature) {
+            Err(why) => {
+                let entry = declared(&case.name).unwrap_or_else(|| {
+                    panic!(
+                        "{}: the wire form cannot carry this case ({why}), and it is not \
+                         declared in DIVERGENCES",
+                        case.name
+                    )
+                });
+                assert_eq!(
+                    entry.outcome,
+                    RustOutcome::Unrepresentable,
+                    "{}: declared as reachable, but the wire form refused it ({why})",
+                    case.name
+                );
+                seen_divergences.insert(entry.case);
+            }
+            Ok(creature) => {
+                let result = creature_validate(&creature, &options);
+                match declared(&case.name) {
+                    None => assert_matches_corpus(case, &result),
+                    Some(entry) => {
+                        seen_divergences.insert(entry.case);
+                        match entry.outcome {
+                            RustOutcome::Unrepresentable => panic!(
+                                "{}: declared unrepresentable ({}), but it converted and \
+                                 returned {result:?} — the declaration is stale",
+                                case.name, entry.why
+                            ),
+                            RustOutcome::Accepted(expected) => {
+                                let stats = result.unwrap_or_else(|failure| {
+                                    panic!(
+                                        "{}: declared accepted ({}), got {failure}",
+                                        case.name, entry.why
+                                    )
+                                });
+                                assert_eq!(
+                                    [
+                                        stats.input,
+                                        stats.constant,
+                                        stats.hidden,
+                                        stats.output,
+                                        stats.connections
+                                    ],
+                                    expected,
+                                    "{}: the declared Rust behaviour changed ({})",
+                                    case.name,
+                                    entry.why
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let declared_names: BTreeSet<&str> = DIVERGENCES.iter().map(|entry| entry.case).collect();
+    assert_eq!(
+        seen_divergences, declared_names,
+        "a declared divergence names no corpus case (stale entry)"
+    );
+}
+
+/// The corpus is vendored whole: every case names a site the manifest declares,
+/// and every site the manifest calls covered still has a case.
+#[test]
+fn every_coverage_site_still_has_a_case() {
+    let cases = load_corpus();
+    let coverage = load_coverage();
+
+    let sites: BTreeMap<&str, &str> = coverage
+        .sites
+        .iter()
+        .map(|site| (site.id.as_str(), site.status.as_str()))
+        .collect();
+
+    let mut covered: BTreeSet<&str> = BTreeSet::new();
+    for case in &cases {
+        assert!(
+            sites.contains_key(case.rule.as_str()),
+            "{}: names rule {:?}, which coverage.json does not declare",
+            case.name,
+            case.rule
+        );
+        covered.insert(sites.get_key_value(case.rule.as_str()).expect("declared").0);
+    }
+
+    let missing: Vec<&str> = sites
+        .iter()
+        .filter(|(id, status)| **status != "not-expressible" && !covered.contains(*id))
+        .map(|(id, _)| *id)
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "the vendored corpus lost the cases for {missing:?}"
+    );
+}
+
+/// Two thirds of the corpus is replayed verbatim; the rest is declared. This
+/// pins the split so a future change cannot quietly move a case into the
+/// divergence table.
+#[test]
+fn the_declared_divergences_are_the_only_ones() {
+    let cases = load_corpus();
+    let divergent = cases
+        .iter()
+        .filter(|case| declared(&case.name).is_some())
+        .count();
+
+    assert_eq!(
+        divergent,
+        DIVERGENCES.len(),
+        "every declared divergence must name a case that is actually in the corpus"
+    );
+    assert!(
+        cases.len() - divergent >= 37,
+        "only {} of {} cases replay against the Rust port",
+        cases.len() - divergent,
+        cases.len()
+    );
+}

--- a/neat-core/tests/creature_validate_json_boundary.rs
+++ b/neat-core/tests/creature_validate_json_boundary.rs
@@ -1,0 +1,298 @@
+//! Issue #562 — the JSON ABI `creature_validate` crosses the WASM boundary on.
+//!
+//! The shim in `wasm_exports.rs` is three lines over
+//! [`neat_core::creature_validate_json`]; everything worth testing lives in
+//! that native function, so these tests run in the ordinary `cargo test` gate
+//! rather than only in a browser.
+//!
+//! Two properties are pinned here:
+//!
+//! - **the answer is the native answer** — the same class, `reason`, message
+//!   and indices [`neat_core::creature_validate`] returns, in JSON;
+//! - **nothing panics** — a panic in WASM aborts the module, taking the host's
+//!   session with it, so every malformed, truncated, hostile or absurdly large
+//!   payload must come back as a structured `MALFORMED_REQUEST` failure.
+
+use neat_core::{MALFORMED_REQUEST, MAX_REQUEST_NEURONS, ValidateResponse, creature_validate_json};
+
+/// A creature that breaks no rule: one input, one hidden, one output.
+const VALID_CREATURE: &str = r#"{
+    "input": 1,
+    "output": 1,
+    "neurons": [
+        { "type": "hidden", "uuid": "h1", "bias": 0.5, "squash": "IDENTITY" },
+        { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+    ],
+    "synapses": [
+        { "fromUUID": "input-0", "toUUID": "h1", "weight": 1.0 },
+        { "fromUUID": "h1", "toUUID": "output-0", "weight": 1.0 }
+    ]
+}"#;
+
+fn request(creature: &str, options: &str) -> String {
+    format!(r#"{{ "creature": {creature}, "options": {options} }}"#)
+}
+
+fn respond(request: &str) -> ValidateResponse {
+    let json = creature_validate_json(request);
+    serde_json::from_str(&json).unwrap_or_else(|error| {
+        panic!("the boundary must answer with parseable JSON, got {json:?}: {error}")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// The success half.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_valid_creature_answers_with_the_five_counters() {
+    let response = respond(&request(VALID_CREATURE, "{}"));
+
+    assert!(response.ok, "{response:?}");
+    assert!(response.failure.is_none(), "{response:?}");
+    let stats = response.stats.expect("a successful answer carries stats");
+    assert_eq!(
+        (
+            stats.input,
+            stats.constant,
+            stats.hidden,
+            stats.output,
+            stats.connections
+        ),
+        (1, 0, 1, 1, 2)
+    );
+}
+
+#[test]
+fn the_options_bag_reaches_the_rules() {
+    // `neurons` counts the implicit inputs too, so 3 is the match and 2 is not.
+    let matching = respond(&request(VALID_CREATURE, r#"{ "neurons": 3 }"#));
+    assert!(matching.ok, "{matching:?}");
+
+    let mismatched = respond(&request(VALID_CREATURE, r#"{ "neurons": 2 }"#));
+    let failure = mismatched.failure.expect("a mismatch is a failure");
+    assert_eq!(failure.class, "ValidationError");
+    assert_eq!(failure.reason, "OTHER");
+    assert_eq!(failure.message, "Neurons length: 3 expected: 2");
+    assert!(!failure.malformed, "a rule failure is not a boundary fault");
+}
+
+#[test]
+fn an_absent_options_bag_is_the_default_bag() {
+    let bare = format!(r#"{{ "creature": {VALID_CREATURE} }}"#);
+    assert!(respond(&bare).ok);
+}
+
+#[test]
+fn forward_only_travels_over_the_boundary() {
+    // A backward synapse is legal by default and rejected under forwardOnly.
+    let recurrent = r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            { "type": "hidden", "uuid": "h1", "bias": 0.0, "squash": "IDENTITY" },
+            { "type": "hidden", "uuid": "h2", "bias": 0.0, "squash": "IDENTITY" },
+            { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+        ],
+        "synapses": [
+            { "fromUUID": "input-0", "toUUID": "h1", "weight": 1.0 },
+            { "fromUUID": "h1", "toUUID": "h2", "weight": 1.0 },
+            { "fromUUID": "h2", "toUUID": "h1", "weight": 0.5 },
+            { "fromUUID": "h2", "toUUID": "output-0", "weight": 1.0 }
+        ]
+    }"#;
+
+    assert!(respond(&request(recurrent, "{}")).ok);
+
+    let rejected = respond(&request(recurrent, r#"{ "forwardOnly": true }"#));
+    let failure = rejected.failure.expect("forwardOnly rejects h2 -> h1");
+    assert_eq!(failure.class, "ValidationError");
+    assert_eq!(failure.reason, "RECURSIVE_SYNAPSE");
+    assert_eq!(failure.message, "2) Recursive synapse h2 -> h1");
+    assert_eq!(failure.synapse_index, Some(2));
+    assert_eq!(failure.neuron_index, None);
+}
+
+#[test]
+fn a_rule_failure_carries_the_neuron_it_stopped_on() {
+    let orphan = r#"{
+        "input": 1,
+        "output": 1,
+        "neurons": [
+            { "type": "hidden", "uuid": "h1", "bias": 0.5, "squash": "IDENTITY" },
+            { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+        ],
+        "synapses": [ { "fromUUID": "input-0", "toUUID": "h1", "weight": 1.0 } ]
+    }"#;
+
+    let response = respond(&request(orphan, "{}"));
+    assert!(!response.ok);
+    assert!(response.stats.is_none(), "{response:?}");
+    let failure = response.failure.expect("a hidden neuron nothing reads");
+    assert_eq!(failure.class, "ValidationError");
+    assert_eq!(failure.reason, "NO_OUTWARD_CONNECTIONS");
+    assert_eq!(
+        failure.message,
+        "hidden neuron h1 has no outward connections"
+    );
+    assert_eq!(failure.neuron_index, Some(1));
+    assert_eq!(failure.synapse_index, None);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed input — the half that must never panic.
+// ---------------------------------------------------------------------------
+
+#[track_caller]
+fn assert_malformed(payload: &str, what: &str) {
+    let response = respond(payload);
+    assert!(!response.ok, "{what}: expected a failure, got {response:?}");
+    assert!(response.stats.is_none(), "{what}: {response:?}");
+    let failure = response
+        .failure
+        .unwrap_or_else(|| panic!("{what}: a failed answer carries a failure"));
+    assert!(
+        failure.malformed,
+        "{what}: a boundary fault must be flagged malformed, got {failure:?}"
+    );
+    assert!(
+        failure.message.starts_with(MALFORMED_REQUEST),
+        "{what}: message must lead with {MALFORMED_REQUEST}, got {:?}",
+        failure.message
+    );
+    assert!(
+        failure.class == "ValidationError" && failure.reason == "OTHER",
+        "{what}: {failure:?}"
+    );
+}
+
+#[test]
+fn garbage_payloads_fail_loudly_instead_of_panicking() {
+    let valid = request(VALID_CREATURE, "{}");
+    let hostile: [(&str, String); 14] = [
+        ("empty", String::new()),
+        ("not json", "this is not JSON".to_string()),
+        ("bare scalar", "42".to_string()),
+        ("bare null", "null".to_string()),
+        ("array, not object", "[1, 2, 3]".to_string()),
+        ("no creature key", r#"{ "options": {} }"#.to_string()),
+        (
+            "creature is a string",
+            r#"{ "creature": "nope" }"#.to_string(),
+        ),
+        (
+            "truncated mid-creature",
+            valid[..valid.len() / 2].to_string(),
+        ),
+        ("truncated to one brace", "{".to_string()),
+        ("trailing garbage", format!("{valid} and then some")),
+        (
+            "creature missing input",
+            r#"{ "creature": { "output": 1, "neurons": [], "synapses": [] } }"#.to_string(),
+        ),
+        (
+            "negative input",
+            request(
+                &VALID_CREATURE.replace("\"input\": 1", "\"input\": -1"),
+                "{}",
+            ),
+        ),
+        (
+            "non-integer input",
+            request(
+                &VALID_CREATURE.replace("\"input\": 1", "\"input\": 1.5"),
+                "{}",
+            ),
+        ),
+        (
+            "neuron bias is a string",
+            request(
+                &VALID_CREATURE.replace("\"bias\": 0.5", "\"bias\": \"NaN\""),
+                "{}",
+            ),
+        ),
+    ];
+
+    for (what, payload) in &hostile {
+        assert_malformed(payload, what);
+    }
+}
+
+#[test]
+fn a_misspelt_option_is_a_loud_failure_not_a_silent_default() {
+    // Silently ignoring `forwardonly` would validate a production creature
+    // under the wrong rules and call it healthy.
+    assert_malformed(
+        &request(VALID_CREATURE, r#"{ "forwardonly": true }"#),
+        "misspelt option key",
+    );
+}
+
+#[test]
+fn an_absurd_neuron_count_is_refused_before_anything_is_allocated() {
+    // A creature declaring more inputs than memory can hold would abort the
+    // module on the first `Vec::with_capacity` — the allocation happens before
+    // any rule runs, so the ceiling is checked at the boundary.
+    let huge = format!(
+        r#"{{ "creature": {{ "input": {}, "output": 1, "neurons": [], "synapses": [] }} }}"#,
+        u64::from(u32::MAX) * 4
+    );
+    assert_malformed(&huge, "absurd input width");
+
+    let over_ceiling = format!(
+        r#"{{ "creature": {{ "input": {}, "output": 1, "neurons": [], "synapses": [] }} }}"#,
+        MAX_REQUEST_NEURONS + 1
+    );
+    assert_malformed(&over_ceiling, "one neuron past the ceiling");
+}
+
+#[test]
+fn deeply_nested_json_is_refused_rather_than_overflowing_the_stack() {
+    let payload = format!(
+        r#"{{ "creature": {}{} }}"#,
+        "[".repeat(2_000),
+        "]".repeat(2_000)
+    );
+    assert_malformed(&payload, "deeply nested creature");
+}
+
+#[test]
+fn a_creature_with_no_neurons_reports_a_rule_rather_than_a_boundary_fault() {
+    // `input: 0` must reach rule 2 and answer in NEAT-AI's own words — the
+    // boundary deserialises with serde alone so the width check in
+    // `parse_creature_json` cannot shadow the rule.
+    let response =
+        respond(r#"{ "creature": { "input": 0, "output": 1, "neurons": [], "synapses": [] } }"#);
+    let failure = response
+        .failure
+        .expect("rule 2 rejects a widthless creature");
+    assert!(!failure.malformed, "{failure:?}");
+    assert_eq!(failure.class, "ValidationError");
+    assert_eq!(failure.reason, "OTHER");
+    assert_eq!(
+        failure.message,
+        "Must have at least one input neurons was: 0"
+    );
+}
+
+#[test]
+fn a_creature_at_the_ceiling_is_still_validated() {
+    // The ceiling is a boundary guard, not a rule: a creature that reaches it
+    // is validated and reports its own first broken rule.
+    let neurons: Vec<String> = (0..MAX_REQUEST_NEURONS - 2)
+        .map(|i| {
+            format!(r#"{{ "type": "hidden", "uuid": "h{i}", "bias": 0.0, "squash": "IDENTITY" }}"#)
+        })
+        .collect();
+    let creature = format!(
+        r#"{{ "input": 1, "output": 1, "neurons": [{}, {{ "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }}], "synapses": [] }}"#,
+        neurons.join(", ")
+    );
+
+    let response = respond(&request(&creature, "{}"));
+    let failure = response
+        .failure
+        .expect("unwired hidden neurons are invalid");
+    assert!(!failure.malformed, "{failure:?}");
+    assert_eq!(failure.reason, "NO_INWARD_CONNECTIONS");
+}

--- a/neat-core/tests/fixtures/creature_validate/README.md
+++ b/neat-core/tests/fixtures/creature_validate/README.md
@@ -1,0 +1,92 @@
+# 🧾 Vendored `creatureValidate` conformance corpus
+
+These JSON files are **copied verbatim from NEAT-AI** and are the executable
+description of what `src/architecture/CreatureValidate.ts` does today. They are
+replayed against this crate's `creature_validate` by
+`neat-core/tests/creature_validate_conformance.rs` (Issue #562).
+
+> [!IMPORTANT]
+> Do not edit these files here. They describe NEAT-AI's behaviour; a case that
+> disagrees with `creature_validate` is either a port bug in this crate or a
+> deliberate, declared divergence — never a fixture to relax. Changing a rule
+> means changing the rule and re-vendoring the corpus, in a change that says so.
+
+## 📌 Provenance
+
+| | |
+|---|---|
+| Source repository | [`stSoftwareAU/NEAT-AI`](https://github.com/stSoftwareAU/NEAT-AI) |
+| Source path | `test/fixtures/validate/` |
+| Commit | `dce35fad87868aa8cb3fc91fc44f0ca9841216f7` |
+| Branch | `milestone/3800-move-creature-validation-into-neat-ai-core-as` |
+| Introduced by | NEAT-AI [#3801](https://github.com/stSoftwareAU/NEAT-AI/issues/3801) via PR [#3804](https://github.com/stSoftwareAU/NEAT-AI/pull/3804) (merge `4160c2fb6d4ec1cb97839242eb464266ab29a33f`) |
+| Vendored | 2026-08-21 |
+
+Checksums of the vendored bytes, so a silent edit here is visible:
+
+```text
+35b43e4f0408a72ca6cc787f5d3e8b264923b1a6a76c62f61a1f1a95dc13326d  coverage.json
+938435b4d33cd8af5bafa67a86ca72d87087bbeb026ee0ebf12a5fb2e9a146d2  forward-only.json
+1a7199583a33c9352e2f86b582a274c6fc2dc4b1edab8e4dc8b911ad16b64173  happy-paths.json
+613e7cdf8712b35da10cd00733095bcb758aad202a5a57c8bbe13a069ebe5023  if-squash.json
+9877aefd9975eddf70f91ee5d8d85aa6892fd27944aecbc5bef97c67264aa9ae  memetic.json
+b3388a84ad5d89cd67750b80c5cb194443a44531b72f7e6cc64d6debb80cee88  neuron-identity.json
+bd4079fac623924cef586c49f35f78009ea2cdf7da97a36fa755adcb823023fb  neuron-ordering.json
+ba27e2f031978dede9ad6c18d557d01e77b6343f817ed350af992305ae6c5ed7  options-and-counts.json
+23c3fbfa9391168e1b88e3dcd85ca57de55acc56bafaef48bc3ffe6a1cc35610  per-type-rules.json
+04087020b07ff799a6333d8a3da63ab3747a13539b3dd6379fae4ce9117df000  synapses.json
+```
+
+Re-vendor with (from a NEAT-AI checkout at the recorded commit):
+
+```bash
+cp test/fixtures/validate/*.json <neat-ai-core>/neat-core/tests/fixtures/creature_validate/
+```
+
+…then update the commit and checksums above, and run
+`cargo test -p neat-core --test creature_validate_conformance`.
+
+## 🧬 What is in here
+
+| File | Pins |
+|------|------|
+| `coverage.json` | the manifest: every validation site in `CreatureValidate.ts`, in source order, with its status (`covered`, `shadowed`, `not-expressible`) |
+| `options-and-counts.json` | the options bag and the declared input / output widths |
+| `neuron-identity.json` | ids, duplicate ids, non-finite biases |
+| `neuron-ordering.json` | outputs last, inputs first, constants before hiddens |
+| `if-squash.json` | the three `IF` roles and the inward-degree floor |
+| `per-type-rules.json` | what each neuron type may and may not be wired to |
+| `synapses.json` | sort order, duplicates, self and recursive synapses |
+| `forward-only.json` | the extra leg a `forwardOnly` creature runs |
+| `memetic.json` | memetic biases and weights resolving to real neurons and synapses |
+| `happy-paths.json` | creatures that break no rule, pinned by their exact `stats` |
+
+Two JSON conventions carry values JSON has no literal for, and the Rust runner
+honours both: `null` (or an absent key) is `undefined`, and `"NaN"` /
+`"Infinity"` / `"-Infinity"` are the matching non-finite numbers.
+
+## 🔀 The two creature shapes
+
+The corpus describes creatures in NEAT-AI's **runtime** shape — every neuron
+listed, inputs included, integer ids, integer `from` / `to`. This crate
+validates the **wire** shape (`CreatureExport`): input neurons are implicit,
+neurons are named by UUID, and ids are derived by the loader before any rule
+runs. `to_export` in the Rust runner is the single adapter between them.
+
+```mermaid
+flowchart LR
+    C["corpus case<br/>runtime shape"] --> A["to_export<br/>drop inputs, UUID the synapses"]
+    A -->|converts| V["creature_validate"]
+    A -->|"cannot convert"| D["DIVERGENCES<br/>declared + why"]
+    V --> M{"same class, reason<br/>and message text?"}
+    M -- yes --> P["case passes"]
+    M -- no --> F["test fails"]
+    D --> R["pinned Rust outcome<br/>(also asserted)"]
+```
+
+Ten of the 47 cases describe something the wire shape cannot express — a
+non-integer count serde rejects before any rule runs, an input neuron carrying
+its own id, the host-only `neuron.index` check. None is skipped: each is
+declared in `DIVERGENCES` in the runner with why it diverges *and* what this
+crate does instead, and that behaviour is asserted too. Both a stale
+declaration and a changed outcome fail the test.

--- a/neat-core/tests/fixtures/creature_validate/coverage.json
+++ b/neat-core/tests/fixtures/creature_validate/coverage.json
@@ -1,0 +1,335 @@
+{
+  "description": "Every validation site in src/architecture/CreatureValidate.ts, in source order, and how the corpus accounts for it. status covered = a case reaches the site; shadowed = an earlier check always fires first, so the case records what actually happens; not-expressible = the check tests a TypeScript object identity no JSON fixture can describe.",
+  "sites": [
+    {
+      "id": "OPTIONS_NEURONS_MISMATCH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "INPUT_COUNT_INVALID",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "OUTPUT_COUNT_INVALID",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "NEURON_NO_ID",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "NEURON_ID_INVALID",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "NEURON_ID_DUPLICATE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "INPUT_NEURON_ID_MISMATCH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "NEURON_BIAS_NOT_FINITE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "TYPE_AFTER_OUTPUT",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "INPUT_NEURON_PAST_INPUT_COUNT",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "NEURON_ORDER_CONSTANT_AFTER_HIDDEN",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "NEURON_ORDER"
+    },
+    {
+      "id": "IF_TOO_FEW_INWARD",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "IF_CONDITIONS"
+    },
+    {
+      "id": "IF_MISSING_CONDITION",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "IF_CONDITIONS"
+    },
+    {
+      "id": "IF_MISSING_POSITIVE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "IF_CONDITIONS"
+    },
+    {
+      "id": "IF_MISSING_NEGATIVE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "IF_CONDITIONS"
+    },
+    {
+      "id": "INPUT_HAS_INWARD",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "INVALID_CONNECTION"
+    },
+    {
+      "id": "CONSTANT_HAS_INWARD",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "INVALID_CONNECTION"
+    },
+    {
+      "id": "CONSTANT_HAS_SQUASH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "INVALID_SQUASH"
+    },
+    {
+      "id": "CONSTANT_NO_OUTWARD",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "NO_OUTWARD_CONNECTIONS"
+    },
+    {
+      "id": "HIDDEN_NO_INWARD",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "NO_INWARD_CONNECTIONS"
+    },
+    {
+      "id": "HIDDEN_NO_OUTWARD",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "NO_OUTWARD_CONNECTIONS"
+    },
+    {
+      "id": "HIDDEN_BIAS_UNDEFINED",
+      "kind": "throw",
+      "status": "shadowed",
+      "error": "TopologyError",
+      "reason": "INVALID_STATE",
+      "note": "Unreachable: the generic non-input bias check (NEURON_BIAS_NOT_FINITE) rejects an undefined bias first, because Number.isFinite(undefined) is false."
+    },
+    {
+      "id": "HIDDEN_BIAS_NOT_FINITE",
+      "kind": "throw",
+      "status": "shadowed",
+      "error": "TopologyError",
+      "reason": "INVALID_STATE",
+      "note": "Unreachable for the same reason as HIDDEN_BIAS_UNDEFINED: NEURON_BIAS_NOT_FINITE fires on any non-finite bias of a non-input neuron."
+    },
+    {
+      "id": "INVALID_NEURON_TYPE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "INVALID_NEURON_TYPE"
+    },
+    {
+      "id": "NEURON_INDEX_MISMATCH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "NEURON_CREATURE_MISMATCH",
+      "kind": "throw",
+      "status": "not-expressible",
+      "error": "TopologyError",
+      "reason": "INVALID_STATE",
+      "note": "Checks neuron.creature !== creature — a TypeScript object-identity comparison with no language-neutral equivalent, so no JSON fixture can express it. Kept in the hand-written TypeScript tests instead."
+    },
+    {
+      "id": "STATS_INPUT_MISMATCH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "STATS_OUTPUT_MISMATCH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "INVALID_STATE"
+    },
+    {
+      "id": "SYNAPSE_TO_INPUT",
+      "kind": "throw",
+      "status": "shadowed",
+      "error": "TopologyError",
+      "reason": "INVALID_CONNECTION",
+      "note": "Unreachable: any synapse targeting an input neuron makes that neuron fail INPUT_HAS_INWARD in the earlier neuron loop."
+    },
+    {
+      "id": "SELF_CONNECTION_FORWARD_ONLY",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "SELF_CONNECTION"
+    },
+    {
+      "id": "SORT_FAILURE_FROM",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "SORT_FAILURE"
+    },
+    {
+      "id": "SORT_FAILURE_TO",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "SORT_FAILURE"
+    },
+    {
+      "id": "DUPLICATE_SYNAPSE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "TopologyError",
+      "reason": "INVALID_CONNECTION"
+    },
+    {
+      "id": "RECURSIVE_SYNAPSE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "RECURSIVE_SYNAPSE"
+    },
+    {
+      "id": "OPTIONS_CONNECTIONS_MISMATCH",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "OTHER"
+    },
+    {
+      "id": "WASM_FORWARD_ONLY",
+      "kind": "throw",
+      "status": "shadowed",
+      "error": "TopologyError",
+      "reason": "INVALID_CONNECTION",
+      "note": "Unreachable: validateForwardOnly reports self-connections, backward connections, sort failures and duplicates, and the TypeScript synapse loop rejects every one of them first."
+    },
+    {
+      "id": "WASM_STRUCTURAL",
+      "kind": "throw",
+      "status": "shadowed",
+      "error": "ValidationError",
+      "reason": "OTHER",
+      "note": "Unreachable: every structural code (synapse targets input, constant has inward, hidden no inward/outward, non-finite bias, IF conditions) is already rejected by the neuron loop."
+    },
+    {
+      "id": "WASM_CYCLE",
+      "kind": "throw",
+      "status": "shadowed",
+      "error": "TopologyError",
+      "reason": "INVALID_CONNECTION",
+      "note": "Unreachable: a cycle needs a synapse with from > to, which the recursive-synapse check rejects because forwardOnly forces feedbackLoop false."
+    },
+    {
+      "id": "MEMETIC_BIAS_UNKNOWN_NEURON",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    {
+      "id": "MEMETIC_WEIGHT_UNKNOWN_NEURON",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    {
+      "id": "MEMETIC_WEIGHTS_NOT_ARRAY",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    {
+      "id": "MEMETIC_WEIGHT_MISSING_TO_ID",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    {
+      "id": "MEMETIC_WEIGHT_MISSING_WEIGHT",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    {
+      "id": "MEMETIC_WEIGHT_TO_ID_UNKNOWN",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    {
+      "id": "MEMETIC_WEIGHT_NO_SYNAPSE",
+      "kind": "throw",
+      "status": "covered",
+      "error": "ValidationError",
+      "reason": "MEMETIC"
+    },
+    { "id": "OK_MINIMAL", "kind": "ok", "status": "covered" },
+    { "id": "OK_CONSTANTS", "kind": "ok", "status": "covered" },
+    { "id": "OK_HIDDEN", "kind": "ok", "status": "covered" },
+    { "id": "OK_IF", "kind": "ok", "status": "covered" },
+    { "id": "OK_RECURRENT_DEFAULT", "kind": "ok", "status": "covered" },
+    { "id": "OK_RECURRENT_FEEDBACK_TRUE", "kind": "ok", "status": "covered" },
+    { "id": "OK_FORWARD_ONLY", "kind": "ok", "status": "covered" },
+    { "id": "OK_MEMETIC", "kind": "ok", "status": "covered" }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/forward-only.json
+++ b/neat-core/tests/fixtures/creature_validate/forward-only.json
@@ -1,0 +1,144 @@
+{
+  "group": "forward-only",
+  "description": "The forwardOnly leg (validateForwardOnly, validateStructuralIntegrity, detectCycles). Every one of its throw sites is shadowed by an earlier TypeScript check — these cases record what actually happens.",
+  "cases": [
+    {
+      "name": "forward-only-backward-synapse-shadowed",
+      "rule": "WASM_FORWARD_ONLY",
+      "notes": "A backward synapse would fail validateForwardOnly, but forwardOnly forces feedbackLoop false, so the recursive-synapse check in the synapse loop fires first.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000002,
+            "uuid": "h2",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 },
+          { "from": 2, "to": 1, "weight": 0.5 },
+          { "from": 2, "to": 3, "weight": 1 }
+        ]
+      },
+      "options": { "forwardOnly": true },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "RECURSIVE_SYNAPSE",
+        "messageContains": "Recursive synapse h2 -> h1"
+      }
+    },
+    {
+      "name": "forward-only-structural-defect-shadowed",
+      "rule": "WASM_STRUCTURAL",
+      "notes": "A hidden neuron with no inward synapse is a structural-integrity defect, but the per-type hidden check in the neuron loop rejects it long before the forwardOnly leg runs.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "options": { "forwardOnly": true },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "NO_INWARD_CONNECTIONS",
+        "messageContains": "hidden neuron h1 has no inward connections"
+      }
+    },
+    {
+      "name": "forward-only-cycle-shadowed",
+      "rule": "WASM_CYCLE",
+      "notes": "A cycle needs at least one synapse with from > to, so the recursive-synapse check always fires before detectCycles.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000002,
+            "uuid": "h2",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000003,
+            "uuid": "h3",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 },
+          { "from": 2, "to": 3, "weight": 1 },
+          { "from": 3, "to": 1, "weight": 1 },
+          { "from": 3, "to": 4, "weight": 1 }
+        ]
+      },
+      "options": { "forwardOnly": true },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "RECURSIVE_SYNAPSE",
+        "messageContains": "Recursive synapse h3 -> h1"
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/happy-paths.json
+++ b/neat-core/tests/fixtures/creature_validate/happy-paths.json
@@ -1,0 +1,208 @@
+{
+  "group": "happy-paths",
+  "description": "Creatures creatureValidate accepts, pinned by their exact stats object.",
+  "cases": [
+    {
+      "name": "ok-minimal",
+      "rule": "OK_MINIMAL",
+      "notes": "One input wired straight to one output — the smallest valid creature.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 1,
+          "constant": 0,
+          "hidden": 0,
+          "output": 1,
+          "connections": 1
+        }
+      }
+    },
+    {
+      "name": "ok-with-constant",
+      "rule": "OK_CONSTANTS",
+      "notes": "A constant carries a bias, no squash, no inward and at least one outward synapse.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "constant", "id": 1000001, "uuid": "c1", "bias": 1 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 0.5 }
+        ]
+      },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 1,
+          "constant": 1,
+          "hidden": 0,
+          "output": 1,
+          "connections": 2
+        }
+      }
+    },
+    {
+      "name": "ok-with-hidden-layer",
+      "rule": "OK_HIDDEN",
+      "notes": "Required computational order is input, constant, hidden, output.",
+      "creature": {
+        "input": 2,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          { "type": "constant", "id": 1000001, "uuid": "c1", "bias": 1 },
+          {
+            "type": "hidden",
+            "id": 1000002,
+            "uuid": "h1",
+            "bias": 0.25,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 3, "weight": 0.5 },
+          { "from": 1, "to": 3, "weight": -0.5 },
+          { "from": 2, "to": 4, "weight": 0.1 },
+          { "from": 3, "to": 4, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 2,
+          "constant": 1,
+          "hidden": 1,
+          "output": 1,
+          "connections": 4
+        }
+      }
+    },
+    {
+      "name": "ok-recurrent-default-options",
+      "rule": "OK_RECURRENT_DEFAULT",
+      "notes": "A backward synapse (from > to) is accepted when feedbackLoop is left undefined.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000002,
+            "uuid": "h2",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 },
+          { "from": 2, "to": 1, "weight": 0.5 },
+          { "from": 2, "to": 3, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 1,
+          "constant": 0,
+          "hidden": 2,
+          "output": 1,
+          "connections": 4
+        }
+      }
+    },
+    {
+      "name": "ok-forward-only",
+      "rule": "OK_FORWARD_ONLY",
+      "notes": "Exercises the forwardOnly leg: validateForwardOnly, validateStructuralIntegrity and detectCycles all pass.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0.5,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "options": { "forwardOnly": true },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 1,
+          "constant": 0,
+          "hidden": 1,
+          "output": 1,
+          "connections": 2
+        }
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/if-squash.json
+++ b/neat-core/tests/fixtures/creature_validate/if-squash.json
@@ -1,0 +1,206 @@
+{
+  "group": "if-squash",
+  "description": "IF neurons need a condition, a positive and a negative inward synapse. Only checked for neurons past index 2.",
+  "cases": [
+    {
+      "name": "if-too-few-inward",
+      "rule": "IF_TOO_FEW_INWARD",
+      "creature": {
+        "input": 3,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          { "type": "input", "id": 2 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "if1",
+            "bias": 2,
+            "squash": "IF"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 3, "weight": -0.3 },
+          { "from": 3, "to": 4, "weight": 0.8 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "IF_CONDITIONS",
+        "messageContains": "'IF' should have at least 3 inward connections was: 1"
+      }
+    },
+    {
+      "name": "if-missing-condition",
+      "rule": "IF_MISSING_CONDITION",
+      "notes": "An untyped synapse counts as positive.",
+      "creature": {
+        "input": 3,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          { "type": "input", "id": 2 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "if1",
+            "bias": 2,
+            "squash": "IF"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 3, "weight": -0.3, "type": "positive" },
+          { "from": 1, "to": 3, "weight": -0.3, "type": "positive" },
+          { "from": 2, "to": 3, "weight": -0.3, "type": "negative" },
+          { "from": 3, "to": 4, "weight": 0.8 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "IF_CONDITIONS",
+        "messageContains": "'IF' should have a condition(s)"
+      }
+    },
+    {
+      "name": "if-missing-positive",
+      "rule": "IF_MISSING_POSITIVE",
+      "creature": {
+        "input": 3,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          { "type": "input", "id": 2 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "if1",
+            "bias": 2,
+            "squash": "IF"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 3, "weight": -0.3, "type": "condition" },
+          { "from": 1, "to": 3, "weight": -0.3, "type": "condition" },
+          { "from": 2, "to": 3, "weight": -0.3, "type": "negative" },
+          { "from": 3, "to": 4, "weight": 0.8 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "IF_CONDITIONS",
+        "messageContains": "'IF' should have a positive connection(s)"
+      }
+    },
+    {
+      "name": "if-missing-negative",
+      "rule": "IF_MISSING_NEGATIVE",
+      "creature": {
+        "input": 3,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          { "type": "input", "id": 2 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "if1",
+            "bias": 2,
+            "squash": "IF"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 3, "weight": -0.3, "type": "condition" },
+          { "from": 1, "to": 3, "weight": -0.3, "type": "positive" },
+          { "from": 2, "to": 3, "weight": -0.3, "type": "positive" },
+          { "from": 3, "to": 4, "weight": 0.8 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "IF_CONDITIONS",
+        "messageContains": "'IF' should have a negative connection(s)"
+      }
+    },
+    {
+      "name": "if-with-all-three-synapse-types",
+      "rule": "OK_IF",
+      "notes": "The IF rules only bind for neurons past index 2; this creature is the accepted shape.",
+      "creature": {
+        "input": 3,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          { "type": "input", "id": 2 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "if1",
+            "bias": 2,
+            "squash": "IF"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 3, "weight": -0.3, "type": "condition" },
+          { "from": 1, "to": 3, "weight": -0.3, "type": "positive" },
+          { "from": 2, "to": 3, "weight": -0.3, "type": "negative" },
+          { "from": 3, "to": 4, "weight": 0.8 }
+        ]
+      },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 3,
+          "constant": 0,
+          "hidden": 1,
+          "output": 1,
+          "connections": 4
+        }
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/memetic.json
+++ b/neat-core/tests/fixtures/creature_validate/memetic.json
@@ -1,0 +1,342 @@
+{
+  "group": "memetic",
+  "description": "The memetic block: bias and weight entries are keyed by runtime neuron id and must resolve to a real neuron and a real synapse.",
+  "cases": [
+    {
+      "name": "memetic-valid",
+      "rule": "OK_MEMETIC",
+      "notes": "Bias keyed by the hidden neuron id; weight keyed by the source id with toId naming a real synapse target.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "forwardOnly": true,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 3,
+          "score": -0.5,
+          "biases": { "1000001": 0.1 },
+          "weights": { "0": [{ "toId": 1000001, "weight": 0.5 }] }
+        }
+      },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 1,
+          "constant": 0,
+          "hidden": 1,
+          "output": 1,
+          "connections": 2
+        }
+      }
+    },
+    {
+      "name": "memetic-bias-unknown-neuron",
+      "rule": "MEMETIC_BIAS_UNKNOWN_NEURON",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": { "999": 0.1 },
+          "weights": {}
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "Neuron with id 999 not found in the creature."
+      }
+    },
+    {
+      "name": "memetic-weight-unknown-source-neuron",
+      "rule": "MEMETIC_WEIGHT_UNKNOWN_NEURON",
+      "notes": "Weight keys are neuron ids; the message calls them synapse ids.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": {},
+          "weights": { "999": [{ "toId": 1000001, "weight": 0.5 }] }
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "Synapse with id 999 not found in the creature."
+      }
+    },
+    {
+      "name": "memetic-weights-not-an-array",
+      "rule": "MEMETIC_WEIGHTS_NOT_ARRAY",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": {},
+          "weights": { "0": { "toId": 1000001, "weight": 0.5 } }
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "Synapse with id 0 has invalid weights."
+      }
+    },
+    {
+      "name": "memetic-weight-missing-to-id",
+      "rule": "MEMETIC_WEIGHT_MISSING_TO_ID",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": {},
+          "weights": { "0": [{ "weight": 0.5 }] }
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "Memetic from id 0 to id undefined is invalid."
+      }
+    },
+    {
+      "name": "memetic-weight-missing-weight",
+      "rule": "MEMETIC_WEIGHT_MISSING_WEIGHT",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": {},
+          "weights": { "0": [{ "toId": 1000001 }] }
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "has invalid weight at index 0."
+      }
+    },
+    {
+      "name": "memetic-weight-to-id-has-no-neuron",
+      "rule": "MEMETIC_WEIGHT_TO_ID_UNKNOWN",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": {},
+          "weights": { "0": [{ "toId": 999, "weight": 0.5 }] }
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "Memetic from id 0 has no valid neuron."
+      }
+    },
+    {
+      "name": "memetic-weight-without-matching-synapse",
+      "rule": "MEMETIC_WEIGHT_NO_SYNAPSE",
+      "notes": "Both endpoints exist, but there is no input-0 to output-0 synapse.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ],
+        "memetic": {
+          "generation": 1,
+          "score": 0,
+          "biases": {},
+          "weights": { "0": [{ "toId": -1, "weight": 0.5 }] }
+        }
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "MEMETIC",
+        "messageContains": "Memetic from id 0 to id -1 has no matching synapses."
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/neuron-identity.json
+++ b/neat-core/tests/fixtures/creature_validate/neuron-identity.json
@@ -1,0 +1,293 @@
+{
+  "group": "neuron-identity",
+  "description": "Per-neuron id, bias and index rules, checked before the per-type rules.",
+  "cases": [
+    {
+      "name": "neuron-missing-id",
+      "rule": "NEURON_NO_ID",
+      "notes": "A null id in the fixture is an absent (undefined) id in memory.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": null,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "no id"
+      }
+    },
+    {
+      "name": "neuron-id-not-integer",
+      "rule": "NEURON_ID_INVALID",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1.5,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "invalid neuron id: -1.5"
+      }
+    },
+    {
+      "name": "neuron-id-above-int32-max",
+      "rule": "NEURON_ID_INVALID",
+      "notes": "MAX_NEURON_ID is 2147483647; ids above it are rejected, negative output ids are not.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 2147483648,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "invalid neuron id: 2147483648"
+      }
+    },
+    {
+      "name": "neuron-id-duplicate",
+      "rule": "NEURON_ID_DUPLICATE",
+      "notes": "The first hidden neuron is fully valid; the duplicate is detected on the second.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h2",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 1, "to": 3, "weight": 1 },
+          { "from": 2, "to": 3, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "duplicate neuron id: 1000001"
+      }
+    },
+    {
+      "name": "input-neuron-id-not-index",
+      "rule": "INPUT_NEURON_ID_MISMATCH",
+      "notes": "An input neuron's id must equal its array position.",
+      "creature": {
+        "input": 2,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 5 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "invalid input neuron id: 5"
+      }
+    },
+    {
+      "name": "output-bias-not-finite",
+      "rule": "NEURON_BIAS_NOT_FINITE",
+      "notes": "JSON cannot carry Infinity, so the corpus uses the string sentinel \"Infinity\".",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": "Infinity",
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "invalid bias: Infinity"
+      }
+    },
+    {
+      "name": "hidden-bias-undefined-shadowed",
+      "rule": "HIDDEN_BIAS_UNDEFINED",
+      "notes": "The hidden-specific 'should have a bias' TopologyError is unreachable: the generic non-input bias check fires first. Recording current behaviour, not the intended one (see README).",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": null,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "invalid bias: undefined"
+      }
+    },
+    {
+      "name": "hidden-bias-nan-shadowed",
+      "rule": "HIDDEN_BIAS_NOT_FINITE",
+      "notes": "As above: the hidden-specific finite-bias TopologyError is shadowed by the generic non-input bias check.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": "NaN",
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "invalid bias: NaN"
+      }
+    },
+    {
+      "name": "neuron-index-mismatch",
+      "rule": "NEURON_INDEX_MISMATCH",
+      "notes": "neuron.index must equal the neuron's array position.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY",
+            "index": 5
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "does not match expected index 1"
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/neuron-ordering.json
+++ b/neat-core/tests/fixtures/creature_validate/neuron-ordering.json
@@ -1,0 +1,117 @@
+{
+  "group": "neuron-ordering",
+  "description": "Required neuron order: input, constant, hidden, output.",
+  "cases": [
+    {
+      "name": "type-after-output-neuron",
+      "rule": "TYPE_AFTER_OUTPUT",
+      "notes": "Nothing but an output neuron may follow the first output neuron.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 0, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "type hidden after output neuron"
+      }
+    },
+    {
+      "name": "input-neuron-past-input-count",
+      "rule": "INPUT_NEURON_PAST_INPUT_COUNT",
+      "notes": "An input neuron sitting past creature.input, with its id still matching its index.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          { "type": "input", "id": 2 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 3, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "input neuron after the maximum input neurons"
+      }
+    },
+    {
+      "name": "constant-after-hidden",
+      "rule": "NEURON_ORDER_CONSTANT_AFTER_HIDDEN",
+      "notes": "Only checked inside the computational slice (after the inputs, before the outputs).",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          { "type": "constant", "id": 1000002, "uuid": "c1", "bias": 1 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 3, "weight": 1 },
+          { "from": 2, "to": 3, "weight": 0.5 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "NEURON_ORDER",
+        "messageContains": "type constant after hidden neuron"
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/options-and-counts.json
+++ b/neat-core/tests/fixtures/creature_validate/options-and-counts.json
@@ -1,0 +1,221 @@
+{
+  "group": "options-and-counts",
+  "description": "The options block and the input/output neuron counts.",
+  "cases": [
+    {
+      "name": "options-neurons-mismatch",
+      "rule": "OPTIONS_NEURONS_MISMATCH",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "options": { "neurons": 3 },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Neurons length: 2 expected: 3"
+      }
+    },
+    {
+      "name": "options-connections-mismatch",
+      "rule": "OPTIONS_CONNECTIONS_MISMATCH",
+      "notes": "Checked after the neuron and synapse loops, so the creature itself must be valid.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "options": { "connections": 9 },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Synapses length: 1 expected: 9"
+      }
+    },
+    {
+      "name": "input-count-zero",
+      "rule": "INPUT_COUNT_INVALID",
+      "creature": {
+        "input": 0,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Must have at least one input neurons was: 0"
+      }
+    },
+    {
+      "name": "input-count-not-integer",
+      "rule": "INPUT_COUNT_INVALID",
+      "creature": {
+        "input": 1.5,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Must have at least one input neurons was: 1.5"
+      }
+    },
+    {
+      "name": "output-count-zero",
+      "rule": "OUTPUT_COUNT_INVALID",
+      "creature": {
+        "input": 1,
+        "output": 0,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Must have at least one output neurons was: 0"
+      }
+    },
+    {
+      "name": "output-count-not-integer",
+      "rule": "OUTPUT_COUNT_INVALID",
+      "creature": {
+        "input": 1,
+        "output": 2.5,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Must have at least one output neurons was: 2.5"
+      }
+    },
+    {
+      "name": "stats-input-count-mismatch",
+      "rule": "STATS_INPUT_MISMATCH",
+      "notes": "creature.input claims two inputs but only one neuron has type input.",
+      "creature": {
+        "input": 2,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "OTHER",
+        "messageContains": "Expected 2 input neurons found: 1"
+      }
+    },
+    {
+      "name": "stats-output-count-mismatch",
+      "rule": "STATS_OUTPUT_MISMATCH",
+      "notes": "A missing output neuron is a TopologyError, not a ValidationError.",
+      "creature": {
+        "input": 1,
+        "output": 2,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 1, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_STATE",
+        "messageContains": "Expected 2 output neurons found: 1"
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/per-type-rules.json
+++ b/neat-core/tests/fixtures/creature_validate/per-type-rules.json
@@ -1,0 +1,239 @@
+{
+  "group": "per-type-rules",
+  "description": "The per-neuron-type switch: input, constant, hidden and unknown types.",
+  "cases": [
+    {
+      "name": "input-neuron-with-inward-connection",
+      "rule": "INPUT_HAS_INWARD",
+      "notes": "Input neurons may not be a synapse target.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 0, "weight": 0.5 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_CONNECTION",
+        "messageContains": "'input' neuron 0 has inward connections: 1"
+      }
+    },
+    {
+      "name": "constant-with-inward-connection",
+      "rule": "CONSTANT_HAS_INWARD",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "constant", "id": 1000001, "uuid": "c1", "bias": 1 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_CONNECTION",
+        "messageContains": "'constant' neuron 1000001 has inward connections: 1"
+      }
+    },
+    {
+      "name": "constant-with-squash",
+      "rule": "CONSTANT_HAS_SQUASH",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "constant",
+            "id": 1000001,
+            "uuid": "c1",
+            "bias": 1,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 0.5 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_SQUASH",
+        "messageContains": "'constant' has squash: IDENTITY"
+      }
+    },
+    {
+      "name": "constant-without-outward-connection",
+      "rule": "CONSTANT_NO_OUTWARD",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "constant", "id": 1000001, "uuid": "c1", "bias": 1 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [{ "from": 0, "to": 2, "weight": 1 }]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "NO_OUTWARD_CONNECTIONS",
+        "messageContains": "constants neuron c1 has no outward connections"
+      }
+    },
+    {
+      "name": "hidden-without-inward-connection",
+      "rule": "HIDDEN_NO_INWARD",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "NO_INWARD_CONNECTIONS",
+        "messageContains": "hidden neuron h1 has no inward connections"
+      }
+    },
+    {
+      "name": "hidden-without-outward-connection",
+      "rule": "HIDDEN_NO_OUTWARD",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 0, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "NO_OUTWARD_CONNECTIONS",
+        "messageContains": "hidden neuron h1 has no outward connections"
+      }
+    },
+    {
+      "name": "unknown-neuron-type",
+      "rule": "INVALID_NEURON_TYPE",
+      "notes": "Any type outside input/constant/hidden/output falls through to the switch default.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "banana",
+            "id": 1000001,
+            "uuid": "b1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_NEURON_TYPE",
+        "messageContains": "Invalid type: banana"
+      }
+    }
+  ]
+}

--- a/neat-core/tests/fixtures/creature_validate/synapses.json
+++ b/neat-core/tests/fixtures/creature_validate/synapses.json
@@ -1,0 +1,278 @@
+{
+  "group": "synapses",
+  "description": "The synapse loop: targets, sort order, duplicates and recursion.",
+  "cases": [
+    {
+      "name": "synapse-points-at-input-shadowed",
+      "rule": "SYNAPSE_TO_INPUT",
+      "notes": "The 'connection points to an input node' TopologyError is unreachable: the same synapse makes the input neuron fail the earlier 'input neuron has inward connections' check in the neuron loop. Recording current behaviour (see README).",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 0, "weight": 0.5 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_CONNECTION",
+        "messageContains": "'input' neuron 0 has inward connections: 1"
+      }
+    },
+    {
+      "name": "forward-only-self-connection",
+      "rule": "SELF_CONNECTION_FORWARD_ONLY",
+      "notes": "Self-connections are only rejected under forwardOnly.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 1, "weight": 0.25 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "options": { "forwardOnly": true },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "SELF_CONNECTION",
+        "messageContains": "Self connection synapse h1 -> h1"
+      }
+    },
+    {
+      "name": "synapses-not-sorted-by-from",
+      "rule": "SORT_FAILURE_FROM",
+      "creature": {
+        "input": 2,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          { "type": "input", "id": 1 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 1, "to": 2, "weight": 1 },
+          { "from": 0, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "SORT_FAILURE",
+        "messageContains": "1) synapses not sorted"
+      }
+    },
+    {
+      "name": "synapses-not-sorted-by-to",
+      "rule": "SORT_FAILURE_TO",
+      "notes": "Same 'from', descending 'to'.",
+      "creature": {
+        "input": 1,
+        "output": 2,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -2,
+            "uuid": "output-1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 2, "weight": 1 },
+          { "from": 0, "to": 1, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "SORT_FAILURE",
+        "messageContains": "synapses not sorted 0->1 last to: 2"
+      }
+    },
+    {
+      "name": "duplicate-synapse",
+      "rule": "DUPLICATE_SYNAPSE",
+      "notes": "Current NEAT-AI behaviour is TopologyError/INVALID_CONNECTION even though ValidationErrorName already carries a DUPLICATE_SYNAPSE reason. Flagged for stSoftwareAU/NEAT-AI-core#556; the corpus freezes what happens today rather than resolving the discrepancy.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 0, "to": 1, "weight": 0.5 },
+          { "from": 1, "to": 2, "weight": 1 }
+        ]
+      },
+      "expect": {
+        "outcome": "throws",
+        "error": "TopologyError",
+        "reason": "INVALID_CONNECTION",
+        "messageContains": "duplicate synapse input-0 -> h1"
+      }
+    },
+    {
+      "name": "recursive-synapse-rejected-when-feedback-loop-false",
+      "rule": "RECURSIVE_SYNAPSE",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000002,
+            "uuid": "h2",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 },
+          { "from": 2, "to": 1, "weight": 0.5 },
+          { "from": 2, "to": 3, "weight": 1 }
+        ]
+      },
+      "options": { "feedbackLoop": false },
+      "expect": {
+        "outcome": "throws",
+        "error": "ValidationError",
+        "reason": "RECURSIVE_SYNAPSE",
+        "messageContains": "Recursive synapse h2 -> h1"
+      }
+    },
+    {
+      "name": "recursive-synapse-accepted-when-feedback-loop-true",
+      "rule": "OK_RECURRENT_FEEDBACK_TRUE",
+      "notes": "The same creature as the case above, accepted because feedbackLoop is explicitly true.",
+      "creature": {
+        "input": 1,
+        "output": 1,
+        "neurons": [
+          { "type": "input", "id": 0 },
+          {
+            "type": "hidden",
+            "id": 1000001,
+            "uuid": "h1",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "hidden",
+            "id": 1000002,
+            "uuid": "h2",
+            "bias": 0,
+            "squash": "IDENTITY"
+          },
+          {
+            "type": "output",
+            "id": -1,
+            "uuid": "output-0",
+            "bias": 0,
+            "squash": "IDENTITY"
+          }
+        ],
+        "synapses": [
+          { "from": 0, "to": 1, "weight": 1 },
+          { "from": 1, "to": 2, "weight": 1 },
+          { "from": 2, "to": 1, "weight": 0.5 },
+          { "from": 2, "to": 3, "weight": 1 }
+        ]
+      },
+      "options": { "feedbackLoop": true },
+      "expect": {
+        "outcome": "ok",
+        "stats": {
+          "input": 1,
+          "constant": 0,
+          "hidden": 2,
+          "output": 1,
+          "connections": 4
+        }
+      }
+    }
+  ]
+}

--- a/quality.sh
+++ b/quality.sh
@@ -101,6 +101,12 @@ echo "🧪 Running tests..."
 # neat-core is library + integration tests only (no [[bin]]); --bins is harmless if added later
 cargo test --workspace --lib --tests --all-features -- --test-threads=2
 
+# Issue #562 — doctests are part of the public API surface (the
+# `creature_validate` examples), so a doctest that stops compiling must fail
+# the gate rather than pass unrun.
+echo "🧪 Running doctests..."
+cargo test --workspace --doc --all-features
+
 echo "📖 Building documentation..."
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 


### PR DESCRIPTION
# creature_validate: both consumers, proven conformance

## Summary

`creature_validate` was ported (Issues #559–#561) but reachable only from Rust
and unproven against the TypeScript it replaces. This change makes it reachable
by both consumer kinds and proves it agrees, case by case, with NEAT-AI's own
conformance corpus. Closes #562.

- **Native API** — `creature_validate` was already re-exported from `lib.rs`; it
  now carries worked doctests (a valid creature returning `ValidationStats`, an
  invalid one returning a `ValidationFailure` naming its `reason`), and
  `cargo test --doc` was added to `quality.sh` and CI so a doctest that stops
  compiling fails the gate instead of passing unrun.
- **WASM export** — `#[wasm_bindgen(js_name = creature_validate)]` in
  `wasm_exports.rs`, a rename over the new native
  `neat-core/src/creature_validate_json.rs`. The ABI is **JSON in, JSON out**:
  the existing exports split between packed byte buffers and scalar arguments,
  and neither fits a whole creature in and a structured failure out. The whole
  ABI lives in the native module so it is covered by `cargo test` rather than
  only in a browser.
- **Malformed input cannot panic** — a panic in WASM aborts the module and
  `catch_unwind` is unavailable there, so anything that is not a request comes
  back as a structured failure carrying `"malformed": true` and a
  `MALFORMED_REQUEST:` message, the JSON twin of `topology_ops`'
  `MALFORMED_BUFFER`. A creature declaring more than `MAX_REQUEST_NEURONS`
  neurons is refused **before** the per-neuron allocation, which would otherwise
  abort on a payload saying `"input": 17179869180`.
- **A real panic fixed** — rule 11 computed `neurons.len() - output` on a
  `usize`. A creature declaring more outputs than it carries neurons underflowed
  and panicked. It now saturates, which *is* the JavaScript semantics (the
  comparison against a negative number is false), and rule 22 reports the
  miscount.
- **Conformance** — the NEAT-AI#3801 corpus is vendored under
  `neat-core/tests/fixtures/creature_validate/` with its source commit and
  checksums recorded, and replayed against `creature_validate`.

### Wire ABI

```jsonc
// in
{ "creature": { /* CreatureExport */ },
  "options": { "neurons": 3, "connections": 2, "feedbackLoop": false, "forwardOnly": true } }

// out — one of
{ "ok": true,  "stats": { "input": 1, "constant": 0, "hidden": 1, "output": 1, "connections": 2 } }
{ "ok": false, "failure": { "class": "ValidationError", "reason": "NO_INWARD_CONNECTIONS",
                            "message": "hidden neuron h1 has no inward connections",
                            "neuronIndex": 1, "synapseIndex": null, "malformed": false } }
```

Two decisions worth a reviewer's eye:

- **An unknown option key is a failure**, not a silent default — ignoring
  `forwardonly` would validate a production creature under the wrong rules and
  call it healthy. Unknown *creature* keys stay ignored, so NEAT-AI's own extra
  fields still parse.
- **The creature is deserialised with serde alone**, deliberately not through
  `parse_creature_json`, whose width check would shadow rules 2 and 3 and answer
  `InvalidInputCount` where NEAT-AI expects
  `Must have at least one input neurons was: 0`.

## Evidence

Backend/WASM change — no web interface to screenshot. The evidence is the gate.

```mermaid
flowchart LR
    JS["NEAT-AI TypeScript"] -->|request JSON| W["wasm_exports<br/>creature_validate"]
    RS["Rust consumers"] -->|CreatureExport| V["creature_validate"]
    W --> J["creature_validate_json"]
    J -->|"not a request,<br/>or too many neurons"| MF["failure<br/>malformed: true"]
    J --> V
    V -->|"Ok(stats)"| OK["ok: true + stats"]
    V -->|"Err(failure)"| ERR["ok: false + class,<br/>reason, message, indices"]
```

**`./quality.sh` passes**, including the new doctest step:

```text
🧪 Running tests...
test result: ok. 226 passed  (lib)
test result: ok. 3 passed    (creature_validate_conformance)
test result: ok. 11 passed   (creature_validate_json_boundary)
🧪 Running doctests...
test neat-core/src/creature_validate.rs - creature_validate::creature_validate (line 580) ... ok
test neat-core/src/creature_validate.rs - creature_validate::creature_validate (line 607) ... ok
test neat-core/src/creature_validate_json.rs - creature_validate_json::creature_validate_json (line 236) ... ok
✅ All quality checks passed!
```

**The conformance gate bites.** Mutating one message
(`has no {direction} connections` → `links`) fails it on the offending case:

```text
forward-only-structural-defect-shadowed: message "hidden neuron h1 has no inward links"
  does not contain "hidden neuron h1 has no inward connections"
test result: FAILED. 2 passed; 1 failed
```

**The rule-11 panic was real** — before the fix, a creature with
`input: 1, output: 5` and one hidden neuron gave:

```text
thread 'probe' panicked at neat-core/src/creature_validate.rs:941:38:
attempt to subtract with overflow
```

**Corpus result: 37 of 47 cases replay exactly** — same error class, same
`reason`, same message text; the happy paths match all five counters. The other
ten describe something the wire shape cannot express, each a consequence of the
input format Issue #559 fixed rather than of a rule that was dropped:

| Case | Why | What this crate does |
|------|-----|----------------------|
| `input-count-not-integer`, `output-count-not-integer`, `neuron-id-not-integer`, `hidden-bias-undefined-shadowed`, `memetic-weights-not-an-array` | the value cannot be written on the wire at all | rejected at the parse boundary |
| `neuron-missing-id` | an output's id is derived as `-(outputIndex + 1)` whatever the file says (rule 4 unreachable through one) | — |
| `input-neuron-id-not-index`, `input-neuron-past-input-count` | input neurons are implicit (rules 7 and 10 unreachable) | — |
| `stats-input-count-mismatch` | the wire form carries exactly `input` implicit inputs (rule 21) | accepts, `stats = 2/0/1/1/2` |
| `neuron-index-mismatch` | `neuron.index` stays host-side (NEAT-AI#3802) | ignores the key, accepts |

None is skipped: each is declared in `DIVERGENCES` in the runner **with what
this crate does instead**, and that behaviour is asserted, so a stale
declaration or a changed Rust outcome fails the test as loudly as a mismatch.
The full table is on issue #562, and no contract change (#559) is outstanding —
every divergence is a decision that contract already recorded.

**wasm32 / wasm64 bundles.** The container has no `wasm32-unknown-unknown`
target installed (`rustup` is absent), so both bundles are built by
`.github/workflows/wasm-bundle.yml` on merge to `Develop`, which also runs the
arch parity and export-surface gates. The shim is the same shape as the
existing `version()` export — `&str` in, `String` out — and carries no
target-specific code.

**Release.** Additive change, so the `version-increment` job bumps the patch on
this PR; `release.yml` cuts the `v<version>` tag and `wasm-bundle.yml` publishes
the bundle carrying the new export on merge, per `RELEASING.md`. No manual
version edit is needed, and NEAT-AI's `build.sh` picks the bundle up by SHA.

### Security self-check

- Input validation: the boundary accepts only the declared request shape,
  refuses unknown option keys, and caps the neuron count before allocating.
- Injection surface: no SQL, shell, filesystem or HTTP call is added; the only
  parsing is `serde_json` on caller-supplied text.
- Error handling: failure messages carry the serde diagnostic for the caller's
  *own* payload and no internal state, paths or stack traces.
- Secrets and dependencies: none added; no new third-party crate.

## Test Plan

Added:

- `neat-core/tests/creature_validate_conformance.rs` — replays the vendored
  NEAT-AI#3801 corpus (3 tests): every case matches or is a declared divergence
  with its Rust outcome pinned; every `coverage.json` site still has a case; the
  replayed/declared split is asserted so a case cannot quietly move into the
  divergence table.
- `neat-core/tests/creature_validate_json_boundary.rs` — 11 tests over the ABI:
  the five counters, the options bag, `forwardOnly`, the failure indices, 14
  hostile payloads (empty, non-JSON, truncated, trailing garbage, wrong-typed,
  negative and non-integer widths), a misspelt option key, an absurd neuron
  count, 2 000-deep nesting, a creature at the ceiling, and `input: 0` reaching
  rule 2 in NEAT-AI's own words.
- `creature_validate_json::tests` — 5 unit tests pinning the exact response text
  and the options mapping.
- `creature_validate::tests::declaring_more_outputs_than_neurons_reports_rule_22_rather_than_panicking`
  — the rule-11 underflow regression.
- Two doctests on `creature_validate`.

Modified: `quality.sh` and `.github/workflows/ci.yml` gained a
`cargo test --workspace --doc` step. No existing test was changed or removed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt2vsqh4-7a3a67`<!-- vibe-worker-issue-562 -->