### PR TITLE
fix(creature): parse creature weights to the exact f64 the literal names (GRQ #4261)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,7 @@ the comparison. `neat-core/tests/creature_width_contract.rs` pins the rule at
 all four sites (each was mutation-checked individually — dropping any one call
 fails its own tests).
 
-## `serde_json` keeps `float_roundtrip` (GRQ #4261)
+## `serde_json` keeps `float_roundtrip` (PR #571)
 
 `neat-core/Cargo.toml` builds `serde_json` with `features = ["float_roundtrip"]`
 and that is load-bearing, not tidying. The default number parser is a fast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,19 @@ the comparison. `neat-core/tests/creature_width_contract.rs` pins the rule at
 all four sites (each was mutation-checked individually — dropping any one call
 fails its own tests).
 
+## `serde_json` keeps `float_roundtrip` (GRQ #4261)
+
+`neat-core/Cargo.toml` builds `serde_json` with `features = ["float_roundtrip"]`
+and that is load-bearing, not tidying. The default number parser is a fast
+approximation that can land **1 ULP** from the `f64` a literal names, while
+JavaScript `JSON.parse` and `f64::from_str` are exact — so without the feature a
+creature weight loaded here differs from the one NEAT-AI's TypeScript loaded and
+the two engines score different networks. Nothing fails when that happens; the
+number is simply wrong, which is why a dependency-hygiene sweep must never drop
+the feature as unused, and why it is not exposed as a crate feature a consumer
+could switch off. `neat-core/tests/creature_float_roundtrip.rs` is the gate —
+removing the feature turns all five of its tests red.
+
 ## One activation rule for single-record work (Issue #441)
 
 `neuron_activation_scalar` (`neat-core/src/batch_scoring.rs`) is the single home

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ flowchart LR
     K -. "divergent score" .-> X
 ```
 
-### Creature weights parse to the exact `f64` (GRQ #4261)
+### Creature weights parse to the exact `f64`
 
 `serde_json`'s **default** number parser is a fast approximation that can land
 1 ULP from the `f64` a decimal literal names; the exact algorithm is behind its
@@ -480,7 +480,7 @@ gap above, nothing failed: the number was just marginally wrong.
 `neat-core` therefore builds `serde_json` with `float_roundtrip` **always on**
 (`neat-core/Cargo.toml`). It is not a Cargo feature of this crate and must not
 become one — a consumer that turned it off would get the silent drift back.
-Round-tripping the production GRQ-10 sampler creature (24,232 synapses) is the
+Round-tripping a production trainer sampler creature (24,232 synapses) is the
 measure: exactly one synapse weight differed before
 (`2.2985736498644322e-8` loaded as `2.298573649864432e-8`), none after, and
 `parse -> serialise -> parse` is now an identity as the `creature.rs` module

--- a/README.md
+++ b/README.md
@@ -467,6 +467,44 @@ flowchart LR
     K -. "divergent score" .-> X
 ```
 
+### Creature weights parse to the exact `f64` (GRQ #4261)
+
+`serde_json`'s **default** number parser is a fast approximation that can land
+1 ULP from the `f64` a decimal literal names; the exact algorithm is behind its
+opt-in `float_roundtrip` feature. JavaScript `JSON.parse` — and Rust's own
+`f64::from_str` — are always exact, so without that feature the Rust engines
+(Backpropagation, scorer, Lamarck) trained and scored a *slightly different
+network* from the one NEAT-AI's TypeScript loaded. Unlike the duplicate-synapse
+gap above, nothing failed: the number was just marginally wrong.
+
+`neat-core` therefore builds `serde_json` with `float_roundtrip` **always on**
+(`neat-core/Cargo.toml`). It is not a Cargo feature of this crate and must not
+become one — a consumer that turned it off would get the silent drift back.
+Round-tripping the production GRQ-10 sampler creature (24,232 synapses) is the
+measure: exactly one synapse weight differed before
+(`2.2985736498644322e-8` loaded as `2.298573649864432e-8`), none after, and
+`parse -> serialise -> parse` is now an identity as the `creature.rs` module
+docs have always claimed. The cost is ~0.7 ms on a one-off 3 MB creature load
+(5.4 ms → 6.1 ms best-of-25, release build).
+
+`neat-core/tests/creature_float_roundtrip.rs` is the gate: ten literals the
+fast parser gets wrong across the exponent range, every `f64` field on the wire
+(synapse weight, neuron bias, `memetic` weights and biases), the round-trip
+contract, and a 4,000-value sweep asserting that the shortest-form text of
+**any** finite `f64` parses back to that same `f64`. The oracles are the bit
+pattern the sweep started from and `f64::from_str` — neither shares a code path
+with `serde_json`.
+
+```mermaid
+flowchart LR
+    J["creature JSON<br/>weight: 2.2985736498644322e-8"] --> T["TypeScript JSON.parse<br/>exact"]
+    J --> R["parse_creature_json"]
+    R --> F{"serde_json<br/>float_roundtrip?"}
+    F -- "off (was)" --> D["…4432e-8 — 1 ULP low<br/>silent parity gap"]
+    F -- "on (now)" --> E["…44322e-8 — exact"]
+    T --> E
+```
+
 ### Canonical IF decision trees and the graft helper (Issue #555)
 
 `neat-core` owns the fleet's one interpretation of a decision tree built from

--- a/docs/archive/pr-summaries/pr-summary-grq-4261.md
+++ b/docs/archive/pr-summaries/pr-summary-grq-4261.md
@@ -1,0 +1,196 @@
+# GRQ #4261 — creature weights parsed 1 ULP off: `serde_json` built without `float_roundtrip`
+
+## Summary
+
+`neat-core` loaded creature synapse weights and neuron biases up to **1 ULP**
+away from the value the JSON literal names, because `serde_json` was built
+without its `float_roundtrip` feature. The default number parser is a fast
+approximation; the exact algorithm is opt-in. JavaScript `JSON.parse` — and
+Rust's own `f64::from_str` — are always exact, so the Rust engines
+(NEAT-AI-Backpropagation, NEAT-AI-scorer, NEAT-AI-Lamarck) trained and scored a
+*slightly different network* from the one NEAT-AI's TypeScript loaded. Unlike
+the duplicate-synapse parity gap (#556) this failed silently: nothing errored,
+the number was just marginally wrong.
+
+It also made the `creature.rs` module contract untrue — "round tripping —
+`parse -> serialise -> parse` — preserves every field" (Issue #30) — because a
+weight that parsed to the wrong neighbour was re-emitted as that neighbour's
+shortest text and never came back.
+
+The fix is one line of manifest plus its gate: `neat-core/Cargo.toml` now
+declares `serde_json = { version = "1", features = ["float_roundtrip"] }`. No
+public API, no wire format and no serialised layout changes — the *write* side
+was always exact (`serde_json` emits shortest-round-trip text). Values that
+previously drifted now move to the correct `f64`, which is the direction of
+TypeScript parity.
+
+**Non-breaking, patch bump.** No public item is added, removed, narrowed or
+re-typed, and the `.bin` training-stream format is untouched. The behaviour
+change makes the crate match its own documented contract rather than departing
+from it, so under `RELEASING.md` this is a patch (`0.10.0 → 0.10.1`), not a
+major-equivalent. Consumers pinning a **bit-exact** score fixture may need to
+re-baseline it — see "Consumer impact" below for what was actually measured.
+
+## Evidence
+
+Library change with no web interface to screenshot. The evidence is the reported
+drift, reproduced on the real production creature and then cleared, plus a
+side-by-side against the TypeScript parser this fix exists to agree with.
+
+```mermaid
+flowchart LR
+    J["creature JSON<br/>weight: 2.2985736498644322e-8"] --> T["NEAT-AI TypeScript<br/>JSON.parse — exact"]
+    J --> R["parse_creature_json"]
+    R --> F{"serde_json<br/>float_roundtrip?"}
+    F -- "off (before)" --> D["0x3e58ae4569520dda<br/>1 ULP low, silent"]
+    F -- "on (after)" --> E["0x3e58ae4569520ddb"]
+    T --> E
+    D -. "Rust and TS score<br/>different networks" .-> X["parity gap"]
+```
+
+### The real sampler creature, before and after
+
+`GRQ-sampler/samples/GRQ-10-1.json` at the sampler tip (2,602 neurons, 24,232
+synapses, 3.0 MB), through `parse_creature_json -> creature_to_json ->
+parse_creature_json`. Only `neat-core` differs between the two runs:
+
+```text
+# before — serde_json default parser
+round_trip_equal=false
+  synapse[10518] 0.000000022985736498644322 != 0.00000002298573649864432
+weight_drift=1
+
+# after — serde_json with float_roundtrip
+round_trip_equal=true
+weight_drift=0
+```
+
+That is exactly the issue's report — one synapse of 24,232, the
+`input-542 -> neuron-1514601746` weight, adjacent `f64` values
+`0x1.8ae4569520ddbp-26` vs `0x1.8ae4569520ddap-26`.
+
+### Agreement with the TypeScript parser
+
+The `f64` bit pattern each literal yields, straight out of
+`parse_creature_json`, against `JSON.parse` under Deno (V8). Ten literals, all
+ten previously wrong, all ten now identical to TypeScript:
+
+| Literal | neat-core before | neat-core after | TypeScript `JSON.parse` |
+|---|---|---|---|
+| `2.2985736498644322e-8` | `0x3e58ae4569520dda` | `0x3e58ae4569520ddb` | `0x3e58ae4569520ddb` |
+| `-0.20221894534048165` | `0xbfc9e24f766f3abe` | `0xbfc9e24f766f3abf` | `0xbfc9e24f766f3abf` |
+| `-104913124.37877665` | `0xc19903639183de06` | `0xc19903639183de07` | `0xc19903639183de07` |
+| `-187348849289.48602` | `0xc245cf6e4944be35` | `0xc245cf6e4944be36` | `0xc245cf6e4944be36` |
+| `3.518437208883201171875e13` | `0x42c0000000000001` | `0x42c0000000000002` | `0x42c0000000000002` |
+| `7.038531e-26` | `0x3ab5c87fafffffff` | `0x3ab5c87fb0000000` | `0x3ab5c87fb0000000` |
+| `8.988465674311579e307` | `0x7fe0000000000000` | `0x7fdfffffffffffff` | `0x7fdfffffffffffff` |
+| `2.2250738585072011e-308` | `0x0010000000000000` | `0x000fffffffffffff` | `0x000fffffffffffff` |
+| `5.911867584488277e-25` | `0x3ae6ded47f967086` | `0x3ae6ded47f967087` | `0x3ae6ded47f967087` |
+| `-2.3359371920453957e-123` | `0xa678b4fb909fceff` | `0xa678b4fb909fcf00` | `0xa678b4fb909fcf00` |
+
+### How common the drift was
+
+Shortest-form text of 199,894 pseudo-random finite `f64` values, re-parsed:
+
+```text
+before: checked=199894 mismatches=59253   (29.6%)
+after:  checked=199894 mismatches=0
+```
+
+Roughly three in ten weights across the full exponent range. Real creature
+weights cluster in a narrow band, which is why only one synapse of 24,232 drifts
+in practice — but "one weight per creature is silently wrong" is still a network
+neither engine agrees on.
+
+### Cost
+
+Parsing the same 3.0 MB creature, release build, best-of-25 on this host:
+
+| | best | median |
+|---|---|---|
+| before | 5.37 ms | 6.61 ms |
+| after | 6.12 ms | 7.44 ms |
+
+~0.7 ms on a **one-off** creature load, against training runs measured in
+minutes. `Cargo.lock` is unchanged — `float_roundtrip` pulls in no new
+dependency, so there is no supply-chain or `cargo deny` surface to it.
+
+### Consumer impact
+
+Both Rust consumers were built and tested against the patched sibling
+(`../../NEAT-AI-core/neat-core`) on this host:
+
+- **NEAT-AI-Backpropagation** — `cargo test --workspace` green: 144 tests, 0
+  failures across all ten targets, including `mse_surface_agreement`,
+  `trained_creature_validation` and `forward_only_guard`. No score fixture
+  needed re-baselining.
+- **NEAT-AI-scorer** — `cargo build --release -p rust_scorer` green. Its
+  **test** targets do not compile against `neat-core` `Develop`, but that
+  predates this change and is unrelated to it: `rust_scorer/src/scoring.rs`
+  builds `CreatureExport` / `NeuronExport` struct literals that are missing the
+  `memetic` and `id` fields added by #559, and the repo's
+  `neat-core.expected-version` baseline is still `0.9.0`. That acknowledgement
+  is already tracked in stSoftwareAU/GRQ#4259.
+
+### Quality gates
+
+- `./quality.sh` — `✅ All quality checks passed!` (bash syntax, shellcheck,
+  bats, TypeScript gate, Mermaid gate, codespell, rustfmt, clippy `-D warnings`,
+  `cargo test --workspace` 58 green targets, doctests, rustdoc, release build).
+- `cargo check -p neat-core --target wasm32-unknown-unknown` **could not run on
+  this host**: `error[E0463]: can't find crate for 'std'` — the target's std is
+  not installed and there is no `rustup` on the box to add it. The change is
+  target-agnostic: a Cargo feature on `serde_json`, no `cfg`, no `arch`, no SIMD
+  and no new dependency (`Cargo.lock` unchanged).
+
+## Test Plan
+
+New file `neat-core/tests/creature_float_roundtrip.rs`, five tests. Every
+oracle is independent of `serde_json`: either the `f64` bit pattern the test
+itself started from, or `f64::from_str` over the same literal text.
+
+- `synapse_weight_parses_to_the_f64_the_literal_names` — the ten literals above
+  as a synapse weight.
+- `neuron_bias_parses_to_the_f64_the_literal_names` — the same as a neuron bias.
+- `memetic_weight_and_bias_parse_to_the_f64_the_literals_name` — `memetic`
+  row weights and the `biases` map, the other two `f64` fields on the wire.
+- `parse_serialise_parse_preserves_every_hard_weight` — the Issue #30 round-trip
+  contract the module docs state, asserted on the whole `CreatureExport`.
+- `shortest_form_text_of_any_f64_parses_back_to_that_f64` — the **general
+  case**: a fixed-seed xorshift sweep of 4,000 `f64` values, each formatted to
+  its shortest text and parsed back, asserted against the bit pattern it started
+  from. This is what stops the fix being mistaken for a special case on the ten
+  literals, and it carries a floor assertion (`checked > 3_000`) so it cannot
+  skip its way to green.
+
+### Mutation evidence
+
+Every one of the five is red against the unfixed manifest and green with it —
+verified by running the file both ways:
+
+```text
+# neat-core/Cargo.toml at `serde_json = "1"`
+test result: FAILED. 0 passed; 5 failed
+
+# with features = ["float_roundtrip"]
+test result: ok. 5 passed; 0 failed
+```
+
+The failure messages name the drift directly, e.g.
+`2.2985736498644322e-8: parsed 2.298573649864432e-8 (0x3e58ae4569520dda) but the
+literal names 2.2985736498644322e-8 (0x3e58ae4569520ddb)`. Reverting the one
+manifest line is the whole mutation, so there is no second site to sweep.
+
+No existing test was removed, weakened or modified.
+
+### Documentation
+
+- `neat-core/src/creature.rs` — module docs gain an **Exact float parsing**
+  paragraph beside the round-trip contract it repairs, and
+  `parse_creature_json` states the guarantee.
+- `README.md` — new section "Creature weights parse to the exact `f64`
+  (GRQ #4261)" beside the other cross-engine parity rules, with the measured
+  numbers and a Mermaid diagram.
+- `AGENTS.md` — a short durable note that the feature is load-bearing and must
+  not be dropped as unused by a dependency-hygiene sweep, naming the test that
+  guards it.

--- a/neat-core/Cargo.toml
+++ b/neat-core/Cargo.toml
@@ -17,7 +17,12 @@ crate-type = ["cdylib", "rlib"]
 # Native builds omit wasm-bindgen; WASM targets link it for `accumulate` exports.
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# GRQ #4261 - `float_roundtrip` is not optional. serde_json's default number
+# parser is a fast approximation that can land 1 ULP away from the f64 the
+# literal names, so a creature weight loaded here differed from the one
+# JavaScript `JSON.parse` gives NEAT-AI and the two engines scored different
+# networks. The feature selects the exact algorithm, matching `f64::from_str`.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 # Issue #179 - opt-in data-parallel record scoring. `rayon` is native-only
 # (it is not wasm-friendly), so it is declared under a `cfg(not(wasm32))`

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -10,6 +10,19 @@
 //! serialisations of the same `CreatureExport` produce byte-identical JSON
 //! (serde emits fields in declaration order).
 //!
+//! **Exact float parsing (GRQ #4261).** "Preserves every field" includes the
+//! last bit of every `f64`. `serde_json`'s *default* number parser is a fast
+//! approximation that can land 1 ULP from the value the literal names, so a
+//! weight such as `2.2985736498644322e-8` loaded as its neighbour
+//! `2.298573649864432e-8` and the round trip above was not an identity. That
+//! is also a cross-engine parity gap: JavaScript `JSON.parse` is exact, so the
+//! Rust engines trained and scored a *slightly different network* from the one
+//! NEAT-AI's TypeScript loaded, silently. `neat-core` therefore builds
+//! `serde_json` with its `float_roundtrip` feature — the exact algorithm,
+//! agreeing with `f64::from_str` on every input. The feature is **not
+//! optional**: dropping it reintroduces the drift with nothing failing loudly.
+//! `neat-core/tests/creature_float_roundtrip.rs` is the gate.
+//!
 //! The `#[serde(rename = "...")]` attributes (`semanticVersion`, `forwardOnly`,
 //! `fromUUID`, `toUUID`, `type`) apply symmetrically on both input and output,
 //! so the canonical TypeScript camelCase shape is preserved.
@@ -60,7 +73,7 @@
 //! Issues: #1965 (initial deserialisation), #30 (symmetric serialisation),
 //! #550 (observation-width contract), #556 (duplicate-synapse rule),
 //! #559 (validation contract input format), GRQ #4257 (both memetic weight
-//! forms).
+//! forms), GRQ #4261 (exact float parsing).
 
 use serde::de::{MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -631,6 +644,10 @@ pub fn validate_no_duplicate_synapses(creature: &CreatureExport) -> Result<(), C
 /// [`CreatureError::InvalidInputCount`] / [`CreatureError::InvalidOutputCount`]
 /// rather than a struct with a zero width. A missing `input` / `output` key or
 /// a negative literal is a [`CreatureError::Json`] error (Issue #550).
+///
+/// Every weight and bias parses to **exactly** the `f64` its literal names —
+/// the same value `f64::from_str` and JavaScript `JSON.parse` produce — via
+/// `serde_json`'s `float_roundtrip` feature (GRQ #4261, module docs above).
 pub fn parse_creature_json(json: &str) -> Result<CreatureExport, CreatureError> {
     let creature: CreatureExport = serde_json::from_str(json)?;
     validate_creature_width(&creature)?;

--- a/neat-core/tests/creature_float_roundtrip.rs
+++ b/neat-core/tests/creature_float_roundtrip.rs
@@ -1,0 +1,213 @@
+//! GRQ #4261 — a creature weight must parse to the **exact** `f64` its JSON
+//! literal names, so the Rust and TypeScript engines load the same network.
+//!
+//! `serde_json`'s default number parser is a fast approximation that lands up
+//! to 1 ULP away from the nearest `f64`; the exact algorithm is behind its
+//! opt-in `float_roundtrip` feature. JavaScript `JSON.parse` — and Rust's own
+//! `f64::from_str` — are always exact, so without that feature the Backprop,
+//! scorer and Lamarck engines trained and scored a *slightly different network*
+//! from the one NEAT-AI's TypeScript loaded, silently: nothing failed, the
+//! number was just marginally wrong.
+//!
+//! The oracle here is deliberately **not** `serde_json`. Every expectation is
+//! either the `f64` bit pattern the test itself started from, or
+//! `f64::from_str` over the same literal text — two routes that share no code
+//! with the parser under test, so a fault in it moves only one side of the
+//! assertion.
+
+use std::collections::BTreeMap;
+
+use neat_core::creature::MemeticWeights;
+use neat_core::{CreatureExport, creature_to_json, parse_creature_json};
+
+// ---------------------------------------------------------------------------
+// Literals the fast parser gets wrong.
+// ---------------------------------------------------------------------------
+
+/// Decimal literals whose nearest `f64` the approximate parser misses by 1 ULP.
+///
+/// The first is the weight from the issue — synapse 10511 of
+/// `GRQ-sampler/samples/GRQ-10-1.json`, `input-542 -> neuron-1514601746`. The
+/// rest were found by round-tripping shortest-form `f64` text through the
+/// unfixed parser, and cover ordinary magnitudes as well as the extremes, so
+/// the fix cannot be mistaken for a special case on one exponent range.
+const HARD_LITERALS: &[&str] = &[
+    "2.2985736498644322e-8",
+    "-0.20221894534048165",
+    "-104913124.37877665",
+    "-187348849289.48602",
+    "3.518437208883201171875e13",
+    "7.038531e-26",
+    "8.988465674311579e307",
+    "2.2250738585072011e-308",
+    "5.911867584488277e-25",
+    "-2.3359371920453957e-123",
+];
+
+// ---------------------------------------------------------------------------
+// Fixtures — `input-0 -> h -> output-0`, one literal under test per creature.
+// ---------------------------------------------------------------------------
+
+/// A creature whose synapse `h -> output-0` carries `weight`, whose hidden
+/// neuron carries `bias`, and whose memetic block repeats both.
+fn creature_json(weight: &str, bias: &str) -> String {
+    format!(
+        r#"{{
+  "input": 1,
+  "output": 1,
+  "neurons": [
+    {{ "type": "hidden", "uuid": "h", "bias": {bias}, "squash": "TANH" }},
+    {{ "type": "output", "uuid": "output-0", "bias": 0.0, "squash": "IDENTITY" }}
+  ],
+  "synapses": [
+    {{ "fromUUID": "input-0", "toUUID": "h", "weight": 1.0 }},
+    {{ "fromUUID": "h", "toUUID": "output-0", "weight": {weight} }}
+  ],
+  "memetic": {{
+    "generation": 7,
+    "biases": {{ "h": {bias} }},
+    "weights": [
+      {{ "fromUUID": "h", "toUUID": "output-0", "weight": {weight} }}
+    ]
+  }}
+}}"#
+    )
+}
+
+fn parse(json: &str) -> CreatureExport {
+    parse_creature_json(json).expect("the creature parses")
+}
+
+/// The `f64` the literal text names, by a route that never touches
+/// `serde_json`.
+fn exact(literal: &str) -> f64 {
+    literal
+        .parse::<f64>()
+        .expect("the literal is valid float text")
+}
+
+/// Bit-level equality — `-0.0 == 0.0` and `NaN != NaN` under `==`, and a 1 ULP
+/// drift is exactly what this file exists to catch, so compare the payloads.
+fn assert_same_f64(actual: f64, expected: f64, what: &str) {
+    assert_eq!(
+        actual.to_bits(),
+        expected.to_bits(),
+        "{what}: parsed {actual:e} (0x{:016x}) but the literal names {expected:e} (0x{:016x})",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}
+
+/// The memetic block's single row weight.
+fn memetic_row_weight(creature: &CreatureExport) -> f64 {
+    let memetic = creature.memetic.as_ref().expect("the memetic block parsed");
+    match &memetic.weights {
+        MemeticWeights::Rows(rows) => rows[0].weight.expect("the row carries a weight"),
+        MemeticWeights::ById(_) => panic!("the fixture writes the row form"),
+    }
+}
+
+/// The memetic block's biases, keyed by neuron.
+fn memetic_biases(creature: &CreatureExport) -> &BTreeMap<String, f64> {
+    &creature
+        .memetic
+        .as_ref()
+        .expect("the memetic block parsed")
+        .biases
+}
+
+// ---------------------------------------------------------------------------
+// Every `f64` field on the wire parses exactly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn synapse_weight_parses_to_the_f64_the_literal_names() {
+    for literal in HARD_LITERALS {
+        let creature = parse(&creature_json(literal, "0.25"));
+        assert_same_f64(creature.synapses[1].weight, exact(literal), literal);
+    }
+}
+
+#[test]
+fn neuron_bias_parses_to_the_f64_the_literal_names() {
+    for literal in HARD_LITERALS {
+        let creature = parse(&creature_json("1.0", literal));
+        assert_same_f64(creature.neurons[0].bias, exact(literal), literal);
+    }
+}
+
+#[test]
+fn memetic_weight_and_bias_parse_to_the_f64_the_literals_name() {
+    for literal in HARD_LITERALS {
+        let creature = parse(&creature_json(literal, literal));
+        assert_same_f64(memetic_row_weight(&creature), exact(literal), literal);
+        assert_same_f64(memetic_biases(&creature)["h"], exact(literal), literal);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The round-trip contract the module docs state (Issue #30).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_serialise_parse_preserves_every_hard_weight() {
+    for literal in HARD_LITERALS {
+        let first = parse(&creature_json(literal, literal));
+        let written = creature_to_json(&first).expect("the creature serialises");
+        let second = parse_creature_json(&written).expect("the re-serialised creature parses");
+
+        assert_eq!(
+            first, second,
+            "{literal}: parse -> serialise -> parse changed the creature"
+        );
+        assert_same_f64(second.synapses[1].weight, exact(literal), literal);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The general case: any `f64`, not the ten above.
+// ---------------------------------------------------------------------------
+
+/// Deterministic xorshift64 — a fixed seed, so a failure is reproducible and
+/// the sweep is not a flaky test.
+fn xorshift64(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+/// Shortest-form text of **any** finite `f64` must parse back to that exact
+/// `f64`.
+///
+/// This is the property the fix has to hold in general, and the oracle is the
+/// `f64` the sweep started from — no parser, fast or exact, is consulted for
+/// the expected value. Roughly 30% of these bit patterns drift by 1 ULP
+/// through the approximate parser, so the sweep is red long before it ends
+/// against unfixed code.
+#[test]
+fn shortest_form_text_of_any_f64_parses_back_to_that_f64() {
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    let mut checked = 0usize;
+
+    for _ in 0..4_000 {
+        let value = f64::from_bits(xorshift64(&mut state));
+        if !value.is_finite() {
+            continue;
+        }
+        // `{:?}` emits the shortest text that names this exact `f64`, and is
+        // always valid JSON number syntax for a finite value.
+        let literal = format!("{value:?}");
+        let creature = parse(&creature_json(&literal, &literal));
+
+        assert_same_f64(creature.synapses[1].weight, value, &literal);
+        assert_same_f64(creature.neurons[0].bias, value, &literal);
+        checked += 1;
+    }
+
+    assert!(
+        checked > 3_000,
+        "the sweep must actually exercise the parser, not skip its way to green \
+         (only {checked} finite values reached it)"
+    );
+}


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/GRQ#4261 here, in the dependency's own repo.

serde_json was built without float_roundtrip, so creature weights loaded up to 1 ULP off and the Rust engines scored a different network from TypeScript; enables the exact parser and gates it with a regression suite.

**Head:** `issue-4261-serde-json-float-roundtrip` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/GRQ#4261: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.