### PR TITLE
creature: parse and validate memetic.weights in both valid wire forms (GRQ#4257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.9.11"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.9.11"
+version = "0.10.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Two details a caller can trip over:
   its neuron by runtime **id** or by wire **UUID** (see below), never by array
   index, so a creature whose ids differ from its positions still resolves.
 
-##### Both memetic weight forms (GRQ #4257)
+##### Both memetic weight forms
 
 `memetic.weights` is written by NEAT-AI in **two** shapes, and neither is
 legacy:
@@ -683,9 +683,10 @@ runtime id. `biases` keys are read in both vocabularies for the same reason. A
 reference that resolves in neither is still `Validation` / `MEMETIC`: accepting
 both forms never accepts a neuron that does not exist.
 
-Modelling only the map cost the fleet a whole Backprop stage — the GRQ-10
-sampler fittest creature carries the row form, and `neat_ai_backpropagation`
-exited 1 with `Creature JSON error: invalid type: sequence, expected a map`.
+Modelling only the map caused a production failure where a sampler creature
+carrying the row form could not parse, exiting with `Creature JSON error:
+invalid type: sequence, expected a map`. Supporting both forms resolved the
+issue.
 
 ```mermaid
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -660,10 +660,32 @@ Two details a caller can trip over:
 - **`feedback_loop` is a tri-state.** `None` and `Some(true)` both allow a
   recursive synapse; only `Some(false)` rejects one, and `forward_only: true`
   forces that `Some(false)` whatever the caller asked for.
-- **Memetic entries match on neuron id, not index.** The synapse set is built
-  from `neurons[s.from].id -> neurons[s.to].id` using the same derived ids as
-  the neuron half, so a creature whose ids differ from its positions still
-  resolves.
+- **Memetic entries match on neuron identity, not position.** A reference names
+  its neuron by runtime **id** or by wire **UUID** (see below), never by array
+  index, so a creature whose ids differ from its positions still resolves.
+
+##### Both memetic weight forms (GRQ #4257)
+
+`memetic.weights` is written by NEAT-AI in **two** shapes, and neither is
+legacy:
+
+| Form | Shape | Written by |
+|------|-------|------------|
+| `MemeticWeights::Rows` | `[{ "fromUUID": …, "toUUID": …, "weight": … }, …]` | `MemeticWireExport.ts` — any JSON that leaves the process |
+| `MemeticWeights::ById` | `{ "<fromId>": [{ "toId": …, "weight": … }, …] }` | the in-memory `MemeticWeightsInterface` `creatureValidate` sees host-side |
+
+`MemeticWeights` is the single home of that either/or: it dispatches on the
+JSON shape (so a value that is neither names both shapes it could have been),
+and serialises back in **whichever form was read**, keeping the byte-identical
+round trip. Rule 31 resolves the rows by wire UUID — `input-N`, `output-N`, or
+the stable `uuid`, the same vocabulary the synapses use — and the map by
+runtime id. `biases` keys are read in both vocabularies for the same reason. A
+reference that resolves in neither is still `Validation` / `MEMETIC`: accepting
+both forms never accepts a neuron that does not exist.
+
+Modelling only the map cost the fleet a whole Backprop stage — the GRQ-10
+sampler fittest creature carries the row form, and `neat_ai_backpropagation`
+exited 1 with `Creature JSON error: invalid type: sequence, expected a map`.
 
 ```mermaid
 flowchart LR

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,6 +135,42 @@ Each major-equivalent bump is recorded here so downstream consumers can see what
 changed without diffing the API. The generated `v<version>` GitHub release notes
 point back at this file.
 
+### `0.10.0` — `MemeticExport::weights` is a two-form enum (GRQ#4257)
+
+`MemeticExport::weights` changes type from
+`BTreeMap<String, Vec<MemeticWeightExport>>` to the new `MemeticWeights` enum.
+NEAT-AI writes `memetic.weights` two ways and **both are current**: a
+UUID-keyed array of `{fromUUID, toUUID, weight}` rows
+(`src/creature/MemeticWireExport.ts`, the form every creature that leaves a
+NEAT-AI process carries) and the id-keyed map
+(`{"<fromId>": [{toId, weight}, …]}`). Modelling only the map made every
+sampler creature carrying the row form fail to parse — `invalid type: sequence,
+expected a map` — which exited the GRQ Backprop stage 1.
+
+The enum is deliberately not flattened into one canonical shape: a creature is
+written back out in the form it was read, so this crate never rewrites one
+valid form into the other. `MemeticExport::biases` keys and the map form's keys
+now also resolve as wire UUIDs, not just as id text.
+
+**Migration** — reach the map through `by_id()` (or match, and handle rows):
+
+```rust
+// Before (0.9.x)
+let entries = memetic.weights.get("0");
+
+// After (0.10.0) — `None` when the creature carried the row form
+let entries = memetic.weights.by_id().and_then(|by_id| by_id.get("0"));
+
+// or handle both forms explicitly
+match &memetic.weights {
+    MemeticWeights::Rows(rows) => { /* {fromUUID, toUUID, weight} */ }
+    MemeticWeights::ById(by_id) => { /* {"<fromId>": [{toId, weight}]} */ }
+}
+```
+
+`MemeticWeightExport` is unchanged; the row form has its own
+`MemeticWeightRowExport`.
+
 ### `0.8.0` — `get_training_state_num_neurons` / `get_training_state_num_synapses` removed (Issue #424)
 
 The public `neat_core::get_training_state_num_neurons` and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,7 +135,7 @@ Each major-equivalent bump is recorded here so downstream consumers can see what
 changed without diffing the API. The generated `v<version>` GitHub release notes
 point back at this file.
 
-### `0.10.0` — `MemeticExport::weights` is a two-form enum (GRQ#4257)
+### `0.10.0` — `MemeticExport::weights` is a two-form enum
 
 `MemeticExport::weights` changes type from
 `BTreeMap<String, Vec<MemeticWeightExport>>` to the new `MemeticWeights` enum.
@@ -143,9 +143,9 @@ NEAT-AI writes `memetic.weights` two ways and **both are current**: a
 UUID-keyed array of `{fromUUID, toUUID, weight}` rows
 (`src/creature/MemeticWireExport.ts`, the form every creature that leaves a
 NEAT-AI process carries) and the id-keyed map
-(`{"<fromId>": [{toId, weight}, …]}`). Modelling only the map made every
-sampler creature carrying the row form fail to parse — `invalid type: sequence,
-expected a map` — which exited the GRQ Backprop stage 1.
+(`{"<fromId>": [{toId, weight}, …]}`). Modelling only the map caused
+production creatures carrying the row form to fail parsing with
+`invalid type: sequence, expected a map`, which exited a production backpropagation stage.
 
 The enum is deliberately not flattened into one canonical shape: a creature is
 written back out in the form it was read, so this crate never rewrites one
@@ -170,6 +170,41 @@ match &memetic.weights {
 
 `MemeticWeightExport` is unchanged; the row form has its own
 `MemeticWeightRowExport`.
+
+### `0.9.0` — struct-of-arrays hot synapse fields (Issue #533)
+
+`CompiledNetwork` gains two public fields — `hot_weights: Vec<f32>` and
+`hot_from: Vec<u16>` — a parallel struct-of-arrays view built by `hot_synapse_soa`
+at every construction path. The interleaved gather kernels
+(`weighted_sum_interleaved` / `weighted_sum_interleaved_8`) now take those two
+slices instead of `&[SynapseData]`.
+
+**Migration** — callers constructing `CompiledNetwork` literals must supply
+the two fields; `hot_synapse_soa` is exported for that:
+
+```rust
+// Before (0.8.x)
+let net = CompiledNetwork {
+    synapses: vec![...],
+    neurons: vec![...],
+    // ...
+};
+
+// After (0.9.0)
+let net = CompiledNetwork {
+    synapses: vec![...],
+    neurons: vec![...],
+    hot_weights: hot_synapse_soa(&synapses).0,
+    hot_from: hot_synapse_soa(&synapses).1,
+    // ...
+};
+```
+
+The fields are public and must stay in sync with `synapses`; `debug_assert_hot_soa`
+runs at every interleaved entry point and panics in debug builds if they drift.
+Consumers only using the aggregated and single-record paths are unaffected — those
+paths still take the full `SynapseData` and the struct-of-arrays view never
+changes their results, only the bandwidth to the interleaved hot path.
 
 ### `0.8.0` — `get_training_state_num_neurons` / `get_training_state_num_synapses` removed (Issue #424)
 

--- a/docs/archive/pr-summaries/pr-summary-grq-4257.md
+++ b/docs/archive/pr-summaries/pr-summary-grq-4257.md
@@ -39,6 +39,11 @@ a serde error, which is the divergence
 `creature_validate_conformance.rs` declares for `memetic-weights-not-an-array`;
 and a creature that still cannot be parsed still fails the caller's stage.
 
+The `weights` field changes type, so this is **breaking** under `RELEASING.md`:
+the commit carries the `feat(creature)!:` marker and the breaking-change log
+records the `0.10.0` migration, which is what keeps `version-gate` from shipping
+it on a patch bump.
+
 ```mermaid
 flowchart LR
     J["memetic.weights JSON"] --> D{"shape?"}
@@ -55,26 +60,26 @@ flowchart LR
 
 Backend/library change — no web interface to screenshot.
 
-**The reported failure, reproduced and fixed.** A scratch binary against this
-crate's `parse_creature_json` + `creature_validate`, over the real GRQ-sampler
-creatures (deleted after the run):
+**The reported failure, reproduced and fixed.** A scratch test against this
+crate's `parse_creature_json` + `creature_validate`, over the real
+`GRQ-sampler/samples/GRQ-10-1.json` at the sampler tip — the creature named in
+GRQ#4257 — deleted after the run:
 
 ```
-# before
-FAIL GRQ-sampler/samples/GRQ-10-sloth.json  Creature JSON error: invalid type: sequence, expected a map at line 143217 column 13
-FAIL GRQ-sampler/samples/Enceladus.json     Creature JSON error: invalid type: sequence, expected a map at line 66484 column 13
+# before (this branch's merge base, Develop @ 4db5b9b)
+BASELINE ERROR: Creature JSON error: invalid type: sequence, expected a map at line 139268 column 13
 
 # after
-OK GRQ-10-sloth.json  weights=rows  valid (connections=24092)
-OK Enceladus.json     weights=rows  valid (connections=13266)
-OK GRQ-13-1.json      weights=rows  valid (connections=24214)
-OK GRQ-25-1.json      weights=rows  valid (connections=24214)
-OK GRQ-10-1.json      weights=no memetic  valid (connections=24216)
+rows=10  biases=5  neurons=2593
+validate ok: ValidationStats { input: 2511, constant: 275, hidden: 2317, output: 1, connections: 24216 }
 ```
 
-Those creatures also carry UUID-keyed `biases`, so `valid` is what proves the
-validator half was needed too — the parse fix alone would have left rule 31
-reporting `Neuron with id <uuid> not found in the creature.`
+That creature carries UUID-keyed `biases` (`neuron-913681343`,
+`9983497c-76c2-…`) and rows whose `fromUUID` is `input-226`, so `validate ok` is
+what proves the validator half was needed too — the parse fix alone would have
+left rule 31 reporting `Neuron with id <uuid> not found in the creature.` A
+`serde_json::Value` diff of the re-serialised creature shows the whole `memetic`
+block, rows included, surviving the round trip unchanged.
 
 **Mutation evidence** (AGENTS.md rule 2 — every mutation reverted before
 commit), all against `tests/creature_memetic_weight_forms.rs`:

--- a/docs/archive/pr-summaries/pr-summary-grq-4257.md
+++ b/docs/archive/pr-summaries/pr-summary-grq-4257.md
@@ -74,6 +74,22 @@ rows=10  biases=5  neurons=2593
 validate ok: ValidationStats { input: 2511, constant: 275, hidden: 2317, output: 1, connections: 24216 }
 ```
 
+**The stage itself, end to end.** The same `neat_ai_backpropagation` 0.1.22
+binary, rebuilt against each side, over that creature and 32 synthesised
+`.bin` records:
+
+```console
+# before — sibling neat-core at Develop
+$ neat_ai_backpropagation train GRQ-10-1.json /tmp/bp-data --epochs 1 --max-records 32 …
+error: Creature JSON error: invalid type: sequence, expected a map at line 139268 column 13
+EXIT=1
+
+# after — sibling neat-core on this branch
+$ neat_ai_backpropagation train GRQ-10-1.json /tmp/bp-data --epochs 1 --max-records 32 …
+train: baseline_mse=1.015693731845 best_mse=1.015182269401 accepted_epochs=1
+EXIT=0
+```
+
 That creature carries UUID-keyed `biases` (`neuron-913681343`,
 `9983497c-76c2-…`) and rows whose `fromUUID` is `input-226`, so `validate ok` is
 what proves the validator half was needed too — the parse fix alone would have
@@ -94,7 +110,10 @@ commit), all against `tests/creature_memetic_weight_forms.rs`:
 **Gates.** `./quality.sh` green (fmt, clippy `-D warnings`, `cargo test
 --workspace` 229 + suites, doctests, rustdoc, release build). The consumer
 builds against this checkout: `cargo build --release` in
-NEAT-AI-Backpropagation is green.
+NEAT-AI-Backpropagation is green, and it never reads `memetic.weights` from
+Rust, so the breaking field-type change needs no code change there — only the
+`neat-core.expected-version` baseline bump its CI gate wants after the
+`0.10.0` release (tracked in stSoftwareAU/GRQ#4259).
 `cargo check -p neat-core --target wasm32-unknown-unknown` could not run here —
 `the wasm32-unknown-unknown target may not be installed` — and the change is
 target-agnostic (serde, `std::collections`, `std::fmt`; no `arch` or SIMD code

--- a/docs/archive/pr-summaries/pr-summary-grq-4257.md
+++ b/docs/archive/pr-summaries/pr-summary-grq-4257.md
@@ -1,0 +1,121 @@
+# creature: accept both memetic weight forms (GRQ #4257)
+
+## Summary
+
+`memetic.weights` was modelled as an id-keyed map only, so every creature
+carrying NEAT-AI's **wire** form — the UUID row array — failed at the parse
+boundary. That took out the whole GRQ-10 Backprop stage:
+`neat_ai_backpropagation` exited 1 with
+`Creature JSON error: invalid type: sequence, expected a map`, on a creature
+both stacks consider valid.
+
+Both shapes are current, and NEAT-AI writes both:
+
+| Form | Shape | Written by |
+|------|-------|------------|
+| `MemeticWeights::Rows` | `[{ "fromUUID": …, "toUUID": …, "weight": … }, …]` | `src/creature/MemeticWireExport.ts` — any JSON that leaves the process |
+| `MemeticWeights::ById` | `{ "<fromId>": [{ "toId": …, "weight": … }, …] }` | the in-memory `MemeticWeightsInterface` `creatureValidate` sees host-side |
+
+`MemeticWeights` (`neat-core/src/creature.rs`) is the single home of that
+either/or. It dispatches on the JSON shape via `deserialize_any` rather than an
+untagged enum, so a value that is *neither* form reports both shapes it could
+have been instead of serde's "did not match any variant", and it serialises back
+in **whichever form was read** — the variant is the record of the shape the file
+used, so the byte-identical round trip holds.
+
+Rule 31 (`neat-core/src/creature_validate.rs`) resolves whichever form was read.
+A memetic reference names its neuron in one of two vocabularies:
+`resolve_memetic_reference` is the one home of that — runtime **id** for the
+map form, wire **UUID** (`input-N`, `output-N`, or the stable `uuid`) for the
+rows, resolved through the same `WireIndex` the synapse endpoints resolve
+through (extracted from `resolve_synapse_endpoints`, so the `input-N` special
+case is stated once). `biases` keys are read in both vocabularies for the same
+reason: the wire exporter keys them by UUID, the in-memory record by id.
+
+Fail-loud is preserved end to end. A reference that resolves in neither
+vocabulary is still `Validation` / `MEMETIC`, so accepting both forms never
+accepts a neuron that does not exist; a map value that is not an array is still
+a serde error, which is the divergence
+`creature_validate_conformance.rs` declares for `memetic-weights-not-an-array`;
+and a creature that still cannot be parsed still fails the caller's stage.
+
+```mermaid
+flowchart LR
+    J["memetic.weights JSON"] --> D{"shape?"}
+    D -- "[ … ]" --> R["MemeticWeights::Rows"]
+    D -- "{ … }" --> M["MemeticWeights::ById"]
+    D -- neither --> E["serde error naming both forms"]
+    R --> RV["rule 31 by wire UUID<br/>via WireIndex"]
+    M --> MV["rule 31 by runtime id"]
+    RV --> S["serialised back as an array"]
+    MV --> T["serialised back as a map"]
+```
+
+## Evidence
+
+Backend/library change — no web interface to screenshot.
+
+**The reported failure, reproduced and fixed.** A scratch binary against this
+crate's `parse_creature_json` + `creature_validate`, over the real GRQ-sampler
+creatures (deleted after the run):
+
+```
+# before
+FAIL GRQ-sampler/samples/GRQ-10-sloth.json  Creature JSON error: invalid type: sequence, expected a map at line 143217 column 13
+FAIL GRQ-sampler/samples/Enceladus.json     Creature JSON error: invalid type: sequence, expected a map at line 66484 column 13
+
+# after
+OK GRQ-10-sloth.json  weights=rows  valid (connections=24092)
+OK Enceladus.json     weights=rows  valid (connections=13266)
+OK GRQ-13-1.json      weights=rows  valid (connections=24214)
+OK GRQ-25-1.json      weights=rows  valid (connections=24214)
+OK GRQ-10-1.json      weights=no memetic  valid (connections=24216)
+```
+
+Those creatures also carry UUID-keyed `biases`, so `valid` is what proves the
+validator half was needed too — the parse fix alone would have left rule 31
+reporting `Neuron with id <uuid> not found in the creature.`
+
+**Mutation evidence** (AGENTS.md rule 2 — every mutation reverted before
+commit), all against `tests/creature_memetic_weight_forms.rs`:
+
+| Mutation | Result |
+|----------|--------|
+| `deserialize_any` → `deserialize_map` (the pre-fix behaviour) | 14 of 19 red |
+| `resolve_memetic_reference` drops the wire-UUID fallback | 9 of 19 red |
+| the row form serialised as an empty map | 2 red (both round-trip tests) |
+| the row form skips the matching-synapse check | 1 red (`a_row_naming_two_real_neurons_with_no_synapse_between_them_is_rejected`) |
+
+**Gates.** `./quality.sh` green (fmt, clippy `-D warnings`, `cargo test
+--workspace` 229 + suites, doctests, rustdoc, release build). The consumer
+builds against this checkout: `cargo build --release` in
+NEAT-AI-Backpropagation is green.
+`cargo check -p neat-core --target wasm32-unknown-unknown` could not run here —
+`the wasm32-unknown-unknown target may not be installed` — and the change is
+target-agnostic (serde, `std::collections`, `std::fmt`; no `arch` or SIMD code
+touched).
+
+## Test Plan
+
+New — `neat-core/tests/creature_memetic_weight_forms.rs` (19 tests):
+
+- **Parse** — the UUID row array parses into `Rows` (the reported exit 1); the
+  id-keyed map still parses into `ById`; a row missing `toUUID`/`weight` still
+  parses so rule 31 can report it; a map value that is not an array is still a
+  parse error; a scalar `weights` fails naming both forms.
+- **Round trip** — the row form is written back as an array and the map form as
+  a map, each re-parsing unchanged; `ancestry` survives via `extra`.
+- **Rule 31, row form** — a resolving block passes with its counters; a bias
+  keyed by a wire UUID resolves; a bias key naming nothing is still rejected;
+  unknown `fromUUID`, unknown `toUUID`, missing `fromUUID`, missing `toUUID`,
+  missing `weight`, and two real neurons with no synapse between them each
+  report their `MEMETIC` message verbatim.
+- **Rule 31, map form** — still validates by runtime id, so neither form
+  weakens the other.
+
+Modified (type change, no coverage removed):
+
+- `neat-core/tests/creature_validate_contract.rs` — reads the map through
+  `MemeticWeights::by_id()`.
+- `neat-core/tests/creature_validate_synapse_rules.rs` — its `weights(…)`
+  fixture builds `MemeticWeights::ById`.

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -49,12 +49,23 @@
 //! this crate reads. Both are optional and skipped when absent, so a creature
 //! written before they existed parses and round trips byte-identically.
 //!
+//! **Two memetic weight forms (GRQ #4257).** `memetic.weights` is written by
+//! NEAT-AI in either the UUID-keyed row array
+//! `[{fromUUID, toUUID, weight}, …]` (its wire exporter) or the id-keyed map
+//! `{"<fromId>": [{toId, weight}, …]}` (its in-memory record). Both are
+//! current, so [`MemeticWeights`] is the single home of that either/or:
+//! it dispatches on the JSON shape, and serialises back in whichever form was
+//! read.
+//!
 //! Issues: #1965 (initial deserialisation), #30 (symmetric serialisation),
 //! #550 (observation-width contract), #556 (duplicate-synapse rule),
-//! #559 (validation contract input format).
+//! #559 (validation contract input format), GRQ #4257 (both memetic weight
+//! forms).
 
-use serde::{Deserialize, Serialize};
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
 
 use crate::loss::MSE_TILE_LANES;
 use crate::network::{CompiledNetwork, MAX_NODE_COUNT, NeuronData, SynapseData, hot_synapse_soa};
@@ -150,21 +161,131 @@ pub struct SynapseExport {
 /// [`extra`](Self::extra) rather than dropped, so a creature round trips
 /// through this crate without losing its fine-tuning history.
 ///
-/// Both maps are keyed by the **JSON key text**, not by a parsed integer: the
-/// keys are neuron ids written as strings (TypeScript does `Number(neuronId)`
-/// when it reads them), and a key that is not a number at all is a `MEMETIC`
-/// validation failure rather than a parse error.
+/// `biases` is keyed by the **JSON key text**, not by a parsed value: a key is
+/// either a neuron id written as a string (TypeScript does `Number(neuronId)`
+/// when it reads them) or the neuron's wire UUID, which is what NEAT-AI's wire
+/// exporter writes. A key that is neither is a `MEMETIC` validation failure
+/// rather than a parse error.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct MemeticExport {
-    /// Bias delta per neuron id.
+    /// Bias delta per neuron, keyed by runtime id or by wire UUID.
     #[serde(default)]
     pub biases: BTreeMap<String, f64>,
-    /// Weight deltas per source neuron id.
+    /// Weight deltas, in either of the two valid forms — see [`MemeticWeights`].
     #[serde(default)]
-    pub weights: BTreeMap<String, Vec<MemeticWeightExport>>,
+    pub weights: MemeticWeights,
     /// Every other key on the TypeScript record, preserved verbatim.
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// The two valid shapes of `memetic.weights` — GRQ #4257.
+///
+/// NEAT-AI writes memetic weights in **two** forms and considers both current:
+///
+/// - [`Rows`](Self::Rows) — the UUID-keyed array
+///   `[{ "fromUUID": …, "toUUID": …, "weight": … }, …]` produced by
+///   `src/creature/MemeticWireExport.ts` for any JSON that leaves the process.
+///   The UUIDs are the same wire labels the synapses use: `input-N` for an
+///   implicit input neuron, `output-N` for an output, the stable `uuid`
+///   otherwise.
+/// - [`ById`](Self::ById) — the id-keyed map
+///   `{ "<fromId>": [{ "toId": …, "weight": … }, …] }` of NEAT-AI's in-memory
+///   `MemeticWeightsInterface`, which is what `creatureValidate` sees host-side.
+///
+/// Modelling only the map cost the fleet a whole Backprop stage: the GRQ-10
+/// sampler fittest creature carries the row form, and
+/// `neat_ai_backpropagation` exited 1 with
+/// `Creature JSON error: invalid type: sequence, expected a map`.
+///
+/// Whichever form was read is the form written back — the variant *is* the
+/// record of which shape the file used, so a creature still round trips
+/// byte-identically. An absent `weights` key defaults to an empty
+/// [`ById`](Self::ById) map, matching the shape this crate has always emitted
+/// for it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemeticWeights {
+    /// The UUID-keyed row array — NEAT-AI's `MemeticWeightWireRow[]`.
+    Rows(Vec<MemeticWeightRowExport>),
+    /// The id-keyed map — NEAT-AI's `MemeticWeightsInterface`.
+    ById(BTreeMap<String, Vec<MemeticWeightExport>>),
+}
+
+impl Default for MemeticWeights {
+    fn default() -> Self {
+        Self::ById(BTreeMap::new())
+    }
+}
+
+impl MemeticWeights {
+    /// The rows, when the creature carries the UUID-keyed array form.
+    #[must_use]
+    pub fn rows(&self) -> Option<&[MemeticWeightRowExport]> {
+        match self {
+            Self::Rows(rows) => Some(rows.as_slice()),
+            Self::ById(_) => None,
+        }
+    }
+
+    /// The map, when the creature carries the id-keyed form.
+    #[must_use]
+    pub const fn by_id(&self) -> Option<&BTreeMap<String, Vec<MemeticWeightExport>>> {
+        match self {
+            Self::ById(map) => Some(map),
+            Self::Rows(_) => None,
+        }
+    }
+}
+
+/// What a `weights` value must look like, in one sentence — the text serde
+/// puts after `expected` when it is neither form.
+const MEMETIC_WEIGHTS_EXPECTING: &str = "memetic weights as an array of {fromUUID, toUUID, weight} rows, or as a map of neuron id to \
+     [{toId, weight}] entries";
+
+impl Serialize for MemeticWeights {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Rows(rows) => rows.serialize(serializer),
+            Self::ById(map) => map.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MemeticWeights {
+    /// Dispatch on the JSON shape rather than on an untagged enum, so a value
+    /// that is *neither* form reports both shapes it could have been instead of
+    /// serde's "did not match any variant".
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct FormVisitor;
+
+        impl<'de> Visitor<'de> for FormVisitor {
+            type Value = MemeticWeights;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(MEMETIC_WEIGHTS_EXPECTING)
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut rows = Vec::with_capacity(seq.size_hint().unwrap_or_default());
+                while let Some(row) = seq.next_element::<MemeticWeightRowExport>()? {
+                    rows.push(row);
+                }
+                Ok(MemeticWeights::Rows(rows))
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut entries = BTreeMap::new();
+                while let Some((key, value)) =
+                    map.next_entry::<String, Vec<MemeticWeightExport>>()?
+                {
+                    entries.insert(key, value);
+                }
+                Ok(MemeticWeights::ById(entries))
+            }
+        }
+
+        deserializer.deserialize_any(FormVisitor)
+    }
 }
 
 /// One memetic weight delta — NEAT-AI's `MemeticWeightInterface`.
@@ -177,6 +298,25 @@ pub struct MemeticWeightExport {
     /// Destination neuron id.
     #[serde(rename = "toId", default, skip_serializing_if = "Option::is_none")]
     pub to_id: Option<i64>,
+    /// The fine-tuned weight.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+}
+
+/// One row of the UUID-keyed weight form — NEAT-AI's `MemeticWeightWireRow`
+/// (`src/creature/MemeticWireExport.ts`), GRQ #4257.
+///
+/// Every field is optional for the same reason [`MemeticWeightExport`]'s are:
+/// the `MEMETIC` rule must be able to *report* a row missing an endpoint or a
+/// weight, and a serde error at the parse boundary never reaches a rule.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct MemeticWeightRowExport {
+    /// Wire UUID of the source neuron — `input-N`, `output-N`, or a `uuid`.
+    #[serde(rename = "fromUUID", default, skip_serializing_if = "Option::is_none")]
+    pub from_uuid: Option<String>,
+    /// Wire UUID of the destination neuron.
+    #[serde(rename = "toUUID", default, skip_serializing_if = "Option::is_none")]
+    pub to_uuid: Option<String>,
     /// The fine-tuned weight.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weight: Option<f64>,

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -121,8 +121,25 @@
 //! Two TypeScript checks are unreachable in the Rust shape because serde
 //! rejects the input earlier, and that is deliberate — a malformed file fails
 //! at the parse boundary instead of reaching the validator: a non-integer
-//! neuron `id` (rule 5) and a non-array memetic `weights` entry (rule 31) are
-//! [`crate::creature::CreatureError::Json`].
+//! neuron `id` (rule 5) and a non-array memetic `weights` **map value** (rule
+//! 31) are [`crate::creature::CreatureError::Json`].
+//!
+//! # Both memetic weight forms resolve (GRQ #4257)
+//!
+//! `memetic.weights` arrives in either of the two shapes NEAT-AI writes — see
+//! [`crate::creature::MemeticWeights`] — and rule 31 resolves whichever one the
+//! file carries:
+//!
+//! - the id-keyed map is resolved by **runtime neuron id**, as the TypeScript
+//!   resolves it host-side;
+//! - the UUID-keyed row array is resolved by **wire UUID** (`input-N`,
+//!   `output-N`, or the stable `uuid`) — the same vocabulary the synapses use,
+//!   through the same `WireIndex` the synapse endpoints resolve through.
+//!
+//! `biases` keys are read in both vocabularies for the same reason: the wire
+//! exporter keys them by UUID, the in-memory record by id. A key that resolves
+//! in neither is still `Validation` / `MEMETIC`, so accepting both forms never
+//! accepts a reference to a neuron that does not exist.
 //!
 //! # Runtime ids are derived, not required (Issue #560)
 //!
@@ -211,10 +228,13 @@
 //! checks and its diagnostics dump against the same neuron or synapse the
 //! shared rules stopped on.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 
-use crate::creature::{CreatureExport, MemeticExport, parse_squash_name, parse_synapse_type};
+use crate::creature::{
+    CreatureExport, MemeticExport, MemeticWeightExport, MemeticWeightRowExport, MemeticWeights,
+    parse_squash_name, parse_synapse_type,
+};
 use crate::synapse_type::SynapseType;
 use crate::topology_invariants::{
     ConnectionIndex, IfFault, IfRoles, WiringFault, hidden_wiring_fault, if_neuron_fault,
@@ -687,7 +707,8 @@ fn validate_neuron_rules(
     }
 
     let views = neuron_views(creature);
-    let (from, to, synapse_types) = resolve_synapse_endpoints(creature)?;
+    let wire = WireIndex::build(creature);
+    let (from, to, synapse_types) = resolve_synapse_endpoints(creature, &wire)?;
     let connections = ConnectionIndex::build(&from, &to, total_neurons);
 
     walk_neurons(
@@ -876,6 +897,44 @@ fn neuron_views(creature: &CreatureExport) -> Vec<NeuronView<'_>> {
     views
 }
 
+/// The one home of the rule that turns a **wire UUID** into the index the
+/// rules walk over: `input-N` names an implicit input neuron, and every other
+/// UUID names a listed one.
+///
+/// Both the synapse endpoints and the memetic row form (GRQ #4257) are written
+/// in that same wire vocabulary, so both resolve through this rather than each
+/// restating the `input-N` special case.
+struct WireIndex<'a> {
+    /// Listed neurons by UUID, at their walk index (`input + i`).
+    uuid_to_index: HashMap<&'a str, u32>,
+    /// The declared observation width — the implicit `input-N` range.
+    input: usize,
+}
+
+impl<'a> WireIndex<'a> {
+    fn build(creature: &'a CreatureExport) -> Self {
+        let mut uuid_to_index: HashMap<&str, u32> = HashMap::with_capacity(creature.neurons.len());
+        for (i, neuron) in creature.neurons.iter().enumerate() {
+            uuid_to_index.insert(neuron.uuid.as_str(), (creature.input + i) as u32);
+        }
+
+        Self {
+            uuid_to_index,
+            input: creature.input,
+        }
+    }
+
+    /// The walk index this UUID names, or `None` when it names no neuron.
+    fn resolve(&self, uuid: &str) -> Option<u32> {
+        if let Some(index) = self.uuid_to_index.get(uuid) {
+            return Some(*index);
+        }
+        // Implicit input neurons are wired as `input-N`, never listed.
+        let index: usize = uuid.strip_prefix("input-")?.parse().ok()?;
+        (index < self.input).then_some(index as u32)
+    }
+}
+
 /// Resolve every synapse's `fromUUID` / `toUUID` to the neuron indices the
 /// rules use, keeping the declared synapse roles alongside.
 ///
@@ -887,20 +946,9 @@ fn neuron_views(creature: &CreatureExport) -> Vec<NeuronView<'_>> {
 #[allow(clippy::type_complexity)]
 fn resolve_synapse_endpoints(
     creature: &CreatureExport,
+    wire: &WireIndex<'_>,
 ) -> Result<(Vec<u32>, Vec<u32>, Vec<SynapseType>), ValidationFailure> {
-    let mut uuid_to_index: HashMap<&str, u32> = HashMap::with_capacity(creature.neurons.len());
-    for (i, neuron) in creature.neurons.iter().enumerate() {
-        uuid_to_index.insert(neuron.uuid.as_str(), (creature.input + i) as u32);
-    }
-
-    let resolve = |uuid: &str| -> Option<u32> {
-        if let Some(index) = uuid_to_index.get(uuid) {
-            return Some(*index);
-        }
-        // Implicit input neurons are wired as `input-N`, never listed.
-        let index: usize = uuid.strip_prefix("input-")?.parse().ok()?;
-        (index < creature.input).then_some(index as u32)
-    };
+    let resolve = |uuid: &str| wire.resolve(uuid);
 
     let mut from = Vec::with_capacity(creature.synapses.len());
     let mut to = Vec::with_capacity(creature.synapses.len());
@@ -1356,38 +1404,45 @@ fn forward_only_rules(
 }
 
 /// Rule 31: every memetic bias and weight resolves to a real neuron, and every
-/// weight entry names a synapse that exists.
+/// weight entry names a synapse that exists — in **either** valid weight form
+/// (GRQ #4257).
 ///
-/// The match is on **neuron ids**, not indices: the synapse set is built from
-/// `views[from].id -> views[to].id`, exactly as the TypeScript builds it, so a
-/// creature whose ids differ from its indices still resolves. A neuron with no
-/// id contributes nothing to either lookup — rule 4 is what rejects a missing
-/// id, and this half must not report it under the wrong rule.
+/// A memetic reference names a neuron in one of two vocabularies, and both are
+/// current: the runtime **id** written as a string, which is what NEAT-AI's
+/// in-memory record uses, or the **wire UUID**, which is what its wire exporter
+/// writes (`input-N`, `output-N`, or the stable `uuid`).
+/// [`resolve_memetic_reference`] is the single home of that either/or, and it
+/// resolves to the walk index so both forms share one synapse set. A reference
+/// that is neither is reported as "not found", the outcome TypeScript's
+/// `Number(key)` reaches for a non-numeric key too.
 ///
-/// A key that is not an integer cannot match any id and is reported as "not
-/// found", which is the outcome TypeScript's `Number(key)` reaches for every
-/// non-integer key too.
+/// A neuron with no id contributes nothing to the id half of the lookup — rule
+/// 4 is what rejects a missing id, and this half must not report it under the
+/// wrong rule.
 fn memetic_rules(
     views: &[NeuronView<'_>],
+    wire: &WireIndex<'_>,
     from_indices: &[u32],
     to_indices: &[u32],
     memetic: &MemeticExport,
 ) -> Result<(), ValidationFailure> {
-    let known_ids: HashSet<i64> = views.iter().filter_map(|view| view.id).collect();
-
-    let mut pairs: HashSet<String> = HashSet::with_capacity(from_indices.len());
-    for (&from_index, &to_index) in from_indices.iter().zip(to_indices) {
-        if let (Some(from_id), Some(to_id)) =
-            (views[from_index as usize].id, views[to_index as usize].id)
-        {
-            pairs.insert(format!("{from_id}->{to_id}"));
+    let mut id_to_index: HashMap<i64, u32> = HashMap::with_capacity(views.len());
+    for (index, view) in views.iter().enumerate() {
+        if let Some(id) = view.id {
+            id_to_index.insert(id, index as u32);
         }
     }
 
-    let known = |key: &str| -> bool { key.parse::<i64>().is_ok_and(|id| known_ids.contains(&id)) };
+    let pairs: HashSet<(u32, u32)> = from_indices
+        .iter()
+        .zip(to_indices)
+        .map(|(&from_index, &to_index)| (from_index, to_index))
+        .collect();
+
+    let resolve = |key: &str| resolve_memetic_reference(key, &id_to_index, wire);
 
     for neuron_id in memetic.biases.keys() {
-        if !known(neuron_id) {
+        if resolve(neuron_id).is_none() {
             return Err(ValidationFailure::validation(
                 reason::MEMETIC,
                 format!("Neuron with id {neuron_id} not found in the creature."),
@@ -1395,13 +1450,52 @@ fn memetic_rules(
         }
     }
 
-    for (synapse_id, weights) in &memetic.weights {
-        if !known(synapse_id) {
+    match &memetic.weights {
+        MemeticWeights::ById(by_id) => {
+            memetic_map_rules(by_id, &id_to_index, &pairs, &resolve)?;
+        }
+        MemeticWeights::Rows(rows) => {
+            memetic_row_rules(rows, &pairs, &resolve)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// The neuron a memetic key names — by runtime id, or by wire UUID.
+///
+/// The id half is tried first: the id-keyed form is the one TypeScript
+/// validates host-side, and its keys are integers. A key that names no id
+/// falls through to the wire vocabulary, which is how the exported form keys
+/// both its biases and its rows.
+fn resolve_memetic_reference(
+    key: &str,
+    id_to_index: &HashMap<i64, u32>,
+    wire: &WireIndex<'_>,
+) -> Option<u32> {
+    if let Ok(id) = key.parse::<i64>()
+        && let Some(index) = id_to_index.get(&id)
+    {
+        return Some(*index);
+    }
+    wire.resolve(key)
+}
+
+/// Rule 31 over the id-keyed map form — message for message what the
+/// TypeScript `for (const synapseId in memetic.weights)` loop reports.
+fn memetic_map_rules(
+    by_id: &BTreeMap<String, Vec<MemeticWeightExport>>,
+    id_to_index: &HashMap<i64, u32>,
+    pairs: &HashSet<(u32, u32)>,
+    resolve: &impl Fn(&str) -> Option<u32>,
+) -> Result<(), ValidationFailure> {
+    for (synapse_id, weights) in by_id {
+        let Some(from_index) = resolve(synapse_id) else {
             return Err(ValidationFailure::validation(
                 reason::MEMETIC,
                 format!("Synapse with id {synapse_id} not found in the creature."),
             ));
-        }
+        };
 
         for (index, entry) in weights.iter().enumerate() {
             let Some(to_id) = entry.to_id else {
@@ -1419,18 +1513,73 @@ fn memetic_rules(
                     ),
                 ));
             }
-            if !known_ids.contains(&to_id) {
+            let Some(&to_index) = id_to_index.get(&to_id) else {
                 return Err(ValidationFailure::validation(
                     reason::MEMETIC,
                     format!("Memetic from id {synapse_id} has no valid neuron."),
                 ));
-            }
-            if !pairs.contains(&format!("{synapse_id}->{to_id}")) {
+            };
+            if !pairs.contains(&(from_index, to_index)) {
                 return Err(ValidationFailure::validation(
                     reason::MEMETIC,
                     format!("Memetic from id {synapse_id} to id {to_id} has no matching synapses."),
                 ));
             }
+        }
+    }
+
+    Ok(())
+}
+
+/// Rule 31 over the UUID-keyed row form (GRQ #4257).
+///
+/// The checks and their wording are the map form's, in the same order — a row
+/// carries its own source, so the "not found" check that the map form runs once
+/// per key runs once per row here. A row has no key to name it, so every
+/// message ends in the row's index: that is the only locator an array offers.
+fn memetic_row_rules(
+    rows: &[MemeticWeightRowExport],
+    pairs: &HashSet<(u32, u32)>,
+    resolve: &impl Fn(&str) -> Option<u32>,
+) -> Result<(), ValidationFailure> {
+    for (index, row) in rows.iter().enumerate() {
+        let (Some(from_uuid), Some(to_uuid)) = (row.from_uuid.as_deref(), row.to_uuid.as_deref())
+        else {
+            // TypeScript interpolates an absent field as `undefined`.
+            let from_uuid = row.from_uuid.as_deref().unwrap_or("undefined");
+            let to_uuid = row.to_uuid.as_deref().unwrap_or("undefined");
+            return Err(ValidationFailure::validation(
+                reason::MEMETIC,
+                format!("Memetic from id {from_uuid} to id {to_uuid} is invalid at index {index}."),
+            ));
+        };
+
+        if row.weight.is_none() {
+            return Err(ValidationFailure::validation(
+                reason::MEMETIC,
+                format!(
+                    "Memetic from id {from_uuid} to id {to_uuid} has invalid weight at index {index}."
+                ),
+            ));
+        }
+
+        let Some(from_index) = resolve(from_uuid) else {
+            return Err(ValidationFailure::validation(
+                reason::MEMETIC,
+                format!("Synapse with id {from_uuid} not found in the creature."),
+            ));
+        };
+        let Some(to_index) = resolve(to_uuid) else {
+            return Err(ValidationFailure::validation(
+                reason::MEMETIC,
+                format!("Memetic from id {from_uuid} has no valid neuron."),
+            ));
+        };
+        if !pairs.contains(&(from_index, to_index)) {
+            return Err(ValidationFailure::validation(
+                reason::MEMETIC,
+                format!("Memetic from id {from_uuid} to id {to_uuid} has no matching synapses."),
+            ));
         }
     }
 
@@ -1465,7 +1614,8 @@ pub fn validate_synapse_and_memetic_rules(
     stats: &mut ValidationStats,
 ) -> Result<(), ValidationFailure> {
     let views = neuron_views(creature);
-    let (from_indices, to_indices, synapse_types) = resolve_synapse_endpoints(creature)?;
+    let wire = WireIndex::build(creature);
+    let (from_indices, to_indices, synapse_types) = resolve_synapse_endpoints(creature, &wire)?;
 
     synapse_walk(&views, &from_indices, &to_indices, options, stats)?;
 
@@ -1493,7 +1643,7 @@ pub fn validate_synapse_and_memetic_rules(
     }
 
     if let Some(memetic) = creature.memetic.as_ref() {
-        memetic_rules(&views, &from_indices, &to_indices, memetic)?;
+        memetic_rules(&views, &wire, &from_indices, &to_indices, memetic)?;
     }
 
     Ok(())

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -61,10 +61,11 @@ pub mod wasm_arch;
 
 // Re-export key types for convenience
 pub use creature::{
-    CreatureError, CreatureExport, MemeticExport, MemeticWeightExport, NeuronExport, SynapseExport,
-    compile_creature, creature_to_json, creature_to_json_pretty, parse_creature_json,
-    parse_squash_name, parse_synapse_type, squash_name_from, synapse_type_name_from,
-    validate_creature_width, validate_no_duplicate_synapses,
+    CreatureError, CreatureExport, MemeticExport, MemeticWeightExport, MemeticWeightRowExport,
+    MemeticWeights, NeuronExport, SynapseExport, compile_creature, creature_to_json,
+    creature_to_json_pretty, parse_creature_json, parse_squash_name, parse_synapse_type,
+    squash_name_from, synapse_type_name_from, validate_creature_width,
+    validate_no_duplicate_synapses,
 };
 // Issue #559 — the shared creature-validation contract.
 pub use creature_validate::{

--- a/neat-core/tests/creature_memetic_weight_forms.rs
+++ b/neat-core/tests/creature_memetic_weight_forms.rs
@@ -1,0 +1,379 @@
+//! GRQ #4257 — `memetic.weights` arrives in **two** valid forms, and both must
+//! parse, round trip and validate.
+//!
+//! NEAT-AI's wire exporter (`src/creature/MemeticWireExport.ts`) writes the
+//! UUID-keyed row array `[{ fromUUID, toUUID, weight }, …]`; its in-memory
+//! runtime record is the id-keyed map `{ "<fromId>": [{ toId, weight }, …] }`.
+//! Neither is legacy. Modelling only the map made
+//! `neat_ai_backpropagation` exit 1 on the GRQ-10 sampler fittest creature with
+//! `Creature JSON error: invalid type: sequence, expected a map`, so the whole
+//! Backprop stage failed on a creature both stacks consider valid.
+//!
+//! The rows carry the same wire UUIDs the synapses do — `input-N` for an
+//! implicit input neuron, `output-N` for an output, the stable `uuid`
+//! otherwise — so rule 31 resolves them exactly as
+//! `resolve_synapse_endpoints` resolves a synapse endpoint.
+
+use neat_core::creature::{MemeticWeightRowExport, MemeticWeights};
+use neat_core::creature_validate::{ValidateOptions, creature_validate, reason};
+use neat_core::{CreatureExport, creature_to_json, parse_creature_json};
+
+// ---------------------------------------------------------------------------
+// Fixtures — `input-0 -> h -> output-0`, the shape the sampler creature uses.
+// ---------------------------------------------------------------------------
+
+/// A creature whose `memetic.weights` is written as `{WEIGHTS}` and whose
+/// `memetic.biases` is written as `{BIASES}`.
+const TEMPLATE: &str = r#"{
+  "input": 2,
+  "output": 1,
+  "neurons": [
+    { "type": "hidden", "uuid": "h", "bias": 0.25, "squash": "TANH" },
+    { "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }
+  ],
+  "synapses": [
+    { "fromUUID": "input-0", "toUUID": "h", "weight": 1.0 },
+    { "fromUUID": "input-1", "toUUID": "h", "weight": -0.5 },
+    { "fromUUID": "h", "toUUID": "output-0", "weight": 2.0 }
+  ],
+  "memetic": {
+    "generation": 7,
+    "score": -0.25,
+    "biases": {BIASES},
+    "weights": {WEIGHTS}
+  }
+}"#;
+
+fn creature_json(biases: &str, weights: &str) -> String {
+    TEMPLATE
+        .replace("{BIASES}", biases)
+        .replace("{WEIGHTS}", weights)
+}
+
+/// The wire form the sampler writes: UUID rows and UUID-keyed biases.
+fn wire_form(weights: &str) -> String {
+    creature_json(r#"{ "h": 0.125 }"#, weights)
+}
+
+fn parse(json: &str) -> CreatureExport {
+    parse_creature_json(json).expect("the creature parses")
+}
+
+fn validate_err(json: &str) -> String {
+    let creature = parse(json);
+    let failure = creature_validate(&creature, &ValidateOptions::default())
+        .expect_err("this creature breaks rule 31");
+    assert_eq!(failure.reason, reason::MEMETIC);
+    failure.message
+}
+
+// ---------------------------------------------------------------------------
+// 1. Parsing — the reported exit 1.
+// ---------------------------------------------------------------------------
+
+/// The exact failure from `GRQ-10-sloth.log`: a UUID row array where the
+/// id-keyed map was the only modelled form.
+#[test]
+fn the_uuid_row_array_parses_into_rows() {
+    let json = wire_form(
+        r#"[
+      { "fromUUID": "input-0", "toUUID": "h", "weight": 0.5 },
+      { "fromUUID": "h", "toUUID": "output-0", "weight": -0.25 }
+    ]"#,
+    );
+
+    let creature = parse(&json);
+    let weights = &creature.memetic.as_ref().expect("memetic block").weights;
+
+    assert_eq!(
+        weights.rows(),
+        Some(
+            [
+                MemeticWeightRowExport {
+                    from_uuid: Some("input-0".to_string()),
+                    to_uuid: Some("h".to_string()),
+                    weight: Some(0.5),
+                },
+                MemeticWeightRowExport {
+                    from_uuid: Some("h".to_string()),
+                    to_uuid: Some("output-0".to_string()),
+                    weight: Some(-0.25),
+                },
+            ]
+            .as_slice()
+        )
+    );
+    assert!(weights.by_id().is_none(), "the map form was not written");
+}
+
+/// The id-keyed map still parses into the map form — the other valid shape is
+/// not traded away for the new one.
+#[test]
+fn the_id_keyed_map_still_parses_into_the_map() {
+    let json = creature_json(
+        r#"{ "-1": 0.75 }"#,
+        r#"{ "0": [{ "toId": 2, "weight": 0.5 }] }"#,
+    );
+
+    let creature = parse(&json);
+    let weights = &creature.memetic.as_ref().expect("memetic block").weights;
+
+    let by_id = weights.by_id().expect("the map form was written");
+    assert_eq!(by_id["0"][0].to_id, Some(2));
+    assert_eq!(by_id["0"][0].weight, Some(0.5));
+    assert!(weights.rows().is_none());
+}
+
+/// A row missing `toUUID` or `weight` must still *parse*, for the same reason
+/// `MemeticWeightExport` keeps its fields optional: rule 31 has to be able to
+/// report it, and a serde error at the parse boundary never reaches a rule.
+#[test]
+fn a_row_missing_its_fields_still_parses_so_the_rule_can_report_it() {
+    let json = wire_form(r#"[{ "fromUUID": "h" }]"#);
+
+    let creature = parse(&json);
+    let rows = creature.memetic.as_ref().expect("memetic").weights.rows();
+
+    assert_eq!(
+        rows,
+        Some(
+            [MemeticWeightRowExport {
+                from_uuid: Some("h".to_string()),
+                to_uuid: None,
+                weight: None,
+            }]
+            .as_slice()
+        )
+    );
+}
+
+/// The map form's values are still typed arrays — a bare object under a key is
+/// a serde error, which is the divergence
+/// `creature_validate_conformance.rs` declares for `memetic-weights-not-an-array`.
+#[test]
+fn a_map_value_that_is_not_an_array_is_still_a_parse_error() {
+    let json = creature_json(r#"{}"#, r#"{ "0": { "toId": 2, "weight": 0.5 } }"#);
+
+    let error = parse_creature_json(&json).expect_err("a bare object is not a weight list");
+    assert!(
+        error.to_string().contains("Creature JSON error"),
+        "reported as a JSON error: {error}"
+    );
+}
+
+/// Neither form is `weights: 3` — a scalar names the two shapes it could have
+/// been rather than failing with serde's bare "invalid type" text.
+#[test]
+fn a_scalar_weights_value_fails_loud_naming_both_forms() {
+    let json = wire_form("3");
+
+    let error = parse_creature_json(&json).expect_err("a number is neither form");
+    let text = error.to_string();
+    assert!(text.contains("fromUUID"), "names the row form: {text}");
+    assert!(text.contains("map"), "names the map form: {text}");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Round trip — whichever form was read is the form written back.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_row_form_round_trips_as_rows() {
+    let json = wire_form(
+        r#"[
+      { "fromUUID": "input-1", "toUUID": "h", "weight": 0.5 }
+    ]"#,
+    );
+
+    let creature = parse(&json);
+    let written = creature_to_json(&creature).expect("serialises");
+
+    assert!(
+        written.contains(r#""weights":[{"fromUUID":"input-1","toUUID":"h","weight":0.5}]"#),
+        "the array form is written back as an array: {written}"
+    );
+    assert_eq!(parse(&written), creature, "and re-parses unchanged");
+}
+
+#[test]
+fn the_map_form_round_trips_as_a_map() {
+    let json = creature_json(r#"{}"#, r#"{ "0": [{ "toId": 2, "weight": 0.5 }] }"#);
+
+    let creature = parse(&json);
+    let written = creature_to_json(&creature).expect("serialises");
+
+    assert!(
+        written.contains(r#""weights":{"0":[{"toId":2,"weight":0.5}]}"#),
+        "the map form is written back as a map: {written}"
+    );
+    assert_eq!(parse(&written), creature, "and re-parses unchanged");
+}
+
+/// `ancestry` — the key added alongside the row form — is carried verbatim by
+/// `MemeticExport::extra` rather than dropped.
+#[test]
+fn the_ancestry_key_survives_the_row_form_round_trip() {
+    let json = wire_form(r#"[{ "fromUUID": "h", "toUUID": "output-0", "weight": 0.5 }]"#).replace(
+        "\"score\": -0.25",
+        "\"score\": -0.25, \"ancestry\": [{\"generation\": 6}]",
+    );
+
+    let creature = parse(&json);
+    let written = creature_to_json(&creature).expect("serialises");
+
+    assert!(written.contains("\"ancestry\""), "kept: {written}");
+    assert_eq!(parse(&written), creature);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Rule 31 — the row form resolves against the creature's wire UUIDs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_row_form_memetic_block_that_resolves_passes() {
+    let json = wire_form(
+        r#"[
+      { "fromUUID": "input-0", "toUUID": "h", "weight": 0.5 },
+      { "fromUUID": "h", "toUUID": "output-0", "weight": -0.25 }
+    ]"#,
+    );
+
+    let stats = creature_validate(&parse(&json), &ValidateOptions::default())
+        .expect("every row names a real synapse");
+    assert_eq!(
+        (stats.input, stats.hidden, stats.output, stats.connections),
+        (2, 1, 1, 3)
+    );
+}
+
+/// A bias keyed by a wire UUID resolves too — the wire form keys biases the
+/// same way it keys the rows.
+#[test]
+fn a_bias_keyed_by_a_wire_uuid_resolves() {
+    let json = creature_json(
+        r#"{ "output-0": 0.5, "input-1": -0.25 }"#,
+        r#"[{ "fromUUID": "h", "toUUID": "output-0", "weight": 0.5 }]"#,
+    );
+
+    creature_validate(&parse(&json), &ValidateOptions::default())
+        .expect("both bias keys name a real neuron");
+}
+
+/// A bias key that is neither a neuron id nor a wire UUID is still rejected —
+/// accepting both forms must not accept a reference to nothing.
+#[test]
+fn a_bias_key_naming_nothing_is_still_rejected() {
+    let json = creature_json(
+        r#"{ "ghost": 0.5 }"#,
+        r#"[{ "fromUUID": "h", "toUUID": "output-0", "weight": 0.5 }]"#,
+    );
+
+    assert_eq!(
+        validate_err(&json),
+        "Neuron with id ghost not found in the creature."
+    );
+}
+
+#[test]
+fn a_row_whose_from_uuid_names_no_neuron_is_rejected() {
+    let json = wire_form(r#"[{ "fromUUID": "ghost", "toUUID": "h", "weight": 0.5 }]"#);
+
+    assert_eq!(
+        validate_err(&json),
+        "Synapse with id ghost not found in the creature."
+    );
+}
+
+#[test]
+fn a_row_whose_to_uuid_names_no_neuron_is_rejected() {
+    let json = wire_form(r#"[{ "fromUUID": "h", "toUUID": "ghost", "weight": 0.5 }]"#);
+
+    assert_eq!(
+        validate_err(&json),
+        "Memetic from id h has no valid neuron."
+    );
+}
+
+#[test]
+fn a_row_without_a_to_uuid_is_rejected() {
+    let json = wire_form(r#"[{ "fromUUID": "h", "weight": 0.5 }]"#);
+
+    assert_eq!(
+        validate_err(&json),
+        "Memetic from id h to id undefined is invalid at index 0."
+    );
+}
+
+#[test]
+fn a_row_without_a_from_uuid_is_rejected_with_its_index() {
+    let json = wire_form(
+        r#"[
+      { "fromUUID": "h", "toUUID": "output-0", "weight": 0.5 },
+      { "toUUID": "output-0", "weight": 0.5 }
+    ]"#,
+    );
+
+    assert_eq!(
+        validate_err(&json),
+        "Memetic from id undefined to id output-0 is invalid at index 1."
+    );
+}
+
+#[test]
+fn a_row_without_a_weight_is_rejected_with_its_index() {
+    let json = wire_form(
+        r#"[
+      { "fromUUID": "input-0", "toUUID": "h", "weight": 0.5 },
+      { "fromUUID": "h", "toUUID": "output-0" }
+    ]"#,
+    );
+
+    assert_eq!(
+        validate_err(&json),
+        "Memetic from id h to id output-0 has invalid weight at index 1."
+    );
+}
+
+/// Both endpoints exist, but nothing connects them — the same rule the map
+/// form enforces by id.
+#[test]
+fn a_row_naming_two_real_neurons_with_no_synapse_between_them_is_rejected() {
+    let json = wire_form(r#"[{ "fromUUID": "input-0", "toUUID": "output-0", "weight": 0.5 }]"#);
+
+    assert_eq!(
+        validate_err(&json),
+        "Memetic from id input-0 to id output-0 has no matching synapses."
+    );
+}
+
+/// The map form keeps validating by runtime id — the derived hidden id, not
+/// the UUID — so the two forms coexist without either weakening the other.
+#[test]
+fn the_map_form_still_validates_by_runtime_id() {
+    let json = creature_json(
+        r#"{ "-1": 0.5 }"#,
+        r#"{ "99": [{ "toId": -1, "weight": 0.5 }] }"#,
+    );
+
+    assert_eq!(
+        validate_err(&json),
+        "Synapse with id 99 not found in the creature."
+    );
+}
+
+/// A hand-built creature reaches the row form without going through JSON.
+#[test]
+fn a_hand_built_creature_can_carry_the_row_form() {
+    let json = wire_form(r#"[{ "fromUUID": "h", "toUUID": "output-0", "weight": 0.5 }]"#);
+    let mut creature = parse(&json);
+
+    creature.memetic.as_mut().expect("memetic").weights =
+        MemeticWeights::Rows(vec![MemeticWeightRowExport {
+            from_uuid: Some("input-1".to_string()),
+            to_uuid: Some("h".to_string()),
+            weight: Some(-1.5),
+        }]);
+
+    creature_validate(&creature, &ValidateOptions::default())
+        .expect("input-1 -> h is a real synapse");
+}

--- a/neat-core/tests/creature_validate_contract.rs
+++ b/neat-core/tests/creature_validate_contract.rs
@@ -354,8 +354,12 @@ fn the_memetic_block_round_trips_including_keys_the_validator_does_not_read() {
     let memetic = creature.memetic.as_ref().expect("memetic block present");
 
     assert_eq!(memetic.biases.get("-1"), Some(&0.75));
+    let by_id = memetic
+        .weights
+        .by_id()
+        .expect("the id-keyed form was written");
     assert_eq!(
-        memetic.weights.get("0").map(Vec::as_slice),
+        by_id.get("0").map(Vec::as_slice),
         Some(
             [MemeticWeightExport {
                 to_id: Some(-1),
@@ -388,7 +392,13 @@ fn a_memetic_weight_missing_its_fields_still_parses_so_the_rule_can_report_it() 
     }"#;
 
     let creature = parse_creature_json(json).expect("parses");
-    let weights = &creature.memetic.as_ref().expect("memetic").weights["0"];
+    let weights = &creature
+        .memetic
+        .as_ref()
+        .expect("memetic")
+        .weights
+        .by_id()
+        .expect("the id-keyed form was written")["0"];
 
     assert_eq!(weights[0].to_id, None);
     assert_eq!(weights[0].weight, None);

--- a/neat-core/tests/creature_validate_synapse_rules.rs
+++ b/neat-core/tests/creature_validate_synapse_rules.rs
@@ -5,7 +5,9 @@
 //! verbatim: NEAT-AI's own error-message tests read this text, so a drifted
 //! string is a broken contract rather than cosmetic.
 
-use neat_core::creature::{MemeticExport, MemeticWeightExport};
+use std::collections::BTreeMap;
+
+use neat_core::creature::{MemeticExport, MemeticWeightExport, MemeticWeights};
 use neat_core::creature_validate::{
     FailureClass, ValidateOptions, ValidationStats, reason, validate_synapse_and_memetic_rules,
 };
@@ -385,9 +387,10 @@ fn memetic_creature(memetic: MemeticExport) -> CreatureExport {
 }
 
 fn weights(key: &str, entries: Vec<MemeticWeightExport>) -> MemeticExport {
-    let mut memetic = MemeticExport::default();
-    memetic.weights.insert(key.to_string(), entries);
-    memetic
+    MemeticExport {
+        weights: MemeticWeights::ById(BTreeMap::from([(key.to_string(), entries)])),
+        ..MemeticExport::default()
+    }
 }
 
 fn weight(to_id: i64, value: f64) -> MemeticWeightExport {


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/GRQ#4257 here, in the dependency's own repo.

MemeticExport::weights becomes the MemeticWeights enum so the UUID row array and the id-keyed map both parse, round trip in the form they were read, and resolve through MEMETIC rule 31 — clearing the GRQ-10 Backprop exit 1.

**Head:** `issue-4257-memetic-weights-array-form` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/GRQ#4257: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.