### PR TITLE
if_graft: emit creatures the shared validator accepts (Issue #555 / #562)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.11"
+version = "0.9.12"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/neat-core/src/decision_tree.rs
+++ b/neat-core/src/decision_tree.rs
@@ -191,6 +191,17 @@ fn edge(from: &str, to: &str, weight: f64, role: SynapseType) -> SynapseExport {
     }
 }
 
+/// Leave a fixture's synapse list in the canonical `(from, to)` order
+/// [`crate::creature_validate()`] rule 25 requires.
+///
+/// Each fixture is declared node by node so it reads as the tree it describes;
+/// that grouping is not the wire order, so the assembled creature is put
+/// through the same sort [`crate::if_graft`] applies to a grafted one.
+fn canonical(mut creature: CreatureExport) -> CreatureExport {
+    crate::if_graft::sort_synapses_canonically(&mut creature);
+    creature
+}
+
 /// The three shared `1.0` constants every fixture tree stands on.
 fn shared_constants() -> Vec<NeuronExport> {
     vec![
@@ -225,7 +236,7 @@ pub fn stump_creature() -> CreatureExport {
     let mut neurons = shared_constants();
     neurons.push(if_neuron("output-0", "output"));
 
-    CreatureExport {
+    canonical(CreatureExport {
         memetic: None,
         input: 1,
         output: 1,
@@ -239,7 +250,7 @@ pub fn stump_creature() -> CreatureExport {
         ),
         semantic_version: None,
         forward_only: true,
-    }
+    })
 }
 
 /// Depth-2 binary decision tree over two observations.
@@ -273,7 +284,7 @@ pub fn depth2_tree_creature() -> CreatureExport {
     synapses.push(edge("high", "output-0", 1.0, SynapseType::Positive));
     synapses.push(edge("low", "output-0", 1.0, SynapseType::Negative));
 
-    CreatureExport {
+    canonical(CreatureExport {
         memetic: None,
         input: 2,
         output: 1,
@@ -281,7 +292,7 @@ pub fn depth2_tree_creature() -> CreatureExport {
         synapses,
         semantic_version: None,
         forward_only: true,
-    }
+    })
 }
 
 /// Purely linear creature — `output-0 = 2 * input-0`, no `IF` node at all.
@@ -366,7 +377,7 @@ pub fn residual_correction_creature() -> CreatureExport {
         },
     ];
 
-    CreatureExport {
+    canonical(CreatureExport {
         memetic: None,
         input: 1,
         output: 1,
@@ -374,5 +385,5 @@ pub fn residual_correction_creature() -> CreatureExport {
         synapses,
         semantic_version: None,
         forward_only: true,
-    }
+    })
 }

--- a/neat-core/src/if_graft.rs
+++ b/neat-core/src/if_graft.rs
@@ -16,6 +16,11 @@
 //! source creature is never mutated — a graft either returns a new, validated
 //! [`CreatureExport`] or it returns an error.
 //!
+//! What comes back is a creature the shared validator accepts, not merely one
+//! that compiles: the constants a graft introduces are listed ahead of every
+//! hidden neuron and the whole synapse list is left in canonical
+//! `(from, to)` order, which are [`crate::creature_validate()`] rules 11 and 25.
+//!
 //! ```mermaid
 //! flowchart LR
 //!     A["IfNodeSpec"] --> B{"names new?<br/>roles present?<br/>edges resolve?"}
@@ -110,8 +115,9 @@ pub struct IfNodeSpec {
     pub uuid: String,
     /// Bias added to whichever branch the condition selects.
     pub bias: f64,
-    /// Constant neurons introduced by this graft, placed immediately before the
-    /// node so its own edges may reference them.
+    /// Constant neurons introduced by this graft, listed ahead of every hidden
+    /// neuron — where `creature_validate` rule 11 requires them — so the node's
+    /// own edges may reference them.
     pub constants: Vec<ConstantSpec>,
     /// Inbound edges summed to decide the branch (`> 0` selects positive).
     pub condition: Vec<GraftEdge>,
@@ -471,8 +477,11 @@ pub fn validate_creature_topology(creature: &CreatureExport) -> Result<(), Graft
 /// Returns a **new** creature; the input is never modified. Placement is chosen
 /// so the node is evaluated after every source and before every target, which
 /// preserves the `forwardOnly` reading order the compiled forward pass relies
-/// on. The result is put through [`validate_creature_topology`] before it is
-/// returned, so a malformed creature is never emitted.
+/// on; any constants the spec declares are listed ahead of every hidden neuron,
+/// and the synapse list comes back in canonical `(from, to)` order, so the
+/// result satisfies [`crate::creature_validate()`] as well. The creature is put
+/// through [`validate_creature_topology`] before it is returned, so a malformed
+/// creature is never emitted.
 ///
 /// # Errors
 ///
@@ -623,12 +632,26 @@ pub fn graft_if_node(
     }
 }
 
-/// Assemble the grafted creature: constants then the node at `position`, with
-/// the branch synapses (condition, positive, negative) and outward edges
-/// appended in that order.
+/// Assemble the grafted creature: the constants ahead of every hidden neuron,
+/// the node at `position`, and the whole synapse list left in canonical
+/// `(from, to)` order.
+///
+/// Both placements are what [`crate::creature_validate()`] requires of a valid
+/// creature — neurons listed `input, constant, hidden, output` (rule 11) and
+/// synapses sorted ascending by resolved index (rule 25) — so a grafted
+/// creature satisfies the shared validator, not merely the compiler.
 fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) -> CreatureExport {
+    // A constant may never follow a hidden neuron, so the constants go in front
+    // of the first non-constant rather than beside the node, which can legally
+    // sit after several hidden neurons.
+    let constants_at = creature
+        .neurons
+        .iter()
+        .position(|n| n.neuron_type != "constant")
+        .unwrap_or(creature.neurons.len())
+        .min(position);
     let mut neurons = Vec::with_capacity(creature.neurons.len() + spec.constants.len() + 1);
-    neurons.extend_from_slice(&creature.neurons[..position]);
+    neurons.extend_from_slice(&creature.neurons[..constants_at]);
     for constant in &spec.constants {
         neurons.push(NeuronExport {
             id: None,
@@ -638,6 +661,7 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
             squash: None,
         });
     }
+    neurons.extend_from_slice(&creature.neurons[constants_at..position]);
     neurons.push(NeuronExport {
         id: None,
         neuron_type: "hidden".to_string(),
@@ -674,7 +698,7 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
         });
     }
 
-    CreatureExport {
+    let mut grafted = CreatureExport {
         memetic: None,
         input: creature.input,
         output: creature.output,
@@ -682,7 +706,27 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
         synapses,
         semantic_version: creature.semantic_version.clone(),
         forward_only: creature.forward_only,
-    }
+    };
+    sort_synapses_canonically(&mut grafted);
+    grafted
+}
+
+/// Leave a creature's synapse list in canonical wire order — ascending by
+/// `(from index, to index)`, the order [`crate::creature_validate()`] rule 25
+/// requires.
+///
+/// Appending a graft's synapses to the base creature's list leaves them out of
+/// order, so the assembled creature is re-sorted rather than emitted piecemeal.
+/// An endpoint naming no neuron sorts last (`u32::MAX`) instead of being
+/// dropped, so the validator still reports it rather than the graft quietly
+/// reordering a broken creature. The sort is stable, so synapses sharing a pair
+/// keep their relative order and remain reportable as duplicates.
+pub(crate) fn sort_synapses_canonically(creature: &mut CreatureExport) {
+    let map = index_map(creature);
+    let resolve = |uuid: &str| -> usize { map.get(uuid).copied().unwrap_or(usize::MAX) };
+    creature
+        .synapses
+        .sort_by_key(|s| (resolve(&s.from_uuid), resolve(&s.to_uuid)));
 }
 
 /// Graft a sequence of `IF` nodes, each able to reference the ones before it.

