### PR TITLE
creature_validate: make the forward-only leg linear, and add a packed request shape (NEAT-AI#3832)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.10.2"
+version = "0.10.4"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.10.2"
+version = "0.10.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/docs/research/ikaruga-neat-ai-comparison.md
+++ b/docs/research/ikaruga-neat-ai-comparison.md
@@ -50,7 +50,7 @@ The `mame-neat` sibling crate mirrors this layout against MAME.
 
 The table lists the modules present in `neat-core/src/` today. `pc_inference` / `pc_learning` (the predictive-coding inference engine and learning rule) were in this inventory when the research was written and were **removed in Issue #414**; `wasm_dataset` was likewise **removed in Issue #415**.
 
-Source footprint: **~23,200** LOC across `neat-core/src/`, measured on `Develop` at Issue #561. `tests/scripts/research_docs_removed_modules.bats` fails loud once the tree drifts more than 10% from that figure — refresh the number here when it does. No evolutionary operator code is present — by design.
+Source footprint: **~26,200** LOC across `neat-core/src/`, measured on `Develop` at NEAT-AI#3832. `tests/scripts/research_docs_removed_modules.bats` fails loud once the tree drifts more than 10% from that figure — refresh the number here when it does. No evolutionary operator code is present — by design.
 
 ## Feature-by-feature comparison
 

--- a/neat-core/benches/BASELINE.md
+++ b/neat-core/benches/BASELINE.md
@@ -618,6 +618,36 @@ Allocation count for one call at production shape (4,127 neurons / 2,461 inputs
 The count is now independent of neuron count — asserted permanently by
 `reverse_topological_order_allocation_count_does_not_scale_with_neurons`.
 
+## Cycle detection: rescan → outward adjacency (NEAT-AI#3832)
+
+`detect_cycles` ran Kahn's algorithm with a **rescan**: for every dequeued
+neuron it walked the whole synapse list looking for the ones leaving it, so the
+relaxation pass was `O(neurons × synapses)`. It now builds an outward
+compressed-row adjacency once and reads each source's targets directly, which
+makes the walk linear in neurons plus synapses. The answer is unchanged —
+`detect_cycles_linear_parity.rs` replays 20 000 random topologies against the
+rescan kept verbatim as the oracle, including the shapes where the two could
+plausibly have diverged (duplicated pairs, sources past the last neuron,
+synapses into and out of inputs, unsorted lists).
+
+This is the forward-only leg of `creature_validate`, and it is also
+`TypedTopology.detectCycles` on the host: on GRQ's 4 272-neuron, 22 928-synapse
+production creature it was **10.75 ms of the 10.8 ms** the whole rule set spent.
+
+**Measured 2026-08-22**, Apple M4 Pro (12 cores, 24 GB, macOS 26.5.2 arm64),
+rustc 1.97.1, Criterion 0.8.2, `--release` bench profile. New benchmark in the
+existing `topology_ops` group; times are Criterion's mean `[lower, upper]`.
+
+| Shape | Before (rescan) | After (adjacency) | Change |
+| --- | --- | --- | --- |
+| `n1666_21513` (100 inputs) | 8.538 ms `[8.527, 8.548]` | 80.26 µs `[80.07, 80.47]` | **−99.1%** (106×) |
+| `n4127_21513` (2,461 inputs) | 8.986 ms `[8.968, 9.003]` | 47.42 µs `[47.33, 47.51]` | **−99.5%** (189×) |
+
+The second shape is faster than the first despite carrying more neurons: with
+2,461 of its 4,127 neurons as inputs, the adjacency covers only the 1,666
+sources Kahn's queue can dequeue. Under the rescan the same shape was *slower*,
+because the rescan's cost was set by the synapse list, not by the queue.
+
 ## Reproducing
 
 ```bash

--- a/neat-core/benches/hot_paths.rs
+++ b/neat-core/benches/hot_paths.rs
@@ -24,7 +24,9 @@ use neat_core::simd::{
 use neat_core::squash::{SquashType, apply_squash};
 use neat_core::squash_simd::squash_x4;
 use neat_core::topological_backprop::{PropagateInput, propagate_topological_loop};
-use neat_core::topology_ops::{compute_reverse_topological_order, scan_available_connections};
+use neat_core::topology_ops::{
+    compute_reverse_topological_order, detect_cycles, scan_available_connections,
+};
 use neat_core::unsquash::apply_unsquash;
 
 /// Deterministic network/backprop fixtures, shared with the `bench_fixtures`
@@ -387,6 +389,23 @@ fn bench_topology_ops(c: &mut Criterion) {
                 });
             },
         );
+
+        // The forward-only leg of `creature_validate`, and `TypedTopology`'s
+        // own `detectCycles` (NEAT-AI#3832). The relaxation pass used to
+        // rescan the whole synapse list per dequeued neuron, so this group is
+        // where the quadratic term would come back — throughput is neurons
+        // plus synapses because a linear walk is the contract.
+        group.bench_function(BenchmarkId::new("detect_cycles", spec.label), |b| {
+            b.iter(|| {
+                let out = detect_cycles(
+                    black_box(&from_indices),
+                    black_box(&to_indices),
+                    black_box(num_neurons),
+                    black_box(num_inputs),
+                );
+                black_box(out);
+            });
+        });
     }
     group.finish();
 }

--- a/neat-core/src/creature_validate_packed.rs
+++ b/neat-core/src/creature_validate_packed.rs
@@ -216,9 +216,26 @@ mod neuron_flag {
 /// The one home of the layout arithmetic: the host sizes its buffer with the
 /// same formula, and a request of any other length is refused rather than
 /// read short.
+///
+/// Sized for a request that exists — a creature the caller is holding. The
+/// boundary cannot assume that of the counts it reads out of a *buffer*, so it
+/// computes the same length in a wider type instead, so a header claiming
+/// more synapses than any buffer could hold is refused rather than wrapped.
 #[must_use]
 pub const fn packed_request_len(neuron_count: usize, synapse_count: usize) -> usize {
     synapse_section_offset(neuron_count) + synapse_count * 9
+}
+
+/// [`packed_request_len`] in a width no target can overflow.
+///
+/// A header can claim `u32::MAX` synapses, and `u32::MAX * 9` does not fit a
+/// `usize` on wasm32 — it would wrap, agree with a short buffer's length, and
+/// send the reads below off the end of it. Sixty-four bits hold the largest
+/// length the counts can express (about 39 GB) with room to spare, so the
+/// comparison against `buffer.len()` is decided before any offset is built.
+const fn packed_request_len_wide(neuron_count: u64, synapse_count: u64) -> u64 {
+    let unaligned = PACKED_HEADER_BYTES as u64 + neuron_count * 19;
+    unaligned.next_multiple_of(4) + synapse_count * 9
 }
 
 /// Offset of the first per-synapse array, four-aligned so the `u32` endpoint
@@ -458,21 +475,27 @@ impl PackedRequest {
             ));
         }
 
-        let neuron_count = read_u32(buffer, 8) as usize;
-        let synapse_count = read_u32(buffer, 12) as usize;
-        if neuron_count > MAX_REQUEST_NEURONS {
+        let declared_neurons = u64::from(read_u32(buffer, 8));
+        let declared_synapses = u64::from(read_u32(buffer, 12));
+        if declared_neurons > MAX_REQUEST_NEURONS as u64 {
             return Err(format!(
-                "creature declares {neuron_count} neurons, exceeding the maximum of {MAX_REQUEST_NEURONS}"
+                "creature declares {declared_neurons} neurons, exceeding the maximum of {MAX_REQUEST_NEURONS}"
             ));
         }
 
-        let expected = packed_request_len(neuron_count, synapse_count);
-        if buffer.len() != expected {
+        // Decided in 64 bits, before a single offset is built from the counts:
+        // a buffer of the agreed length bounds every read below.
+        let expected = packed_request_len_wide(declared_neurons, declared_synapses);
+        if buffer.len() as u64 != expected {
             return Err(format!(
-                "a request for {neuron_count} neurons and {synapse_count} synapses is {expected} bytes, this one is {}",
+                "a request for {declared_neurons} neurons and {declared_synapses} synapses is {expected} bytes, this one is {}",
                 buffer.len()
             ));
         }
+
+        // The buffer is that long, so both counts fit the address space.
+        let neuron_count = declared_neurons as usize;
+        let synapse_count = declared_synapses as usize;
 
         let option_bits = read_u32(buffer, 16);
         let options = ValidateOptions {
@@ -906,6 +929,38 @@ mod tests {
 
         assert!(answer.contains(MALFORMED_REQUEST));
         assert!(answer.contains("bytes, this one is"));
+    }
+
+    /// A synapse count no buffer could hold is refused on its arithmetic, not
+    /// on a wrapped length.
+    ///
+    /// `u32::MAX * 9` does not fit a `usize` on wasm32. Computed there it
+    /// wraps to 4 294 967 247 — 48 bytes short of nothing — and a header-only
+    /// buffer padded to that would have been *accepted*, sending every read
+    /// below off the end of it. The length is settled in 64 bits, so the count
+    /// is refused whatever the target's pointer width.
+    #[test]
+    fn a_synapse_count_no_buffer_could_hold_is_refused() {
+        let mut buffer = vec![0u8; PACKED_HEADER_BYTES];
+        write_u32(&mut buffer, 0, PACKED_MAGIC);
+        write_u32(&mut buffer, 4, PACKED_VERSION);
+        write_u32(&mut buffer, 8, 0);
+        write_u32(&mut buffer, 12, u32::MAX);
+
+        let answer = creature_validate_packed(&buffer, "");
+
+        assert!(answer.contains(MALFORMED_REQUEST), "{answer}");
+        assert!(answer.contains("38654705703 bytes"), "{answer}");
+
+        // The length itself, asserted in a value no 32-bit width can hold:
+        // 48 header bytes plus nine per synapse. This is the assertion that
+        // stays honest on a wasm32 host, where the `usize` form wraps and the
+        // check above would agree with a buffer that is nowhere near this long.
+        assert_eq!(
+            packed_request_len_wide(0, u64::from(u32::MAX)),
+            38_654_705_703
+        );
+        assert!(packed_request_len_wide(0, u64::from(u32::MAX)) > u64::from(u32::MAX));
     }
 
     #[test]

--- a/neat-core/src/creature_validate_packed.rs
+++ b/neat-core/src/creature_validate_packed.rs
@@ -1,0 +1,1024 @@
+//! The packed ABI `creature_validate` crosses the WASM boundary on when the
+//! host is validating a large creature (NEAT-AI#3832).
+//!
+//! [`mod@crate::creature_validate_json`] is JSON in, JSON out. That is the
+//! right shape for a *failure* — a record with a class, a reason and a message
+//! — but the wrong shape for a creature: on a 4 272-neuron, 22 928-synapse
+//! production creature the request is 850 KB, and the host spends 3.5 ms
+//! building the string before the rules have looked at anything.
+//! `creatureValidate` runs after every mutation, breed and discovery step, so
+//! that cost is paid on the hot path.
+//!
+//! This module is the same rules over a **packed buffer**: one little-endian
+//! byte block the host fills from the typed arrays it already holds
+//! (`TypedTopology`), copied into linear memory as a single `memcpy`. Both
+//! shapes meet at the same seam — the shared rule walk in
+//! [`mod@crate::creature_validate`] — so a creature cannot
+//! be judged differently depending on how it was described.
+//!
+//! # No strings, and what that costs
+//!
+//! The buffer carries **no text at all**: a neuron's type, activation and UUID
+//! travel as codes and flags. That is what makes it fast — the strings are
+//! most of the payload and all of the per-neuron allocation — and the rules
+//! need none of them to reach a *verdict*. They need them only to write the
+//! *message*, so a packed request can say "this creature is healthy, and here
+//! are its counters" but cannot say "hidden neuron `neuron-1803232510` has no
+//! outward connections".
+//!
+//! So a broken creature comes back as `{"ok":false,"detailRequired":true}`,
+//! and the host asks [`crate::creature_validate_json()`] for the failure. That call is
+//! the slow one, and it is the one that never happens on a healthy creature:
+//! a failure throws, ending whatever the host was doing.
+//!
+//! Reporting the failure from the JSON shape rather than reconstructing it
+//! here is also what keeps the message single-sourced — there is exactly one
+//! place a `creatureValidate` message is written, and it is
+//! [`mod@crate::creature_validate`].
+//!
+//! ```mermaid
+//! flowchart LR
+//!   H["host: TypedTopology + neuron block"] --> P["creature_validate_packed"]
+//!   P -- "ok + stats" --> S["done"]
+//!   P -- "detailRequired" --> J["creature_validate (JSON)"] --> F["class, reason, message"]
+//!   P -- "buffer is not a request" --> M["malformed — never a verdict"]
+//! ```
+//!
+//! # Request layout
+//!
+//! One buffer, little-endian throughout, laid out as a header followed by five
+//! per-neuron arrays and three per-synapse arrays. `N` is the neuron count and
+//! `S` the synapse count; the buffer is exactly [`packed_request_len`] bytes
+//! and a request of any other length is refused.
+//!
+//! | Offset | Type | Field |
+//! |--------|------|-------|
+//! | 0  | `u32` | [`PACKED_MAGIC`] |
+//! | 4  | `u32` | [`PACKED_VERSION`] |
+//! | 8  | `u32` | `N`, the neuron count |
+//! | 12 | `u32` | `S`, the synapse count |
+//! | 16 | `u32` | option flags — see below |
+//! | 20 | `u32` | `options.neurons`, read only when its flag is set |
+//! | 24 | `u32` | `options.connections`, read only when its flag is set |
+//! | 28 | `u32` | reserved, written as `0` |
+//! | 32 | `f64` | the declared `input` width |
+//! | 40 | `f64` | the declared `output` width |
+//! | 48 | `f64 × N` | neuron ids |
+//! | 48 + 8N | `f64 × N` | neuron biases |
+//! | 48 + 16N | `u8 × N` | neuron kinds |
+//! | 48 + 17N | `u8 × N` | neuron flags |
+//! | 48 + 18N | `u8 × N` | activation codes |
+//! | `E` | `u32 × S` | synapse `from` positions |
+//! | `E` + 4S | `u32 × S` | synapse `to` positions |
+//! | `E` + 8S | `u8 × S` | synapse role codes |
+//!
+//! `E` is `48 + 19N` rounded up to the next multiple of four, so the `u32`
+//! arrays stay four-aligned however many neurons the creature carries.
+//!
+//! ## Option flags (offset 16)
+//!
+//! | Bit | Meaning |
+//! |-----|---------|
+//! | 0 | `forwardOnly` |
+//! | 1 | `feedbackLoop` was given |
+//! | 2 | `feedbackLoop`'s value, read only when bit 1 is set |
+//! | 3 | `options.neurons` was given |
+//! | 4 | `options.connections` was given |
+//!
+//! ## Neuron flags (offset 48 + 17N)
+//!
+//! | Bit | Meaning |
+//! |-----|---------|
+//! | 0 | the neuron carries an id; when clear, rule 4 reports "no id" |
+//! | 1 | the neuron carries a bias; when clear, rule 8 reads `undefined` |
+//! | 2 | the neuron carries an activation; when clear, it has none |
+//!
+//! A *present* id or bias is sent verbatim, non-finite values included: `NaN`
+//! reaches rule 5 or rule 8 exactly as it would through the JSON shape's
+//! sentinel strings. The flags are only for what JavaScript calls `undefined`.
+//!
+//! ## Neuron kinds (offset 48 + 16N)
+//!
+//! `0` input, `1` constant, `2` hidden, `3` output, and anything else the
+//! type rule 20 rejects — a host sends [`KIND_OTHER`] for a type it does not
+//! recognise, and the message naming that type comes from the JSON shape.
+//!
+//! ## Activation codes (offset 48 + 18N)
+//!
+//! [`SquashType`] as a `u8`, with [`SQUASH_UNKNOWN`] for a name this crate
+//! does not know. Only two things are read off it: whether it is
+//! [`SquashType::If`] (rule 12 and the forward-only structural leg), and
+//! whether the neuron has one at all (rule 15). Every other code is "some
+//! other activation".
+//!
+//! ## Synapse roles (offset `E` + 8S)
+//!
+//! [`SynapseType`] as a `u8` — `0` standard, `1` condition, `2` negative,
+//! `3` positive, which is the encoding `TypedTopology.synapseTypes` already
+//! carries.
+//!
+//! ## Endpoints
+//!
+//! A `from` or `to` is the neuron's **array position**, the same integer the
+//! host holds. A position no neuron occupies — including the
+//! [`ENDPOINT_NONE`] sentinel a host sends for an endpoint that is not an
+//! index at all — is a rule failure, reported the same way any other is.
+//!
+//! # The memetic record
+//!
+//! `memetic` is irregular, optional, and small — five entries and 618 bytes on
+//! the creature that motivated this module — so it stays JSON, passed
+//! alongside the buffer. An empty string is a creature with no memetic record.
+//!
+//! # Malformed input cannot panic
+//!
+//! Same contract as the JSON shape: a buffer that is not a request comes back
+//! as an ordinary structured failure carrying `"malformed": true` and a
+//! message leading with [`MALFORMED_REQUEST`], never as a trap. A panic in
+//! WASM aborts the module and takes the host's session with it.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::creature::parse_squash_name;
+use crate::creature_validate::{
+    NeuronKind, NeuronView, ValidateOptions, validate_declared_widths, validate_prepared,
+};
+use crate::creature_validate_json::{
+    MALFORMED_REQUEST, MAX_REQUEST_NEURONS, ValidationFailureJson, ValidationStatsJson,
+};
+use crate::creature_validate_runtime::memetic_view;
+use crate::squash::SquashType;
+use crate::synapse_type::SynapseType;
+
+/// The four bytes a packed request opens with — `"NVAL"` read little-endian.
+///
+/// A host that sends the wrong buffer entirely (a compiled network, a training
+/// batch) is told so, rather than having its bytes read as a creature.
+pub const PACKED_MAGIC: u32 = 0x4C41_564E;
+
+/// The layout revision this crate reads.
+///
+/// Bumped whenever the byte layout changes. A host built against a different
+/// revision is refused rather than mis-read: the vendored bundle and the host
+/// advance together, so a mismatch is a stale build, not a runtime condition
+/// to tolerate.
+pub const PACKED_VERSION: u32 = 1;
+
+/// Bytes before the first per-neuron array.
+pub const PACKED_HEADER_BYTES: usize = 48;
+
+/// The kind code for a type none of the four rules recognise (rule 20).
+pub const KIND_OTHER: u8 = 4;
+
+/// The activation code for a name this crate cannot parse.
+///
+/// Matches what the JSON shape does with an unknown name: it is "not `IF`",
+/// and nothing else about it is a rule here — NEAT-AI checks the name itself
+/// host-side in `neuron.validate()`.
+pub const SQUASH_UNKNOWN: u8 = u8::MAX;
+
+/// The endpoint a host sends for a `from` or `to` that is not a neuron
+/// position at all.
+///
+/// Any value at or past the neuron count is refused the same way; this is the
+/// one a host can always reach for, since a creature can never carry
+/// `u32::MAX` neurons.
+pub const ENDPOINT_NONE: u32 = u32::MAX;
+
+/// Option flag bits at offset 16 — see the module documentation.
+mod option_flag {
+    /// `forwardOnly`.
+    pub(super) const FORWARD_ONLY: u32 = 1 << 0;
+    /// `feedbackLoop` was given at all.
+    pub(super) const FEEDBACK_LOOP_SET: u32 = 1 << 1;
+    /// `feedbackLoop`'s value, read only when [`FEEDBACK_LOOP_SET`] is set.
+    pub(super) const FEEDBACK_LOOP_VALUE: u32 = 1 << 2;
+    /// `options.neurons` was given.
+    pub(super) const NEURONS_SET: u32 = 1 << 3;
+    /// `options.connections` was given.
+    pub(super) const CONNECTIONS_SET: u32 = 1 << 4;
+}
+
+/// Neuron flag bits — see the module documentation.
+mod neuron_flag {
+    /// The neuron carries an id.
+    pub(super) const HAS_ID: u8 = 1 << 0;
+    /// The neuron carries a bias.
+    pub(super) const HAS_BIAS: u8 = 1 << 1;
+    /// The neuron carries an activation.
+    pub(super) const HAS_SQUASH: u8 = 1 << 2;
+}
+
+/// Bytes a packed request for `neuron_count` neurons and `synapse_count`
+/// synapses occupies.
+///
+/// The one home of the layout arithmetic: the host sizes its buffer with the
+/// same formula, and a request of any other length is refused rather than
+/// read short.
+#[must_use]
+pub const fn packed_request_len(neuron_count: usize, synapse_count: usize) -> usize {
+    synapse_section_offset(neuron_count) + synapse_count * 9
+}
+
+/// Offset of the first per-synapse array, four-aligned so the `u32` endpoint
+/// arrays are readable as words on the host side whatever `N` is.
+const fn synapse_section_offset(neuron_count: usize) -> usize {
+    let unaligned = PACKED_HEADER_BYTES + neuron_count * 19;
+    unaligned.next_multiple_of(4)
+}
+
+/// What [`creature_validate_packed`] answers with.
+///
+/// Deliberately **not** [`crate::ValidateResponse`]: this shape can say
+/// "a rule was broken and I cannot name it", which the JSON shape can never
+/// say and must never learn to.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackedValidateResponse {
+    /// `true` when the creature broke no rule.
+    pub ok: bool,
+    /// The counters — present only when `ok`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stats: Option<ValidationStatsJson>,
+    /// `true` when a rule was broken and the host must ask
+    /// [`crate::creature_validate_json()`] which one, and in what words.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail_required: Option<bool>,
+    /// The boundary fault — present only when the buffer was never a request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ValidationFailureJson>,
+}
+
+impl PackedValidateResponse {
+    /// A healthy creature, and what was counted walking it.
+    fn healthy(stats: ValidationStatsJson) -> Self {
+        Self {
+            ok: true,
+            stats: Some(stats),
+            detail_required: None,
+            failure: None,
+        }
+    }
+
+    /// A rule was broken. Which one, and in what words, is the JSON shape's to
+    /// say — see the module documentation.
+    fn detail_required() -> Self {
+        Self {
+            ok: false,
+            stats: None,
+            detail_required: Some(true),
+            failure: None,
+        }
+    }
+
+    /// A boundary fault: the buffer never reached a rule.
+    ///
+    /// Reported exactly as the JSON shape reports one — `ValidationError` /
+    /// `OTHER`, `malformed` set, and the message led by [`MALFORMED_REQUEST`]
+    /// — so neither the host nor a log reader can mistake it for a verdict on
+    /// the creature.
+    fn malformed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            ok: false,
+            stats: None,
+            detail_required: None,
+            failure: Some(ValidationFailureJson {
+                class: crate::creature_validate::FailureClass::Validation
+                    .as_str()
+                    .to_string(),
+                reason: crate::creature_validate::reason::OTHER.to_string(),
+                message: format!("{MALFORMED_REQUEST} {detail}"),
+                neuron_index: None,
+                synapse_index: None,
+                malformed: true,
+            }),
+        }
+    }
+}
+
+/// Validate a creature described by a packed buffer, answering with JSON.
+///
+/// This is the whole of the WASM export:
+/// `wasm_exports::wasm_creature_validate_packed` is a `#[wasm_bindgen]` rename
+/// over it, so the ABI is testable natively. The buffer layout, the
+/// `detailRequired` contract and the malformed-input contract are in the
+/// module documentation.
+///
+/// Never panics and never returns an error: a buffer that is not a request
+/// comes back as a structured failure carrying `"malformed": true`.
+///
+/// `memetic_json` is the creature's memetic record as JSON, or `""` for a
+/// creature that carries none.
+///
+/// ```
+/// use neat_core::{
+///     RuntimeCreature, ValidateOptions, creature_validate_packed, encode_packed_request,
+/// };
+///
+/// let creature: RuntimeCreature = serde_json::from_str(
+///     r#"{ "input": 1, "output": 1,
+///          "neurons": [ { "type": "input",  "id": 0,  "uuid": "input-0" },
+///                       { "type": "output", "id": -1, "uuid": "output-0",
+///                         "bias": 0.0, "squash": "IDENTITY" } ],
+///          "synapses": [ { "from": 0, "to": 1 } ] }"#,
+/// )?;
+///
+/// let buffer = encode_packed_request(&creature, &ValidateOptions::default());
+/// let answer = creature_validate_packed(&buffer, "");
+///
+/// assert_eq!(
+///     answer,
+///     r#"{"ok":true,"stats":{"input":1,"constant":0,"hidden":0,"output":1,"connections":1}}"#
+/// );
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[must_use]
+pub fn creature_validate_packed(buffer: &[u8], memetic_json: &str) -> String {
+    let response = validate_packed_request(buffer, memetic_json);
+    // The response is derived `Serialize` over owned `String`s and plain
+    // numbers, so this cannot fail — but a fallback that says so beats an
+    // `unwrap` that would abort the module if it ever did.
+    serde_json::to_string(&response).unwrap_or_else(|error| {
+        format!(
+            r#"{{"ok":false,"failure":{{"class":"ValidationError","reason":"OTHER","message":"{MALFORMED_REQUEST} response could not be serialised: {error}","neuronIndex":null,"synapseIndex":null,"malformed":true}}}}"#
+        )
+    })
+}
+
+/// The typed half of [`creature_validate_packed`], kept separate so the tests
+/// read the answer as a value rather than as text.
+fn validate_packed_request(buffer: &[u8], memetic_json: &str) -> PackedValidateResponse {
+    let request = match PackedRequest::decode(buffer) {
+        Ok(request) => request,
+        Err(detail) => return PackedValidateResponse::malformed(detail),
+    };
+
+    let memetic: Option<Value> = if memetic_json.is_empty() {
+        None
+    } else {
+        match serde_json::from_str(memetic_json) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                return PackedValidateResponse::malformed(format!(
+                    "the memetic record is not JSON: {error}"
+                ));
+            }
+        }
+    };
+
+    if validate_declared_widths(
+        request.neuron_count,
+        request.declared_input,
+        request.declared_output,
+        &request.options,
+    )
+    .is_err()
+    {
+        return PackedValidateResponse::detail_required();
+    }
+
+    // Rules 2 and 3 passed, so both widths are integers of at least one.
+    let input = request.declared_input as usize;
+    let output = request.declared_output as usize;
+
+    let views = request.neuron_views();
+    // An endpoint naming no neuron is a rule failure in the runtime shape
+    // (`INVALID_SYNAPSE_REFERENCE`), so it is one here — reported by the JSON
+    // shape rather than indexed out of bounds.
+    if request
+        .from_indices
+        .iter()
+        .chain(request.to_indices.iter())
+        .any(|endpoint| *endpoint as usize >= request.neuron_count)
+    {
+        return PackedValidateResponse::detail_required();
+    }
+
+    let memetic = memetic.as_ref().map(memetic_view);
+
+    match validate_prepared(
+        &views,
+        None,
+        input,
+        output,
+        &request.from_indices,
+        &request.to_indices,
+        &request.synapse_types,
+        &request.options,
+        memetic.as_ref(),
+    ) {
+        Ok(stats) => PackedValidateResponse::healthy(stats.into()),
+        Err(_) => PackedValidateResponse::detail_required(),
+    }
+}
+
+/// A decoded packed request — the buffer, read once into the shapes the rules
+/// take.
+struct PackedRequest {
+    neuron_count: usize,
+    declared_input: f64,
+    declared_output: f64,
+    options: ValidateOptions,
+    ids: Vec<f64>,
+    biases: Vec<f64>,
+    kinds: Vec<u8>,
+    flags: Vec<u8>,
+    squash_codes: Vec<u8>,
+    from_indices: Vec<u32>,
+    to_indices: Vec<u32>,
+    synapse_types: Vec<SynapseType>,
+}
+
+impl PackedRequest {
+    /// Read a buffer, or say why it is not a request.
+    ///
+    /// Every read is bounds-checked against a length the header agreed to
+    /// first: a host that miscounted its own creature is told so, rather than
+    /// trapping the module on a short slice.
+    fn decode(buffer: &[u8]) -> Result<Self, String> {
+        if buffer.len() < PACKED_HEADER_BYTES {
+            return Err(format!(
+                "a packed request is at least {PACKED_HEADER_BYTES} bytes, this one is {}",
+                buffer.len()
+            ));
+        }
+
+        let magic = read_u32(buffer, 0);
+        if magic != PACKED_MAGIC {
+            return Err(format!(
+                "buffer does not open with the packed-request magic {PACKED_MAGIC:#010x} (read {magic:#010x})"
+            ));
+        }
+
+        let version = read_u32(buffer, 4);
+        if version != PACKED_VERSION {
+            return Err(format!(
+                "packed request layout version {version}, this bundle reads version {PACKED_VERSION}"
+            ));
+        }
+
+        let neuron_count = read_u32(buffer, 8) as usize;
+        let synapse_count = read_u32(buffer, 12) as usize;
+        if neuron_count > MAX_REQUEST_NEURONS {
+            return Err(format!(
+                "creature declares {neuron_count} neurons, exceeding the maximum of {MAX_REQUEST_NEURONS}"
+            ));
+        }
+
+        let expected = packed_request_len(neuron_count, synapse_count);
+        if buffer.len() != expected {
+            return Err(format!(
+                "a request for {neuron_count} neurons and {synapse_count} synapses is {expected} bytes, this one is {}",
+                buffer.len()
+            ));
+        }
+
+        let option_bits = read_u32(buffer, 16);
+        let options = ValidateOptions {
+            neurons: (option_bits & option_flag::NEURONS_SET != 0)
+                .then(|| read_u32(buffer, 20) as usize),
+            connections: (option_bits & option_flag::CONNECTIONS_SET != 0)
+                .then(|| read_u32(buffer, 24) as usize),
+            feedback_loop: (option_bits & option_flag::FEEDBACK_LOOP_SET != 0)
+                .then_some(option_bits & option_flag::FEEDBACK_LOOP_VALUE != 0),
+            forward_only: option_bits & option_flag::FORWARD_ONLY != 0,
+        };
+
+        let ids_at = PACKED_HEADER_BYTES;
+        let biases_at = ids_at + neuron_count * 8;
+        let kinds_at = biases_at + neuron_count * 8;
+        let flags_at = kinds_at + neuron_count;
+        let squash_at = flags_at + neuron_count;
+        let from_at = synapse_section_offset(neuron_count);
+        let to_at = from_at + synapse_count * 4;
+        let roles_at = to_at + synapse_count * 4;
+
+        Ok(Self {
+            neuron_count,
+            declared_input: read_f64(buffer, 32),
+            declared_output: read_f64(buffer, 40),
+            options,
+            ids: (0..neuron_count)
+                .map(|i| read_f64(buffer, ids_at + i * 8))
+                .collect(),
+            biases: (0..neuron_count)
+                .map(|i| read_f64(buffer, biases_at + i * 8))
+                .collect(),
+            kinds: buffer[kinds_at..kinds_at + neuron_count].to_vec(),
+            flags: buffer[flags_at..flags_at + neuron_count].to_vec(),
+            squash_codes: buffer[squash_at..squash_at + neuron_count].to_vec(),
+            from_indices: (0..synapse_count)
+                .map(|i| read_u32(buffer, from_at + i * 4))
+                .collect(),
+            to_indices: (0..synapse_count)
+                .map(|i| read_u32(buffer, to_at + i * 4))
+                .collect(),
+            synapse_types: buffer[roles_at..roles_at + synapse_count]
+                .iter()
+                .map(|role| SynapseType::from(*role))
+                .collect(),
+        })
+    }
+
+    /// The walk's view of every neuron.
+    ///
+    /// The text fields are reconstructed from the codes, not carried: a
+    /// `declared_type` and an activation name that round-trip, and no UUID at
+    /// all. They reach only the messages, and a packed request never answers
+    /// with one — see the module documentation.
+    fn neuron_views(&self) -> Vec<NeuronView<'static>> {
+        (0..self.neuron_count)
+            .map(|index| {
+                let flags = self.flags[index];
+                let declared = self.ids[index];
+                let has_id = flags & neuron_flag::HAS_ID != 0;
+                let kind = kind_from_code(self.kinds[index]);
+
+                NeuronView {
+                    id: has_id
+                        .then_some(declared)
+                        .filter(|id| crate::creature_validate::is_js_integer(*id))
+                        .map(|id| id as i64),
+                    non_integer_id: has_id
+                        .then_some(declared)
+                        .filter(|id| !crate::creature_validate::is_js_integer(*id)),
+                    kind,
+                    declared_type: declared_type_for(kind),
+                    uuid: None,
+                    bias: (flags & neuron_flag::HAS_BIAS != 0).then_some(self.biases[index]),
+                    squash: (flags & neuron_flag::HAS_SQUASH != 0)
+                        .then(|| squash_name_for(self.squash_codes[index])),
+                }
+            })
+            .collect()
+    }
+}
+
+/// A `u32` at `offset`, which the caller has already bounds-checked.
+fn read_u32(buffer: &[u8], offset: usize) -> u32 {
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&buffer[offset..offset + 4]);
+    u32::from_le_bytes(bytes)
+}
+
+/// An `f64` at `offset`, read byte-wise so the buffer needs no alignment
+/// beyond the one byte a `&[u8]` guarantees.
+fn read_f64(buffer: &[u8], offset: usize) -> f64 {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&buffer[offset..offset + 8]);
+    f64::from_le_bytes(bytes)
+}
+
+/// The kind a code names — anything past the four is rule 20's to reject.
+fn kind_from_code(code: u8) -> NeuronKind {
+    match code {
+        0 => NeuronKind::Input,
+        1 => NeuronKind::Constant,
+        2 => NeuronKind::Hidden,
+        3 => NeuronKind::Output,
+        _ => NeuronKind::Invalid,
+    }
+}
+
+/// The code a kind travels as — the inverse of [`kind_from_code`].
+fn code_from_kind(kind: NeuronKind) -> u8 {
+    match kind {
+        NeuronKind::Input => 0,
+        NeuronKind::Constant => 1,
+        NeuronKind::Hidden => 2,
+        NeuronKind::Output => 3,
+        NeuronKind::Invalid => KIND_OTHER,
+    }
+}
+
+/// The `type` string a kind was declared with, as far as a code can say.
+///
+/// Reaches only the messages the packed shape does not answer with, so the
+/// unrecognised case names no type: the host's own word for it is in the JSON
+/// request it falls back to.
+fn declared_type_for(kind: NeuronKind) -> &'static str {
+    match kind {
+        NeuronKind::Input => "input",
+        NeuronKind::Constant => "constant",
+        NeuronKind::Hidden => "hidden",
+        NeuronKind::Output => "output",
+        NeuronKind::Invalid => "",
+    }
+}
+
+/// The activation name a code travels as.
+///
+/// A code this crate cannot name still has to read as *an* activation — rule
+/// 15 asks whether a constant carries one at all, and JavaScript's truthiness
+/// test makes an empty string no activation — so an unknown code takes a name
+/// that is deliberately not one [`parse_squash_name`] accepts.
+fn squash_name_for(code: u8) -> &'static str {
+    if code <= SquashType::Mean as u8 {
+        crate::creature::squash_name_from(SquashType::from(code))
+    } else {
+        "UNKNOWN_SQUASH"
+    }
+}
+
+/// The code an activation name travels as, or [`SQUASH_UNKNOWN`] for a name
+/// this crate does not know.
+#[must_use]
+pub fn squash_code_for(name: &str) -> u8 {
+    parse_squash_name(name).map_or(SQUASH_UNKNOWN, |squash| squash as u8)
+}
+
+/// Pack a runtime creature into the buffer [`creature_validate_packed`] reads.
+///
+/// The mirror of NEAT-AI's `CreatureValidatePack.ts`, and the reason the
+/// layout is testable from both ends: a Rust consumer holding a
+/// [`RuntimeCreature`] can reach the packed path without hand-rolling the
+/// offsets, and the conformance replay encodes the corpus through this rather
+/// than restating the layout in a test.
+///
+/// [`RuntimeCreature`]: crate::RuntimeCreature
+///
+/// ```
+/// use neat_core::{RuntimeCreature, ValidateOptions, encode_packed_request, packed_request_len};
+///
+/// let creature = RuntimeCreature::default();
+/// let buffer = encode_packed_request(&creature, &ValidateOptions::default());
+/// assert_eq!(buffer.len(), packed_request_len(0, 0));
+/// ```
+#[must_use]
+pub fn encode_packed_request(
+    creature: &crate::RuntimeCreature,
+    options: &ValidateOptions,
+) -> Vec<u8> {
+    let neuron_count = creature.neurons.len();
+    let synapse_count = creature.synapses.len();
+    let mut buffer = vec![0u8; packed_request_len(neuron_count, synapse_count)];
+
+    let mut option_bits = 0u32;
+    if options.forward_only {
+        option_bits |= option_flag::FORWARD_ONLY;
+    }
+    if let Some(feedback_loop) = options.feedback_loop {
+        option_bits |= option_flag::FEEDBACK_LOOP_SET;
+        if feedback_loop {
+            option_bits |= option_flag::FEEDBACK_LOOP_VALUE;
+        }
+    }
+    if let Some(neurons) = options.neurons {
+        option_bits |= option_flag::NEURONS_SET;
+        write_u32(&mut buffer, 20, neurons as u32);
+    }
+    if let Some(connections) = options.connections {
+        option_bits |= option_flag::CONNECTIONS_SET;
+        write_u32(&mut buffer, 24, connections as u32);
+    }
+
+    write_u32(&mut buffer, 0, PACKED_MAGIC);
+    write_u32(&mut buffer, 4, PACKED_VERSION);
+    write_u32(&mut buffer, 8, neuron_count as u32);
+    write_u32(&mut buffer, 12, synapse_count as u32);
+    write_u32(&mut buffer, 16, option_bits);
+    write_f64(&mut buffer, 32, creature.input.unwrap_or(f64::NAN));
+    write_f64(&mut buffer, 40, creature.output.unwrap_or(f64::NAN));
+
+    let ids_at = PACKED_HEADER_BYTES;
+    let biases_at = ids_at + neuron_count * 8;
+    let kinds_at = biases_at + neuron_count * 8;
+    let flags_at = kinds_at + neuron_count;
+    let squash_at = flags_at + neuron_count;
+
+    for (index, neuron) in creature.neurons.iter().enumerate() {
+        let mut flags = 0u8;
+        if let Some(id) = neuron.id {
+            flags |= neuron_flag::HAS_ID;
+            write_f64(&mut buffer, ids_at + index * 8, id);
+        }
+        if let Some(bias) = crate::creature_validate_runtime::bias_value(neuron.bias.as_ref()) {
+            flags |= neuron_flag::HAS_BIAS;
+            write_f64(&mut buffer, biases_at + index * 8, bias);
+        }
+        if let Some(squash) = neuron.squash.as_deref() {
+            flags |= neuron_flag::HAS_SQUASH;
+            buffer[squash_at + index] = squash_code_for(squash);
+        }
+        buffer[kinds_at + index] = code_from_kind(NeuronKind::from_declared_runtime(
+            neuron.neuron_type.as_deref().unwrap_or(""),
+        ));
+        buffer[flags_at + index] = flags;
+    }
+
+    let from_at = synapse_section_offset(neuron_count);
+    let to_at = from_at + synapse_count * 4;
+    let roles_at = to_at + synapse_count * 4;
+
+    for (index, synapse) in creature.synapses.iter().enumerate() {
+        write_u32(&mut buffer, from_at + index * 4, endpoint(synapse.from));
+        write_u32(&mut buffer, to_at + index * 4, endpoint(synapse.to));
+        buffer[roles_at + index] =
+            crate::creature::parse_synapse_type(synapse.synapse_type.as_deref()) as u8;
+    }
+
+    buffer
+}
+
+/// A synapse endpoint as the buffer carries it — the position itself, or
+/// [`ENDPOINT_NONE`] for anything that is not one.
+fn endpoint(position: Option<f64>) -> u32 {
+    position
+        .filter(|value| {
+            crate::creature_validate::is_js_integer(*value)
+                && *value >= 0.0
+                && *value < f64::from(ENDPOINT_NONE)
+        })
+        .map_or(ENDPOINT_NONE, |value| value as u32)
+}
+
+/// Write a `u32` at `offset`, which the caller has sized the buffer for.
+fn write_u32(buffer: &mut [u8], offset: usize, value: u32) {
+    buffer[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Write an `f64` at `offset`, which the caller has sized the buffer for.
+fn write_f64(buffer: &mut [u8], offset: usize, value: f64) {
+    buffer[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RuntimeCreature;
+
+    fn runtime(json: &str) -> RuntimeCreature {
+        serde_json::from_str(json).expect("a readable runtime creature")
+    }
+
+    /// The two-neuron creature every case below starts from.
+    fn healthy() -> RuntimeCreature {
+        runtime(
+            r#"{ "input": 1, "output": 1,
+                 "neurons": [ { "type": "input",  "id": 0,  "uuid": "input-0" },
+                              { "type": "output", "id": -1, "uuid": "output-0",
+                                "bias": 0.25, "squash": "IDENTITY" } ],
+                 "synapses": [ { "from": 0, "to": 1 } ] }"#,
+        )
+    }
+
+    fn answer(creature: &RuntimeCreature, options: &ValidateOptions) -> PackedValidateResponse {
+        validate_packed_request(&encode_packed_request(creature, options), "")
+    }
+
+    #[test]
+    fn a_healthy_creature_answers_with_its_counters() {
+        let answer = creature_validate_packed(
+            &encode_packed_request(&healthy(), &ValidateOptions::default()),
+            "",
+        );
+
+        assert_eq!(
+            answer,
+            r#"{"ok":true,"stats":{"input":1,"constant":0,"hidden":0,"output":1,"connections":1}}"#
+        );
+    }
+
+    #[test]
+    fn a_broken_creature_sends_the_host_to_the_json_shape() {
+        // A non-input neuron with no bias at all is rule 8.
+        let mut creature = healthy();
+        creature.neurons[1].bias = None;
+
+        let answer = creature_validate_packed(
+            &encode_packed_request(&creature, &ValidateOptions::default()),
+            "",
+        );
+
+        assert_eq!(answer, r#"{"ok":false,"detailRequired":true}"#);
+    }
+
+    /// The flag, not the value in the slot, is what says a neuron carries an
+    /// id.
+    ///
+    /// The host reuses one scratch buffer across calls, so the id slot of a
+    /// neuron carrying none holds whatever the *previous* creature left there.
+    /// A decoder that read the slot regardless of the flag would hand that
+    /// stale id to rule 4 and call the creature healthy — which is exactly the
+    /// buffer this builds: a valid creature with the id flag cleared and the
+    /// id left in place.
+    #[test]
+    fn a_cleared_id_flag_beats_whatever_the_slot_still_holds() {
+        let creature = healthy();
+        let neuron_count = creature.neurons.len();
+        let mut buffer = encode_packed_request(&creature, &ValidateOptions::default());
+        assert!(validate_packed_request(&buffer, "").ok);
+
+        // The output neuron's id stays `-1` in the slot; only its flag goes.
+        let flags_at = PACKED_HEADER_BYTES + neuron_count * 17;
+        let output = neuron_count - 1;
+        assert_eq!(read_f64(&buffer, PACKED_HEADER_BYTES + output * 8), -1.0);
+        buffer[flags_at + output] &= !neuron_flag::HAS_ID;
+
+        assert_eq!(
+            validate_packed_request(&buffer, ""),
+            PackedValidateResponse::detail_required(),
+            "a neuron with no id is rule 4, whatever the slot still holds"
+        );
+    }
+
+    #[test]
+    fn a_declared_width_rule_also_sends_the_host_to_the_json_shape() {
+        let mut creature = healthy();
+        creature.input = Some(0.0);
+
+        assert_eq!(
+            answer(&creature, &ValidateOptions::default()),
+            PackedValidateResponse::detail_required()
+        );
+    }
+
+    #[test]
+    fn an_endpoint_naming_no_neuron_is_a_rule_failure_not_a_trap() {
+        let mut creature = healthy();
+        creature.synapses[0].to = Some(99.0);
+
+        assert_eq!(
+            answer(&creature, &ValidateOptions::default()),
+            PackedValidateResponse::detail_required()
+        );
+    }
+
+    #[test]
+    fn the_memetic_record_travels_alongside_the_buffer() {
+        let creature = healthy();
+        let buffer = encode_packed_request(&creature, &ValidateOptions::default());
+
+        // `-1` is the output neuron's id, and `0 -> 1` is the only synapse.
+        let healthy_record = r#"{"biases":{"0":0.5},"weights":{"0":[{"toId":-1,"weight":0.5}]}}"#;
+        assert!(validate_packed_request(&buffer, healthy_record).ok);
+
+        // A bias naming a neuron the creature does not carry is rule 31.
+        let broken = r#"{"biases":{"404":0.5},"weights":{}}"#;
+        assert_eq!(
+            validate_packed_request(&buffer, broken),
+            PackedValidateResponse::detail_required()
+        );
+    }
+
+    #[test]
+    fn a_memetic_record_that_is_not_json_is_a_boundary_fault() {
+        let buffer = encode_packed_request(&healthy(), &ValidateOptions::default());
+        let answer = creature_validate_packed(&buffer, "{not json");
+
+        assert!(answer.contains(MALFORMED_REQUEST));
+        assert!(answer.contains("\"malformed\":true"));
+    }
+
+    #[test]
+    fn a_buffer_that_is_not_a_request_is_refused_rather_than_read() {
+        for (label, buffer) in [
+            ("empty", Vec::new()),
+            ("short", vec![0u8; PACKED_HEADER_BYTES - 1]),
+            ("wrong magic", vec![0u8; PACKED_HEADER_BYTES]),
+        ] {
+            let answer = creature_validate_packed(&buffer, "");
+            assert!(
+                answer.contains(MALFORMED_REQUEST),
+                "{label}: expected a boundary fault, got {answer}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_request_from_another_layout_revision_is_refused() {
+        let mut buffer = encode_packed_request(&healthy(), &ValidateOptions::default());
+        write_u32(&mut buffer, 4, PACKED_VERSION + 1);
+
+        let answer = creature_validate_packed(&buffer, "");
+
+        assert!(answer.contains(MALFORMED_REQUEST));
+        assert!(answer.contains("layout version"));
+    }
+
+    #[test]
+    fn a_buffer_whose_length_disagrees_with_its_header_is_refused() {
+        let mut buffer = encode_packed_request(&healthy(), &ValidateOptions::default());
+        buffer.push(0);
+
+        let answer = creature_validate_packed(&buffer, "");
+
+        assert!(answer.contains(MALFORMED_REQUEST));
+        assert!(answer.contains("bytes, this one is"));
+    }
+
+    #[test]
+    fn a_creature_past_the_boundary_ceiling_is_refused_before_any_allocation() {
+        let mut buffer = vec![0u8; PACKED_HEADER_BYTES];
+        write_u32(&mut buffer, 0, PACKED_MAGIC);
+        write_u32(&mut buffer, 4, PACKED_VERSION);
+        write_u32(&mut buffer, 8, u32::MAX);
+
+        let answer = creature_validate_packed(&buffer, "");
+
+        assert!(answer.contains(MALFORMED_REQUEST));
+        assert!(answer.contains("exceeding the maximum"));
+    }
+
+    #[test]
+    fn the_options_survive_the_round_trip() {
+        let creature = healthy();
+        let options = ValidateOptions {
+            neurons: Some(2),
+            connections: Some(1),
+            feedback_loop: Some(false),
+            forward_only: true,
+        };
+
+        let buffer = encode_packed_request(&creature, &options);
+        let decoded = PackedRequest::decode(&buffer).expect("a request this crate wrote");
+
+        assert_eq!(decoded.options, options);
+        assert!(answer(&creature, &options).ok);
+    }
+
+    /// Every option travels, including the two that are only distinguishable
+    /// from absent by a flag: `feedbackLoop: true` is not the same request as
+    /// no `feedbackLoop` at all, and neither is `connections: 0`.
+    #[test]
+    fn an_option_that_is_present_and_falsy_is_not_an_absent_option() {
+        let creature = healthy();
+
+        for options in [
+            ValidateOptions {
+                feedback_loop: Some(true),
+                ..ValidateOptions::default()
+            },
+            ValidateOptions {
+                connections: Some(0),
+                ..ValidateOptions::default()
+            },
+            ValidateOptions {
+                neurons: Some(0),
+                ..ValidateOptions::default()
+            },
+        ] {
+            let buffer = encode_packed_request(&creature, &options);
+            let decoded = PackedRequest::decode(&buffer).expect("a request this crate wrote");
+            assert_eq!(decoded.options, options);
+        }
+    }
+
+    /// The layout arithmetic the host repeats: the `u32` endpoint arrays land
+    /// four-aligned for every neuron count, not just the even ones.
+    #[test]
+    fn the_synapse_section_is_four_aligned_for_every_neuron_count() {
+        for neuron_count in 0..64 {
+            let offset = synapse_section_offset(neuron_count);
+            assert_eq!(offset % 4, 0, "{neuron_count} neurons");
+            assert!(offset >= PACKED_HEADER_BYTES + neuron_count * 19);
+            assert!(offset < PACKED_HEADER_BYTES + neuron_count * 19 + 4);
+        }
+    }
+
+    /// A kind code and the kind it names are one another's inverse, so a host
+    /// writing `code_from_kind`'s answer is read back as the same kind.
+    #[test]
+    fn the_kind_codes_round_trip() {
+        for kind in [
+            NeuronKind::Input,
+            NeuronKind::Constant,
+            NeuronKind::Hidden,
+            NeuronKind::Output,
+            NeuronKind::Invalid,
+        ] {
+            assert_eq!(kind_from_code(code_from_kind(kind)), kind);
+        }
+        // Anything past the four is the type rule 20 rejects.
+        assert_eq!(kind_from_code(KIND_OTHER), NeuronKind::Invalid);
+        assert_eq!(kind_from_code(200), NeuronKind::Invalid);
+    }
+
+    /// An activation code has to read back as a name the rules treat the same
+    /// way — `IF` above all, since rule 12 and the forward-only structural leg
+    /// both branch on it.
+    #[test]
+    fn the_activation_codes_round_trip_through_their_names() {
+        assert_eq!(squash_name_for(squash_code_for("IF")), "IF");
+        assert_eq!(squash_code_for("IF"), SquashType::If as u8);
+        assert_eq!(squash_name_for(squash_code_for("TANH")), "TANH");
+
+        // A name this crate does not know is "not IF", and still an activation.
+        assert_eq!(squash_code_for("NOT_A_REAL_ACTIVATION"), SQUASH_UNKNOWN);
+        let unknown = squash_name_for(SQUASH_UNKNOWN);
+        assert!(!unknown.is_empty());
+        assert!(parse_squash_name(unknown).is_err());
+    }
+
+    /// An endpoint that is not an array position at all becomes the sentinel,
+    /// which the walk refuses the same way it refuses any out-of-range one.
+    #[test]
+    fn an_endpoint_that_is_not_a_position_becomes_the_sentinel() {
+        assert_eq!(endpoint(None), ENDPOINT_NONE);
+        assert_eq!(endpoint(Some(-1.0)), ENDPOINT_NONE);
+        assert_eq!(endpoint(Some(1.5)), ENDPOINT_NONE);
+        assert_eq!(endpoint(Some(f64::NAN)), ENDPOINT_NONE);
+        assert_eq!(endpoint(Some(7.0)), 7);
+    }
+}

--- a/neat-core/src/creature_validate_runtime.rs
+++ b/neat-core/src/creature_validate_runtime.rs
@@ -134,7 +134,7 @@ pub struct RuntimeSynapse {
 /// Read a bias: a number, a `"NaN"` / `"Infinity"` / `"-Infinity"` sentinel, or
 /// `undefined` for anything else — including a value of the wrong type, which
 /// is no more a bias than an absent one and is rule 8's to report.
-fn bias_value(bias: Option<&Value>) -> Option<f64> {
+pub(crate) fn bias_value(bias: Option<&Value>) -> Option<f64> {
     match bias {
         Some(Value::Number(number)) => number.as_f64(),
         Some(Value::String(text)) => match text.as_str() {
@@ -254,7 +254,7 @@ fn resolve_endpoints(
 /// array, an entry that is not an object, a missing `toId` — each is a rule 31
 /// failure reported in NEAT-AI's own words, not a parse error that would tell
 /// the host nothing about its creature.
-fn memetic_view(memetic: &Value) -> crate::creature_validate::MemeticView<'_> {
+pub(crate) fn memetic_view(memetic: &Value) -> crate::creature_validate::MemeticView<'_> {
     let record: Option<&Map<String, Value>> = memetic.as_object();
 
     let member = |name: &str| -> Vec<(&str, &Value)> {

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod batch_scoring;
 pub mod creature;
 pub mod creature_validate;
 pub mod creature_validate_json;
+pub mod creature_validate_packed;
 pub mod creature_validate_runtime;
 pub mod decision_tree;
 pub mod derivative;
@@ -77,6 +78,13 @@ pub use creature_validate::{
 pub use creature_validate_json::{
     MALFORMED_REQUEST, MAX_REQUEST_NEURONS, ValidateResponse, ValidationFailureJson,
     ValidationStatsJson, creature_validate_json,
+};
+// NEAT-AI#3832 — the packed ABI the same rules cross the boundary on when the
+// creature is large enough for the JSON wire form to dominate the rules.
+pub use creature_validate_packed::{
+    ENDPOINT_NONE, KIND_OTHER, PACKED_HEADER_BYTES, PACKED_MAGIC, PACKED_VERSION,
+    PackedValidateResponse, SQUASH_UNKNOWN, creature_validate_packed, encode_packed_request,
+    packed_request_len, squash_code_for,
 };
 // NEAT-AI#3803 — the runtime creature shape a host holds in memory.
 pub use creature_validate_runtime::{

--- a/neat-core/src/topology_ops.rs
+++ b/neat-core/src/topology_ops.rs
@@ -678,6 +678,15 @@ pub fn validate_structural_integrity(
 /// Uses Kahn's algorithm on non-input neurons. Self-loops are explicitly
 /// detected as cycles.
 ///
+/// # Cost
+///
+/// Linear in neurons plus synapses (NEAT-AI#3832). The relaxation pass reads
+/// an outward adjacency built once up front; it used to rescan the whole
+/// synapse list for every dequeued neuron, which is `O(neurons × synapses)` —
+/// 10.8 ms of the 10.9 ms `creature_validate` spent on a 4 272-neuron,
+/// 22 928-synapse production creature, and the same cost again on every
+/// `TypedTopology.detectCycles` call from the host.
+///
 /// # Returns
 /// `0` if acyclic, `1` if a cycle is detected.
 #[cfg_attr(target_family = "wasm", wasm_bindgen)]
@@ -721,6 +730,8 @@ pub fn detect_cycles(
         }
     }
 
+    let outward = OutwardEdges::build(from_indices, to_indices, n, input_count);
+
     let mut queue: Vec<usize> = Vec::new();
     for i in input_count..n {
         if in_degree[i] == 0 {
@@ -736,11 +747,8 @@ pub fn detect_cycles(
         head += 1;
         processed += 1;
 
-        for s in 0..from_indices.len() {
-            if from_indices[s] as usize != idx {
-                continue;
-            }
-            let to = to_indices[s] as usize;
+        for &target in outward.targets(idx) {
+            let to = target as usize;
             if to == idx || to < input_count || to >= n {
                 continue;
             }
@@ -753,6 +761,75 @@ pub fn detect_cycles(
 
     let non_input_count = n - input_count;
     if processed < non_input_count { 1 } else { 0 }
+}
+
+/// The targets of every synapse leaving a non-input neuron, grouped by source.
+///
+/// A compressed-row adjacency over `input_count..num_neurons`, which is
+/// exactly the range Kahn's queue can hold. Edges leaving an input neuron, or
+/// a source past `num_neurons`, are left out: the queue never dequeues one, so
+/// the relaxation pass could never have reached them, and leaving them out
+/// keeps the in-degree bookkeeping identical to the rescan this replaces.
+struct OutwardEdges {
+    /// `starts[s]..starts[s + 1]` slices [`Self::edge_targets`] for the source
+    /// at walk index `s + first_source`.
+    starts: Vec<u32>,
+    /// `to` endpoints, grouped by source and otherwise in synapse order.
+    edge_targets: Vec<u32>,
+    /// The walk index `starts[0]` describes — the first non-input neuron.
+    first_source: usize,
+}
+
+impl OutwardEdges {
+    /// Group `from`/`to` by source, for the sources in `first_source..num_neurons`.
+    fn build(
+        from_indices: &[u32],
+        to_indices: &[u32],
+        num_neurons: usize,
+        first_source: usize,
+    ) -> Self {
+        let source_count = num_neurons - first_source;
+        let mut starts = vec![0u32; source_count + 1];
+
+        let in_range = |from: u32| {
+            let from = from as usize;
+            (first_source..num_neurons).contains(&from)
+        };
+
+        for &from in from_indices {
+            if in_range(from) {
+                // Counting pass: offset by one so the prefix sum below lands
+                // each source's start without a second shift.
+                starts[from as usize - first_source + 1] += 1;
+            }
+        }
+        for s in 0..source_count {
+            starts[s + 1] += starts[s];
+        }
+
+        let mut edge_targets = vec![0u32; starts[source_count] as usize];
+        let mut cursor = starts.clone();
+        for (&from, &to) in from_indices.iter().zip(to_indices) {
+            if in_range(from) {
+                let slot = from as usize - first_source;
+                edge_targets[cursor[slot] as usize] = to;
+                cursor[slot] += 1;
+            }
+        }
+
+        Self {
+            starts,
+            edge_targets,
+            first_source,
+        }
+    }
+
+    /// Every `to` endpoint leaving `source`, which must be a source this index
+    /// covers — the caller only ever asks about a neuron it dequeued.
+    fn targets(&self, source: usize) -> &[u32] {
+        let slot = source - self.first_source;
+        &self.edge_targets[self.starts[slot] as usize..self.starts[slot + 1] as usize]
+    }
 }
 
 #[cfg(test)]

--- a/neat-core/src/wasm_exports.rs
+++ b/neat-core/src/wasm_exports.rs
@@ -19,6 +19,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::creature_validate_json::creature_validate_json;
+use crate::creature_validate_packed::creature_validate_packed;
 use crate::derivative::apply_derivative;
 use crate::error::apply_calculate_error;
 use crate::fused_error::apply_fused_error_distribution;
@@ -194,6 +195,31 @@ pub fn wasm_scan_max_bias(
 #[wasm_bindgen(js_name = creature_validate)]
 pub fn wasm_creature_validate(request: &str) -> String {
     creature_validate_json(request)
+}
+
+// ---------------------------------------------------------------------------
+// creature_validate_packed — packed buffer in, JSON out (NEAT-AI#3832).
+//
+// The same rules over the typed arrays a host already holds, because the JSON
+// wire form costs more than the rules on a large creature: 850 KB and 3.5 ms
+// of `JSON.stringify` before a rule has looked at anything, on a creature
+// validated after every mutation, breed and discovery step. The layout, and
+// why the buffer carries no strings, are documented on
+// `crate::creature_validate_packed`; this shim only renames it for JS.
+//
+//   In:  the packed request buffer, and the memetic record as JSON ("" for a
+//        creature carrying none)
+//   Out: { "ok": true,  "stats": { input, constant, hidden, output, connections } }
+//        { "ok": false, "detailRequired": true } — a rule was broken; ask
+//        `creature_validate` for the class, reason and message
+//        { "ok": false, "failure": { …, "malformed": true } } — the buffer was
+//        never a request, which is never a verdict on the creature
+// ---------------------------------------------------------------------------
+
+/// JS `creature_validate_packed(request: Uint8Array, memetic: string) -> string`.
+#[wasm_bindgen(js_name = creature_validate_packed)]
+pub fn wasm_creature_validate_packed(request: &[u8], memetic: &str) -> String {
+    creature_validate_packed(request, memetic)
 }
 
 // ---------------------------------------------------------------------------

--- a/neat-core/tests/creature_validate_packed_conformance.rs
+++ b/neat-core/tests/creature_validate_packed_conformance.rs
@@ -1,0 +1,204 @@
+//! The packed shape and the runtime JSON shape never disagree about a creature
+//! (NEAT-AI#3832).
+//!
+//! `creature_validate_packed` exists only to be faster. It answers the same
+//! question as [`creature_validate_json`] over the same rules, so the one
+//! thing that can go wrong is a *shape* bug: a code the encoder writes and the
+//! decoder reads back as something else, an option that does not survive the
+//! flags, a defect the buffer cannot carry. Any of those would show up as the
+//! two shapes disagreeing — the packed one calling a broken creature healthy,
+//! or sending the host to fetch a failure the JSON shape does not report.
+//!
+//! So this replays NEAT-AI's own `creatureValidate` conformance corpus — the
+//! same corpus `creature_validate_runtime_conformance.rs` replays — through
+//! both shapes and asserts they agree, case by case:
+//!
+//! | The runtime shape says | The packed shape must say |
+//! |------------------------|---------------------------|
+//! | healthy, with counters | healthy, with the **same** counters |
+//! | a rule was broken | `detailRequired` — go ask the JSON shape |
+//!
+//! A packed answer is never `malformed` for a corpus creature: the encoder
+//! writes what the decoder reads, and a boundary fault there would be a bug in
+//! this crate rather than a verdict.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use neat_core::{
+    PackedValidateResponse, RuntimeCreature, ValidateOptions, ValidateResponse,
+    creature_validate_json, creature_validate_packed, encode_packed_request,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Where the vendored corpus lives — the same directory the runtime replay
+/// reads, so the two cannot drift onto different corpora.
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/creature_validate")
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusFile {
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    name: String,
+    creature: Value,
+    #[serde(default)]
+    options: Option<Value>,
+}
+
+/// The options bag as the corpus writes it, so the two shapes are asked the
+/// same question rather than each defaulting its own way.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CaseOptions {
+    #[serde(default)]
+    neurons: Option<usize>,
+    #[serde(default)]
+    connections: Option<usize>,
+    #[serde(default)]
+    feedback_loop: Option<bool>,
+    #[serde(default)]
+    forward_only: Option<bool>,
+}
+
+impl From<CaseOptions> for ValidateOptions {
+    fn from(options: CaseOptions) -> Self {
+        Self {
+            neurons: options.neurons,
+            connections: options.connections,
+            feedback_loop: options.feedback_loop,
+            forward_only: options.forward_only.unwrap_or(false),
+        }
+    }
+}
+
+fn load_corpus() -> Vec<Case> {
+    let mut files: Vec<PathBuf> = fs::read_dir(fixture_dir())
+        .expect("the vendored corpus directory must exist")
+        .map(|entry| entry.expect("readable directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .filter(|path| path.file_name().is_some_and(|name| name != "coverage.json"))
+        .collect();
+    files.sort();
+    assert!(!files.is_empty(), "the corpus must not be empty");
+
+    let mut cases = Vec::new();
+    for path in files {
+        let text = fs::read_to_string(&path).expect("readable corpus file");
+        let file: CorpusFile = serde_json::from_str(&text)
+            .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+        cases.extend(file.cases);
+    }
+    cases
+}
+
+/// Ask the JSON shape, exactly as a host would.
+fn json_answer(case: &Case) -> ValidateResponse {
+    let request = match &case.options {
+        Some(options) => json!({ "runtimeCreature": case.creature, "options": options }),
+        None => json!({ "runtimeCreature": case.creature }),
+    };
+    let text = creature_validate_json(&request.to_string());
+    serde_json::from_str(&text).unwrap_or_else(|error| panic!("unreadable response: {error}"))
+}
+
+/// Ask the packed shape the same question, encoding the case through the
+/// crate's own encoder rather than restating the layout here.
+fn packed_answer(case: &Case) -> PackedValidateResponse {
+    let creature: RuntimeCreature = serde_json::from_value(case.creature.clone())
+        .unwrap_or_else(|error| panic!("{}: unreadable creature: {error}", case.name));
+    let options: ValidateOptions = case
+        .options
+        .clone()
+        .map(|options| {
+            serde_json::from_value::<CaseOptions>(options)
+                .unwrap_or_else(|error| panic!("{}: unreadable options: {error}", case.name))
+        })
+        .unwrap_or_default()
+        .into();
+
+    // The memetic record travels alongside the buffer rather than inside it.
+    let memetic = case
+        .creature
+        .get("memetic")
+        .filter(|memetic| !memetic.is_null())
+        .map(ToString::to_string)
+        .unwrap_or_default();
+
+    let text = creature_validate_packed(&encode_packed_request(&creature, &options), &memetic);
+    serde_json::from_str(&text).unwrap_or_else(|error| panic!("unreadable response: {error}"))
+}
+
+#[test]
+fn every_corpus_case_reaches_the_same_verdict_through_both_shapes() {
+    let mut replayed = 0usize;
+
+    for case in load_corpus() {
+        replayed += 1;
+        let json = json_answer(&case);
+        let packed = packed_answer(&case);
+
+        assert!(
+            packed.failure.is_none(),
+            "{}: the packed buffer never reached a rule — {:?}",
+            case.name,
+            packed.failure
+        );
+
+        assert_eq!(
+            packed.ok, json.ok,
+            "{}: the two shapes disagree — JSON says {}, packed says {} (JSON failure: {:?})",
+            case.name, json.ok, packed.ok, json.failure
+        );
+
+        if json.ok {
+            assert_eq!(
+                packed.stats, json.stats,
+                "{}: the two shapes counted differently",
+                case.name
+            );
+            assert_eq!(
+                packed.detail_required, None,
+                "{}: a healthy creature needs no detail",
+                case.name
+            );
+        } else {
+            assert_eq!(
+                packed.detail_required,
+                Some(true),
+                "{}: a broken creature must send the host to the JSON shape",
+                case.name
+            );
+        }
+    }
+
+    assert!(
+        replayed >= 40,
+        "only {replayed} cases replayed — the corpus should not have shrunk"
+    );
+}
+
+/// The corpus is only evidence if it exercises both answers through the packed
+/// shape — a replay where everything passed would assert nothing about the
+/// `detailRequired` half.
+#[test]
+fn the_corpus_reaches_both_answers_through_the_packed_shape() {
+    let mut healthy = 0;
+    let mut broken = 0;
+
+    for case in load_corpus() {
+        if packed_answer(&case).ok {
+            healthy += 1;
+        } else {
+            broken += 1;
+        }
+    }
+
+    assert!(healthy >= 5, "only {healthy} corpus creatures passed");
+    assert!(broken >= 20, "only {broken} corpus creatures were rejected");
+}

--- a/neat-core/tests/detect_cycles_linear_parity.rs
+++ b/neat-core/tests/detect_cycles_linear_parity.rs
@@ -1,0 +1,246 @@
+//! `detect_cycles` answers exactly what the quadratic rescan answered
+//! (NEAT-AI#3832).
+//!
+//! The relaxation pass used to rescan the whole synapse list once per dequeued
+//! neuron. On a 4 272-neuron, 22 928-synapse production creature that was
+//! 10.8 ms of the 10.9 ms `creature_validate` spent, and the same cost again on
+//! every `TypedTopology.detectCycles` call from the host. Replacing it with an
+//! outward adjacency built once makes the walk linear in neurons plus
+//! synapses.
+//!
+//! Speeding a validator up is only worth anything if it answers the same, so
+//! this file pins the new walk against [`rescan_detect_cycles`] below — the
+//! algorithm as it stood, transcribed — over topologies that include every
+//! shape the two could plausibly disagree on:
+//!
+//! | Shape | Why it could diverge |
+//! |-------|----------------------|
+//! | a duplicated `(from, to)` pair | the in-degree must be decremented once per copy, not once per pair |
+//! | an endpoint at or past `num_neurons` | the counting pass admits `from >= num_neurons`; the walk can never dequeue it, so its in-degree contribution must stay |
+//! | a synapse into an input neuron | counted by neither pass |
+//! | a synapse out of an input neuron | inputs are never queued, so it must not relax anything |
+//! | a self-loop on a non-input neuron | short-circuits to "cycle" before either walk starts |
+//! | an unsorted synapse list | the adjacency groups by source, so it must not depend on synapse order |
+
+use neat_core::topology_ops::detect_cycles;
+
+/// Kahn's algorithm as `detect_cycles` ran it before the outward adjacency —
+/// rescanning every synapse for each dequeued neuron.
+///
+/// Kept verbatim rather than tidied: it is the oracle, so anything "obviously
+/// redundant" about it is exactly what the parity assertion is protecting.
+fn rescan_detect_cycles(
+    from_indices: &[u32],
+    to_indices: &[u32],
+    num_neurons: u32,
+    num_inputs: u32,
+) -> u32 {
+    let n = num_neurons as usize;
+    let input_count = num_inputs as usize;
+
+    if from_indices.len() != to_indices.len() {
+        return 0;
+    }
+    if input_count > n {
+        return 0;
+    }
+
+    for i in 0..from_indices.len() {
+        if from_indices[i] == to_indices[i] && (from_indices[i] as usize) >= input_count {
+            return 1;
+        }
+    }
+
+    let mut in_degree = vec![0i32; n];
+    for i in 0..from_indices.len() {
+        let from = from_indices[i] as usize;
+        let to = to_indices[i] as usize;
+        if from == to {
+            continue;
+        }
+        if from >= input_count && to >= input_count && to < n {
+            in_degree[to] += 1;
+        }
+    }
+
+    let mut queue: Vec<usize> = Vec::new();
+    for i in input_count..n {
+        if in_degree[i] == 0 {
+            queue.push(i);
+        }
+    }
+
+    let mut processed = 0usize;
+    let mut head = 0;
+    while head < queue.len() {
+        let idx = queue[head];
+        head += 1;
+        processed += 1;
+
+        for s in 0..from_indices.len() {
+            if from_indices[s] as usize != idx {
+                continue;
+            }
+            let to = to_indices[s] as usize;
+            if to == idx || to < input_count || to >= n {
+                continue;
+            }
+            in_degree[to] -= 1;
+            if in_degree[to] == 0 {
+                queue.push(to);
+            }
+        }
+    }
+
+    let non_input_count = n - input_count;
+    if processed < non_input_count { 1 } else { 0 }
+}
+
+/// A reproducible pseudo-random source — the parity corpus has to be the same
+/// corpus on every machine and every run, so a failure is a failure anyone can
+/// reproduce from the seed alone.
+struct Lcg(u64);
+
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        // Numerical Recipes' 64-bit LCG constants.
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+
+    /// A value in `0..bound`, for a non-zero bound.
+    fn below(&mut self, bound: u32) -> u32 {
+        (self.next() >> 33) as u32 % bound
+    }
+}
+
+/// One random topology: neuron count, input width and a synapse list drawn
+/// from a range **wider** than the neuron count, so out-of-range endpoints and
+/// input-targeting synapses turn up without being special-cased in.
+fn random_topology(rng: &mut Lcg) -> (Vec<u32>, Vec<u32>, u32, u32) {
+    let num_neurons = 2 + rng.below(14);
+    let num_inputs = rng.below(num_neurons);
+    let synapse_count = rng.below(24);
+    // Two past the last neuron: enough to draw an endpoint the walk must
+    // refuse to dequeue, without swamping the corpus with them.
+    let endpoint_bound = num_neurons + 2;
+
+    let mut from = Vec::with_capacity(synapse_count as usize);
+    let mut to = Vec::with_capacity(synapse_count as usize);
+    for _ in 0..synapse_count {
+        from.push(rng.below(endpoint_bound));
+        to.push(rng.below(endpoint_bound));
+    }
+
+    (from, to, num_neurons, num_inputs)
+}
+
+#[test]
+fn the_linear_walk_answers_what_the_rescan_answered() {
+    let mut rng = Lcg(0x3832_0000_0000_0001);
+
+    for case in 0..20_000 {
+        let (from, to, num_neurons, num_inputs) = random_topology(&mut rng);
+
+        assert_eq!(
+            detect_cycles(&from, &to, num_neurons, num_inputs),
+            rescan_detect_cycles(&from, &to, num_neurons, num_inputs),
+            "case {case}: from={from:?} to={to:?} num_neurons={num_neurons} num_inputs={num_inputs}"
+        );
+    }
+}
+
+/// The corpus above is only worth its runtime if it actually reaches both
+/// answers — a generator that only ever drew acyclic topologies would assert
+/// nothing.
+#[test]
+fn the_random_corpus_reaches_both_answers() {
+    let mut rng = Lcg(0x3832_0000_0000_0001);
+    let mut cyclic = 0;
+    let mut acyclic = 0;
+
+    for _ in 0..20_000 {
+        let (from, to, num_neurons, num_inputs) = random_topology(&mut rng);
+        match detect_cycles(&from, &to, num_neurons, num_inputs) {
+            0 => acyclic += 1,
+            _ => cyclic += 1,
+        }
+    }
+
+    assert!(cyclic > 1_000, "corpus found only {cyclic} cyclic cases");
+    assert!(acyclic > 1_000, "corpus found only {acyclic} acyclic cases");
+}
+
+/// A duplicated edge contributes twice to the in-degree, so the walk has to
+/// relax it twice. Grouping by source rather than rescanning is exactly where
+/// an "obvious" dedup would silently change the answer.
+#[test]
+fn a_duplicated_synapse_is_relaxed_once_per_copy() {
+    // input 0 → hidden 1 → output 2, with 1 → 2 listed twice.
+    let from = [0, 1, 1];
+    let to = [1, 2, 2];
+
+    assert_eq!(detect_cycles(&from, &to, 3, 1), 0);
+    assert_eq!(rescan_detect_cycles(&from, &to, 3, 1), 0);
+}
+
+/// A source past the last neuron can never be dequeued, so its contribution to
+/// the target's in-degree is never taken back — and the topology is reported
+/// as cyclic even though nothing in range forms a cycle. That is what the
+/// rescan did; the adjacency must not "fix" it here.
+#[test]
+fn a_source_past_the_last_neuron_still_holds_its_target_down() {
+    let from = [9];
+    let to = [2];
+
+    assert_eq!(detect_cycles(&from, &to, 3, 1), 1);
+    assert_eq!(rescan_detect_cycles(&from, &to, 3, 1), 1);
+}
+
+/// A synapse leaving an input neuron relaxes its target the same way any other
+/// does — inputs are never *queued*, but they are also never counted into an
+/// in-degree, so the target starts at zero and is queued from the seed pass.
+#[test]
+fn a_synapse_out_of_an_input_neuron_leaves_its_target_free() {
+    let from = [0, 0];
+    let to = [1, 2];
+
+    assert_eq!(detect_cycles(&from, &to, 3, 1), 0);
+    assert_eq!(rescan_detect_cycles(&from, &to, 3, 1), 0);
+}
+
+/// Synapse order is not part of the answer: the adjacency groups by source, so
+/// a list sorted by `(from, to)` and the same list reversed must agree.
+#[test]
+fn the_answer_does_not_depend_on_synapse_order() {
+    let from = [0, 1, 2, 3];
+    let to = [1, 2, 3, 4];
+    let reversed_from = [3, 2, 1, 0];
+    let reversed_to = [4, 3, 2, 1];
+
+    assert_eq!(detect_cycles(&from, &to, 5, 1), 0);
+    assert_eq!(detect_cycles(&reversed_from, &reversed_to, 5, 1), 0);
+}
+
+/// The walk stays linear: a wide, deep, forward-only chain is the shape the
+/// rescan was quadratic on, and it has to come back acyclic.
+#[test]
+fn a_large_forward_only_chain_is_acyclic() {
+    let num_inputs = 64u32;
+    let num_neurons = 4_096u32;
+
+    let mut from = Vec::new();
+    let mut to = Vec::new();
+    for target in num_inputs..num_neurons {
+        // Two feeders each: one input, one immediate predecessor.
+        from.push(target % num_inputs);
+        to.push(target);
+        from.push(target - 1);
+        to.push(target);
+    }
+
+    assert_eq!(detect_cycles(&from, &to, num_neurons, num_inputs), 0);
+}


### PR DESCRIPTION
Closes the NEAT-AI-core half of [NEAT-AI#3832](https://github.com/stSoftwareAU/NEAT-AI/issues/3832).

`creatureValidate` runs after every mutation, breed and discovery step, and #3832 measured it costing 11–16× the TypeScript rules it replaced. Two separate causes, both fixed here — and the second only became visible once the first was gone.

## 1. `detect_cycles` was quadratic

Kahn's relaxation pass rescanned the **whole synapse list** for every dequeued neuron, so it was `O(neurons × synapses)`. On GRQ's 4 272-neuron / 22 928-synapse production creature that was **10.75 ms of the 10.8 ms** the entire rule set spent — and the same cost again on every `TypedTopology.detectCycles` call from the host, which the *deleted TypeScript rules also made*. Both stacks were paying it; #3832's "before" column was slow for the same reason as its "after" column.

It now builds an outward compressed-row adjacency once and reads each source's targets directly.

| Shape (`topology_ops` bench) | Before | After | Change |
| --- | --- | --- | --- |
| `n1666_21513` (100 inputs) | 8.538 ms | 80.26 µs | **−99.1%** (106×) |
| `n4127_21513` (2,461 inputs) | 8.986 ms | 47.42 µs | **−99.5%** (189×) |

Numbers, host and toolchain are recorded in `benches/BASELINE.md`; `detect_cycles` is now a benchmark in the existing `topology_ops` group, so the quadratic term cannot come back unnoticed.

**The answer is unchanged.** `detect_cycles_linear_parity.rs` replays 20 000 random topologies against the rescan kept **verbatim in the test module** as an independent oracle, plus the shapes the two could plausibly diverge on: a duplicated `(from, to)` pair (the in-degree must be decremented once per copy, not once per pair), a source at or past `num_neurons` (never dequeued, so its contribution must *stay*), synapses into and out of input neurons, and an unsorted synapse list.

## 2. The JSON wire form cost more than the rules

With the walk linear, the remaining cost was the wire, exactly as #3832's own breakdown said: an 850 KB request and 3.5 ms of `JSON.stringify` on the host before a rule looked at anything. At that point the WASM path was still **2.4× slower** than the TypeScript it replaced.

`creature_validate_packed` is option 1 from the issue: the same rules over a packed buffer — a header, five per-neuron arrays and three per-synapse arrays, filled from the typed arrays a host already holds (`TypedTopology`) and copied into linear memory as a single `memcpy`. 850 KB → 288 KB, and no per-neuron allocation on either side.

It carries **no text at all** — types, activations and UUIDs travel as codes and flags. That is what makes it cheap, and it is also its one limitation: the rules need no strings to reach a *verdict*, only to write a *message*. So a broken creature comes back as `{"ok":false,"detailRequired":true}` and the host asks `creature_validate` (JSON) for the class, reason and message. That is the slow call, and it is the one a healthy creature never makes, since a failure throws and ends whatever the host was doing.

Both shapes meet at the same seam (`validate_prepared`), so there is still exactly one place a rule is evaluated and one place a message is written — the single-source-of-truth property from #3800 is intact, and no rule is re-implemented in TypeScript.

Measured end-to-end from NEAT-AI (Deno, wasm64 bundle, same process, same creature), against the deleted TypeScript rules restored as the baseline:

| Creature | Neurons | Synapses | TS rules | WASM packed | Speed-up |
| --- | ---: | ---: | ---: | ---: | ---: |
| small | 8 | 16 | 2.73 µs | 2.24 µs | 1.22× |
| medium | 73 | 1 260 | 53.19 µs | 34.52 µs | 1.54× |
| large | 93 | 1 660 | 68.50 µs | 47.35 µs | 1.45× |
| **GRQ `.network.json`** | **4 272** | **22 928** | **3 425 µs** | **1 083 µs** | **3.16×** |
| GRQ-cluster | 5 104 | 24 216 | 3 857 µs | 1 230 µs | 3.14× |
| GRQ-portfolio/best | 4 085 | 20 234 | 851 µs | 613 µs | 1.39× |

Rust consumers are unaffected — `creature_validate(&CreatureExport, &ValidateOptions)` was never on the JSON path — and gain the `detect_cycles` fix for free. `encode_packed_request` is public so a Rust caller holding a `RuntimeCreature` can reach the packed path without hand-rolling the offsets, and so the conformance replay encodes the corpus through the crate's own encoder rather than restating the layout in a test.

## Evidence the tests can fail

Every mutation was applied one at a time and reverted before commit.

| Mutation | Killed by |
| --- | --- |
| dedupe targets in the outward adjacency | `detect_cycles_linear_parity` — 2 tests red |
| drop the source upper bound (`from < num_neurons`) | `detect_cycles_linear_parity` — 3 tests red |
| swap the `constant` / `hidden` kind codes | `creature_validate_packed_conformance` — 2 red |
| read the bias slot regardless of its flag | `creature_validate_packed_conformance` |
| read the id slot regardless of its flag | `a_cleared_id_flag_beats_whatever_the_slot_still_holds` |
| `forwardOnly` dropped from the option flags | `creature_validate_packed_conformance` |
| every activation code reads back as `IDENTITY` | `creature_validate_packed_conformance` |
| the activation flag ignored | `creature_validate_packed_conformance` |
| the memetic record ignored | `creature_validate_packed_conformance` |
| non-position endpoint truncated instead of sentinelled | `an_endpoint_that_is_not_a_position_becomes_the_sentinel` |

The id-flag mutation is worth calling out: it initially **survived** the corpus replay, because a stale id in the slot still broke *some* rule. The test added for it is the case that actually matters — the host reuses one scratch buffer, so a neuron carrying no id has the *previous* creature's id sitting in its slot, and a decoder that read the slot regardless of the flag would call that creature healthy.

`creature_validate_packed_conformance.rs` replays NEAT-AI's own `creatureValidate` corpus through **both** shapes and asserts they never disagree about a creature — same verdict, and the same five counters when it passes.

## Scope

Additive only. The JSON ABI, its request and response shapes and every existing export are untouched; `creature_validate_packed` is a new export alongside `creature_validate`.

- `./quality.sh` green (the `ikaruga-neat-ai-comparison.md` LOC figure is refreshed because the tree moved past its 10% window, which is what that gate asks for).
- `cargo check -p neat-core --target wasm32-unknown-unknown` green (per AGENTS.md — no PR gate builds it).
- The wasm64 bundle builds and passes `check_wasm64_bundle.ts`.

## Follow-up

The NEAT-AI half — packing the request, and falling back to the JSON shape for the message — is written and its full validation suite (124 tests, corpus included) is green against a locally built bundle. It will be raised once this merges and the bundle is published, since it needs `neatCore.rev` advanced to pick up the new export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWsvjiLUFrtT7ovjoQwcfy
