### PR TITLE
Verify duplicate (from, to) synapse rejection coverage in creature validation (Issue #572)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -452,6 +452,13 @@ pair is `CreatureError::DuplicateSynapse { from_uuid, to_uuid }`, naming the
 first pair that repeats in declaration order. Distinct pairs that share one
 endpoint — fan-out from a source, fan-in to a target — are untouched.
 
+The ordered pair is the **whole** key: the synapse *role* plays no part in it.
+Many synapses may carry the same role into one neuron — two `condition` edges
+into an `IF` neuron are what a decision stump is built from — as long as their
+sources differ. Only an exact repeat of `(fromUUID, toUUID)` is rejected, which
+is also why an `IF` neuron needs up to three separate constants (each with
+`bias = 1`) rather than one constant wired three times (Issue #572).
+
 Consumers that assemble a `CreatureExport` in Rust rather than parsing one
 should call `validate_no_duplicate_synapses` at their own boundary
 (NEAT-AI-Forests already guards this itself).

--- a/docs/archive/pr-summaries/pr-summary-572.md
+++ b/docs/archive/pr-summaries/pr-summary-572.md
@@ -1,0 +1,109 @@
+# Duplicate `(from, to)` synapse rejection — verified, and the role pinned out of it
+
+## Summary
+
+Issue #572 asked for the existing duplicate-`(from, to)` rejection coverage to
+be verified and recorded. It is correct on every entry point, and the evidence
+is below. What was **not** pinned anywhere is the other half of the rule the
+user clarified: many synapses may carry the **same role** into one neuron as
+long as their sources differ — GRQ #4277 reads as though that were forbidden.
+Four tests now state the rule precisely and the docs say it in words. No
+behaviour change: the only source edits are doc comments. Closes #572.
+
+The rule, exactly:
+
+> A creature is rejected when two synapses share the same ordered
+> `(fromUUID, toUUID)` pair — and only then. The synapse role is not part of
+> the key, so two `positive` edges into one `IF` neuron are legal when their
+> sources differ. This is why an `IF` neuron needs up to three separate
+> constants (each with `bias = 1`) rather than one constant wired three times:
+> one constant feeding condition, positive and negative is the same pair three
+> times.
+
+```mermaid
+flowchart LR
+    A["3 synapses into if-0"] --> B{"same ordered<br/>(from, to) pair?"}
+    B -->|"yes — one constant<br/>wired 3 times"| R["rejected<br/>DuplicateSynapse / rule 26"]
+    B -->|"no — 3 constants,<br/>bias = 1 each"| K["accepted"]
+    B -->|"no — 2 sources,<br/>same role"| K
+```
+
+## Evidence
+
+Backend-only change, so there is no UI to screenshot. The evidence is the test
+runs and the mutation sweep.
+
+### Existing coverage, verified green on the default branch
+
+```text
+$ cargo test -p neat-core --test creature_duplicate_synapses \
+      --test creature_validate_synapse_rules
+test result: ok. 8 passed; 0 failed    (creature_duplicate_synapses)
+test result: ok. 26 passed; 0 failed   (creature_validate_synapse_rules)
+```
+
+Where each entry point is covered:
+
+| Entry point | Rejects a repeated pair | Covered by |
+|---|---|---|
+| `compile_creature` | `CreatureError::DuplicateSynapse` | `creature_duplicate_synapses.rs` |
+| `validate_no_duplicate_synapses` (consumer boundary) | `CreatureError::DuplicateSynapse` | `creature_duplicate_synapses.rs` |
+| `creature_validate` (export shape, rules 25/26) | `Topology` / `INVALID_CONNECTION` | `creature_validate_synapse_rules.rs`, `creature_validate_contract.rs` |
+| `creature_validate_json` (runtime/wire shape) | `Topology` / `INVALID_CONNECTION` | `creature_validate_runtime_conformance.rs`, corpus case `duplicate-synapse` |
+
+A duplicate separated by another pair is stopped by rule 25 (`SORT_FAILURE`)
+before it reaches rule 26; `validate_no_duplicate_synapses` is order-independent
+and rejects it either way. Both paths reject — only the reported reason differs
+(already pinned by `a_non_adjacent_duplicate_pair_is_still_rejected_by_both_paths`).
+
+### Mutation evidence — the new tests can fail
+
+Each mutation was applied alone and reverted; the suite is unmodified at commit
+time.
+
+| # | Mutation | Result |
+|---|---|---|
+| M1 | key the duplicate set on `(from, to, weight)` | `compile_rejects_a_repeated_pair_that_shares_one_role` **red** (+ 4 existing) |
+| M2 | key the duplicate set on `to` alone | `compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ` **red** (+ 2 existing) |
+| M3 | `positive_sum = val` instead of `+=` in the `IF` branch | `compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ` **red** — and nothing else, so the `5.5` oracle is what catches it |
+| M4 | drop the `from == last_from` guard so any repeated target reads as a duplicate (GRQ #4277's reading, encoded) | `same_role_fan_in_from_distinct_sources_breaks_no_rule` **red** (+ 6 existing) |
+| M5 | `else if false` in place of rule 26's `to == last_to` | `repeating_one_pair_of_that_creature_is_still_a_duplicate` **red** (+ 1 existing) |
+
+The oracles are independent of the code under test: M3's target is the network's
+`IF` aggregation, and the expected `5.5` is derived in the test from the
+declared constants and weights (`1.0 * 2.0 + 1.0 * 3.0 + bias 0.5`), not read
+back from the compiler.
+
+### Quality gate
+
+```text
+$ ./quality.sh < /dev/null
+✅ All quality checks passed!
+```
+
+## Test Plan
+
+Added to `neat-core/tests/creature_duplicate_synapses.rs`:
+
+- `compile_rejects_a_repeated_pair_that_shares_one_role` — two `positive`
+  synapses from one constant are still the same pair twice, so
+  `CreatureError::DuplicateSynapse` names both endpoints.
+- `compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ` — an
+  `IF` neuron fed two `positive` synapses from two distinct `bias = 1`
+  constants compiles, and both contribute to the branch (`activate` → `5.5`).
+
+Added to `neat-core/tests/creature_validate_synapse_rules.rs`:
+
+- `same_role_fan_in_from_distinct_sources_breaks_no_rule` — six constants, two
+  per role, into one `IF` neuron clear rules 12 and 26 through the whole
+  `creature_validate` entry point (`constant = 6`, `connections = 7`).
+- `repeating_one_pair_of_that_creature_is_still_a_duplicate` — repeating one of
+  those pairs stops on rule 26 with the verbatim
+  `1) duplicate synapse k-cond-a -> if-0`.
+
+Documentation updated to state the rule precisely: the README
+"Duplicate `(fromUUID, toUUID)` synapses are rejected" section, the
+`validate_no_duplicate_synapses` doc comment, and the rule-26 note in the
+`creature_validate` module docs.
+
+No existing test was modified or removed.

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -620,6 +620,11 @@ pub fn validate_creature_width(creature: &CreatureExport) -> Result<(), Creature
 /// is therefore to fail closed with [`CreatureError::DuplicateSynapse`],
 /// naming the first pair that repeats in declaration order.
 ///
+/// The ordered pair is the whole key — the synapse **role** plays no part in
+/// it. Many synapses may carry the same role into one neuron as long as their
+/// sources differ; only an exact repeat of `(fromUUID, toUUID)` is rejected
+/// (Issue #572).
+///
 /// [`compile_creature`] calls this before building the network. Consumers that
 /// assemble a [`CreatureExport`] in Rust, or feed one straight into their own
 /// scorer, should call it at their own boundary.

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -83,7 +83,10 @@
 //! [`crate::creature::validate_no_duplicate_synapses`] (Issue #556) — one
 //! ordered `(from, to)` pair, at most once — reported here under the
 //! TypeScript's own class and reason (`TopologyError` / `INVALID_CONNECTION`,
-//! *not* `DUPLICATE_SYNAPSE`, which `creatureValidate` never raises).
+//! *not* `DUPLICATE_SYNAPSE`, which `creatureValidate` never raises). The
+//! synapse **role** plays no part in either rule: rule 12 wants one edge of
+//! each role and rule 26 wants each pair once, so an `IF` neuron fed two
+//! `positive` edges from two different sources breaks neither (Issue #572).
 //!
 //! # Input format
 //!

--- a/neat-core/tests/creature_duplicate_synapses.rs
+++ b/neat-core/tests/creature_duplicate_synapses.rs
@@ -142,6 +142,27 @@ fn compile_reports_the_first_repeated_pair_in_declaration_order() {
     }
 }
 
+/// What repeats is the **pair**, not the role: two `positive` synapses from the
+/// same constant are still `("c", "if-0")` twice, and are rejected for exactly
+/// the reason a mixed-role repeat is.
+#[test]
+fn compile_rejects_a_repeated_pair_that_shares_one_role() {
+    let mut creature = if_triple_from_one_constant();
+    creature.synapses = vec![
+        synapse("c", "if-0", 1.0, Some("positive")),
+        synapse("c", "if-0", 2.0, Some("positive")),
+        synapse("if-0", "output-0", 1.0, None),
+    ];
+    match compile_creature(&creature) {
+        Err(CreatureError::DuplicateSynapse { from_uuid, to_uuid }) => {
+            assert_eq!(from_uuid, "c");
+            assert_eq!(to_uuid, "if-0");
+        }
+        Err(other) => panic!("expected DuplicateSynapse, got {other:?}"),
+        Ok(_) => panic!("a repeated (from, to) pair must not compile"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Acceptance — the rule must not reject legitimate topologies
 // ---------------------------------------------------------------------------
@@ -208,6 +229,51 @@ fn compile_accepts_an_if_neuron_fed_by_three_distinct_constants() {
     assert!(
         (output[0] - 4.5).abs() < 1e-5,
         "expected 4.5, got {}",
+        output[0]
+    );
+}
+
+/// A **repeated role** into one neuron is legal as long as the sources differ:
+/// the rule keys on the ordered `(from, to)` pair alone and never reads the
+/// role. Two `positive` synapses into the same `IF` neuron therefore compile,
+/// and both contribute to the branch they name.
+#[test]
+fn compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ() {
+    let creature = CreatureExport {
+        memetic: None,
+        input: 1,
+        output: 1,
+        neurons: vec![
+            neuron("constant", "k-cond", 1.0, "IDENTITY"),
+            neuron("constant", "k-pos-a", 1.0, "IDENTITY"),
+            neuron("constant", "k-pos-b", 1.0, "IDENTITY"),
+            neuron("constant", "k-neg", 1.0, "IDENTITY"),
+            neuron("hidden", "if-0", 0.5, "IF"),
+            neuron("output", "output-0", 0.0, "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("k-cond", "if-0", 1.0, Some("condition")),
+            synapse("k-pos-a", "if-0", 2.0, Some("positive")),
+            synapse("k-pos-b", "if-0", 3.0, Some("positive")),
+            synapse("k-neg", "if-0", -4.0, Some("negative")),
+            synapse("if-0", "output-0", 1.0, None),
+        ],
+        semantic_version: None,
+        forward_only: true,
+    };
+    assert!(
+        validate_no_duplicate_synapses(&creature).is_ok(),
+        "distinct sources make distinct pairs, whatever the roles say"
+    );
+    let mut network = compile_creature(&creature).expect("repeated roles must compile");
+
+    // Each constant activates at its own bias of 1.0. condition = 1.0 * 1.0 =
+    // 1.0 > 0, so the positive branch is taken and *both* positive synapses
+    // contribute: 1.0 * 2.0 + 1.0 * 3.0 + bias 0.5 = 5.5.
+    let output = network.activate(&[0.0], 1);
+    assert!(
+        (output[0] - 5.5).abs() < 1e-5,
+        "expected 5.5, got {}",
         output[0]
     );
 }

--- a/neat-core/tests/creature_validate_synapse_rules.rs
+++ b/neat-core/tests/creature_validate_synapse_rules.rs
@@ -9,7 +9,8 @@ use std::collections::BTreeMap;
 
 use neat_core::creature::{MemeticExport, MemeticWeightExport, MemeticWeights};
 use neat_core::creature_validate::{
-    FailureClass, ValidateOptions, ValidationStats, reason, validate_synapse_and_memetic_rules,
+    FailureClass, ValidateOptions, ValidationStats, creature_validate, reason,
+    validate_synapse_and_memetic_rules,
 };
 use neat_core::{
     CreatureExport, NeuronExport, SynapseExport, stump_creature, validate_no_duplicate_synapses,
@@ -230,6 +231,95 @@ fn a_non_adjacent_duplicate_pair_is_still_rejected_by_both_paths() {
         validate_no_duplicate_synapses(&creature).is_err(),
         "Issue #556's pair check rejects the same creature regardless of order"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Rule 26 — the role plays no part in it (Issue #572).
+// ---------------------------------------------------------------------------
+
+/// An `IF` neuron fed **two synapses of each role**, one per distinct constant:
+/// six inward pairs, none of them repeated. Rule 12 wants one of each role and
+/// rule 26 wants each `(from, to)` pair at most once — both hold here, so the
+/// creature is legal even though three roles each arrive twice.
+fn doubled_role_if_creature() -> CreatureExport {
+    CreatureExport {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            constant("k-cond-a", 1),
+            constant("k-cond-b", 2),
+            constant("k-pos-a", 3),
+            constant("k-pos-b", 4),
+            constant("k-neg-a", 5),
+            constant("k-neg-b", 6),
+            neuron("hidden", "if-0", 7),
+            neuron("output", "o", -1),
+        ],
+        synapses: vec![
+            role_edge("k-cond-a", "if-0", "condition"),
+            role_edge("k-cond-b", "if-0", "condition"),
+            role_edge("k-pos-a", "if-0", "positive"),
+            role_edge("k-pos-b", "if-0", "positive"),
+            role_edge("k-neg-a", "if-0", "negative"),
+            role_edge("k-neg-b", "if-0", "negative"),
+            edge("if-0", "o"),
+        ],
+        semantic_version: None,
+        forward_only: false,
+        memetic: None,
+    }
+}
+
+/// A constant carries no squash (rule 15) and the `bias = 1.0` the `IF`
+/// branches read as their value.
+fn constant(uuid: &str, id: i64) -> NeuronExport {
+    NeuronExport {
+        id: Some(id),
+        neuron_type: "constant".to_string(),
+        uuid: uuid.to_string(),
+        bias: 1.0,
+        squash: None,
+    }
+}
+
+fn role_edge(from: &str, to: &str, role: &str) -> SynapseExport {
+    SynapseExport {
+        synapse_type: Some(role.to_string()),
+        ..edge(from, to)
+    }
+}
+
+/// The whole entry point, not just this half: a repeated role must clear the
+/// `IF` rule as well as the duplicate one. GRQ #4277 reads as though same-role
+/// fan-in into one neuron were forbidden — it is not; only an exact repeat of
+/// the ordered `(from, to)` pair is.
+#[test]
+fn same_role_fan_in_from_distinct_sources_breaks_no_rule() {
+    let mut creature = doubled_role_if_creature();
+    creature.neurons[6].squash = Some("IF".to_string());
+
+    let stats = creature_validate(&creature, &ValidateOptions::default())
+        .expect("repeated roles from distinct sources are a legal creature");
+
+    assert_eq!(stats.constant, 6);
+    assert_eq!(stats.connections, 7, "one tally per synapse walked");
+}
+
+/// The same creature with one of those pairs repeated: same role, same source,
+/// same target — and now rule 26 stops it.
+#[test]
+fn repeating_one_pair_of_that_creature_is_still_a_duplicate() {
+    let mut creature = doubled_role_if_creature();
+    creature
+        .synapses
+        .insert(1, role_edge("k-cond-a", "if-0", "condition"));
+
+    let failure = run_err(&creature, &ValidateOptions::default());
+
+    assert_eq!(failure.class, FailureClass::Topology);
+    assert_eq!(failure.reason, reason::INVALID_CONNECTION);
+    assert_eq!(failure.message, "1) duplicate synapse k-cond-a -> if-0");
+    assert_eq!(failure.synapse_index, Some(1));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Duplicate `(from, to)` synapse rejection — verified, and the role pinned out of it

## Summary

Issue #572 asked for the existing duplicate-`(from, to)` rejection coverage to
be verified and recorded. It is correct on every entry point, and the evidence
is below. What was **not** pinned anywhere is the other half of the rule the
user clarified: many synapses may carry the **same role** into one neuron as
long as their sources differ — GRQ #4277 reads as though that were forbidden.
Four tests now state the rule precisely and the docs say it in words. No
behaviour change: the only source edits are doc comments. Closes #572.

The rule, exactly:

> A creature is rejected when two synapses share the same ordered
> `(fromUUID, toUUID)` pair — and only then. The synapse role is not part of
> the key, so two `positive` edges into one `IF` neuron are legal when their
> sources differ. This is why an `IF` neuron needs up to three separate
> constants (each with `bias = 1`) rather than one constant wired three times:
> one constant feeding condition, positive and negative is the same pair three
> times.

```mermaid
flowchart LR
    A["3 synapses into if-0"] --> B{"same ordered<br/>(from, to) pair?"}
    B -->|"yes — one constant<br/>wired 3 times"| R["rejected<br/>DuplicateSynapse / rule 26"]
    B -->|"no — 3 constants,<br/>bias = 1 each"| K["accepted"]
    B -->|"no — 2 sources,<br/>same role"| K
```

## Evidence

Backend-only change, so there is no UI to screenshot. The evidence is the test
runs and the mutation sweep.

### Existing coverage, verified green on the default branch

```text
$ cargo test -p neat-core --test creature_duplicate_synapses \
      --test creature_validate_synapse_rules
test result: ok. 8 passed; 0 failed    (creature_duplicate_synapses)
test result: ok. 26 passed; 0 failed   (creature_validate_synapse_rules)
```

Where each entry point is covered:

| Entry point | Rejects a repeated pair | Covered by |
|---|---|---|
| `compile_creature` | `CreatureError::DuplicateSynapse` | `creature_duplicate_synapses.rs` |
| `validate_no_duplicate_synapses` (consumer boundary) | `CreatureError::DuplicateSynapse` | `creature_duplicate_synapses.rs` |
| `creature_validate` (export shape, rules 25/26) | `Topology` / `INVALID_CONNECTION` | `creature_validate_synapse_rules.rs`, `creature_validate_contract.rs` |
| `creature_validate_json` (runtime/wire shape) | `Topology` / `INVALID_CONNECTION` | `creature_validate_runtime_conformance.rs`, corpus case `duplicate-synapse` |

A duplicate separated by another pair is stopped by rule 25 (`SORT_FAILURE`)
before it reaches rule 26; `validate_no_duplicate_synapses` is order-independent
and rejects it either way. Both paths reject — only the reported reason differs
(already pinned by `a_non_adjacent_duplicate_pair_is_still_rejected_by_both_paths`).

### Mutation evidence — the new tests can fail

Each mutation was applied alone and reverted; the suite is unmodified at commit
time.

| # | Mutation | Result |
|---|---|---|
| M1 | key the duplicate set on `(from, to, weight)` | `compile_rejects_a_repeated_pair_that_shares_one_role` **red** (+ 4 existing) |
| M2 | key the duplicate set on `to` alone | `compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ` **red** (+ 2 existing) |
| M3 | `positive_sum = val` instead of `+=` in the `IF` branch | `compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ` **red** — and nothing else, so the `5.5` oracle is what catches it |
| M4 | drop the `from == last_from` guard so any repeated target reads as a duplicate (GRQ #4277's reading, encoded) | `same_role_fan_in_from_distinct_sources_breaks_no_rule` **red** (+ 6 existing) |
| M5 | `else if false` in place of rule 26's `to == last_to` | `repeating_one_pair_of_that_creature_is_still_a_duplicate` **red** (+ 1 existing) |

The oracles are independent of the code under test: M3's target is the network's
`IF` aggregation, and the expected `5.5` is derived in the test from the
declared constants and weights (`1.0 * 2.0 + 1.0 * 3.0 + bias 0.5`), not read
back from the compiler.

### Quality gate

```text
$ ./quality.sh < /dev/null
✅ All quality checks passed!
```

## Test Plan

Added to `neat-core/tests/creature_duplicate_synapses.rs`:

- `compile_rejects_a_repeated_pair_that_shares_one_role` — two `positive`
  synapses from one constant are still the same pair twice, so
  `CreatureError::DuplicateSynapse` names both endpoints.
- `compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ` — an
  `IF` neuron fed two `positive` synapses from two distinct `bias = 1`
  constants compiles, and both contribute to the branch (`activate` → `5.5`).

Added to `neat-core/tests/creature_validate_synapse_rules.rs`:

- `same_role_fan_in_from_distinct_sources_breaks_no_rule` — six constants, two
  per role, into one `IF` neuron clear rules 12 and 26 through the whole
  `creature_validate` entry point (`constant = 6`, `connections = 7`).
- `repeating_one_pair_of_that_creature_is_still_a_duplicate` — repeating one of
  those pairs stops on rule 26 with the verbatim
  `1) duplicate synapse k-cond-a -> if-0`.

Documentation updated to state the rule precisely: the README
"Duplicate `(fromUUID, toUUID)` synapses are rejected" section, the
`validate_no_duplicate_synapses` doc comment, and the rule-26 note in the
`creature_validate` module docs.

No existing test was modified or removed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt44zo53-1ff5f3`<!-- vibe-worker-issue-572 -->