--- a/neat-core/tests/decision_tree_fixture.rs
+++ b/neat-core/tests/decision_tree_fixture.rs
@@ -13,8 +13,8 @@ use neat_core::decision_tree::{
     depth2_tree_creature, linear_base_creature, residual_correction_creature, stump_creature,
 };
 use neat_core::{
-    CreatureExport, SynapseType, compile_creature, creature_to_json, mse_sum_batch_packed,
-    parse_creature_json,
+    CreatureExport, SynapseType, ValidateOptions, compile_creature, creature_to_json,
+    creature_validate, mse_sum_batch_packed, parse_creature_json,
 };
 
 /// f32 tolerance for a handful of adds — the fixtures are exact in f32, but the
@@ -293,4 +293,30 @@ fn stripping_synapse_roles_changes_the_branch_output() {
         (intact - broken).abs() > TOL,
         "dropping synapse roles must change the output ({intact} vs {broken})"
     );
+}
+
+/// Every canonical fixture is a **valid** creature by the shared definition
+/// (Issue #562), not merely one that compiles: a consumer that gates its own
+/// output on `creature_validate` must be able to start from one of these.
+#[test]
+fn every_canonical_fixture_satisfies_creature_validate() {
+    for (what, creature) in [
+        ("stump", stump_creature()),
+        ("depth-2 tree", depth2_tree_creature()),
+        ("linear base", linear_base_creature()),
+        ("residual correction", residual_correction_creature()),
+    ] {
+        let options = ValidateOptions {
+            neurons: None,
+            connections: None,
+            feedback_loop: None,
+            forward_only: creature.forward_only,
+        };
+        if let Err(failure) = creature_validate(&creature, &options) {
+            panic!(
+                "the {what} fixture is not a valid creature: {} ({}): {}",
+                failure.class, failure.reason, failure.message
+            );
+        }
+    }
 }

