### PR TITLE
if_graft: typed outward edges, batched grafts and the IDENTITY relay (NEAT-AI-Forests #48)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,8 +267,10 @@ this you **must**:
 `neat-core/src/if_graft.rs` is the single home of the rule that builds an `IF`
 node: which synapse carries which [`SynapseType`] role, that all three roles
 must be present, that the node's own constants come first, and where the node
-may sit so every edge still points forwards. `graft_if_node`,
-`graft_if_tree` and `graft_if_correction` all route through it, and every
+may sit so every edge still points forwards. `graft_if_node`, `graft_if_nodes`,
+`graft_if_tree`, `graft_relay_node` and `graft_if_correction` all route through
+one internal `NodePlan` — add a node kind there, never a second copy of the
+placement rules — and every
 rejection is a typed `GraftError` with **no creature produced** — a caller never
 hand-edits neuron/synapse JSON to add a decision node, and NEAT-AI-Forests reads
 its interpretation of the roles from here rather than inventing one.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -539,8 +539,8 @@ outputs beside each builder:
 
 **Graft helper** — `neat-core/src/if_graft.rs`. A caller describes the node
 (`IfNodeSpec`, or `IfCorrectionSpec` for the common depth-1 correction) and
-`graft_if_node` / `graft_if_tree` / `graft_if_correction` return a **new**
-validated `CreatureExport`; the source is never mutated. Placement is chosen so
+`graft_if_node` / `graft_if_nodes` / `graft_if_tree` / `graft_if_correction`
+return a **new** validated `CreatureExport`; the source is never mutated. Placement is chosen so
 the node is evaluated after every source and before every target, which is what
 preserves the `forwardOnly` reading order the compiled forward pass relies on.
 Every rejection is a typed `GraftError` and **no creature is produced** —
@@ -549,6 +549,16 @@ input or a constant, a self edge, a duplicate edge, a non-finite weight or bias,
 or no position that keeps every edge pointing forwards. `graft_if_correction`
 on `linear_base_creature()` reproduces `residual_correction_creature()` exactly,
 which is how the helper and the fixture keep each other honest.
+
+**Whole trees and both-branch corrections** (NEAT-AI-Forests #48) —
+`graft_if_nodes` grafts a post-order batch as one all-or-nothing change, where a
+node may leave its outward edge to a later node in the same batch (the nested
+child feeding a parent that does not exist yet); only the assembled creature is
+validated. `IfNodeSpec::with_target_role` emits a **typed** outward edge, which
+is how a correction reaches one named branch of an `IF` destination, and
+`graft_relay_node` adds the IDENTITY relay that carries the same value into the
+other branch — a creature may not hold two synapses between the same ordered
+pair, so the second branch needs a second source.
 
 `validate_creature_topology` is the shared gate both ends run: it reuses
 `validate_creature_width`, `validate_topology` and

--- a/docs/archive/pr-summaries/pr-summary-forests-48.md
+++ b/docs/archive/pr-summaries/pr-summary-forests-48.md
@@ -1,0 +1,94 @@
+# if_graft: typed outward edges, batched grafts and the IDENTITY relay
+
+## Summary
+
+`if_graft` could only build one complete `IF` node at a time with untyped
+outward edges, so two shapes NEAT-AI-Forests needs had to be hand-written there
+instead (NEAT-AI-Forests #48):
+
+1. **A nested tree.** `graft_if_node` requires every outward edge to name a
+   neuron that already exists and refuses a node with none (`NoTargets`), so a
+   post-order tree could not be grafted node by node — the child needs its
+   parent as a target before the parent exists. `graft_if_tree` validates after
+   every node, so it could not batch them either.
+2. **A correction entering both branches of an `IF` destination.** An untyped
+   synapse into an `IF` neuron feeds one branch only, and `with_target` emitted
+   nothing else.
+
+This adds:
+
+- `GraftEdge::role` (`SynapseType`, `Standard` = untyped as before) and
+  `IfNodeSpec::with_target_role` / `RelaySpec::with_target_role` — a **typed**
+  outward edge that reaches one named branch. A role set on an *inbound* edge is
+  refused (`InboundEdgeHasRole`) rather than ignored: an inbound edge takes its
+  role from the branch it is listed under.
+- `graft_if_nodes` — an all-or-nothing batch where a node may leave `targets`
+  empty **provided** a later node in the same batch names it as a branch source.
+  The assembled creature is validated once, at the end. A node nothing ever
+  reads is still `NoTargets`.
+- `RelaySpec` / `graft_relay_node` — an IDENTITY hidden neuron that passes its
+  inbound sum on, so a node's value can reach a second branch of a destination
+  it already feeds (a creature may not carry two synapses between the same
+  ordered pair).
+- Placement now lists a grafted node after **every** constant the creature
+  carries, not merely after the last one it reads. Reading three of four
+  constants used to land the node between them, leaving a constant behind a
+  hidden neuron — `creature_validate` rule 11. Where no such position exists the
+  new `ConstantAfterPosition` names the blocking constant instead of emitting a
+  creature the validator rejects.
+
+All four kinds of graft now reduce to one internal `NodePlan`, so the name,
+finiteness, duplicate-edge, placement and ordering rules have a single home.
+
+Additive: existing signatures, `GraftEdge::new`, and every previously accepted
+spec behave as before.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    S["IfNodeSpec / RelaySpec"] --> P["NodePlan"]
+    P --> C{"names new? roles present?<br/>edges resolve?"}
+    C -- no --> E["Err(GraftError) — no creature"]
+    C -- yes --> Q{"position: after every source<br/>and every constant,<br/>before every target"}
+    Q -- none exists --> E
+    Q -- ok --> B["build + canonical sort"]
+    B --> V["validate_creature_topology<br/>(once per batch)"]
+    V -- fails --> E
+    V -- passes --> O["Ok(CreatureExport)"]
+```
+
+`cargo test --workspace` is green (all suites), as are `cargo fmt --check` and
+`cargo clippy --workspace --all-targets --all-features -D warnings`.
+
+**Mutation evidence** — each new rule was mutated in turn and the suite went red
+for it (all mutations reverted):
+
+| Mutation | Test that died |
+|----------|----------------|
+| drop the "after every constant" clamp (`earliest.max(last + 1)` → `earliest`) | `a_grafted_node_is_listed_after_every_constant_the_creature_carries` |
+| emit outward edges untyped (`synapse_type_name_from(edge.role)` → `None`) | `a_typed_outward_edge_reaches_the_named_branch_of_an_if_target`, `a_relay_carries_a_second_typed_edge_into_the_same_target` |
+| never require targets in a batch (`!fed_to_a_later_node` → `false`) | `a_batched_graft_still_refuses_a_node_nothing_ever_reads` |
+
+## Test Plan
+
+Added to `neat-core/tests/if_graft.rs` (11 tests), each asserting on an
+observable outcome — the returned creature, its compiled activations, or the
+typed error:
+
+- `a_typed_outward_edge_reaches_the_named_branch_of_an_if_target` — the
+  correction lands only on the branch the `IF` output takes; the delta is
+  derived from the spec, not read back from the graft.
+- `an_outward_edge_with_no_role_stays_untyped` — the default is unchanged.
+- `rejects_an_explicit_role_on_an_inbound_edge`.
+- `a_batched_graft_wires_a_child_into_its_parents_branch` — nested tree
+  activations against an independently written `tree_value`, plus child-before-
+  parent order and the `positive` role on the child's edge.
+- `a_batched_graft_still_refuses_a_node_nothing_ever_reads`.
+- `a_batched_graft_is_all_or_nothing` — the source creature is untouched.
+- `a_batched_graft_of_nothing_returns_the_creature_unchanged`.
+- `a_grafted_node_is_listed_after_every_constant_the_creature_carries` — plus
+  `creature_validate` acceptance.
+- `a_relay_carries_a_second_typed_edge_into_the_same_target` — the correction
+  applies on both branches of an `IF` output.
+- `a_relay_with_no_source_or_no_target_is_refused`.

--- a/neat-core/src/if_graft.rs
+++ b/neat-core/src/if_graft.rs
@@ -42,6 +42,23 @@
 //! three (`<uuid>-condition-one`, `<uuid>-positive-one`, `<uuid>-negative-one`),
 //! each with bias [`GRAFT_CONSTANT_BIAS`], leaving the thresholds and leaf
 //! values in the trainable **weights**.
+//!
+//! ## Whole trees, and corrections that enter both branches
+//!
+//! Two shapes need more than one node at a time, so a consumer used to write
+//! them out by hand (NEAT-AI-Forests #48):
+//!
+//! * a **nested tree**, whose child exists only to feed the parent that does
+//!   not exist yet. [`graft_if_nodes`] takes the whole post-order batch: a node
+//!   may leave its outward edge to a later node in the same batch, and only the
+//!   assembled creature is validated. It is still all or nothing — the first
+//!   rejection returns a [`GraftError`] and no partial creature escapes.
+//! * a correction entering **both branches of an `IF` destination**. An untyped
+//!   edge into an `IF` neuron feeds one branch, so the node takes the other with
+//!   a typed outward edge ([`IfNodeSpec::with_target_role`]); the second, equal
+//!   edge comes through an IDENTITY [`RelaySpec`] ([`graft_relay_node`]),
+//!   because a creature may not carry two synapses between the same ordered
+//!   pair of neurons.
 
 use std::collections::{HashMap, HashSet};
 
@@ -63,24 +80,47 @@ pub const GRAFT_CONSTANT_BIAS: f64 = 1.0;
 
 /// One weighted edge of a grafted node.
 ///
-/// `uuid` names the **source** neuron for a branch edge
+/// `uuid` names the **source** neuron for an inbound edge
 /// ([`IfNodeSpec::with_condition`] / [`with_positive`](IfNodeSpec::with_positive)
-/// / [`with_negative`](IfNodeSpec::with_negative)) and the **destination**
-/// neuron for an outward edge ([`IfNodeSpec::with_target`]).
+/// / [`with_negative`](IfNodeSpec::with_negative) / [`RelaySpec::with_source`])
+/// and the **destination** neuron for an outward edge
+/// ([`IfNodeSpec::with_target`]).
 #[derive(Debug, Clone, PartialEq)]
 pub struct GraftEdge {
     /// UUID of the neuron at the other end of the edge.
     pub uuid: String,
     /// Connection weight.
     pub weight: f64,
+    /// Role the emitted synapse carries.
+    ///
+    /// [`SynapseType::Standard`] emits an **untyped** synapse — the additive
+    /// edge a point-wise neuron takes. The three `IF` roles emit their role
+    /// string, which is how an outward edge reaches one named branch of an `IF`
+    /// destination; an untyped edge into an `IF` neuron feeds the positive
+    /// branch only (NEAT-AI-Forests #48).
+    ///
+    /// Only **outward** edges carry a role: an inbound edge takes its role from
+    /// the branch it is listed under, so one set here is refused with
+    /// [`GraftError::InboundEdgeHasRole`] rather than silently ignored.
+    pub role: SynapseType,
 }
 
 impl GraftEdge {
-    /// Build an edge from a UUID and a weight.
+    /// Build an untyped edge from a UUID and a weight.
     pub fn new(uuid: impl Into<String>, weight: f64) -> Self {
         Self {
             uuid: uuid.into(),
             weight,
+            role: SynapseType::Standard,
+        }
+    }
+
+    /// Build an outward edge that carries `role`.
+    pub fn with_role(uuid: impl Into<String>, weight: f64, role: SynapseType) -> Self {
+        Self {
+            uuid: uuid.into(),
+            weight,
+            role,
         }
     }
 }
@@ -172,10 +212,82 @@ impl IfNodeSpec {
         self
     }
 
-    /// Add an outward edge from the node to an existing neuron.
+    /// Add an untyped outward edge from the node to an existing neuron.
     #[must_use]
     pub fn with_target(mut self, uuid: impl Into<String>, weight: f64) -> Self {
         self.targets.push(GraftEdge::new(uuid, weight));
+        self
+    }
+
+    /// Add an outward edge carrying `role` — the way into one named branch of
+    /// an `IF` destination (NEAT-AI-Forests #48).
+    #[must_use]
+    pub fn with_target_role(
+        mut self,
+        uuid: impl Into<String>,
+        weight: f64,
+        role: SynapseType,
+    ) -> Self {
+        self.targets.push(GraftEdge::with_role(uuid, weight, role));
+        self
+    }
+}
+
+/// Description of an **IDENTITY relay** to graft onto a creature: a hidden
+/// neuron that passes its inbound sum on unchanged.
+///
+/// A creature may not carry two synapses between the same ordered pair of
+/// neurons, so a node whose value must reach *two* branches of one `IF`
+/// destination needs a second source. The relay is that source: the node feeds
+/// one branch directly and the relay carries the same value into the other
+/// (NEAT-AI-Forests #48).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelaySpec {
+    /// UUID for the new relay; must not already exist in the creature.
+    pub uuid: String,
+    /// Bias added to the relayed sum — `0.0` for a pass-through.
+    pub bias: f64,
+    /// Untyped inbound edges, summed into the relay.
+    pub sources: Vec<GraftEdge>,
+    /// Outward edges from the relay to existing non-input, non-constant
+    /// neurons, each optionally carrying a role.
+    pub targets: Vec<GraftEdge>,
+}
+
+impl RelaySpec {
+    /// Start a specification for a relay with the given UUID and bias.
+    pub fn new(uuid: impl Into<String>, bias: f64) -> Self {
+        Self {
+            uuid: uuid.into(),
+            bias,
+            sources: Vec::new(),
+            targets: Vec::new(),
+        }
+    }
+
+    /// Add an inbound edge the relay sums.
+    #[must_use]
+    pub fn with_source(mut self, uuid: impl Into<String>, weight: f64) -> Self {
+        self.sources.push(GraftEdge::new(uuid, weight));
+        self
+    }
+
+    /// Add an untyped outward edge from the relay to an existing neuron.
+    #[must_use]
+    pub fn with_target(mut self, uuid: impl Into<String>, weight: f64) -> Self {
+        self.targets.push(GraftEdge::new(uuid, weight));
+        self
+    }
+
+    /// Add an outward edge carrying `role`.
+    #[must_use]
+    pub fn with_target_role(
+        mut self,
+        uuid: impl Into<String>,
+        weight: f64,
+        role: SynapseType,
+    ) -> Self {
+        self.targets.push(GraftEdge::with_role(uuid, weight, role));
         self
     }
 }
@@ -251,7 +363,32 @@ pub enum GraftError {
     /// No `negative` edge was supplied.
     MissingNegativeSynapse,
     /// No outward edge was supplied, so the node could not influence anything.
+    ///
+    /// In a batched graft ([`graft_if_nodes`]) a node may leave `targets` empty
+    /// **provided** a later node in the same batch names it as a branch source;
+    /// this is what a node nothing ever reads returns.
     NoTargets,
+    /// No inbound edge was supplied, so the node would emit only its bias.
+    NoSources,
+    /// An inbound edge carried an explicit role. An inbound edge takes its role
+    /// from the branch it is listed under, so an explicit one is refused rather
+    /// than ignored.
+    InboundEdgeHasRole {
+        /// Source neuron UUID.
+        from: String,
+        /// Destination neuron UUID — the grafted node.
+        to: String,
+    },
+    /// The creature lists a constant after the latest position the node can
+    /// take, so no placement satisfies both the forward-only reading order and
+    /// the `input, constant, hidden, output` neuron order
+    /// ([`crate::creature_validate()`] rule 11).
+    ConstantAfterPosition {
+        /// The constant that cannot precede the node.
+        constant: String,
+        /// The target that forced the earliest possible position.
+        target: String,
+    },
     /// Two synapses would connect the same ordered pair of neurons.
     DuplicateEdge {
         /// Source neuron UUID.
@@ -329,6 +466,15 @@ impl std::fmt::Display for GraftError {
             GraftError::MissingPositiveSynapse => write!(f, "IF node has no positive synapse"),
             GraftError::MissingNegativeSynapse => write!(f, "IF node has no negative synapse"),
             GraftError::NoTargets => write!(f, "Grafted node has no outward connection"),
+            GraftError::NoSources => write!(f, "Grafted node has no inward connection"),
+            GraftError::InboundEdgeHasRole { from, to } => write!(
+                f,
+                "Inbound synapse from {from} to {to} sets a role; an inbound edge takes its role from the branch it is listed under"
+            ),
+            GraftError::ConstantAfterPosition { constant, target } => write!(
+                f,
+                "No position leaves constant {constant} ahead of the node and the node ahead of target {target}"
+            ),
             GraftError::DuplicateEdge { from, to } => {
                 write!(f, "Duplicate synapse from {from} to {to}")
             }
@@ -472,53 +618,30 @@ pub fn validate_creature_topology(creature: &CreatureExport) -> Result<(), Graft
     Ok(())
 }
 
-/// Graft one `IF` node (and any constants it declares) onto a creature.
+/// One node to place: everything the placement rules and the builder need,
+/// whatever kind of node the caller described.
 ///
-/// Returns a **new** creature; the input is never modified. Placement is chosen
-/// so the node is evaluated after every source and before every target, which
-/// preserves the `forwardOnly` reading order the compiled forward pass relies
-/// on; any constants the spec declares are listed ahead of every hidden neuron,
-/// and the synapse list comes back in canonical `(from, to)` order, so the
-/// result satisfies [`crate::creature_validate()`] as well. The creature is put
-/// through [`validate_creature_topology`] before it is returned, so a malformed
-/// creature is never emitted.
-///
-/// # Errors
-///
-/// Returns a [`GraftError`] when the base creature is already malformed, when
-/// the specification names an unknown or duplicate neuron, when any `IF` role
-/// is missing, when a weight or bias is not finite, or when no position exists
-/// that keeps every edge pointing forwards.
-pub fn graft_if_node(
-    creature: &CreatureExport,
-    spec: &IfNodeSpec,
-) -> Result<CreatureExport, GraftError> {
-    validate_creature_topology(creature)?;
-    let map = index_map(creature);
+/// Both an `IF` node ([`IfNodeSpec`]) and an IDENTITY relay ([`RelaySpec`])
+/// reduce to this, so the name, finiteness, duplicate-edge, placement and
+/// ordering rules have one home rather than one copy per node kind.
+struct NodePlan<'a> {
+    /// UUID of the new neuron.
+    uuid: &'a str,
+    /// Bias of the new neuron.
+    bias: f64,
+    /// Activation of the new neuron.
+    squash: SquashType,
+    /// Constants the node introduces alongside itself.
+    constants: &'a [ConstantSpec],
+    /// Inbound edges paired with the role each will carry.
+    inbound: Vec<(&'a GraftEdge, SynapseType)>,
+    /// Outward edges; each carries its own [`GraftEdge::role`].
+    targets: &'a [GraftEdge],
+}
 
-    // Names this graft introduces must be new, and unique among themselves.
-    let mut introduced: HashSet<&str> = HashSet::with_capacity(spec.constants.len() + 1);
-    let new_names =
-        std::iter::once(spec.uuid.as_str()).chain(spec.constants.iter().map(|c| c.uuid.as_str()));
-    for uuid in new_names {
-        if map.contains_key(uuid) || !introduced.insert(uuid) {
-            return Err(GraftError::DuplicateUuid(uuid.to_string()));
-        }
-    }
-
-    if !spec.bias.is_finite() {
-        return Err(GraftError::NonFiniteBias {
-            uuid: spec.uuid.clone(),
-        });
-    }
-    for constant in &spec.constants {
-        if !constant.bias.is_finite() {
-            return Err(GraftError::NonFiniteBias {
-                uuid: constant.uuid.clone(),
-            });
-        }
-    }
-
+/// Reduce an [`IfNodeSpec`] to a [`NodePlan`], applying the `IF`-only rules:
+/// all three roles present, and no inbound edge naming a role of its own.
+fn if_plan(spec: &IfNodeSpec) -> Result<NodePlan<'_>, GraftError> {
     if spec.condition.is_empty() {
         return Err(GraftError::MissingConditionSynapse);
     }
@@ -528,7 +651,84 @@ pub fn graft_if_node(
     if spec.negative.is_empty() {
         return Err(GraftError::MissingNegativeSynapse);
     }
-    if spec.targets.is_empty() {
+    let mut inbound =
+        Vec::with_capacity(spec.condition.len() + spec.positive.len() + spec.negative.len());
+    for (role, edges) in [
+        (SynapseType::Condition, &spec.condition),
+        (SynapseType::Positive, &spec.positive),
+        (SynapseType::Negative, &spec.negative),
+    ] {
+        for edge in edges {
+            inbound.push((edge, role));
+        }
+    }
+    Ok(NodePlan {
+        uuid: &spec.uuid,
+        bias: spec.bias,
+        squash: SquashType::If,
+        constants: &spec.constants,
+        inbound,
+        targets: &spec.targets,
+    })
+}
+
+/// Reduce a [`RelaySpec`] to a [`NodePlan`]: an IDENTITY neuron whose inbound
+/// edges are all untyped.
+fn relay_plan(spec: &RelaySpec) -> NodePlan<'_> {
+    NodePlan {
+        uuid: &spec.uuid,
+        bias: spec.bias,
+        squash: SquashType::Identity,
+        constants: &[],
+        inbound: spec
+            .sources
+            .iter()
+            .map(|edge| (edge, SynapseType::Standard))
+            .collect(),
+        targets: &spec.targets,
+    }
+}
+
+/// Check a plan against the creature, choose the node's position, and build the
+/// resulting creature — everything but the final validation.
+///
+/// `require_targets` is `false` only inside [`graft_if_nodes`], where a node may
+/// leave its outward edge to a later node in the same batch; a node nothing
+/// reads is still refused, by that later node's absence.
+fn place_and_build(
+    creature: &CreatureExport,
+    plan: &NodePlan<'_>,
+    require_targets: bool,
+) -> Result<CreatureExport, GraftError> {
+    let map = index_map(creature);
+
+    // Names this graft introduces must be new, and unique among themselves.
+    let mut introduced: HashSet<&str> = HashSet::with_capacity(plan.constants.len() + 1);
+    let new_names =
+        std::iter::once(plan.uuid).chain(plan.constants.iter().map(|c| c.uuid.as_str()));
+    for uuid in new_names {
+        if map.contains_key(uuid) || !introduced.insert(uuid) {
+            return Err(GraftError::DuplicateUuid(uuid.to_string()));
+        }
+    }
+
+    if !plan.bias.is_finite() {
+        return Err(GraftError::NonFiniteBias {
+            uuid: plan.uuid.to_string(),
+        });
+    }
+    for constant in plan.constants {
+        if !constant.bias.is_finite() {
+            return Err(GraftError::NonFiniteBias {
+                uuid: constant.uuid.clone(),
+            });
+        }
+    }
+
+    if plan.inbound.is_empty() {
+        return Err(GraftError::NoSources);
+    }
+    if require_targets && plan.targets.is_empty() {
         return Err(GraftError::NoTargets);
     }
 
@@ -536,35 +736,39 @@ pub fn graft_if_node(
     let mut earliest = 0usize;
     let mut latest_source: Option<&str> = None;
     let mut seen_sources: HashSet<&str> = HashSet::new();
-    for edges in [&spec.condition, &spec.positive, &spec.negative] {
-        for edge in edges {
-            if edge.uuid == spec.uuid {
-                return Err(GraftError::SelfEdge(spec.uuid.clone()));
-            }
-            if !edge.weight.is_finite() {
-                return Err(GraftError::NonFiniteWeight {
-                    from: edge.uuid.clone(),
-                    to: spec.uuid.clone(),
-                    weight: edge.weight,
-                });
-            }
-            if !seen_sources.insert(edge.uuid.as_str()) {
-                return Err(GraftError::DuplicateEdge {
-                    from: edge.uuid.clone(),
-                    to: spec.uuid.clone(),
-                });
-            }
-            if introduced.contains(edge.uuid.as_str()) {
-                // A constant this graft introduces is placed before the node.
-                continue;
-            }
-            let index = *map
-                .get(edge.uuid.as_str())
-                .ok_or_else(|| GraftError::UnknownSourceUuid(edge.uuid.clone()))?;
-            if index >= creature.input && index - creature.input + 1 > earliest {
-                earliest = index - creature.input + 1;
-                latest_source = Some(edge.uuid.as_str());
-            }
+    for (edge, _) in &plan.inbound {
+        if edge.role != SynapseType::Standard {
+            return Err(GraftError::InboundEdgeHasRole {
+                from: edge.uuid.clone(),
+                to: plan.uuid.to_string(),
+            });
+        }
+        if edge.uuid == plan.uuid {
+            return Err(GraftError::SelfEdge(plan.uuid.to_string()));
+        }
+        if !edge.weight.is_finite() {
+            return Err(GraftError::NonFiniteWeight {
+                from: edge.uuid.clone(),
+                to: plan.uuid.to_string(),
+                weight: edge.weight,
+            });
+        }
+        if !seen_sources.insert(edge.uuid.as_str()) {
+            return Err(GraftError::DuplicateEdge {
+                from: edge.uuid.clone(),
+                to: plan.uuid.to_string(),
+            });
+        }
+        if introduced.contains(edge.uuid.as_str()) {
+            // A constant this graft introduces is placed before the node.
+            continue;
+        }
+        let index = *map
+            .get(edge.uuid.as_str())
+            .ok_or_else(|| GraftError::UnknownSourceUuid(edge.uuid.clone()))?;
+        if index >= creature.input && index - creature.input + 1 > earliest {
+            earliest = index - creature.input + 1;
+            latest_source = Some(edge.uuid.as_str());
         }
     }
 
@@ -572,20 +776,20 @@ pub fn graft_if_node(
     let mut latest = creature.neurons.len();
     let mut earliest_target: Option<&str> = None;
     let mut seen_targets: HashSet<&str> = HashSet::new();
-    for edge in &spec.targets {
-        if edge.uuid == spec.uuid {
-            return Err(GraftError::SelfEdge(spec.uuid.clone()));
+    for edge in plan.targets {
+        if edge.uuid == plan.uuid {
+            return Err(GraftError::SelfEdge(plan.uuid.to_string()));
         }
         if !edge.weight.is_finite() {
             return Err(GraftError::NonFiniteWeight {
-                from: spec.uuid.clone(),
+                from: plan.uuid.to_string(),
                 to: edge.uuid.clone(),
                 weight: edge.weight,
             });
         }
         if !seen_targets.insert(edge.uuid.as_str()) {
             return Err(GraftError::DuplicateEdge {
-                from: spec.uuid.clone(),
+                from: plan.uuid.to_string(),
                 to: edge.uuid.clone(),
             });
         }
@@ -608,6 +812,24 @@ pub fn graft_if_node(
         }
     }
 
+    // A constant may never follow a hidden neuron, so the node is listed after
+    // every constant the creature already carries — not merely after the last
+    // one it reads, which would leave a later constant behind a hidden neuron
+    // ([`crate::creature_validate()`] rule 11).
+    let last_constant = creature
+        .neurons
+        .iter()
+        .rposition(|n| n.neuron_type == "constant");
+    if let Some(last) = last_constant {
+        earliest = earliest.max(last + 1);
+        if last + 1 > latest {
+            return Err(GraftError::ConstantAfterPosition {
+                constant: creature.neurons[last].uuid.clone(),
+                target: earliest_target.unwrap_or_default().to_string(),
+            });
+        }
+    }
+
     if earliest > latest {
         return Err(GraftError::ForwardOrderViolation {
             source: latest_source.unwrap_or_default().to_string(),
@@ -615,7 +837,13 @@ pub fn graft_if_node(
         });
     }
 
-    let grafted = build_grafted(creature, spec, earliest);
+    Ok(build_grafted(creature, plan, earliest))
+}
+
+/// Report a creature that failed a shared gate as [`GraftError::MalformedResult`]
+/// — the graft was well formed but what it assembled was not, so the creature is
+/// never returned.
+fn validated(grafted: CreatureExport) -> Result<CreatureExport, GraftError> {
     match validate_creature_topology(&grafted) {
         Ok(()) => Ok(grafted),
         Err(GraftError::MalformedTopology { code, index }) => Err(GraftError::MalformedResult {
@@ -632,6 +860,95 @@ pub fn graft_if_node(
     }
 }
 
+/// Graft one `IF` node (and any constants it declares) onto a creature.
+///
+/// Returns a **new** creature; the input is never modified. Placement is chosen
+/// so the node is evaluated after every source and before every target, which
+/// preserves the `forwardOnly` reading order the compiled forward pass relies
+/// on; any constants the spec declares are listed ahead of every hidden neuron,
+/// and the synapse list comes back in canonical `(from, to)` order, so the
+/// result satisfies [`crate::creature_validate()`] as well. The creature is put
+/// through [`validate_creature_topology`] before it is returned, so a malformed
+/// creature is never emitted.
+///
+/// # Errors
+///
+/// Returns a [`GraftError`] when the base creature is already malformed, when
+/// the specification names an unknown or duplicate neuron, when any `IF` role
+/// is missing, when a weight or bias is not finite, or when no position exists
+/// that keeps every edge pointing forwards.
+pub fn graft_if_node(
+    creature: &CreatureExport,
+    spec: &IfNodeSpec,
+) -> Result<CreatureExport, GraftError> {
+    validate_creature_topology(creature)?;
+    let plan = if_plan(spec)?;
+    validated(place_and_build(creature, &plan, true)?)
+}
+
+/// Graft an IDENTITY relay — a hidden neuron that passes its inbound sum on.
+///
+/// The way to reach a second branch of a destination the source already feeds:
+/// a creature may not carry two synapses between the same ordered pair, so the
+/// relay supplies the second, distinct source (NEAT-AI-Forests #48). Same
+/// placement, ordering and validation contract as [`graft_if_node`].
+///
+/// # Errors
+///
+/// Returns a [`GraftError`] when the relay names an unknown or duplicate
+/// neuron, when it has no inbound or no outward edge, when a weight or bias is
+/// not finite, or when no position exists that keeps every edge pointing
+/// forwards.
+pub fn graft_relay_node(
+    creature: &CreatureExport,
+    spec: &RelaySpec,
+) -> Result<CreatureExport, GraftError> {
+    validate_creature_topology(creature)?;
+    let plan = relay_plan(spec);
+    validated(place_and_build(creature, &plan, true)?)
+}
+
+/// Graft a batch of `IF` nodes as one all-or-nothing change, where a node may
+/// feed another node in the same batch.
+///
+/// Unlike [`graft_if_tree`], which validates after every node and so needs each
+/// one to be complete on its own, a node here may leave `targets` empty
+/// **provided** a later node in the batch names it as a branch source — the
+/// post-order shape a nested decision tree has, where the child exists to feed
+/// the parent that does not exist yet (NEAT-AI-Forests #48). Only the assembled
+/// creature is validated, and it is validated once.
+///
+/// All or nothing: the first failure returns its [`GraftError`] and no partial
+/// creature escapes. An empty batch returns the validated base creature.
+///
+/// # Errors
+///
+/// Returns the first [`GraftError`] any node produces, [`GraftError::NoTargets`]
+/// for a node nothing in the batch ever reads, or the base creature's own
+/// validation error.
+pub fn graft_if_nodes(
+    creature: &CreatureExport,
+    specs: &[IfNodeSpec],
+) -> Result<CreatureExport, GraftError> {
+    validate_creature_topology(creature)?;
+    let mut current = creature.clone();
+    for (i, spec) in specs.iter().enumerate() {
+        // A later node naming this one as a branch source supplies its outward
+        // edge, so this node may carry none of its own.
+        let fed_to_a_later_node = specs[i + 1..].iter().any(|later| {
+            later
+                .condition
+                .iter()
+                .chain(&later.positive)
+                .chain(&later.negative)
+                .any(|edge| edge.uuid == spec.uuid)
+        });
+        let plan = if_plan(spec)?;
+        current = place_and_build(&current, &plan, !fed_to_a_later_node)?;
+    }
+    validated(current)
+}
+
 /// Assemble the grafted creature: the constants ahead of every hidden neuron,
 /// the node at `position`, and the whole synapse list left in canonical
 /// `(from, to)` order.
@@ -640,7 +957,11 @@ pub fn graft_if_node(
 /// creature — neurons listed `input, constant, hidden, output` (rule 11) and
 /// synapses sorted ascending by resolved index (rule 25) — so a grafted
 /// creature satisfies the shared validator, not merely the compiler.
-fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) -> CreatureExport {
+fn build_grafted(
+    creature: &CreatureExport,
+    plan: &NodePlan<'_>,
+    position: usize,
+) -> CreatureExport {
     // A constant may never follow a hidden neuron, so the constants go in front
     // of the first non-constant rather than beside the node, which can legally
     // sit after several hidden neurons.
@@ -650,9 +971,9 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
         .position(|n| n.neuron_type != "constant")
         .unwrap_or(creature.neurons.len())
         .min(position);
-    let mut neurons = Vec::with_capacity(creature.neurons.len() + spec.constants.len() + 1);
+    let mut neurons = Vec::with_capacity(creature.neurons.len() + plan.constants.len() + 1);
     neurons.extend_from_slice(&creature.neurons[..constants_at]);
-    for constant in &spec.constants {
+    for constant in plan.constants {
         neurons.push(NeuronExport {
             id: None,
             neuron_type: "constant".to_string(),
@@ -665,36 +986,28 @@ fn build_grafted(creature: &CreatureExport, spec: &IfNodeSpec, position: usize) 
     neurons.push(NeuronExport {
         id: None,
         neuron_type: "hidden".to_string(),
-        uuid: spec.uuid.clone(),
-        bias: spec.bias,
-        squash: Some(squash_name_from(SquashType::If).to_string()),
+        uuid: plan.uuid.to_string(),
+        bias: plan.bias,
+        squash: Some(squash_name_from(plan.squash).to_string()),
     });
     neurons.extend_from_slice(&creature.neurons[position..]);
 
     let mut synapses = creature.synapses.clone();
-    synapses.reserve(
-        spec.condition.len() + spec.positive.len() + spec.negative.len() + spec.targets.len(),
-    );
-    for (role, edges) in [
-        (SynapseType::Condition, &spec.condition),
-        (SynapseType::Positive, &spec.positive),
-        (SynapseType::Negative, &spec.negative),
-    ] {
-        for edge in edges {
-            synapses.push(SynapseExport {
-                from_uuid: edge.uuid.clone(),
-                to_uuid: spec.uuid.clone(),
-                weight: edge.weight,
-                synapse_type: synapse_type_name_from(role).map(str::to_string),
-            });
-        }
-    }
-    for edge in &spec.targets {
+    synapses.reserve(plan.inbound.len() + plan.targets.len());
+    for (edge, role) in &plan.inbound {
         synapses.push(SynapseExport {
-            from_uuid: spec.uuid.clone(),
+            from_uuid: edge.uuid.clone(),
+            to_uuid: plan.uuid.to_string(),
+            weight: edge.weight,
+            synapse_type: synapse_type_name_from(*role).map(str::to_string),
+        });
+    }
+    for edge in plan.targets {
+        synapses.push(SynapseExport {
+            from_uuid: plan.uuid.to_string(),
             to_uuid: edge.uuid.clone(),
             weight: edge.weight,
-            synapse_type: None,
+            synapse_type: synapse_type_name_from(edge.role).map(str::to_string),
         });
     }
 

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -88,8 +88,8 @@ pub use decision_tree::{
     stump_creature,
 };
 pub use if_graft::{
-    GraftError, IfCorrectionSpec, IfNodeSpec, graft_if_correction, graft_if_node, graft_if_tree,
-    validate_creature_topology,
+    GraftEdge, GraftError, IfCorrectionSpec, IfNodeSpec, RelaySpec, graft_if_correction,
+    graft_if_node, graft_if_nodes, graft_if_tree, graft_relay_node, validate_creature_topology,
 };
 pub use network::{CompiledNetwork, NetworkError, NeuronData, SynapseData, hot_synapse_soa};
 pub use squash::SquashType;

--- a/neat-core/tests/if_graft.rs
+++ b/neat-core/tests/if_graft.rs
@@ -8,8 +8,8 @@ use neat_core::decision_tree::{
     RESIDUAL_THRESHOLD, RESIDUAL_VALUE, linear_base_creature, residual_correction_creature,
 };
 use neat_core::if_graft::{
-    GraftError, IfCorrectionSpec, IfNodeSpec, graft_if_correction, graft_if_node, graft_if_tree,
-    validate_creature_topology,
+    GraftError, IfCorrectionSpec, IfNodeSpec, RelaySpec, graft_if_correction, graft_if_node,
+    graft_if_nodes, graft_if_tree, graft_relay_node, validate_creature_topology,
 };
 use neat_core::topology_ops::{
     BACKWARD_CONNECTION, DUPLICATE_CONNECTION, STRUCTURAL_HIDDEN_NO_OUTWARD,
@@ -666,4 +666,326 @@ fn grafted_synapses_are_in_canonical_from_to_order() {
         keys, sorted,
         "synapses are not in canonical (from, to) order"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Typed outward edges, batched grafts and the identity relay
+// (NEAT-AI-Forests #48) — the two shapes a consumer could not express with
+// `graft_if_node` alone: a child feeding its parent's branch, and a correction
+// entering both branches of an `IF` target.
+// ---------------------------------------------------------------------------
+
+/// Three inputs and an `IF` **output** — the production champion's shape. An
+/// untyped edge into it would feed the positive branch only, so a correction
+/// that must apply on both sides needs typed outward edges.
+fn if_output_creature() -> CreatureExport {
+    CreatureExport {
+        memetic: None,
+        input: 3,
+        output: 1,
+        neurons: vec![NeuronExport {
+            id: None,
+            neuron_type: "output".to_string(),
+            uuid: "output-0".to_string(),
+            bias: 0.0,
+            squash: Some("IF".to_string()),
+        }],
+        synapses: vec![
+            SynapseExport {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: Some("condition".to_string()),
+            },
+            SynapseExport {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 2.0,
+                synapse_type: Some("positive".to_string()),
+            },
+            SynapseExport {
+                from_uuid: "input-2".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: -1.0,
+                synapse_type: Some("negative".to_string()),
+            },
+        ],
+        semantic_version: None,
+        forward_only: true,
+    }
+}
+
+/// The correction node used against [`if_output_creature`]: `input-1 > 0.5`
+/// contributes `0.75`, otherwise `-0.25`.
+fn correction_spec(target_role: SynapseType) -> IfNodeSpec {
+    IfNodeSpec::new("corr", 0.0)
+        .with_constant("corr-one", 1.0)
+        .with_constant("corr-pos", 1.0)
+        .with_constant("corr-neg", 1.0)
+        .with_condition("input-1", 1.0)
+        .with_condition("corr-one", -0.5)
+        .with_positive("corr-pos", 0.75)
+        .with_negative("corr-neg", -0.25)
+        .with_target_role("output-0", 1.0, target_role)
+}
+
+/// What the correction node itself emits for a record — derived from the spec
+/// above, not from the graft, so a wiring fault moves only one side.
+fn correction_value(record: &[f32]) -> f32 {
+    if record[1] > 0.5 { 0.75 } else { -0.25 }
+}
+
+#[test]
+fn a_typed_outward_edge_reaches_the_named_branch_of_an_if_target() {
+    let base = if_output_creature();
+    let grafted = graft_if_node(&base, &correction_spec(SynapseType::Positive))
+        .expect("typed graft succeeds");
+    assert_valid(&grafted, "a graft with a typed outward edge");
+
+    let edge = grafted
+        .synapses
+        .iter()
+        .find(|s| s.from_uuid == "corr" && s.to_uuid == "output-0")
+        .expect("outward edge present");
+    assert_eq!(edge.synapse_type.as_deref(), Some("positive"));
+
+    // The condition of the output is `input-0`, so the positive branch is the
+    // one taken when `input-0 > 0`: there the correction lands, and only there.
+    let above = [1.0f32, 1.0, 1.0];
+    let below = [-1.0f32, 1.0, 1.0];
+    assert!(
+        (activate(&grafted, &above) - (activate(&base, &above) + correction_value(&above))).abs()
+            <= TOL
+    );
+    assert!((activate(&grafted, &below) - activate(&base, &below)).abs() <= TOL);
+}
+
+#[test]
+fn an_outward_edge_with_no_role_stays_untyped() {
+    let grafted = graft_if_node(&base_creature(), &valid_spec()).expect("graft succeeds");
+    let edge = grafted
+        .synapses
+        .iter()
+        .find(|s| s.from_uuid == "if-1" && s.to_uuid == "output-0")
+        .expect("outward edge present");
+    assert_eq!(edge.synapse_type, None);
+}
+
+#[test]
+fn rejects_an_explicit_role_on_an_inbound_edge() {
+    let mut spec = valid_spec();
+    spec.condition[0].role = SynapseType::Negative;
+    let err = graft_if_node(&base_creature(), &spec).expect_err("must be rejected");
+    assert!(
+        matches!(err, GraftError::InboundEdgeHasRole { ref from, ref to } if from == "input-0" && to == "if-1"),
+        "unexpected error: {err}"
+    );
+}
+
+/// A child that only its parent reads, described before that parent.
+fn child_spec() -> IfNodeSpec {
+    IfNodeSpec::new("child", 0.0)
+        .with_constant("child-one", 1.0)
+        .with_constant("child-pos", 1.0)
+        .with_constant("child-neg", 1.0)
+        .with_condition("input-0", 1.0)
+        .with_condition("child-one", -0.25)
+        .with_positive("child-pos", 3.0)
+        .with_negative("child-neg", 1.0)
+}
+
+/// The parent whose positive branch reads `child`.
+fn parent_spec() -> IfNodeSpec {
+    IfNodeSpec::new("parent", 0.0)
+        .with_constant("parent-one", 1.0)
+        .with_constant("parent-neg", 1.0)
+        .with_condition("input-1", 1.0)
+        .with_condition("parent-one", -0.1)
+        .with_positive("child", 1.0)
+        .with_negative("parent-neg", 0.0)
+        .with_target("output-0", 1.0)
+}
+
+/// The tree the two specs above describe, evaluated independently of the graft.
+fn tree_value(record: &[f32]) -> f32 {
+    if record[1] > 0.1 {
+        if record[0] > 0.25 { 3.0 } else { 1.0 }
+    } else {
+        0.0
+    }
+}
+
+#[test]
+fn a_batched_graft_wires_a_child_into_its_parents_branch() {
+    let base = base_creature();
+    let grafted =
+        graft_if_nodes(&base, &[child_spec(), parent_spec()]).expect("batched graft succeeds");
+    assert_valid(&grafted, "a batched nested-tree graft");
+
+    let order: Vec<&str> = grafted.neurons.iter().map(|n| n.uuid.as_str()).collect();
+    let pos = |u: &str| order.iter().position(|o| *o == u).expect("neuron present");
+    assert!(pos("child") < pos("parent"), "order was {order:?}");
+
+    let edge = grafted
+        .synapses
+        .iter()
+        .find(|s| s.from_uuid == "child" && s.to_uuid == "parent")
+        .expect("child feeds its parent");
+    assert_eq!(edge.synapse_type.as_deref(), Some("positive"));
+
+    for record in [
+        [0.5f32, 0.5],
+        [0.1, 0.5],
+        [0.5, 0.0],
+        [0.1, 0.0],
+        [0.26, 0.11],
+    ] {
+        let delta = activate(&grafted, &record) - activate(&base, &record);
+        assert!(
+            (delta - tree_value(&record)).abs() <= TOL,
+            "record {record:?}: delta {delta} vs expected {}",
+            tree_value(&record)
+        );
+    }
+}
+
+#[test]
+fn a_batched_graft_still_refuses_a_node_nothing_ever_reads() {
+    // `child` has no target and no later node names it as a branch source.
+    let err = graft_if_nodes(&base_creature(), &[child_spec()]).expect_err("must be rejected");
+    assert!(matches!(err, GraftError::NoTargets), "unexpected: {err}");
+}
+
+#[test]
+fn a_batched_graft_is_all_or_nothing() {
+    let base = base_creature();
+    let broken = parent_spec().with_target("no-such-neuron", 1.0);
+    let err = graft_if_nodes(&base, &[child_spec(), broken]).expect_err("second node is invalid");
+    assert!(
+        matches!(err, GraftError::UnknownTargetUuid(ref u) if u == "no-such-neuron"),
+        "unexpected: {err}"
+    );
+    assert_eq!(base, base_creature(), "the source creature was mutated");
+}
+
+#[test]
+fn a_batched_graft_of_nothing_returns_the_creature_unchanged() {
+    let base = base_creature();
+    assert_eq!(graft_if_nodes(&base, &[]).expect("empty batch"), base);
+}
+
+/// A creature carrying four bias-1 constants, all read by the output, where a
+/// graft reads only the first three.
+fn four_constant_creature() -> CreatureExport {
+    let mut neurons: Vec<NeuronExport> = ["c-a", "c-b", "c-c", "c-d"]
+        .iter()
+        .map(|uuid| NeuronExport {
+            id: None,
+            neuron_type: "constant".to_string(),
+            uuid: (*uuid).to_string(),
+            bias: 1.0,
+            squash: None,
+        })
+        .collect();
+    neurons.push(NeuronExport {
+        id: None,
+        neuron_type: "output".to_string(),
+        uuid: "output-0".to_string(),
+        bias: 0.0,
+        squash: Some("IDENTITY".to_string()),
+    });
+    let mut synapses = vec![SynapseExport {
+        from_uuid: "input-0".to_string(),
+        to_uuid: "output-0".to_string(),
+        weight: 1.0,
+        synapse_type: None,
+    }];
+    synapses.extend(
+        ["c-a", "c-b", "c-c", "c-d"]
+            .iter()
+            .map(|uuid| SynapseExport {
+                from_uuid: (*uuid).to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.0,
+                synapse_type: None,
+            }),
+    );
+    CreatureExport {
+        memetic: None,
+        input: 2,
+        output: 1,
+        neurons,
+        synapses,
+        semantic_version: None,
+        forward_only: true,
+    }
+}
+
+#[test]
+fn a_grafted_node_is_listed_after_every_constant_the_creature_carries() {
+    // Its sources reach `c-c` only, but listing the node there would leave
+    // `c-d` after a hidden neuron, which rule 11 refuses.
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_condition("c-a", -0.25)
+        .with_positive("c-b", 2.0)
+        .with_negative("c-c", 0.0)
+        .with_target("output-0", 1.0);
+    let grafted = graft_if_node(&four_constant_creature(), &spec).expect("graft succeeds");
+    assert_valid(&grafted, "a graft onto a creature with a trailing constant");
+
+    let order: Vec<&str> = grafted.neurons.iter().map(|n| n.uuid.as_str()).collect();
+    let pos = |u: &str| order.iter().position(|o| *o == u).expect("neuron present");
+    assert!(pos("c-d") < pos("if-1"), "order was {order:?}");
+}
+
+#[test]
+fn a_relay_carries_a_second_typed_edge_into_the_same_target() {
+    let base = if_output_creature();
+    // The correction enters the positive branch directly and the negative one
+    // through the relay, so it applies whichever branch the output takes.
+    let grafted = graft_if_node(&base, &correction_spec(SynapseType::Positive))
+        .expect("typed graft succeeds");
+    let relay = RelaySpec::new("corr-relay", 0.0)
+        .with_source("corr", 1.0)
+        .with_target_role("output-0", 1.0, SynapseType::Negative);
+    let grafted = graft_relay_node(&grafted, &relay).expect("relay graft succeeds");
+    assert_valid(&grafted, "a graft wired into both branches of an IF output");
+
+    let node = grafted
+        .neurons
+        .iter()
+        .find(|n| n.uuid == "corr-relay")
+        .expect("relay present");
+    assert_eq!(node.squash.as_deref(), Some("IDENTITY"));
+    assert_eq!(node.neuron_type, "hidden");
+
+    for record in [[1.0f32, 1.0, 1.0], [-1.0, 1.0, 1.0], [-1.0, 0.0, 0.0]] {
+        let delta = activate(&grafted, &record) - activate(&base, &record);
+        assert!(
+            (delta - correction_value(&record)).abs() <= TOL,
+            "record {record:?}: delta {delta} vs expected {}",
+            correction_value(&record)
+        );
+    }
+}
+
+#[test]
+fn a_relay_with_no_source_or_no_target_is_refused() {
+    let base = graft_if_node(
+        &if_output_creature(),
+        &correction_spec(SynapseType::Positive),
+    )
+    .expect("typed graft succeeds");
+    let sourceless = RelaySpec::new("corr-relay", 0.0).with_target("output-0", 1.0);
+    assert!(matches!(
+        graft_relay_node(&base, &sourceless).expect_err("must be rejected"),
+        GraftError::NoSources
+    ));
+
+    let targetless = RelaySpec::new("corr-relay", 0.0).with_source("corr", 1.0);
+    assert!(matches!(
+        graft_relay_node(&base, &targetless).expect_err("must be rejected"),
+        GraftError::NoTargets
+    ));
 }


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/NEAT-AI-Forests#48 here, in the dependency's own repo.

Adds GraftEdge::role plus with_target_role, the all-or-nothing graft_if_nodes batch (a node may leave its outward edge to a later node in the batch), RelaySpec/graft_relay_node, and node placement after every constant — the capability NEAT-AI-Forests #48 needs to stop hand-writing nested trees and IF-output wiring.

**Head:** `issue-48-typed-outward-edges-and-batch-graft` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/NEAT-AI-Forests#48: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.