### PR TITLE
creature: prune a memetic record back to live structure (NEAT-AI-Lamarck#197)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.10.3"
+version = "0.10.5"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.10.3"
+version = "0.10.5"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -743,6 +743,43 @@ carrying the row form could not parse, exiting with `Creature JSON error:
 invalid type: sequence, expected a map`. Supporting both forms resolved the
 issue.
 
+##### Pruning — rule 31's inverse (NEAT-AI-Lamarck#197)
+
+Rule 31 refuses a creature whose memetic record names structure that is gone,
+so **any** consumer pass that removes a neuron or a synapse must prune the
+record with it. That prune lives here, beside the rule:
+
+| Call | Use |
+|------|-----|
+| `CreatureExport::prune_memetic()` | prune the record the creature carries |
+| `MemeticExport::prune_to(&creature)` | prune a record held separately |
+
+Both drop **only dangling** references — a bias whose neuron is gone, a weight
+whose synapse is gone — resolved through the same id-or-UUID vocabulary rule 31
+reads. Everything else survives: `MemeticExport::extra` (`generation`, `score`,
+`ancestry`) verbatim, every still-resolving delta, and the record itself even
+when it empties. A *malformed* row or entry (missing `toUUID`, `toId` or
+`weight`) is a defect in the record as supplied rather than something a removal
+caused, so it is left for rule 31 to report instead of being silently deleted.
+Adding structure resolves every existing key, so a prune after a pure append is
+a no-op; the operation is idempotent.
+
+Without a shared prune every downstream repo hand-rolls one, and the blunt
+version (`memetic = None`) throws away the fine-tuning history the record
+exists to carry — which is what NEAT-AI-Lamarck#197 hit when an unpruned
+synapse removal made rule 31 refuse the rewire and a whole candidate strategy
+silently produced nothing.
+
+```mermaid
+flowchart LR
+    R["consumer removes a<br/>neuron or synapse"] --> P["CreatureExport::prune_memetic()"]
+    P --> K["kept: extra, resolving<br/>biases and weights"]
+    P --> D["dropped: dangling<br/>references only"]
+    K --> V{"creature_validate<br/>rule 31"}
+    D --> V
+    V --> OK["Ok — the record still<br/>describes real structure"]
+```
+
 ```mermaid
 flowchart LR
     W["synapse walk<br/>rules 23–27"] --> N["connections count<br/>rule 28"]

--- a/docs/archive/pr-summaries/pr-summary-lamarck-197.md
+++ b/docs/archive/pr-summaries/pr-summary-lamarck-197.md
@@ -1,0 +1,93 @@
+# Prune a memetic record back to live structure — rule 31's inverse
+
+## Summary
+
+Rule 31 (`MEMETIC`) refuses a creature whose memetic biases or weights name a
+neuron or a synapse it no longer carries, so every consumer that removes
+structure has to prune the record with it. There was no prune here, so each
+downstream repo had to hand-roll one — and the blunt version (`memetic = None`)
+throws away `MemeticExport::extra`, the `generation` / `score` / `ancestry`
+history the record exists to carry.
+
+This adds the prune beside the rule it inverts:
+
+| Call | Use |
+|------|-----|
+| `CreatureExport::prune_memetic()` | prune the record the creature carries |
+| `MemeticExport::prune_to(&creature)` | prune a record held separately |
+
+Both are additive and resolve references through the **same** vocabulary rule 31
+reads (`resolve_memetic_reference` / `WireIndex` / `neuron_views`: runtime id
+first, then wire UUID, with implicit inputs as `input-N` and outputs forced to
+`-(outputIndex + 1)`), so the prune and the rule cannot drift.
+
+Semantics, all covered by tests:
+
+- **Dropped:** only dangling references — a bias whose neuron is gone, a weight
+  row or entry whose `(from, to)` synapse is gone, an id-keyed key that names no
+  neuron.
+- **Kept:** `extra` verbatim, every still-resolving delta, and the record itself
+  even when it empties (`memetic = None` is a different fact).
+- **Malformed ≠ dangling:** a row or entry missing `toUUID` / `toId` / `weight`
+  is a defect in the record as supplied, not something a removal caused, so it
+  is left for rule 31 to report rather than silently deleted.
+- **No-op on append**, and **idempotent**.
+
+Raised for [NEAT-AI-Lamarck#197](https://github.com/stSoftwareAU/NEAT-AI-Lamarck/issues/197):
+Lamarck's `split_incoming_synapse` removed a synapse without pruning, rule 31
+refused the rewire, the caller swallowed the error — and the whole
+`structural_add_neuron` strategy silently produced nothing on exactly the
+fine-tuned creatures that carry a memetic record. Lamarck ships a conservative
+local prune in the meantime and will delegate to this API once it is released.
+
+```mermaid
+flowchart LR
+    R["consumer removes a<br/>neuron or synapse"] --> P["CreatureExport::prune_memetic()"]
+    P --> K["kept: extra, resolving<br/>biases and weights"]
+    P --> D["dropped: dangling<br/>references only"]
+    K --> V{"creature_validate<br/>rule 31"}
+    D --> V
+    V --> OK["Ok — the record still<br/>describes real structure"]
+```
+
+## Evidence
+
+Backend/library change — no web interface to screenshot.
+
+`./quality.sh` passes in full (fmt, clippy, `cargo test --workspace`, doctests,
+`cargo deny`, shell and TypeScript gates, release build).
+
+### Mutation evidence
+
+The new tests were proven able to fail. Each mutation was applied alone to
+`prune_to` and reverted afterwards:
+
+| Mutation | Result |
+|----------|--------|
+| Prune keeps everything (no-op body) | 4 of 7 red — `prune_drops_the_row_naming_a_removed_edge`, `prune_follows_a_removed_neuron`, `prune_keeps_the_record_but_not_a_missing_one`, `prune_to_prunes_a_detached_record` |
+| Rows pruned unconditionally (`retain(|_| false)`) | 3 of 7 red — `prune_drops_the_row_naming_a_removed_edge`, `prune_is_a_no_op_when_nothing_was_removed`, `prune_to_prunes_a_detached_record` |
+| `extra` cleared during the prune (the blunt fix) | 3 of 7 red — `prune_drops_the_row_naming_a_removed_edge`, `prune_is_a_no_op_when_nothing_was_removed`, `prune_keeps_the_record_but_not_a_missing_one` |
+| Unresolvable id-keyed key kept instead of dropped | 1 of 7 red — `prune_drops_dangling_map_entries_and_unresolvable_keys` |
+
+The suite is green with every mutation reverted.
+
+## Test Plan
+
+New: `neat-core/tests/creature_memetic_prune.rs` (7 tests), asserting on the
+record the prune hands back — `creature_validate` is the consequence, not the
+only oracle:
+
+- `prune_drops_the_row_naming_a_removed_edge` — row form; the removed edge's row
+  goes, the others and both `extra` keys stay.
+- `prune_drops_dangling_map_entries_and_unresolvable_keys` — id-keyed form; an
+  unresolvable key goes, a live entry stays, and the entry dies with its edge.
+- `prune_follows_a_removed_neuron` — a neuron removal takes its bias and every
+  weight naming it.
+- `prune_is_a_no_op_when_nothing_was_removed` — a pure append prunes nothing.
+- `prune_keeps_the_record_but_not_a_missing_one` — an emptied record survives
+  with its `extra`; a creature with no record is untouched.
+- `prune_is_idempotent`.
+- `prune_to_prunes_a_detached_record` — the record need not be attached.
+
+Docs: README gains a *Pruning — rule 31's inverse* subsection with the API
+table, the kept/dropped rule and a Mermaid flow.

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -1716,6 +1716,101 @@ fn memetic_row_rules(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Rule 31's inverse — pruning a memetic record back to live structure
+// ---------------------------------------------------------------------------
+
+impl CreatureExport {
+    /// Drop every memetic reference this creature no longer carries.
+    ///
+    /// Rule 31 refuses a creature whose memetic biases or weights name a neuron
+    /// or a synapse that is gone, so **any** pass that removes structure must
+    /// prune the record with it. That prune lives here, beside the rule it is
+    /// the inverse of, so the two cannot drift and no downstream repo has to
+    /// re-derive the resolution vocabulary rule 31 reads — runtime id first,
+    /// then wire UUID (NEAT-AI-Lamarck#197).
+    ///
+    /// A no-op on a creature with no memetic record, and on every pure-append
+    /// edit — adding structure leaves every existing key resolvable, so nothing
+    /// is dropped. Idempotent.
+    ///
+    /// What survives: [`MemeticExport::extra`] verbatim (`generation`, `score`,
+    /// `ancestry` — the fine-tuning history the record exists to carry), every
+    /// bias whose neuron is still listed, every weight whose synapse still
+    /// exists, and the record itself even when emptied. Clearing the record
+    /// (`memetic = None`) is a different fact and is never what this does.
+    pub fn prune_memetic(&mut self) {
+        let Some(mut memetic) = self.memetic.take() else {
+            return;
+        };
+        memetic.prune_to(self);
+        self.memetic = Some(memetic);
+    }
+}
+
+impl MemeticExport {
+    /// Drop every reference that does not resolve against `creature`.
+    ///
+    /// [`CreatureExport::prune_memetic`] is this against the creature that
+    /// carries the record; use `prune_to` when the record is held separately.
+    ///
+    /// Only **dangling** references are dropped — a reference naming a neuron
+    /// or synapse that no longer exists. A *malformed* row or entry (missing
+    /// `toUUID`, `toId` or `weight`) is a defect in the record as supplied, not
+    /// something a removal caused, so it is left for rule 31 to report in
+    /// NEAT-AI's own words rather than quietly deleted here.
+    pub fn prune_to(&mut self, creature: &CreatureExport) {
+        let views = neuron_views(creature);
+        let wire = WireIndex::build(creature);
+
+        let mut id_to_index: HashMap<i64, u32> = HashMap::with_capacity(views.len());
+        for (index, view) in views.iter().enumerate() {
+            if let Some(id) = view.id {
+                id_to_index.insert(id, index as u32);
+            }
+        }
+        let pairs: HashSet<(u32, u32)> = creature
+            .synapses
+            .iter()
+            .filter_map(|synapse| {
+                Some((
+                    wire.resolve(&synapse.from_uuid)?,
+                    wire.resolve(&synapse.to_uuid)?,
+                ))
+            })
+            .collect();
+        let resolve = |key: &str| resolve_memetic_reference(key, &id_to_index, Some(&wire));
+
+        self.biases.retain(|key, _| resolve(key).is_some());
+
+        match &mut self.weights {
+            MemeticWeights::Rows(rows) => rows.retain(|row| {
+                let (Some(from_uuid), Some(to_uuid)) =
+                    (row.from_uuid.as_deref(), row.to_uuid.as_deref())
+                else {
+                    return true; // malformed, not dangling — rule 31 reports it
+                };
+                match (resolve(from_uuid), resolve(to_uuid)) {
+                    (Some(from), Some(to)) => pairs.contains(&(from, to)),
+                    _ => false,
+                }
+            }),
+            MemeticWeights::ById(by_id) => by_id.retain(|key, entries| {
+                let Some(from) = resolve(key) else {
+                    return false;
+                };
+                entries.retain(|entry| match entry.to_id {
+                    None => true, // malformed, not dangling
+                    Some(to_id) => id_to_index
+                        .get(&to_id)
+                        .is_some_and(|&to| pairs.contains(&(from, to))),
+                });
+                true
+            }),
+        }
+    }
+}
+
 /// The memetic record as rule 31 reads it — the neutral form every request
 /// shape maps onto.
 ///

--- a/neat-core/tests/creature_memetic_prune.rs
+++ b/neat-core/tests/creature_memetic_prune.rs
@@ -1,0 +1,298 @@
+//! Pruning a memetic record back to the structure a creature still has —
+//! rule 31's inverse (NEAT-AI-Lamarck#197).
+//!
+//! Rule 31 (`MEMETIC`) refuses a creature whose memetic biases or weights name
+//! a neuron or a synapse it no longer carries, so **every** consumer that
+//! removes structure has to prune the record with it. Without a shared prune,
+//! each downstream repo hand-rolls one — and the blunt version (`memetic =
+//! None`) throws away `MemeticExport::extra`, the `generation` / `score` /
+//! `ancestry` history the record exists to carry. This crate owns rule 31, so
+//! it owns its inverse.
+//!
+//! Every assertion here is on the record the prune hands back: which keys
+//! survived, which went, and that the extras are untouched. The
+//! `creature_validate` assertions are the *consequence*, never the only oracle.
+
+use neat_core::{
+    CreatureExport, MemeticExport, MemeticWeightExport, MemeticWeightRowExport, MemeticWeights,
+    NeuronExport, SynapseExport, ValidateOptions, creature_validate, parse_creature_json,
+};
+use std::collections::BTreeMap;
+
+const OPTIONS: ValidateOptions = ValidateOptions {
+    neurons: None,
+    connections: None,
+    feedback_loop: None,
+    forward_only: true,
+};
+
+/// 2 inputs, `input-0 -> h1`, `input-1 -> h1`, `h1 -> o1`.
+fn creature() -> CreatureExport {
+    parse_creature_json(
+        r#"{
+          "semanticVersion":"4.0.0","forwardOnly":true,"input":2,"output":1,
+          "neurons":[
+            {"id":7,"type":"hidden","uuid":"h1","bias":0.25,"squash":"IDENTITY"},
+            {"type":"output","uuid":"o1","bias":0.0,"squash":"IDENTITY"}
+          ],
+          "synapses":[
+            {"fromUUID":"input-0","toUUID":"h1","weight":1.0},
+            {"fromUUID":"input-1","toUUID":"h1","weight":0.5},
+            {"fromUUID":"h1","toUUID":"o1","weight":1.0}
+          ]
+        }"#,
+    )
+    .unwrap()
+}
+
+fn row(from: &str, to: &str, weight: f64) -> MemeticWeightRowExport {
+    MemeticWeightRowExport {
+        from_uuid: Some(from.to_string()),
+        to_uuid: Some(to.to_string()),
+        weight: Some(weight),
+    }
+}
+
+fn rows_of(memetic: &MemeticExport) -> Vec<(String, String)> {
+    match &memetic.weights {
+        MemeticWeights::Rows(rows) => rows
+            .iter()
+            .map(|r| {
+                (
+                    r.from_uuid.clone().unwrap_or_default(),
+                    r.to_uuid.clone().unwrap_or_default(),
+                )
+            })
+            .collect(),
+        MemeticWeights::ById(_) => panic!("fixture is the row form"),
+    }
+}
+
+fn by_id_of(memetic: &MemeticExport) -> Vec<(String, Vec<i64>)> {
+    match &memetic.weights {
+        MemeticWeights::ById(by_id) => by_id
+            .iter()
+            .map(|(key, entries)| {
+                (
+                    key.clone(),
+                    entries.iter().filter_map(|e| e.to_id).collect::<Vec<_>>(),
+                )
+            })
+            .collect(),
+        MemeticWeights::Rows(_) => panic!("fixture is the map form"),
+    }
+}
+
+/// The row form: a weight naming a removed edge goes, the rest stays, and the
+/// extras the record carries are untouched.
+#[test]
+fn prune_drops_the_row_naming_a_removed_edge() {
+    let mut host = creature();
+    let mut extra = serde_json::Map::new();
+    extra.insert("generation".into(), serde_json::json!(11));
+    extra.insert("score".into(), serde_json::json!(0.42));
+    host.memetic = Some(MemeticExport {
+        biases: BTreeMap::from([("h1".to_string(), 0.01), ("gone".to_string(), 0.02)]),
+        weights: MemeticWeights::Rows(vec![
+            row("input-0", "h1", 0.9),
+            row("input-1", "h1", 0.8),
+            row("h1", "o1", 1.1),
+        ]),
+        extra,
+    });
+    // Remove `input-0 -> h1`, exactly as a neuron split does.
+    host.synapses
+        .retain(|s| !(s.from_uuid == "input-0" && s.to_uuid == "h1"));
+
+    host.prune_memetic();
+
+    let memetic = host.memetic.as_ref().expect("the record itself survives");
+    assert_eq!(
+        rows_of(memetic),
+        vec![
+            ("input-1".to_string(), "h1".to_string()),
+            ("h1".to_string(), "o1".to_string()),
+        ],
+        "only the row naming the removed edge is dropped"
+    );
+    assert_eq!(
+        memetic.biases.keys().collect::<Vec<_>>(),
+        vec!["h1"],
+        "`gone` names no neuron; `h1` does"
+    );
+    assert_eq!(memetic.extra["generation"], serde_json::json!(11));
+    assert_eq!(memetic.extra["score"], serde_json::json!(0.42));
+    creature_validate(&host, &OPTIONS).expect("a pruned creature satisfies rule 31");
+}
+
+/// The id-keyed map form: an entry naming a removed edge goes, a key naming no
+/// neuron goes with its entries, and a still-live entry stays.
+#[test]
+fn prune_drops_dangling_map_entries_and_unresolvable_keys() {
+    let mut host = creature();
+    host.memetic = Some(MemeticExport {
+        biases: BTreeMap::new(),
+        weights: MemeticWeights::ById(BTreeMap::from([
+            (
+                "7".to_string(),
+                vec![MemeticWeightExport {
+                    to_id: Some(-1),
+                    weight: Some(1.1),
+                }],
+            ),
+            (
+                "404".to_string(),
+                vec![MemeticWeightExport {
+                    to_id: Some(-1),
+                    weight: Some(0.3),
+                }],
+            ),
+        ])),
+        extra: serde_json::Map::new(),
+    });
+
+    // Nothing removed yet: `7 -> -1` is `h1 -> o1`, so it survives; key `404`
+    // names no neuron at all.
+    host.prune_memetic();
+    assert_eq!(
+        by_id_of(host.memetic.as_ref().unwrap()),
+        vec![("7".to_string(), vec![-1])]
+    );
+    creature_validate(&host, &OPTIONS).expect("a pruned creature satisfies rule 31");
+
+    // Now remove `h1 -> o1`: the last entry goes, the key stays as an empty
+    // list, and the record is still there.
+    host.synapses.retain(|s| s.to_uuid != "o1");
+    host.prune_memetic();
+    assert_eq!(
+        by_id_of(host.memetic.as_ref().unwrap()),
+        vec![("7".to_string(), vec![])]
+    );
+}
+
+/// A neuron removal takes its bias delta, and every weight naming it, with it.
+#[test]
+fn prune_follows_a_removed_neuron() {
+    let mut host = creature();
+    host.memetic = Some(MemeticExport {
+        biases: BTreeMap::from([("h1".to_string(), 0.01), ("o1".to_string(), 0.03)]),
+        weights: MemeticWeights::Rows(vec![row("input-0", "h1", 0.9), row("h1", "o1", 1.1)]),
+        extra: serde_json::Map::new(),
+    });
+    // Drop `h1` and every edge touching it — a neuron removal.
+    host.neurons.retain(|n| n.uuid != "h1");
+    host.synapses
+        .retain(|s| s.from_uuid != "h1" && s.to_uuid != "h1");
+    host.synapses.push(SynapseExport {
+        from_uuid: "input-0".into(),
+        to_uuid: "o1".into(),
+        weight: 1.0,
+        synapse_type: None,
+    });
+
+    host.prune_memetic();
+
+    let memetic = host.memetic.as_ref().unwrap();
+    assert_eq!(memetic.biases.keys().collect::<Vec<_>>(), vec!["o1"]);
+    assert!(
+        rows_of(memetic).is_empty(),
+        "both rows named the removed neuron: {:?}",
+        rows_of(memetic)
+    );
+    creature_validate(&host, &OPTIONS).expect("a pruned creature satisfies rule 31");
+}
+
+/// Appending structure resolves every existing key, so a prune must be a no-op
+/// there — pruning would throw away valid fine-tuning history.
+#[test]
+fn prune_is_a_no_op_when_nothing_was_removed() {
+    let mut host = creature();
+    host.memetic = Some(MemeticExport {
+        biases: BTreeMap::from([("h1".to_string(), 0.01)]),
+        weights: MemeticWeights::Rows(vec![row("input-0", "h1", 0.9)]),
+        extra: serde_json::Map::from_iter([("ancestry".to_string(), serde_json::json!(["a"]))]),
+    });
+    let before = host.memetic.clone();
+
+    // A pure append: a second edge into the output.
+    host.neurons.push(NeuronExport {
+        id: None,
+        neuron_type: "hidden".into(),
+        uuid: "h2".into(),
+        bias: 0.0,
+        squash: Some("IDENTITY".into()),
+    });
+    host.prune_memetic();
+
+    assert_eq!(host.memetic, before, "an append prunes nothing");
+}
+
+/// A creature with no memetic record is left exactly as it was, and an
+/// emptied-out record is kept rather than cleared: `memetic = None` is a
+/// different fact from "fine-tuned, then rewired".
+#[test]
+fn prune_keeps_the_record_but_not_a_missing_one() {
+    let mut none = creature();
+    none.prune_memetic();
+    assert!(none.memetic.is_none());
+
+    let mut host = creature();
+    host.memetic = Some(MemeticExport {
+        biases: BTreeMap::from([("h1".to_string(), 0.01)]),
+        weights: MemeticWeights::Rows(vec![row("input-0", "h1", 0.9)]),
+        extra: serde_json::Map::from_iter([("generation".to_string(), serde_json::json!(4))]),
+    });
+    host.neurons.clear();
+    host.synapses.clear();
+    host.prune_memetic();
+
+    let memetic = host.memetic.as_ref().expect("the record survives");
+    assert!(memetic.biases.is_empty());
+    assert!(rows_of(memetic).is_empty());
+    assert_eq!(
+        memetic.extra["generation"],
+        serde_json::json!(4),
+        "the history the record exists to carry is never the thing pruned"
+    );
+}
+
+/// Pruning twice changes nothing the first pass left — a second removal in the
+/// same pipeline must not compound.
+#[test]
+fn prune_is_idempotent() {
+    let mut once = creature();
+    once.memetic = Some(MemeticExport {
+        biases: BTreeMap::from([("h1".to_string(), 0.01), ("gone".to_string(), 0.02)]),
+        weights: MemeticWeights::Rows(vec![row("input-0", "h1", 0.9), row("gone", "o1", 0.5)]),
+        extra: serde_json::Map::new(),
+    });
+    once.prune_memetic();
+    let mut twice = once.clone();
+    twice.prune_memetic();
+    assert_eq!(once, twice);
+}
+
+/// `MemeticExport::prune_to` is the same prune against a creature the caller
+/// holds separately — the record need not be attached to be pruned.
+#[test]
+fn prune_to_prunes_a_detached_record() {
+    let mut host = creature();
+    host.synapses
+        .retain(|s| !(s.from_uuid == "input-0" && s.to_uuid == "h1"));
+    let mut memetic = MemeticExport {
+        biases: BTreeMap::from([("h1".to_string(), 0.01)]),
+        weights: MemeticWeights::Rows(vec![row("input-0", "h1", 0.9), row("h1", "o1", 1.1)]),
+        extra: serde_json::Map::new(),
+    };
+
+    memetic.prune_to(&host);
+
+    assert_eq!(
+        rows_of(&memetic),
+        vec![("h1".to_string(), "o1".to_string())]
+    );
+    assert!(
+        host.memetic.is_none(),
+        "prune_to does not attach the record"
+    );
+}


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/NEAT-AI-Lamarck#197 here, in the dependency's own repo.

Adds CreatureExport::prune_memetic() / MemeticExport::prune_to() beside rule 31 so every consumer that removes structure shares one prune instead of hand-rolling a blunt one that discards MemeticExport::extra.

**Head:** `lamarck-197-memetic-prune` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/NEAT-AI-Lamarck#197: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.