--- a/neat-core/tests/if_graft.rs
+++ b/neat-core/tests/if_graft.rs
@@ -15,7 +15,10 @@ use neat_core::topology_ops::{
     BACKWARD_CONNECTION, DUPLICATE_CONNECTION, STRUCTURAL_HIDDEN_NO_OUTWARD,
     STRUCTURAL_IF_MISSING_CONDITION, STRUCTURAL_SYNAPSE_TARGETS_INPUT,
 };
-use neat_core::{CreatureExport, NeuronExport, SynapseExport, SynapseType, compile_creature};
+use neat_core::{
+    CreatureExport, NeuronExport, SynapseExport, SynapseType, ValidateOptions, compile_creature,
+    creature_validate,
+};
 
 const TOL: f32 = 1e-6;
 
@@ -544,4 +547,123 @@ fn gate_rejects_a_widthless_creature() {
     creature.input = 0;
     let err = validate_creature_topology(&creature).expect_err("rejected");
     assert!(matches!(err, GraftError::Creature(_)));
+}
+
+// ---------------------------------------------------------------------------
+// The shared definition of a valid creature (Issue #562) — what the helper
+// hands a consumer has to satisfy `creature_validate`, not merely compile.
+// ---------------------------------------------------------------------------
+
+/// The options a consumer gates a grafted creature with: counts change by
+/// construction, and the creature's own `forwardOnly` decides the ordering
+/// rules.
+fn validate_options(creature: &CreatureExport) -> ValidateOptions {
+    ValidateOptions {
+        neurons: None,
+        connections: None,
+        feedback_loop: None,
+        forward_only: creature.forward_only,
+    }
+}
+
+fn assert_valid(creature: &CreatureExport, what: &str) {
+    if let Err(failure) = creature_validate(creature, &validate_options(creature)) {
+        panic!(
+            "{what} is not a valid creature: {} ({}): {}",
+            failure.class, failure.reason, failure.message
+        );
+    }
+}
+
+#[test]
+fn every_grafted_creature_satisfies_creature_validate() {
+    assert_valid(
+        &graft_if_node(&base_creature(), &valid_spec()).expect("graft succeeds"),
+        "a single grafted node",
+    );
+
+    let second = IfNodeSpec::new("if-2", 0.0)
+        .with_constant("if-2-one", 1.0)
+        .with_constant("if-2-pos", 1.0)
+        .with_constant("if-2-neg", 1.0)
+        .with_condition("if-1", 1.0)
+        .with_condition("if-2-one", -1.0)
+        .with_positive("if-2-pos", 5.0)
+        .with_negative("if-2-neg", 0.0)
+        .with_target("output-0", 1.0);
+    assert_valid(
+        &graft_if_tree(&base_creature(), &[valid_spec(), second]).expect("tree graft succeeds"),
+        "a grafted tree",
+    );
+
+    let spec = IfCorrectionSpec {
+        uuid: "residual-0".to_string(),
+        feature_uuid: "input-0".to_string(),
+        threshold: RESIDUAL_THRESHOLD,
+        positive_value: RESIDUAL_VALUE,
+        negative_value: 0.0,
+        target_uuid: "output-0".to_string(),
+        target_weight: 1.0,
+    };
+    assert_valid(
+        &graft_if_correction(&linear_base_creature(), &spec).expect("graft succeeds"),
+        "a grafted depth-1 correction",
+    );
+}
+
+#[test]
+fn a_graft_off_a_hidden_source_keeps_its_constants_ahead_of_every_hidden_neuron() {
+    // The node's condition reads `hidden-1`, so the node itself must follow it —
+    // but a constant may never follow a hidden neuron (rule 11), so the three
+    // constants this graft introduces still belong at the front.
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_constant("if-1-one", 1.0)
+        .with_constant("if-1-pos", 1.0)
+        .with_constant("if-1-neg", 1.0)
+        .with_condition("hidden-1", 1.0)
+        .with_condition("if-1-one", -0.1)
+        .with_positive("if-1-pos", 1.0)
+        .with_negative("if-1-neg", 0.0)
+        .with_target("output-0", 1.0);
+    let grafted = graft_if_node(&base_creature(), &spec).expect("graft succeeds");
+    assert_valid(&grafted, "a graft whose condition reads a hidden neuron");
+
+    let order: Vec<&str> = grafted.neurons.iter().map(|n| n.uuid.as_str()).collect();
+    let pos = |u: &str| order.iter().position(|o| *o == u).expect("neuron present");
+    for c in ["if-1-one", "if-1-pos", "if-1-neg"] {
+        assert!(
+            pos(c) < pos("hidden-1"),
+            "constant {c} after a hidden neuron: {order:?}"
+        );
+    }
+    assert!(pos("hidden-1") < pos("if-1"), "order was {order:?}");
+}
+
+#[test]
+fn grafted_synapses_are_in_canonical_from_to_order() {
+    let grafted = graft_if_node(&base_creature(), &valid_spec()).expect("graft succeeds");
+    let index: std::collections::HashMap<&str, usize> = grafted
+        .neurons
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.uuid.as_str(), grafted.input + i))
+        .collect();
+    let resolve = |uuid: &str| -> usize {
+        index.get(uuid).copied().unwrap_or_else(|| {
+            uuid.strip_prefix("input-")
+                .and_then(|n| n.parse::<usize>().ok())
+                .expect("every endpoint resolves")
+        })
+    };
+    let keys: Vec<(usize, usize)> = grafted
+        .synapses
+        .iter()
+        .map(|s| (resolve(&s.from_uuid), resolve(&s.to_uuid)))
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        keys, sorted,
+        "synapses are not in canonical (from, to) order"
+    );
 }


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/NEAT-AI-Forests#42 here, in the dependency's own repo.

The canonical IF graft helpers returned creatures that creature_validate rejects — unsorted synapses (rule 25) and constants after hidden neurons (rule 11) — so no consumer gating on the shared validator could use their output.

**Head:** `issue-42-if-graft-emits-validator-clean-creatures` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/NEAT-AI-Forests#42: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.