### PR TITLE
creature_validate: accept the runtime creature shape so a host's defect can reach the rules (NEAT-AI#3803)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.11"
+version = "0.9.12"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/archive/pr-summaries/pr-summary-neat-ai-3803.md
+++ b/docs/archive/pr-summaries/pr-summary-neat-ai-3803.md
@@ -1,0 +1,120 @@
+# creature_validate: accept the runtime creature shape, so a host's defect can reach the rules
+
+## Summary
+
+`creature_validate` crosses the WASM boundary as JSON (Issue #562), and the
+creature it takes is the **export** wire form: index-free, UUID-wired, with the
+input neurons implicit. That form cannot describe most of what a host is asking
+about when it validates a creature it holds in memory, so the validator answers
+the wrong question.
+
+Replaying NEAT-AI's own conformance corpus (NEAT-AI#3801) through the boundary,
+**11 of 55 cases disagreed with the TypeScript, four of them by accepting a
+creature TypeScript rejects**:
+
+| Case | Wire answer | TypeScript |
+|------|-------------|------------|
+| `neuron-missing-id` | `ok` | `no id` |
+| `input-neuron-id-not-index` | `ok` | `invalid input neuron id: 5` |
+| `input-neuron-past-input-count` | `ok` | `input neuron after the maximum input neurons` |
+| `stats-input-count-mismatch` | `ok` | `Expected 2 input neurons found: 1` |
+| `output-bias-not-finite`, `hidden-bias-nan-shadowed`, `hidden-bias-undefined-shadowed` | `MALFORMED_REQUEST: invalid type: null, expected f64` | `invalid bias: NaN` |
+| `neuron-id-not-integer`, `input-count-not-integer`, `output-count-not-integer` | `MALFORMED_REQUEST: invalid type: floating point` | `invalid neuron id: -1.5` |
+| `memetic-weights-not-an-array` | `MALFORMED_REQUEST: invalid type: map` | `Synapse with id 0 has invalid weights.` |
+
+A creature carrying a `NaN` bias — the defect rule 8 exists for, and the one a
+diverged training run actually produces — could not be described on the wire at
+all. A validator that answers "healthy" for a creature the rules reject is worse
+than no validator, so the shape a host sends has to be able to carry the defect
+it is asking about.
+
+This adds that shape. A request now names **exactly one** creature:
+
+- `creature` — the export wire form, unchanged for every existing caller;
+- `runtimeCreature` — every neuron listed (inputs included, with their own ids),
+  synapses wired by array position, and permissive about the values JSON has no
+  literal for (`"NaN"` / `"Infinity"` / `"-Infinity"` biases, absent fields for
+  `undefined`, non-integer ids and widths, a memetic record read verbatim).
+
+Both shapes meet at one seam — `validate_prepared` — so the rules cannot drift
+between them, and the answer does not depend on how the creature was described.
+Naming both keys, or neither, is a boundary fault rather than a verdict.
+
+Unblocks NEAT-AI#3803, which cannot delete its TypeScript rules until the shared
+validator agrees with them.
+
+## Evidence
+
+Backend/WASM change — no web interface to screenshot. The evidence is the gate.
+
+```mermaid
+flowchart LR
+    HOST["NEAT-AI<br/>in-memory creature"] -->|runtimeCreature| J["creature_validate_json"]
+    FILE["creature file"] -->|creature| J
+    J --> RC["creature_validate_runtime<br/>rules 1–3, views by position"]
+    J --> EX["creature_validate<br/>rules 1–3, derived views"]
+    RC --> SEAM["validate_prepared<br/>rules 4–31"]
+    EX --> SEAM
+    SEAM --> OK["ok + stats"]
+    SEAM --> ERR["class, reason, message,<br/>neuronIndex, synapseIndex"]
+```
+
+**54 of 55 corpus cases replay exactly** through the runtime shape — same class,
+same `reason`, same message text, all five counters on the happy paths. The
+55th, `neuron-index-mismatch`, reads `neuron.index`, an in-memory cache that
+stays host-side (NEAT-AI#3802); it is declared in `HOST_ONLY_CASES` and the test
+asserts the rules still do *not* report it, so a stale declaration fails as
+loudly as a mismatch. The export shape's ten divergences are untouched — that
+runner still passes unchanged.
+
+**The gate bites.** Mutating rule 4's message fails the new runner on the
+offending case:
+
+```text
+neuron-missing-id: message "undefined) lacks identity" does not contain "no id"
+test result: FAILED. 1 passed; 1 failed
+```
+
+**`./quality.sh` passes**, including `cargo test --workspace --doc`:
+
+```text
+🧪 Running tests...
+test result: ok. 241 passed  (lib)
+test result: ok. 2 passed    (creature_validate_runtime_conformance)
+test result: ok. 3 passed    (creature_validate_conformance)
+✅ All quality checks passed!
+```
+
+### Security self-check
+
+- Input validation: the runtime shape is read with serde and every value the
+  rules use is range- and type-checked before it indexes anything; a synapse
+  naming a position no neuron occupies is `INVALID_SYNAPSE_REFERENCE`, not an
+  out-of-bounds index.
+- Cannot panic: the boundary keeps its no-panic contract — a payload past
+  `MAX_REQUEST_NEURONS` is refused before the per-neuron allocation, and every
+  other fault is a structured failure.
+- No new dependency, no filesystem, shell, SQL or HTTP surface, and no internal
+  state in any message.
+
+## Test Plan
+
+Added:
+
+- `neat-core/tests/creature_validate_runtime_conformance.rs` — replays the
+  vendored NEAT-AI#3801 corpus through the runtime shape (2 tests): every case
+  matches, and the one host-only exemption is asserted to still be host-only.
+- `creature_validate_runtime::tests` — 12 unit tests over the defects the export
+  form cannot carry: rule 7 (input id ≠ index), rule 10 (input neuron past the
+  width), rule 21 (counted inputs), rules 4 and 5 (missing and non-integer id),
+  rule 8 (the three non-finite sentinels and an absent bias), rules 2 and 3
+  (non-integer widths), rule 20, rule 31 (`weights` that is not an array, and
+  entries missing `toId` / `weight`), a dangling synapse endpoint, and a host's
+  own extra keys being ignored.
+- `creature_validate_json::tests` — 4 boundary tests: a runtime creature over
+  the ABI, the same defect described both ways (export says healthy, runtime
+  names rule 7), exactly-one-creature-key, and the neuron ceiling.
+
+Modified: `memetic_rules` now reads a neutral `MemeticView` both shapes map
+onto, and `creature_validate` derives its views once instead of twice. No
+existing test was changed or removed.

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -87,8 +87,23 @@
 //!
 //! # Input format
 //!
-//! A creature reaches the validator as a [`CreatureExport`] — the JSON wire
-//! shape this crate already parses — not as a second, validator-only struct.
+//! A creature reaches the validator in one of two shapes, and both run the
+//! rules below through one shared seam so neither can drift from the
+//! other:
+//!
+//! | Shape | Entry point | What it is |
+//! |-------|-------------|------------|
+//! | export | [`creature_validate`] | the [`CreatureExport`] wire form this crate already parses — index-free, UUID-wired, input neurons implicit |
+//! | runtime | [`crate::creature_validate_runtime::creature_validate_runtime`] | every neuron listed and synapses wired by position, as a host holds a creature in memory (NEAT-AI#3803) |
+//!
+//! The rest of this section describes the **export** shape, whose derivations
+//! are what put rules 4, 7, 10 and 21 (and, through serde, rules 2, 3, 5 and
+//! the malformed half of 31) out of reach; the runtime shape carries those
+//! defects instead of deriving them away, and its own module documents it.
+//!
+//! The export form reaches the validator as a [`CreatureExport`] — the JSON
+//! wire shape this crate already parses — not as a second, validator-only
+//! struct.
 //! Two fields were added for the rules above, both optional and both skipped
 //! when absent, so every existing [`crate::creature::parse_creature_json`]
 //! caller and every already-written creature file is unaffected:
@@ -637,23 +652,46 @@ pub fn creature_validate(
     creature: &CreatureExport,
     options: &ValidateOptions,
 ) -> Result<ValidationStats, ValidationFailure> {
-    let mut stats = validate_neuron_rules(creature, options)?;
-    validate_synapse_and_memetic_rules(creature, options, &mut stats)?;
+    validate_declared_widths(
+        creature.input + creature.neurons.len(),
+        creature.input as f64,
+        creature.output as f64,
+        options,
+    )?;
 
-    Ok(stats)
+    let views = neuron_views(creature);
+    let (from, to, synapse_types) = resolve_synapse_endpoints(creature)?;
+    let memetic = creature.memetic.as_ref().map(MemeticView::from_export);
+
+    validate_prepared(
+        &views,
+        creature.input,
+        creature.output,
+        &from,
+        &to,
+        &synapse_types,
+        options,
+        memetic.as_ref(),
+    )
 }
 
-/// Rules 1–22 — everything the TypeScript evaluates before it reaches
-/// `creature.synapses.forEach` (Issue #560).
+/// Rules 1–3 — the counts the walk trusts afterwards.
 ///
-/// `stats.connections` stays `0`: [`validate_synapse_and_memetic_rules`] is
-/// what fills it.
-fn validate_neuron_rules(
-    creature: &CreatureExport,
+/// `input` and `output` arrive as `f64` because the runtime shape can carry a
+/// width JavaScript would reject as a non-integer (`1.5`), which the export
+/// form types as `usize` and rejects at the parse boundary. They are rendered
+/// with [`number_text`], so the message is the TypeScript's whichever shape
+/// asked.
+///
+/// # Errors
+///
+/// Returns the [`ValidationFailure`] for the first violated rule.
+pub(crate) fn validate_declared_widths(
+    total_neurons: usize,
+    input: f64,
+    output: f64,
     options: &ValidateOptions,
-) -> Result<ValidationStats, ValidationFailure> {
-    let total_neurons = creature.input + creature.neurons.len();
-
+) -> Result<(), ValidationFailure> {
     // Rule 1 — `if (options && options.neurons)`, a truthiness test.
     if let Some(expected) = options.expected_neurons()
         && total_neurons != expected
@@ -665,26 +703,55 @@ fn validate_neuron_rules(
     }
 
     // Rules 2 and 3 — a creature with no observations or no targets is not a
-    // creature. `input` / `output` are `usize` here, so the TypeScript
-    // `Number.isInteger` half of each test is unrepresentable.
-    if creature.input < 1 {
-        return Err(ValidationFailure::validation(
-            reason::OTHER,
-            format!(
-                "Must have at least one input neurons was: {}",
-                creature.input
-            ),
-        ));
+    // creature. `Number.isInteger(...) === false || ... < 1` in both halves.
+    let width_fault = |declared: f64, role: &str| {
+        (!is_js_integer(declared) || declared < 1.0).then(|| {
+            ValidationFailure::validation(
+                reason::OTHER,
+                format!(
+                    "Must have at least one {role} neurons was: {}",
+                    number_text(Some(declared))
+                ),
+            )
+        })
+    };
+    if let Some(failure) = width_fault(input, "input") {
+        return Err(failure);
     }
-    if creature.output < 1 {
-        return Err(ValidationFailure::validation(
-            reason::OTHER,
-            format!(
-                "Must have at least one output neurons was: {}",
-                creature.output
-            ),
-        ));
+    if let Some(failure) = width_fault(output, "output") {
+        return Err(failure);
     }
+
+    Ok(())
+}
+
+/// `Number.isInteger(value)` — finite, and with nothing after the point.
+pub(crate) fn is_js_integer(value: f64) -> bool {
+    value.is_finite() && value.fract() == 0.0
+}
+
+/// Rules 1–22 — everything the TypeScript evaluates before it reaches
+/// `creature.synapses.forEach` (Issue #560).
+///
+/// `stats.connections` stays `0`: [`validate_synapse_and_memetic_rules`] is
+/// what fills it. [`creature_validate`] derives the views once and runs both
+/// halves over them, so this half stands alone only for the tests that pin it.
+#[cfg(test)]
+fn validate_neuron_rules(
+    creature: &CreatureExport,
+    options: &ValidateOptions,
+) -> Result<ValidationStats, ValidationFailure> {
+    let total_neurons = creature.input + creature.neurons.len();
+
+    // Rules 1–3. `input` / `output` are `usize` here, so the TypeScript
+    // `Number.isInteger` half of rules 2 and 3 is unrepresentable in this
+    // shape; the runtime shape is where a non-integer width can reach them.
+    validate_declared_widths(
+        total_neurons,
+        creature.input as f64,
+        creature.output as f64,
+        options,
+    )?;
 
     let views = neuron_views(creature);
     let (from, to, synapse_types) = resolve_synapse_endpoints(creature)?;
@@ -705,27 +772,37 @@ fn validate_neuron_rules(
 /// walk runs over this derived view rather than over `creature.neurons`
 /// directly — see the *Input format* section of the module documentation.
 #[derive(Debug, Clone, Copy, PartialEq)]
-struct NeuronView<'a> {
+pub(crate) struct NeuronView<'a> {
     /// Runtime integer id, derived as NEAT-AI's loader derives it
-    /// ([`derived_neuron_id`]). `None` only when no id can be derived at all.
-    id: Option<i64>,
+    /// ([`derived_neuron_id`]). `None` when no id can be derived at all, and
+    /// also when the host declared one that is not an integer — see
+    /// [`non_integer_id`](Self::non_integer_id).
+    pub(crate) id: Option<i64>,
+    /// The id exactly as the host declared it, when that was a number but not
+    /// an integer (rule 5's `Number.isInteger` half).
+    ///
+    /// Only the runtime shape ([`mod@crate::creature_validate_runtime`]) can
+    /// carry one: the export form types `id` as an integer, so serde rejects
+    /// `-1.5` at the parse boundary and this stays `None`.
+    pub(crate) non_integer_id: Option<f64>,
     /// The four types the rules branch on, plus [`NeuronKind::Invalid`].
-    kind: NeuronKind,
+    pub(crate) kind: NeuronKind,
     /// The `type` string as declared, reproduced verbatim in messages.
-    declared_type: &'a str,
+    pub(crate) declared_type: &'a str,
     /// The wire UUID; `None` for the implicit input neurons, which are labelled
     /// `input-N` from their index.
-    uuid: Option<&'a str>,
-    /// `None` is TypeScript's `undefined` bias — unreachable from JSON, where
-    /// `bias` is a required number.
-    bias: Option<f64>,
+    pub(crate) uuid: Option<&'a str>,
+    /// `None` is TypeScript's `undefined` bias — unreachable from the export
+    /// form, where `bias` is a required number, and expressible from the
+    /// runtime shape.
+    pub(crate) bias: Option<f64>,
     /// Activation function name, absent for constants and implicit inputs.
-    squash: Option<&'a str>,
+    pub(crate) squash: Option<&'a str>,
 }
 
 /// A neuron type as the rules read it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NeuronKind {
+pub(crate) enum NeuronKind {
     /// One of the implicit `0..input` neurons.
     Input,
     /// A `constant` neuron.
@@ -749,14 +826,29 @@ impl NeuronKind {
             _ => NeuronKind::Invalid,
         }
     }
+
+    /// Read the `type` of a neuron the host listed itself.
+    ///
+    /// The runtime shape lists every neuron, input neurons included, so
+    /// `"input"` is a legitimate type here — the one difference from
+    /// [`NeuronKind::from_declared`], where an entry claiming to be an input
+    /// is invalid because the export form makes inputs implicit.
+    pub(crate) fn from_declared_runtime(declared_type: &str) -> Self {
+        match declared_type {
+            "input" => NeuronKind::Input,
+            other => NeuronKind::from_declared(other),
+        }
+    }
 }
 
 impl NeuronView<'_> {
-    /// `neuron.ID()` — `String(this.id)`, so a missing id reads `undefined`.
+    /// `neuron.ID()` — `String(this.id)`, so a missing id reads `undefined`
+    /// and a non-integer id reads as JavaScript would print it.
     fn id_text(&self) -> String {
-        match self.id {
-            Some(id) => id.to_string(),
-            None => "undefined".to_string(),
+        match (self.id, self.non_integer_id) {
+            (Some(id), _) => id.to_string(),
+            (None, Some(raw)) => number_text(Some(raw)),
+            (None, None) => "undefined".to_string(),
         }
     }
 
@@ -844,6 +936,7 @@ fn neuron_views(creature: &CreatureExport) -> Vec<NeuronView<'_>> {
     for index in 0..creature.input {
         views.push(NeuronView {
             id: Some(index as i64),
+            non_integer_id: None,
             kind: NeuronKind::Input,
             declared_type: "input",
             uuid: None,
@@ -865,6 +958,7 @@ fn neuron_views(creature: &CreatureExport) -> Vec<NeuronView<'_>> {
 
         views.push(NeuronView {
             id,
+            non_integer_id: None,
             kind,
             declared_type: &neuron.neuron_type,
             uuid: Some(neuron.uuid.as_str()),
@@ -943,16 +1037,27 @@ fn walk_neurons(
     for (index, neuron) in views.iter().enumerate() {
         let at = |failure: ValidationFailure| failure.at_neuron(index as u32);
 
-        // Rule 4 — every neuron has an id.
-        let Some(id) = neuron.id else {
+        // Rule 4 — every neuron has an id. A non-integer id *is* an id, so it
+        // reaches rule 5 rather than being reported as missing.
+        if neuron.id.is_none() && neuron.non_integer_id.is_none() {
             return Err(at(ValidationFailure::validation(
                 reason::OTHER,
                 format!("{}) no id", neuron.id_text()),
             )));
-        };
+        }
 
-        // Rule 5 — ids fit int32. Negative ids are legal: an output neuron's
-        // id is `-(outputIndex + 1)` (NEAT-AI #1958).
+        // Rule 5 — an id is an integer that fits int32. Negative ids are legal:
+        // an output neuron's id is `-(outputIndex + 1)` (NEAT-AI #1958).
+        if neuron.non_integer_id.is_some() {
+            let id_text = neuron.id_text();
+            return Err(at(ValidationFailure::validation(
+                reason::OTHER,
+                format!("{id_text}) invalid neuron id: {id_text}"),
+            )));
+        }
+        let id = neuron
+            .id
+            .expect("rules 4 and 5 leave only a neuron carrying an integer id");
         if id > MAX_NEURON_ID {
             return Err(at(ValidationFailure::validation(
                 reason::OTHER,
@@ -1371,7 +1476,7 @@ fn memetic_rules(
     views: &[NeuronView<'_>],
     from_indices: &[u32],
     to_indices: &[u32],
-    memetic: &MemeticExport,
+    memetic: &MemeticView<'_>,
 ) -> Result<(), ValidationFailure> {
     let known_ids: HashSet<i64> = views.iter().filter_map(|view| view.id).collect();
 
@@ -1386,7 +1491,7 @@ fn memetic_rules(
 
     let known = |key: &str| -> bool { key.parse::<i64>().is_ok_and(|id| known_ids.contains(&id)) };
 
-    for neuron_id in memetic.biases.keys() {
+    for neuron_id in &memetic.biases {
         if !known(neuron_id) {
             return Err(ValidationFailure::validation(
                 reason::MEMETIC,
@@ -1403,28 +1508,38 @@ fn memetic_rules(
             ));
         }
 
-        for (index, entry) in weights.iter().enumerate() {
-            let Some(to_id) = entry.to_id else {
+        // `Array.isArray(memeticWeights)` — a record's weights are a list of
+        // deltas or they are nothing this rule can read.
+        let MemeticWeights::Entries(entries) = weights else {
+            return Err(ValidationFailure::validation(
+                reason::MEMETIC,
+                format!("Synapse with id {synapse_id} has invalid weights."),
+            ));
+        };
+
+        for (index, entry) in entries.iter().enumerate() {
+            if !entry.to_id_present {
                 // TypeScript interpolates the absent field as `undefined`.
                 return Err(ValidationFailure::validation(
                     reason::MEMETIC,
                     format!("Memetic from id {synapse_id} to id undefined is invalid."),
                 ));
-            };
-            if entry.weight.is_none() {
+            }
+            let to_id_text = &entry.to_id_text;
+            if !entry.weight_present {
                 return Err(ValidationFailure::validation(
                     reason::MEMETIC,
                     format!(
-                        "Memetic from id {synapse_id} to id {to_id} has invalid weight at index {index}."
+                        "Memetic from id {synapse_id} to id {to_id_text} has invalid weight at index {index}."
                     ),
                 ));
             }
-            if !known_ids.contains(&to_id) {
+            let Some(to_id) = entry.to_id.filter(|id| known_ids.contains(id)) else {
                 return Err(ValidationFailure::validation(
                     reason::MEMETIC,
                     format!("Memetic from id {synapse_id} has no valid neuron."),
                 ));
-            }
+            };
             if !pairs.contains(&format!("{synapse_id}->{to_id}")) {
                 return Err(ValidationFailure::validation(
                     reason::MEMETIC,
@@ -1435,6 +1550,73 @@ fn memetic_rules(
     }
 
     Ok(())
+}
+
+/// The memetic record as rule 31 reads it — the neutral form both request
+/// shapes map onto.
+///
+/// The export form types `weights` as a list of typed deltas, so serde rejects
+/// a malformed record before the rule sees it; the runtime shape
+/// ([`mod@crate::creature_validate_runtime`]) carries whatever the host holds
+/// in memory, so `weights` that is not an array, or an entry missing `toId` or
+/// `weight`, reaches rule 31 and is reported in NEAT-AI's own words.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct MemeticView<'a> {
+    /// The `biases` keys, in iteration order.
+    pub(crate) biases: Vec<&'a str>,
+    /// The `weights` keys and their deltas, in iteration order.
+    pub(crate) weights: Vec<(&'a str, MemeticWeights<'a>)>,
+}
+
+/// The value stored under one `weights` key.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MemeticWeights<'a> {
+    /// The value is not an array — `Array.isArray(...)` is false.
+    NotAnArray,
+    /// The deltas, in order.
+    Entries(Vec<MemeticEntry<'a>>),
+}
+
+/// One memetic weight delta, as the rule reads it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MemeticEntry<'a> {
+    /// `toId` when it is an integer that could name a neuron.
+    pub(crate) to_id: Option<i64>,
+    /// `toId` as JavaScript prints it — `undefined` when the field is absent.
+    pub(crate) to_id_text: std::borrow::Cow<'a, str>,
+    /// Whether the entry carries a `toId` field at all.
+    pub(crate) to_id_present: bool,
+    /// Whether the entry carries a `weight` field at all.
+    pub(crate) weight_present: bool,
+}
+
+impl<'a> MemeticView<'a> {
+    /// The export form's typed record, in the neutral shape.
+    fn from_export(memetic: &'a MemeticExport) -> Self {
+        Self {
+            biases: memetic.biases.keys().map(String::as_str).collect(),
+            weights: memetic
+                .weights
+                .iter()
+                .map(|(key, entries)| {
+                    let entries = entries
+                        .iter()
+                        .map(|entry| MemeticEntry {
+                            to_id: entry.to_id,
+                            to_id_text: entry
+                                .to_id
+                                .map_or(std::borrow::Cow::Borrowed("undefined"), |id| {
+                                    std::borrow::Cow::Owned(id.to_string())
+                                }),
+                            to_id_present: entry.to_id.is_some(),
+                            weight_present: entry.weight.is_some(),
+                        })
+                        .collect();
+                    (key.as_str(), MemeticWeights::Entries(entries))
+                })
+                .collect(),
+        }
+    }
 }
 
 /// Rules 23–31 — the synapse, forward-only and memetic half of
@@ -1466,37 +1648,105 @@ pub fn validate_synapse_and_memetic_rules(
 ) -> Result<(), ValidationFailure> {
     let views = neuron_views(creature);
     let (from_indices, to_indices, synapse_types) = resolve_synapse_endpoints(creature)?;
+    let memetic = creature.memetic.as_ref().map(MemeticView::from_export);
 
-    synapse_walk(&views, &from_indices, &to_indices, options, stats)?;
+    synapse_half(
+        &views,
+        creature.input,
+        creature.output,
+        &from_indices,
+        &to_indices,
+        &synapse_types,
+        options,
+        memetic.as_ref(),
+        stats,
+    )
+}
+
+/// Rules 23–31 over already-derived views — the half
+/// [`validate_synapse_and_memetic_rules`] and [`validate_prepared`] share.
+#[allow(clippy::too_many_arguments)]
+fn synapse_half(
+    views: &[NeuronView<'_>],
+    input: usize,
+    output: usize,
+    from_indices: &[u32],
+    to_indices: &[u32],
+    synapse_types: &[SynapseType],
+    options: &ValidateOptions,
+    memetic: Option<&MemeticView<'_>>,
+    stats: &mut ValidationStats,
+) -> Result<(), ValidationFailure> {
+    synapse_walk(views, from_indices, to_indices, options, stats)?;
 
     if let Some(expected) = options.expected_connections()
-        && creature.synapses.len() != expected
+        && from_indices.len() != expected
     {
         return Err(ValidationFailure::validation(
             reason::OTHER,
             format!(
                 "Synapses length: {} expected: {expected}",
-                creature.synapses.len()
+                from_indices.len()
             ),
         ));
     }
 
     if options.forward_only {
         forward_only_rules(
-            &views,
-            &from_indices,
-            &to_indices,
-            &synapse_types,
-            creature.input,
-            creature.output,
+            views,
+            from_indices,
+            to_indices,
+            synapse_types,
+            input,
+            output,
         )?;
     }
 
-    if let Some(memetic) = creature.memetic.as_ref() {
-        memetic_rules(&views, &from_indices, &to_indices, memetic)?;
+    if let Some(memetic) = memetic {
+        memetic_rules(views, from_indices, to_indices, memetic)?;
     }
 
     Ok(())
+}
+
+/// Rules 4–31 over derived views — the seam every request shape meets at.
+///
+/// Rules 1–3 read the creature's declared widths, so each entry point checks
+/// those itself and hands the walk what it derived: the export form derives
+/// implicit input neurons and resolves UUIDs
+/// ([`creature_validate`]), while the runtime form is already indexed
+/// ([`mod@crate::creature_validate_runtime`]). Everything after that is one
+/// implementation, so the two shapes cannot drift apart.
+///
+/// # Errors
+///
+/// Returns the [`ValidationFailure`] for the first violated rule.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn validate_prepared(
+    views: &[NeuronView<'_>],
+    input: usize,
+    output: usize,
+    from_indices: &[u32],
+    to_indices: &[u32],
+    synapse_types: &[SynapseType],
+    options: &ValidateOptions,
+    memetic: Option<&MemeticView<'_>>,
+) -> Result<ValidationStats, ValidationFailure> {
+    let connections = ConnectionIndex::build(from_indices, to_indices, views.len());
+    let mut stats = walk_neurons(views, input, output, &connections, synapse_types)?;
+    synapse_half(
+        views,
+        input,
+        output,
+        from_indices,
+        to_indices,
+        synapse_types,
+        options,
+        memetic,
+        &mut stats,
+    )?;
+
+    Ok(stats)
 }
 
 #[cfg(test)]
@@ -1828,6 +2078,7 @@ mod tests {
     fn input_view(id: i64) -> NeuronView<'static> {
         NeuronView {
             id: Some(id),
+            non_integer_id: None,
             kind: NeuronKind::Input,
             declared_type: "input",
             uuid: None,
@@ -1839,6 +2090,7 @@ mod tests {
     fn output_view(id: i64) -> NeuronView<'static> {
         NeuronView {
             id: Some(id),
+            non_integer_id: None,
             kind: NeuronKind::Output,
             declared_type: "output",
             uuid: Some("out"),
@@ -2398,6 +2650,7 @@ mod synapse_half_tests {
     ) -> NeuronView<'a> {
         NeuronView {
             id: Some(id),
+            non_integer_id: None,
             kind,
             declared_type,
             uuid: Some(uuid),
@@ -2409,6 +2662,7 @@ mod synapse_half_tests {
     fn input_view() -> NeuronView<'static> {
         NeuronView {
             id: Some(0),
+            non_integer_id: None,
             kind: NeuronKind::Input,
             declared_type: "input",
             uuid: None,

--- a/neat-core/src/creature_validate_json.rs
+++ b/neat-core/src/creature_validate_json.rs
@@ -25,6 +25,23 @@
 //! `forwardonly` would otherwise validate a production creature under the
 //! wrong rules and call it healthy.
 //!
+//! ## Two creature shapes, one set of rules (NEAT-AI#3803)
+//!
+//! A request names **exactly one** creature, in one of two shapes; naming both
+//! or neither is a boundary fault:
+//!
+//! | Key | Shape | Use it when |
+//! |-----|-------|-------------|
+//! | `creature` | the export wire form: index-free, UUID-wired, input neurons implicit | the caller has a creature file |
+//! | `runtimeCreature` | [`crate::creature_validate_runtime::RuntimeCreature`]: every neuron listed, synapses wired by position | the caller holds a creature in memory |
+//!
+//! The export form cannot carry an input neuron's own id or position, a
+//! non-finite or absent bias, a non-integer id or width, or a malformed memetic
+//! record — so a host asking about one of those defects over `creature` is told
+//! its creature is healthy, or told its payload is malformed, when the rules
+//! would have named the fault. `runtimeCreature` is the shape that can carry
+//! them; both run the same rules, so the answer does not depend on the shape.
+//!
 //! The creature is deserialised with serde alone — deliberately *not* through
 //! [`crate::parse_creature_json`], whose width check would shadow rules 2 and 3
 //! and answer `InvalidInputCount` where NEAT-AI expects
@@ -70,6 +87,7 @@ use crate::creature::CreatureExport;
 use crate::creature_validate::{
     ValidateOptions, ValidationFailure, ValidationStats, creature_validate,
 };
+use crate::creature_validate_runtime::{RuntimeCreature, creature_validate_runtime};
 use crate::network::MAX_NODE_COUNT;
 
 /// Message prefix every boundary fault leads with.
@@ -114,10 +132,18 @@ impl From<RequestOptions> for ValidateOptions {
 }
 
 /// A whole request: the creature, and the options to validate it under.
+///
+/// The creature is described in **exactly one** of two shapes — `creature`,
+/// the export wire form, or `runtimeCreature`, the in-memory form a host holds
+/// (NEAT-AI#3803). Naming both, or neither, is a boundary fault: a request that
+/// cannot say which creature it means must not be answered with a verdict.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ValidateRequest {
-    creature: CreatureExport,
+    #[serde(default)]
+    creature: Option<CreatureExport>,
+    #[serde(default, rename = "runtimeCreature")]
+    runtime_creature: Option<RuntimeCreature>,
     #[serde(default)]
     options: RequestOptions,
 }
@@ -259,17 +285,34 @@ fn validate_request(request: &str) -> ValidateResponse {
         Err(error) => return ValidateResponse::malformed(error),
     };
 
-    let declared = request
-        .creature
-        .input
-        .saturating_add(request.creature.neurons.len());
-    if declared > MAX_REQUEST_NEURONS {
-        return ValidateResponse::malformed(format!(
-            "creature declares {declared} neurons, exceeding the maximum of {MAX_REQUEST_NEURONS}"
-        ));
-    }
+    let options = request.options.into();
+    let outcome = match (&request.creature, &request.runtime_creature) {
+        (Some(creature), None) => {
+            let declared = creature.input.saturating_add(creature.neurons.len());
+            if let Some(refusal) = refuse_oversized(declared) {
+                return refusal;
+            }
+            creature_validate(creature, &options)
+        }
+        (None, Some(runtime)) => {
+            if let Some(refusal) = refuse_oversized(runtime.neurons.len()) {
+                return refusal;
+            }
+            creature_validate_runtime(runtime, &options)
+        }
+        (Some(_), Some(_)) => {
+            return ValidateResponse::malformed(
+                "a request names both `creature` and `runtimeCreature`; it must name exactly one",
+            );
+        }
+        (None, None) => {
+            return ValidateResponse::malformed(
+                "a request names neither `creature` nor `runtimeCreature`; it must name exactly one",
+            );
+        }
+    };
 
-    match creature_validate(&request.creature, &request.options.into()) {
+    match outcome {
         Ok(stats) => ValidateResponse {
             ok: true,
             stats: Some(stats.into()),
@@ -281,6 +324,16 @@ fn validate_request(request: &str) -> ValidateResponse {
             failure: Some(failure.into()),
         },
     }
+}
+
+/// Refuse a creature bigger than the boundary will walk, before the per-neuron
+/// allocation a declared count of `17179869180` would abort on.
+fn refuse_oversized(declared: usize) -> Option<ValidateResponse> {
+    (declared > MAX_REQUEST_NEURONS).then(|| {
+        ValidateResponse::malformed(format!(
+            "creature declares {declared} neurons, exceeding the maximum of {MAX_REQUEST_NEURONS}"
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -316,6 +369,104 @@ mod tests {
             r#"{"ok":false,"failure":{"class":"TopologyError","reason":"INVALID_NEURON_TYPE",
 "message":"1000001) Invalid type: banana","neuronIndex":1,"synapseIndex":null,"malformed":false}}"#
                 .replace('\n', "")
+        );
+    }
+
+    #[test]
+    fn a_runtime_creature_is_validated_by_the_same_rules() {
+        let answer = creature_validate_json(
+            r#"{ "runtimeCreature": { "input": 1, "output": 1,
+                 "neurons": [ { "type": "input", "id": 0, "uuid": "input-0" },
+                              { "type": "output", "id": -1, "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" } ],
+                 "synapses": [ { "from": 0, "to": 1, "weight": 1.0 } ] } }"#,
+        );
+
+        assert_eq!(
+            answer,
+            r#"{"ok":true,"stats":{"input":1,"constant":0,"hidden":0,"output":1,"connections":1}}"#
+        );
+    }
+
+    #[test]
+    fn a_defect_the_export_form_cannot_carry_is_named_through_the_runtime_shape() {
+        // The same creature, described both ways: an input neuron whose id is
+        // not its index. The export form derives `id == index` and answers
+        // "healthy"; the runtime form carries the defect and rule 7 names it.
+        let export = creature_validate_json(
+            r#"{ "creature": { "input": 2, "output": 1,
+                 "neurons": [ { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" } ],
+                 "synapses": [ { "fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0 },
+                               { "fromUUID": "input-1", "toUUID": "output-0", "weight": 1.0 } ] } }"#,
+        );
+        assert!(export.contains(r#""ok":true"#), "{export}");
+
+        let runtime = creature_validate_json(
+            r#"{ "runtimeCreature": { "input": 2, "output": 1,
+                 "neurons": [ { "type": "input", "id": 0, "uuid": "input-0" },
+                              { "type": "input", "id": 5, "uuid": "input-1" },
+                              { "type": "output", "id": -1, "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" } ],
+                 "synapses": [ { "from": 0, "to": 2, "weight": 1.0 },
+                               { "from": 1, "to": 2, "weight": 1.0 } ] } }"#,
+        );
+        assert!(
+            runtime.contains(r#""message":"5) invalid input neuron id: 5""#),
+            "{runtime}"
+        );
+        assert!(runtime.contains(r#""malformed":false"#), "{runtime}");
+    }
+
+    #[test]
+    fn a_request_names_exactly_one_creature() {
+        let both = creature_validate_json(
+            r#"{ "creature": { "input": 1, "output": 1, "neurons": [], "synapses": [] },
+                 "runtimeCreature": { "input": 1, "output": 1, "neurons": [], "synapses": [] } }"#,
+        );
+        assert!(both.contains(MALFORMED_REQUEST), "{both}");
+        assert!(both.contains("must name exactly one"), "{both}");
+
+        let neither = creature_validate_json(r#"{ "options": { "forwardOnly": true } }"#);
+        assert!(neither.contains(MALFORMED_REQUEST), "{neither}");
+        assert!(neither.contains("must name exactly one"), "{neither}");
+    }
+
+    #[test]
+    fn an_absurd_declared_width_reaches_the_rules_rather_than_an_allocation() {
+        let neurons: Vec<String> = (0..3)
+            .map(|index| format!(r#"{{ "type": "input", "id": {index} }}"#))
+            .collect();
+        let request = format!(
+            r#"{{ "runtimeCreature": {{ "input": {}, "output": 1, "neurons": [{}], "synapses": [] }} }}"#,
+            MAX_REQUEST_NEURONS + 1,
+            neurons.join(",")
+        );
+        // The declared width is absurd but the payload is small: the walk runs
+        // over the neurons that are actually listed, so this reaches the rules
+        // and is answered as a miscount rather than as an allocation.
+        let answer = creature_validate_json(&request);
+        assert!(answer.contains(r#""ok":false"#), "{answer}");
+        assert!(answer.contains("input neurons found"), "{answer}");
+    }
+
+    #[test]
+    fn a_runtime_creature_past_the_ceiling_is_refused_before_the_rules() {
+        let neurons: Vec<String> = (0..=MAX_REQUEST_NEURONS)
+            .map(|index| format!(r#"{{"type":"input","id":{index}}}"#))
+            .collect();
+        let request = format!(
+            r#"{{ "runtimeCreature": {{ "input": 1, "output": 1, "neurons": [{}], "synapses": [] }} }}"#,
+            neurons.join(",")
+        );
+
+        let answer = creature_validate_json(&request);
+        assert!(
+            answer.contains(MALFORMED_REQUEST),
+            "{}",
+            &answer[..200.min(answer.len())]
+        );
+        assert!(
+            answer.contains("exceeding the maximum"),
+            "{}",
+            &answer[..200.min(answer.len())]
         );
     }
 

--- a/neat-core/src/creature_validate_runtime.rs
+++ b/neat-core/src/creature_validate_runtime.rs
@@ -1,0 +1,511 @@
+//! The **runtime** creature shape [`creature_validate_runtime`] validates for a host
+//! that holds a creature in memory (NEAT-AI#3803).
+//!
+//! [`mod@crate::creature_validate_json`] takes the export wire form — index-free,
+//! UUID-wired, with the input neurons implicit. That form is lossy against
+//! what NEAT-AI's `creatureValidate` actually walks, and the loss is not
+//! cosmetic: replaying NEAT-AI's own conformance corpus over the wire, eleven
+//! cases disagreed with the TypeScript, **four of them by accepting a creature
+//! TypeScript rejects**. A validator that answers "valid" for a creature the
+//! rules reject is worse than no validator at all, so the shape a host sends
+//! has to be able to carry the defect it is asking about:
+//!
+//! | What the export form cannot carry | Rules it puts out of reach |
+//! |-----------------------------------|-----------------------------|
+//! | an input neuron listed with its own id and position | 4, 7, 10, 21 |
+//! | a bias that is `undefined`, `NaN` or infinite | 8 (and 19) |
+//! | a neuron id, or a width, that is not an integer | 2, 3, 5 |
+//! | a memetic `weights` value that is not an array | 31 |
+//!
+//! # Request
+//!
+//! ```json
+//! {
+//!   "runtimeCreature": {
+//!     "input": 1,
+//!     "output": 1,
+//!     "neurons": [
+//!       { "type": "input",  "id": 0,  "uuid": "input-0" },
+//!       { "type": "hidden", "id": 5,  "uuid": "h1", "bias": 0.5, "squash": "TANH" },
+//!       { "type": "output", "id": -1, "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+//!     ],
+//!     "synapses": [
+//!       { "from": 0, "to": 1, "weight": 1.0 },
+//!       { "from": 1, "to": 2, "weight": 1.0 }
+//!     ]
+//!   },
+//!   "options": { "forwardOnly": true }
+//! }
+//! ```
+//!
+//! Every neuron is listed, inputs included, and a synapse names the **array
+//! positions** of its endpoints — the same integers the host holds — so
+//! nothing has to be derived and nothing can be derived *away*. Unknown keys
+//! on a neuron or on the creature are ignored, so a host's own extra fields
+//! (`index`, `tags`, …) travel harmlessly.
+//!
+//! ## The values JSON has no literal for
+//!
+//! `bias`, `id`, `input` and `output` accept a JSON number, and `bias`
+//! additionally accepts the string sentinels `"NaN"`, `"Infinity"` and
+//! `"-Infinity"` — the same convention NEAT-AI's conformance corpus uses. An
+//! absent or `null` field is JavaScript's `undefined`, which is how a host says
+//! "this neuron carries no bias at all" (rule 8) or "no id" (rule 4).
+//!
+//! # Response
+//!
+//! Identical to the export form's — see [`mod@crate::creature_validate_json`].
+//! Both shapes run the same rules through
+//! the shared rule seam in [`mod@crate::creature_validate`], so a creature cannot be
+//! judged differently depending on how it was described.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::creature::parse_synapse_type;
+use crate::creature_validate::{
+    MemeticEntry, MemeticWeights, NeuronKind, NeuronView, ValidateOptions, ValidationFailure,
+    ValidationStats, is_js_integer, reason, validate_declared_widths, validate_prepared,
+};
+use crate::synapse_type::SynapseType;
+
+/// A creature exactly as a host holds it: every neuron listed, synapses wired
+/// by array position.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RuntimeCreature {
+    /// Declared observation count. Any JSON number — rule 2 is what rejects a
+    /// non-integer or a value below one.
+    #[serde(default)]
+    pub input: Option<f64>,
+    /// Declared target count, read the same way by rule 3.
+    #[serde(default)]
+    pub output: Option<f64>,
+    /// Every neuron, in position order, input neurons included.
+    #[serde(default)]
+    pub neurons: Vec<RuntimeNeuron>,
+    /// Every synapse, wired by neuron position.
+    #[serde(default)]
+    pub synapses: Vec<RuntimeSynapse>,
+    /// The memetic record, read verbatim so rule 31 can report a malformed one.
+    #[serde(default)]
+    pub memetic: Option<Value>,
+}
+
+/// One neuron in the runtime shape.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RuntimeNeuron {
+    /// Declared type, verbatim — an unknown one is rule 20's to report.
+    #[serde(default, rename = "type")]
+    pub neuron_type: Option<String>,
+    /// Runtime id. Absent or `null` is `undefined` (rule 4); a non-integer
+    /// reaches rule 5.
+    #[serde(default)]
+    pub id: Option<f64>,
+    /// Wire identity, used by the diagnostic labels in the messages.
+    #[serde(default)]
+    pub uuid: Option<String>,
+    /// Bias — a number, a non-finite sentinel, or absent for `undefined`.
+    #[serde(default)]
+    pub bias: Option<Value>,
+    /// Activation function name.
+    #[serde(default)]
+    pub squash: Option<String>,
+}
+
+/// One synapse in the runtime shape, wired by neuron position.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RuntimeSynapse {
+    /// Source neuron position.
+    #[serde(default)]
+    pub from: Option<f64>,
+    /// Destination neuron position.
+    #[serde(default)]
+    pub to: Option<f64>,
+    /// Connection weight. Unread by the rules, so anything the host holds is
+    /// accepted rather than refused at the boundary.
+    #[serde(default)]
+    pub weight: Option<Value>,
+    /// `"positive"`, `"negative"` or `"condition"`.
+    #[serde(default, rename = "type")]
+    pub synapse_type: Option<String>,
+}
+
+/// Read a bias: a number, a `"NaN"` / `"Infinity"` / `"-Infinity"` sentinel, or
+/// `undefined` for anything else — including a value of the wrong type, which
+/// is no more a bias than an absent one and is rule 8's to report.
+fn bias_value(bias: Option<&Value>) -> Option<f64> {
+    match bias {
+        Some(Value::Number(number)) => number.as_f64(),
+        Some(Value::String(text)) => match text.as_str() {
+            "NaN" => Some(f64::NAN),
+            "Infinity" => Some(f64::INFINITY),
+            "-Infinity" => Some(f64::NEG_INFINITY),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Validate a creature described in the runtime shape.
+///
+/// Rules 1–3 are checked here because they read the declared widths; from the
+/// neuron walk onwards this is
+/// the shared rule seam in [`mod@crate::creature_validate`], the same code the export
+/// form runs.
+///
+/// # Errors
+///
+/// Returns the [`ValidationFailure`] for the first violated rule. A synapse
+/// naming a position no neuron occupies is `Topology` /
+/// `INVALID_SYNAPSE_REFERENCE`: the in-memory TypeScript would read `undefined`
+/// off the neuron array and throw a `TypeError`, so there is no rule to
+/// reproduce and the boundary reports it rather than indexing out of bounds.
+pub fn creature_validate_runtime(
+    creature: &RuntimeCreature,
+    options: &ValidateOptions,
+) -> Result<ValidationStats, ValidationFailure> {
+    let declared_input = creature.input.unwrap_or(f64::NAN);
+    let declared_output = creature.output.unwrap_or(f64::NAN);
+
+    validate_declared_widths(
+        creature.neurons.len(),
+        declared_input,
+        declared_output,
+        options,
+    )?;
+
+    // Rules 2 and 3 passed, so both widths are integers of at least one.
+    let input = declared_input as usize;
+    let output = declared_output as usize;
+
+    let views: Vec<NeuronView<'_>> = creature.neurons.iter().map(neuron_view).collect();
+    let (from, to, synapse_types) = resolve_endpoints(&creature.synapses, views.len())?;
+    let memetic = creature.memetic.as_ref().map(memetic_view);
+
+    validate_prepared(
+        &views,
+        input,
+        output,
+        &from,
+        &to,
+        &synapse_types,
+        options,
+        memetic.as_ref(),
+    )
+}
+
+/// The walk's view of one runtime neuron — no derivation, only reading.
+fn neuron_view(neuron: &RuntimeNeuron) -> NeuronView<'_> {
+    let declared_type = neuron.neuron_type.as_deref().unwrap_or("");
+    let integer_id = neuron.id.filter(|id| is_js_integer(*id));
+    NeuronView {
+        id: integer_id.map(|id| id as i64),
+        non_integer_id: neuron.id.filter(|id| !is_js_integer(*id)),
+        kind: NeuronKind::from_declared_runtime(declared_type),
+        declared_type,
+        uuid: neuron.uuid.as_deref(),
+        bias: bias_value(neuron.bias.as_ref()),
+        squash: neuron.squash.as_deref(),
+    }
+}
+
+/// Resolve every synapse's endpoints, refusing a position no neuron occupies.
+#[allow(clippy::type_complexity)]
+fn resolve_endpoints(
+    synapses: &[RuntimeSynapse],
+    neuron_count: usize,
+) -> Result<(Vec<u32>, Vec<u32>, Vec<SynapseType>), ValidationFailure> {
+    let mut from = Vec::with_capacity(synapses.len());
+    let mut to = Vec::with_capacity(synapses.len());
+    let mut types = Vec::with_capacity(synapses.len());
+
+    for (index, synapse) in synapses.iter().enumerate() {
+        let resolve = |endpoint: &str, position: Option<f64>| -> Result<u32, ValidationFailure> {
+            position
+                .filter(|value| {
+                    is_js_integer(*value) && *value >= 0.0 && (*value as usize) < neuron_count
+                })
+                .map(|value| value as u32)
+                .ok_or_else(|| {
+                    ValidationFailure::topology(
+                        reason::INVALID_SYNAPSE_REFERENCE,
+                        format!(
+                            "{index}) synapse {endpoint} {} does not name a neuron",
+                            position.map_or("undefined".to_string(), |value| value.to_string())
+                        ),
+                    )
+                    .at_synapse(index as u32)
+                })
+        };
+
+        from.push(resolve("from", synapse.from)?);
+        to.push(resolve("to", synapse.to)?);
+        types.push(parse_synapse_type(synapse.synapse_type.as_deref()));
+    }
+
+    Ok((from, to, types))
+}
+
+/// The memetic record as rule 31 reads it, taken verbatim from the host.
+///
+/// Nothing here refuses a malformed record: a `weights` value that is not an
+/// array, an entry that is not an object, a missing `toId` — each is a rule 31
+/// failure reported in NEAT-AI's own words, not a parse error that would tell
+/// the host nothing about its creature.
+fn memetic_view(memetic: &Value) -> crate::creature_validate::MemeticView<'_> {
+    let record: Option<&Map<String, Value>> = memetic.as_object();
+
+    let member = |name: &str| -> Vec<(&str, &Value)> {
+        record
+            .and_then(|record| record.get(name))
+            .and_then(Value::as_object)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+
+    crate::creature_validate::MemeticView {
+        biases: member("biases").into_iter().map(|(key, _)| key).collect(),
+        weights: member("weights")
+            .into_iter()
+            .map(|(key, value)| (key, weights_view(value)))
+            .collect(),
+    }
+}
+
+/// One `weights` value: the deltas it lists, or "not an array at all".
+fn weights_view(value: &Value) -> MemeticWeights<'_> {
+    let Some(entries) = value.as_array() else {
+        return MemeticWeights::NotAnArray;
+    };
+
+    MemeticWeights::Entries(
+        entries
+            .iter()
+            .map(|entry| {
+                let field = |name: &str| entry.as_object().and_then(|entry| entry.get(name));
+                let to_id = field("toId");
+                let number = to_id.and_then(Value::as_f64);
+                MemeticEntry {
+                    to_id: number.filter(|id| is_js_integer(*id)).map(|id| id as i64),
+                    to_id_text: match to_id {
+                        None | Some(Value::Null) => std::borrow::Cow::Borrowed("undefined"),
+                        Some(Value::Number(number)) => std::borrow::Cow::Owned(number.to_string()),
+                        Some(other) => std::borrow::Cow::Owned(other.to_string()),
+                    },
+                    to_id_present: !matches!(to_id, None | Some(Value::Null)),
+                    weight_present: !matches!(field("weight"), None | Some(Value::Null)),
+                }
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::creature_validate::FailureClass;
+
+    /// `input-0` → `h1` → `output-0`, every neuron listed, wired by position.
+    fn healthy() -> Value {
+        serde_json::json!({
+            "input": 1,
+            "output": 1,
+            "neurons": [
+                { "type": "input", "id": 0, "uuid": "input-0" },
+                { "type": "hidden", "id": 1000001, "uuid": "h1", "bias": 0.5, "squash": "TANH" },
+                { "type": "output", "id": -1, "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+            ],
+            "synapses": [
+                { "from": 0, "to": 1, "weight": 1.0 },
+                { "from": 1, "to": 2, "weight": 1.0 }
+            ]
+        })
+    }
+
+    /// Validate `creature`, having patched `mutate` into it first.
+    fn validate(mutate: impl FnOnce(&mut Value)) -> Result<ValidationStats, ValidationFailure> {
+        let mut creature = healthy();
+        mutate(&mut creature);
+        let creature: RuntimeCreature =
+            serde_json::from_value(creature).expect("the runtime shape parses");
+        creature_validate_runtime(&creature, &ValidateOptions::default())
+    }
+
+    #[test]
+    fn a_healthy_runtime_creature_answers_with_its_counters() {
+        let stats = validate(|_| {}).expect("the creature breaks no rule");
+        assert_eq!(
+            (
+                stats.input,
+                stats.constant,
+                stats.hidden,
+                stats.output,
+                stats.connections
+            ),
+            (1, 0, 1, 1, 2)
+        );
+    }
+
+    #[test]
+    fn an_input_neuron_whose_id_is_not_its_index_is_rule_7() {
+        // The export form derives `id == index` for its implicit inputs, so
+        // this defect is unreachable there and reachable here.
+        let failure = validate(|creature| creature["neurons"][0]["id"] = serde_json::json!(5))
+            .expect_err("an input neuron is identified by its position");
+        assert_eq!(failure.class, FailureClass::Validation);
+        assert_eq!(failure.reason, "OTHER");
+        assert_eq!(failure.message, "5) invalid input neuron id: 5");
+        assert_eq!(failure.neuron_index, Some(0));
+    }
+
+    #[test]
+    fn an_input_neuron_past_the_declared_width_is_rule_10() {
+        // An input neuron behind a computational one: the export form lists no
+        // input neurons at all, so it cannot describe this creature.
+        let failure = validate(|creature| {
+            creature["neurons"]
+                .as_array_mut()
+                .expect("neurons are a list")
+                .insert(2, serde_json::json!({ "type": "input", "id": 2 }));
+            creature["synapses"] = serde_json::json!([
+                { "from": 0, "to": 1, "weight": 1.0 },
+                { "from": 1, "to": 3, "weight": 1.0 }
+            ]);
+        })
+        .expect_err("an input neuron may not follow the declared input width");
+        assert_eq!(failure.reason, "OTHER");
+        assert_eq!(
+            failure.message,
+            "2) input neuron after the maximum input neurons"
+        );
+    }
+
+    #[test]
+    fn counted_inputs_that_miss_the_declared_width_are_rule_21() {
+        let failure = validate(|creature| creature["input"] = serde_json::json!(2))
+            .expect_err("two inputs were declared and one was listed");
+        assert_eq!(failure.reason, "OTHER");
+        assert_eq!(failure.message, "Expected 2 input neurons found: 1");
+    }
+
+    #[test]
+    fn a_missing_id_is_rule_4_and_a_non_integer_id_is_rule_5() {
+        let missing = validate(|creature| creature["neurons"][1]["id"] = Value::Null)
+            .expect_err("a neuron with no id");
+        assert_eq!(missing.message, "undefined) no id");
+
+        let fractional =
+            validate(|creature| creature["neurons"][1]["id"] = serde_json::json!(-1.5))
+                .expect_err("a neuron whose id is not an integer");
+        assert_eq!(fractional.message, "-1.5) invalid neuron id: -1.5");
+    }
+
+    #[test]
+    fn the_non_finite_bias_sentinels_reach_rule_8() {
+        for (sentinel, printed) in [
+            ("NaN", "NaN"),
+            ("Infinity", "Infinity"),
+            ("-Infinity", "-Infinity"),
+        ] {
+            let failure =
+                validate(|creature| creature["neurons"][1]["bias"] = serde_json::json!(sentinel))
+                    .expect_err("a non-finite bias is not a bias");
+            assert_eq!(failure.message, format!("1000001) invalid bias: {printed}"));
+        }
+
+        let absent = validate(|creature| {
+            creature["neurons"][1]
+                .as_object_mut()
+                .expect("a neuron is an object")
+                .remove("bias");
+        })
+        .expect_err("an absent bias is `undefined`");
+        assert_eq!(absent.message, "1000001) invalid bias: undefined");
+    }
+
+    #[test]
+    fn a_width_that_is_not_an_integer_reaches_rules_2_and_3() {
+        let input = validate(|creature| creature["input"] = serde_json::json!(1.5))
+            .expect_err("1.5 observations is not a width");
+        assert_eq!(
+            input.message,
+            "Must have at least one input neurons was: 1.5"
+        );
+
+        let output = validate(|creature| creature["output"] = serde_json::json!(2.5))
+            .expect_err("2.5 targets is not a width");
+        assert_eq!(
+            output.message,
+            "Must have at least one output neurons was: 2.5"
+        );
+    }
+
+    #[test]
+    fn a_synapse_naming_no_neuron_is_refused_rather_than_indexed() {
+        let failure = validate(|creature| creature["synapses"][1]["to"] = serde_json::json!(9))
+            .expect_err("position 9 holds no neuron");
+        assert_eq!(failure.class, FailureClass::Topology);
+        assert_eq!(failure.reason, "INVALID_SYNAPSE_REFERENCE");
+        assert_eq!(failure.message, "1) synapse to 9 does not name a neuron");
+        assert_eq!(failure.synapse_index, Some(1));
+    }
+
+    #[test]
+    fn memetic_weights_that_are_not_an_array_are_rule_31() {
+        let failure = validate(|creature| {
+            creature["memetic"] = serde_json::json!({
+                "biases": {},
+                "weights": { "0": { "toId": 1000001, "weight": 0.5 } }
+            });
+        })
+        .expect_err("a weights entry is a list of deltas or it is nothing");
+        assert_eq!(failure.reason, "MEMETIC");
+        assert_eq!(failure.message, "Synapse with id 0 has invalid weights.");
+    }
+
+    #[test]
+    fn a_memetic_entry_missing_its_fields_is_reported_not_refused() {
+        let missing_to_id = validate(|creature| {
+            creature["memetic"] = serde_json::json!({ "weights": { "0": [{ "weight": 0.5 }] } });
+        })
+        .expect_err("a delta names the neuron it feeds");
+        assert_eq!(
+            missing_to_id.message,
+            "Memetic from id 0 to id undefined is invalid."
+        );
+
+        let missing_weight = validate(|creature| {
+            creature["memetic"] = serde_json::json!({ "weights": { "0": [{ "toId": 1000001 }] } });
+        })
+        .expect_err("a delta carries a weight");
+        assert_eq!(
+            missing_weight.message,
+            "Memetic from id 0 to id 1000001 has invalid weight at index 0."
+        );
+    }
+
+    #[test]
+    fn a_neuron_declaring_an_unknown_type_is_rule_20() {
+        let failure =
+            validate(|creature| creature["neurons"][1]["type"] = serde_json::json!("banana"))
+                .expect_err("a creature has four kinds of neuron");
+        assert_eq!(failure.class, FailureClass::Topology);
+        assert_eq!(failure.reason, "INVALID_NEURON_TYPE");
+        assert_eq!(failure.message, "1000001) Invalid type: banana");
+    }
+
+    #[test]
+    fn a_host_key_the_rules_do_not_read_is_ignored() {
+        let stats = validate(|creature| {
+            creature["neurons"][1]["index"] = serde_json::json!(1);
+            creature["neurons"][1]["tags"] = serde_json::json!([{ "name": "grafted" }]);
+        })
+        .expect("a host may carry fields of its own");
+        assert_eq!(stats.hidden, 1);
+    }
+}

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod batch_scoring;
 pub mod creature;
 pub mod creature_validate;
 pub mod creature_validate_json;
+pub mod creature_validate_runtime;
 pub mod decision_tree;
 pub mod derivative;
 pub mod elastic_distribution;
@@ -75,6 +76,10 @@ pub use creature_validate::{
 pub use creature_validate_json::{
     MALFORMED_REQUEST, MAX_REQUEST_NEURONS, ValidateResponse, ValidationFailureJson,
     ValidationStatsJson, creature_validate_json,
+};
+// NEAT-AI#3803 — the runtime creature shape a host holds in memory.
+pub use creature_validate_runtime::{
+    RuntimeCreature, RuntimeNeuron, RuntimeSynapse, creature_validate_runtime,
 };
 // Issue #555 — canonical IF decision-tree fixtures and the graft helper.
 pub use decision_tree::{

--- a/neat-core/src/wasm_exports.rs
+++ b/neat-core/src/wasm_exports.rs
@@ -178,6 +178,9 @@ pub fn wasm_scan_max_bias(
 //
 //   In:  { "creature": <CreatureExport>, "options"?: { neurons?, connections?,
 //         feedbackLoop?, forwardOnly? } }
+//        { "runtimeCreature": <RuntimeCreature>, "options"?: ... } — the
+//        in-memory shape a host holds (NEAT-AI#3803); a request names exactly
+//        one of the two creature keys
 //   Out: { "ok": true,  "stats": { input, constant, hidden, output, connections } }
 //        { "ok": false, "failure": { class, reason, message, neuronIndex,
 //                                    synapseIndex, malformed } }

--- a/neat-core/tests/creature_validate_runtime_conformance.rs
+++ b/neat-core/tests/creature_validate_runtime_conformance.rs
@@ -1,0 +1,192 @@
+//! Replays NEAT-AI's `creatureValidate` conformance corpus through the
+//! **runtime** request shape (NEAT-AI#3803).
+//!
+//! `creature_validate_conformance.rs` replays the same corpus through the
+//! export form, where ten cases describe something the wire shape cannot carry
+//! and are declared as divergences. That is the gap this shape closes: the
+//! corpus creatures *are* the runtime shape, so a case is handed to the
+//! validator as written — no implicit inputs, no derived ids, no widening of a
+//! non-finite bias into "absent".
+//!
+//! Only one case cannot be answered here, and it is not a rule at all:
+//! `neuron-index-mismatch` reads `neuron.index`, an in-memory cache that stays
+//! host-side (NEAT-AI#3802). Every other case must match exactly — class,
+//! `reason`, message text and, for a creature that passes, all five counters.
+//! A case that stops matching fails here by name.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use neat_core::{ValidateResponse, creature_validate_json};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Where the vendored corpus lives.
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/creature_validate")
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusFile {
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    name: String,
+    creature: Value,
+    #[serde(default)]
+    options: Option<Value>,
+    expect: Expect,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Expect {
+    outcome: String,
+    error: Option<String>,
+    reason: Option<String>,
+    message_contains: Option<String>,
+    stats: Option<Value>,
+}
+
+/// The one case this shape cannot answer: `neuron.index` is a host-side cache,
+/// not a rule (NEAT-AI#3802), so no creature description can carry it.
+const HOST_ONLY_CASES: [&str; 1] = ["neuron-index-mismatch"];
+
+fn load_corpus() -> Vec<Case> {
+    let mut files: Vec<PathBuf> = fs::read_dir(fixture_dir())
+        .expect("the vendored corpus directory must exist")
+        .map(|entry| entry.expect("readable directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .filter(|path| path.file_name().is_some_and(|name| name != "coverage.json"))
+        .collect();
+    files.sort();
+    assert!(!files.is_empty(), "the corpus must not be empty");
+
+    let mut cases = Vec::new();
+    for path in files {
+        let text = fs::read_to_string(&path).expect("readable corpus file");
+        let file: CorpusFile = serde_json::from_str(&text)
+            .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+        cases.extend(file.cases);
+    }
+    cases
+}
+
+/// Ask the boundary about one case, exactly as a host would.
+fn answer(case: &Case) -> ValidateResponse {
+    let request = match &case.options {
+        Some(options) => json!({ "runtimeCreature": case.creature, "options": options }),
+        None => json!({ "runtimeCreature": case.creature }),
+    };
+    let text = creature_validate_json(&request.to_string());
+    serde_json::from_str(&text).unwrap_or_else(|error| panic!("unreadable response: {error}"))
+}
+
+#[test]
+fn every_corpus_case_matches_through_the_runtime_shape() {
+    let mut replayed = 0usize;
+    for case in load_corpus() {
+        if HOST_ONLY_CASES.contains(&case.name.as_str()) {
+            continue;
+        }
+        replayed += 1;
+        let response = answer(&case);
+
+        if case.expect.outcome == "ok" {
+            assert!(
+                response.ok,
+                "{}: expected the creature to pass, got {:?}",
+                case.name, response.failure
+            );
+            let stats = serde_json::to_value(response.stats.expect("a passing case carries stats"))
+                .expect("stats serialise");
+            assert_eq!(
+                stats,
+                *case
+                    .expect
+                    .stats
+                    .as_ref()
+                    .expect("an ok case declares stats"),
+                "{}: counters differ",
+                case.name
+            );
+            continue;
+        }
+
+        let failure = response
+            .failure
+            .unwrap_or_else(|| panic!("{}: expected a failure, the creature passed", case.name));
+        assert!(
+            !failure.malformed,
+            "{}: the payload never reached a rule — {}",
+            case.name, failure.message
+        );
+        assert_eq!(
+            failure.class,
+            *case
+                .expect
+                .error
+                .as_ref()
+                .expect("a throwing case declares a class"),
+            "{}: error class differs (message: {})",
+            case.name,
+            failure.message
+        );
+        assert_eq!(
+            failure.reason,
+            *case
+                .expect
+                .reason
+                .as_ref()
+                .expect("a throwing case declares a reason"),
+            "{}: reason differs (message: {})",
+            case.name,
+            failure.message
+        );
+        let expected_text = case
+            .expect
+            .message_contains
+            .as_ref()
+            .expect("a throwing case declares its message");
+        assert!(
+            failure.message.contains(expected_text),
+            "{}: message {:?} does not contain {:?}",
+            case.name,
+            failure.message,
+            expected_text
+        );
+    }
+
+    assert!(
+        replayed >= 40,
+        "only {replayed} cases replayed — the corpus should not have shrunk"
+    );
+}
+
+#[test]
+fn the_host_only_declarations_are_still_host_only() {
+    let corpus = load_corpus();
+    let names: BTreeSet<&str> = corpus.iter().map(|case| case.name.as_str()).collect();
+
+    for declared in HOST_ONLY_CASES {
+        assert!(
+            names.contains(declared),
+            "{declared} is declared host-only but no longer exists in the corpus"
+        );
+        let case = corpus
+            .iter()
+            .find(|case| case.name == declared)
+            .expect("the declared case exists");
+        // A stale declaration must fail loudly: if this shape *can* answer the
+        // case, it belongs in the replay above rather than in the exemption.
+        let response = answer(case);
+        assert!(
+            response.ok,
+            "{declared} is declared host-only, but the rules now report it: {:?}",
+            response.failure
+        );
+    }
+}


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/NEAT-AI#3803 here, in the dependency's own repo.

The export-only JSON request cannot describe an in-memory creature: 11 of 55 NEAT-AI corpus cases diverged, four by accepting a creature TypeScript rejects. Adds a runtimeCreature request shape sharing one rule seam; 54 of 55 cases now replay exactly.

**Head:** `issue-3803-runtime-shape-validate-request` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/NEAT-AI#3803: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.