### PR TITLE
Key synapses by (from, to, type): relax the duplicate-pair rule for IF targets (Issue #577)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,8 +276,10 @@ hand-edits neuron/synapse JSON to add a decision node, and NEAT-AI-Forests reads
 its interpretation of the roles from here rather than inventing one.
 
 `validate_creature_topology` is the gate at both ends. It **reuses**
-`validate_creature_width`, `validate_topology` and
-`validate_structural_integrity` — do not restate their rules here. The ordering
+`validate_creature_width`, `validate_topology_typed`,
+`validate_structural_integrity` and `validate_no_duplicate_synapses` — do not
+restate their rules here. The last of those is what carries the Issue #577 rule
+that only an `IF` target may take two roles from one source. The ordering
 gate runs only for `forwardOnly` creatures; a recurrent creature legitimately
 carries backward edges, which that gate rejects by design. The post-build check
 is deliberate defence in depth: it is unreachable while the pre-checks are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "neat-core"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "criterion",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 # Issue #251: retro-bumped 0.1.46 -> 0.2.0 to signal the #177 breaking change
 # (SynapseData::from_index u32 -> u16). Pre-1.0, a breaking change is a
 # major-equivalent (minor) bump. See RELEASING.md.
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stSoftwareAU/NEAT-AI-core"

--- a/README.md
+++ b/README.md
@@ -434,30 +434,40 @@ flowchart LR
     S -. "input &lt; 1 / output &lt; 1" .-> X
 ```
 
-### Duplicate `(fromUUID, toUUID)` synapses are rejected (Issue #556)
+### Duplicate `(fromUUID, toUUID, type)` synapses are rejected (Issues #556, #577)
 
-NEAT-AI's TypeScript loader keys synapses by the `(fromUUID, toUUID)` pair, so
-a creature carrying that pair twice loses every copy but one before it is
-scored. `compile_creature` used to resolve each synapse independently and
+NEAT-AI's TypeScript loader keys synapses by the `(fromUUID, toUUID, type)`
+triple, so a creature carrying that triple twice loses every copy but one before
+it is scored. `compile_creature` used to resolve each synapse independently and
 **sum** them, so the same JSON scored differently under the two engines —
 observed in production as `rust_scorer` 0.356183 against `Creature.scoreDir`
-0.353147, with the minimal repro an `IF` neuron fed three times (condition /
-positive / negative) by one constant neuron.
+0.353147.
 
 Which copy TypeScript keeps falls out of its map insertion order, so there is
 no value this crate could reproduce and no safe way to dedupe.
 `validate_no_duplicate_synapses` is the single home of the rule and
 `compile_creature` calls it right after `validate_creature_width`: a repeated
-pair is `CreatureError::DuplicateSynapse { from_uuid, to_uuid }`, naming the
-first pair that repeats in declaration order. Distinct pairs that share one
+triple is `CreatureError::DuplicateSynapse { from_uuid, to_uuid }`, naming the
+first one that repeats in declaration order. Distinct pairs that share one
 endpoint — fan-out from a source, fan-in to a target — are untouched.
 
-The ordered pair is the **whole** key: the synapse *role* plays no part in it.
-Many synapses may carry the same role into one neuron — two `condition` edges
-into an `IF` neuron are what a decision stump is built from — as long as their
-sources differ. Only an exact repeat of `(fromUUID, toUUID)` is rejected, which
-is also why an `IF` neuron needs up to three separate constants (each with
-`bias = 1`) rather than one constant wired three times (Issue #572).
+**The role is part of the key, and only an `IF` target may use it**
+(Issue #577). An `IF` neuron keeps a sum per role, so one source may feed two of
+its branches: the contribution that must apply whichever way the node branches
+lands in both sums from one neuron, where it used to need an IDENTITY relay
+purely to be a second distinct source. Measured on a production creature, 455
+such relays had accumulated; removing 415 of them was worth **+4.96e-5** of
+score for behaviour identical to 1.5e-9. Every other squash sums its inward
+synapses regardless of role, so two synapses from one source there are exactly
+one with the summed weight — redundancy with no meaning, rejected as
+`CreatureError::TypedDuplicateSynapse { from_uuid, to_uuid }`. The two variants
+are deliberately distinct: a caller can tell "you repeated yourself" from "that
+target cannot mean what you wrote".
+
+Many synapses may still carry the same role into one neuron — two `condition`
+edges into an `IF` neuron are what a decision stump is built from — as long as
+their sources differ (Issue #572). The wire format is unchanged: `type` is
+already in the JSON, and every previously valid creature stays valid.
 
 Consumers that assemble a `CreatureExport` in Rust rather than parsing one
 should call `validate_no_duplicate_synapses` at their own boundary
@@ -465,13 +475,12 @@ should call `validate_no_duplicate_synapses` at their own boundary
 
 ```mermaid
 flowchart LR
-    J["creature JSON<br/>same (from, to) twice"] --> T["NEAT-AI TypeScript<br/>keyed by (from, to)"]
-    J --> R["compile_creature"]
-    T --> K["keeps one copy<br/>insertion-order dependent"]
-    R --> V["validate_no_duplicate_synapses"]
-    V -. "repeated pair" .-> X["Err(DuplicateSynapse)<br/>fail closed"]
-    V --> C["CompiledNetwork<br/>every pair distinct"]
-    K -. "divergent score" .-> X
+    J["creature JSON"] --> R["compile_creature"]
+    R --> V["validate_no_duplicate_synapses<br/>keyed by (from, to, type)"]
+    V -. "same triple twice" .-> X["Err(DuplicateSynapse)<br/>fail closed"]
+    V -. "two roles, non-IF target" .-> Y["Err(TypedDuplicateSynapse)<br/>fail closed"]
+    V -- "two roles, IF target" --> C["CompiledNetwork<br/>one sum per role"]
+    V --> C
 ```
 
 ### Creature weights parse to the exact `f64`
@@ -545,7 +554,9 @@ the node is evaluated after every source and before every target, which is what
 preserves the `forwardOnly` reading order the compiled forward pass relies on.
 Every rejection is a typed `GraftError` and **no creature is produced** —
 unknown or duplicate UUID, a missing `IF` role, no outward edge, an edge to an
-input or a constant, a self edge, a duplicate edge, a non-finite weight or bias,
+input or a constant, a self edge, a duplicate edge (same pair in the same role,
+or two roles into a target that is not an `IF` neuron), a non-finite weight or
+bias,
 or no position that keeps every edge pointing forwards. `graft_if_correction`
 on `linear_base_creature()` reproduces `residual_correction_creature()` exactly,
 which is how the helper and the fixture keep each other honest.
@@ -556,15 +567,16 @@ node may leave its outward edge to a later node in the same batch (the nested
 child feeding a parent that does not exist yet); only the assembled creature is
 validated. `IfNodeSpec::with_target_role` emits a **typed** outward edge, which
 is how a correction reaches one named branch of an `IF` destination, and
-`graft_relay_node` adds the IDENTITY relay that carries the same value into the
-other branch — a creature may not hold two synapses between the same ordered
-pair, so the second branch needs a second source.
+a node reaches **both** branches of one `IF` destination by listing it once per
+role (Issue #577) — the IDENTITY relay `graft_relay_node` adds is no longer
+needed for that, and remains only for a caller that wants the relayed sum
+itself.
 
 `validate_creature_topology` is the shared gate both ends run: it reuses
-`validate_creature_width`, `validate_topology` and
-`validate_structural_integrity` rather than restating their rules. The ordering
-gate only runs for `forwardOnly` creatures, because a recurrent creature
-legitimately carries backward edges.
+`validate_creature_width`, `validate_topology_typed`,
+`validate_structural_integrity` and `validate_no_duplicate_synapses` rather than
+restating their rules. The ordering gate only runs for `forwardOnly` creatures,
+because a recurrent creature legitimately carries backward edges.
 
 ```mermaid
 flowchart LR
@@ -704,10 +716,12 @@ pub fn validate_synapse_and_memetic_rules(
 connection tally and leaves the neuron counters alone, exactly as the
 TypeScript threads one `stats` literal through both halves. It evaluates, first
 failure wins: the single synapse pass (no synapse into an input neuron; no self
-connection under `forward_only`; sorted by `(from, to)`; no duplicate pair; no
+connection under `forward_only`; sorted by `(from, to, type)`; no duplicate
+triple, and a pair repeated only into an `IF` target; no
 `from > to` when `feedback_loop` is an explicit `Some(false)`), then the
 `connections` count, then — for a forward-only creature — `topology_ops`'
-`validate_topology`, `validate_structural_integrity` and `detect_cycles`, and
+`validate_topology_typed`, `validate_structural_integrity` and `detect_cycles`,
+and
 finally the memetic cross-references.
 
 Two details a caller can trip over:
@@ -784,7 +798,7 @@ flowchart LR
 flowchart LR
     W["synapse walk<br/>rules 23–27"] --> N["connections count<br/>rule 28"]
     N --> FWD{"forward_only?"}
-    FWD -- yes --> T["topology_ops<br/>validate_topology →<br/>validate_structural_integrity →<br/>detect_cycles"]
+    FWD -- yes --> T["topology_ops<br/>validate_topology_typed →<br/>validate_structural_integrity →<br/>detect_cycles"]
     FWD -- no --> M["memetic rules<br/>rule 31"]
     T --> M
     M --> S["Ok(()) — stats.connections tallied"]

--- a/docs/archive/pr-summaries/pr-summary-577.md
+++ b/docs/archive/pr-summaries/pr-summary-577.md
@@ -1,0 +1,137 @@
+# Key synapses by `(from, to, type)`, relaxed for `IF` targets
+
+## Summary
+
+A synapse into an `IF` neuron carries a role and the kernel keeps one sum per
+role, so a contribution that must apply **whichever way the node branches**
+needs two synapses from the same source. Keying synapses by the ordered
+`(from, to)` pair forbade that, and the workaround was an IDENTITY relay neuron
+existing only to be a second distinct source — 455 of them had accumulated on a
+production creature, and removing 415 was worth +4.96e-5 of score for behaviour
+identical to 1.5e-9.
+
+Uniqueness is now the `(from, to, type)` **triple**, and only an `IF` target may
+carry more than one role from one source: every other squash sums its inward
+synapses regardless of role, so two synapses from one source there are exactly
+one with the summed weight — redundancy with no meaning. Canonical sort order
+becomes `(from, to, type)` so it stays total. The wire format is unchanged
+(`type` is already in the JSON) and every currently valid creature stays valid.
+
+The two rejections carry **distinct codes**, as the issue asks, so a caller can
+tell "you repeated yourself" from "that target cannot mean what you wrote":
+
+| Creature | Export rule | Validator rule |
+|----------|-------------|----------------|
+| same `(from, to, type)` twice | `CreatureError::DuplicateSynapse` | `Topology` / `INVALID_CONNECTION` |
+| pair repeated into a non-`IF` target | `CreatureError::TypedDuplicateSynapse` | `Validation` / `DUPLICATE_SYNAPSE` |
+
+What changed, file by file:
+
+- **`creature.rs`** — `validate_no_duplicate_synapses` keys the triple and looks
+  up the target's squash through the new `is_if_squash` helper (which reads the
+  name through `parse_squash_name` rather than comparing to a literal).
+- **`creature_validate.rs`** — rule 25 sorts by `(from, to, type)`, rule 26 is
+  the exact-triple repeat, and rule 26b is the pair repeated into a target that
+  reads no roles. `synapse_walk` now takes the role buffer and fails loud on a
+  length that does not match rather than silently unkeying the rule.
+- **`topology_ops.rs`** — `validate_topology_typed` keys the index-level gate by
+  role, with the new `SORT_ERROR_TYPE` code for roles out of order inside a
+  repeated pair. The existing `validate_topology` is untouched for callers that
+  hold no roles; both share one walk, so the two cannot drift.
+- **`if_graft.rs`** — a node reaches **both** branches of an `IF` target from
+  its own outward edges, so no relay neuron is created for that; the same source
+  in the same role is still `DuplicateEdge`, and two roles into a non-`IF`
+  target are the new `TypedDuplicateEdge`. `validate_creature_topology` now also
+  runs `validate_no_duplicate_synapses`, which is the order-independent leg that
+  knows what a *target* may mean.
+- **`synapse_type.rs`** — `SynapseType` derives `Eq`, `Hash`, `PartialOrd` and
+  `Ord`, since the role is now part of a key and of a sort order.
+
+Closes #577.
+
+## Evidence
+
+Backend/CLI change with no web interface, so the evidence is the test suite and
+`./quality.sh` — no screenshot applies.
+
+```mermaid
+flowchart LR
+    S["synapse (from, to, type)"] --> K{"triple seen<br/>before?"}
+    K -- yes --> D["Err(DuplicateSynapse)<br/>INVALID_CONNECTION"]
+    K -- no --> P{"pair seen<br/>before?"}
+    P -- no --> OK["accepted"]
+    P -- yes --> T{"target is<br/>an IF neuron?"}
+    T -- yes --> OK
+    T -- no --> R["Err(TypedDuplicateSynapse)<br/>DUPLICATE_SYNAPSE"]
+```
+
+The relay this removes, and what replaces it:
+
+```mermaid
+flowchart LR
+    subgraph before["before — a relay per correction"]
+        C1["corr"] -- positive --> O1["IF output"]
+        C1 --> RLY["corr-relay<br/>IDENTITY"]
+        RLY -- negative --> O1
+    end
+    subgraph after["after — Issue #577"]
+        C2["corr"] -- positive --> O2["IF output"]
+        C2 -- negative --> O2
+    end
+```
+
+`./quality.sh` passes clean: fmt, clippy `-D warnings`, `cargo check`, 60 test
+binaries, doctests, `cargo doc -D warnings`, `cargo deny`, Mermaid and
+markdownlint gates.
+
+Behaviour is proven, not just accepted:
+`a_node_reaches_both_branches_of_an_if_target_without_a_relay` asserts the
+relay-free creature produces the **same** correction for every record as the
+relay version, with one fewer neuron and one fewer synapse.
+
+## Test Plan
+
+Existing tests that changed, because the rule they pinned changed — documented
+here as required:
+
+- `neat-core/tests/creature_duplicate_synapses.rs` —
+  `compile_rejects_an_if_neuron_fed_three_times_by_one_constant` asserted the
+  Issue #556 rule that one constant may not feed an `IF` neuron three times.
+  That shape is exactly what Issue #577 legalises, so it is now
+  `compile_accepts_an_if_neuron_fed_three_times_by_one_constant` and asserts the
+  activation. The rejection it used to cover is kept by
+  `compile_rejects_a_repeated_role_from_one_source` (an exact triple repeat),
+  and the display / consumer-boundary tests now build their duplicate from that
+  fixture instead.
+- `neat-core/tests/if_graft.rs` —
+  `rejects_two_synapses_between_the_same_pair` listed one source under two
+  branches of the grafted `IF` node, which is now legal. Split into
+  `accepts_one_source_under_two_branches_of_the_if_node` (asserting both
+  branches' activations and the shared validator's verdict) and
+  `rejects_two_synapses_between_the_same_pair_in_one_role`.
+
+Added:
+
+- `neat-core/tests/creature_duplicate_synapses.rs` —
+  `a_repeated_source_keeps_one_sum_per_role` (the negative branch of the shared
+  source), `compile_rejects_two_roles_from_one_source_into_a_non_if_target`.
+- `neat-core/tests/creature_validate_synapse_rules.rs` —
+  `one_source_may_carry_every_role_into_an_if_target` (half, whole entry point
+  and forward-only leg), `a_repeated_role_into_an_if_target_is_still_an_invalid_connection`,
+  `roles_out_of_order_within_one_pair_are_a_sort_failure`,
+  `two_roles_into_a_non_if_target_are_a_duplicate_synapse` — each asserting the
+  class, `reason`, message text and synapse index verbatim.
+- `neat-core/tests/if_graft.rs` —
+  `a_node_reaches_both_branches_of_an_if_target_without_a_relay`,
+  `rejects_two_roles_into_a_target_that_is_not_an_if_neuron`,
+  `rejects_one_role_repeated_into_an_if_target`.
+- `neat-core/tests/creature_validate_packed_conformance.rs` —
+  `one_source_carries_every_role_into_an_if_target_through_both_shapes` and
+  `the_same_wiring_into_a_non_if_target_is_rejected_through_both_shapes`, so the
+  role buffer is proven to reach the rules through the runtime **and** packed
+  request shapes, not only the export form.
+- `neat-core/src/topology_ops.rs` unit tests — the typed gate accepts one pair
+  once per role (and the untyped gate still calls it a duplicate, which is why
+  the forward-only leg had to pass roles), still rejects a repeated role,
+  reports `SORT_ERROR_TYPE` for descending roles, resets the role when the pair
+  advances, and reports a short role buffer as `MALFORMED_BUFFER`.

--- a/neat-core/src/creature.rs
+++ b/neat-core/src/creature.rs
@@ -47,14 +47,16 @@
 //! a missing key is a serde error, a zero is a typed error, and neither is
 //! ever written back out.
 //!
-//! **Duplicate-synapse rule (Issue #556).** NEAT-AI's TypeScript loader keys
-//! synapses by `(fromUUID, toUUID)` and keeps only one copy of a repeated
-//! pair, so a creature carrying the same pair twice scored differently under
-//! the two engines — this crate applied and summed every copy.
-//! [`validate_no_duplicate_synapses`] is the single home of that rule and
+//! **Duplicate-synapse rule (Issues #556, #577).** NEAT-AI's TypeScript loader
+//! keys synapses by `(fromUUID, toUUID, type)` and keeps only one copy of a
+//! repeated triple, so a creature carrying the same triple twice scored
+//! differently under the two engines — this crate applied and summed every
+//! copy. [`validate_no_duplicate_synapses`] is the single home of that rule and
 //! [`compile_creature`] calls it, failing closed with
 //! [`CreatureError::DuplicateSynapse`] rather than producing a number
-//! TypeScript would never agree with.
+//! TypeScript would never agree with. The role only widens the key for an `IF`
+//! target, which keeps a sum per role; anywhere else a repeated pair is
+//! [`CreatureError::TypedDuplicateSynapse`].
 //!
 //! **Validator extension (Issue #559).** [`NeuronExport::id`] and
 //! [`CreatureExport::memetic`] carry the two pieces
@@ -386,18 +388,34 @@ pub enum CreatureError {
         /// The `output` value that was found.
         found: usize,
     },
-    /// Two or more synapses shared the same `(fromUUID, toUUID)` pair (Issue #556).
+    /// Two or more synapses shared the same `(fromUUID, toUUID, type)` triple
+    /// (Issues #556, #577).
     ///
-    /// NEAT-AI's TypeScript loader keys synapses by that pair and keeps only
+    /// NEAT-AI's TypeScript loader keys synapses by that triple and keeps only
     /// one, while this crate would apply every copy — the same JSON then
     /// scores differently under the two engines. Which copy TypeScript keeps
     /// depends on its map insertion order, so there is no value Rust could
     /// safely reproduce: [`validate_no_duplicate_synapses`] fails closed
     /// instead.
     DuplicateSynapse {
+        /// `fromUUID` of the repeated triple.
+        from_uuid: String,
+        /// `toUUID` of the repeated triple.
+        to_uuid: String,
+    },
+    /// One source fed one target through **two different roles**, and that
+    /// target is not an `IF` neuron (Issue #577).
+    ///
+    /// Only an `IF` neuron keeps a sum per role; every other squash sums its
+    /// inward synapses regardless of role, so two synapses from one source are
+    /// exactly one with the summed weight. The pair therefore says nothing the
+    /// creature could not say with one synapse, and is rejected under its own
+    /// variant so a caller can tell it from a plain repeat
+    /// ([`CreatureError::DuplicateSynapse`]).
+    TypedDuplicateSynapse {
         /// `fromUUID` of the repeated pair.
         from_uuid: String,
-        /// `toUUID` of the repeated pair.
+        /// `toUUID` of the repeated pair — the non-`IF` target.
         to_uuid: String,
     },
 }
@@ -429,6 +447,13 @@ impl std::fmt::Display for CreatureError {
             }
             CreatureError::DuplicateSynapse { from_uuid, to_uuid } => {
                 write!(f, "Duplicate synapse from {from_uuid} to {to_uuid}")
+            }
+            CreatureError::TypedDuplicateSynapse { from_uuid, to_uuid } => {
+                write!(
+                    f,
+                    "Synapses from {from_uuid} to {to_uuid} carry different roles, \
+                     but {to_uuid} is not an 'IF' neuron"
+                )
             }
         }
     }
@@ -607,9 +632,21 @@ pub fn validate_creature_width(creature: &CreatureExport) -> Result<(), Creature
     Ok(())
 }
 
-/// Reject a creature carrying the same `(fromUUID, toUUID)` pair twice.
+/// Whether a declared squash name is the `IF` activation — the one squash that
+/// keeps a separate sum per synapse role, and so the one target a source may
+/// feed through more than one role (Issue #577).
 ///
-/// NEAT-AI's TypeScript loader keys synapses by that pair, so only one copy
+/// Reads the name through [`parse_squash_name`] rather than comparing it to a
+/// literal, so it answers for every spelling that parser accepts and cannot
+/// drift from it. An unknown name is not `IF`.
+pub(crate) fn is_if_squash(squash: Option<&str>) -> bool {
+    squash.is_some_and(|name| matches!(parse_squash_name(name), Ok(SquashType::If)))
+}
+
+/// Reject a creature carrying the same `(fromUUID, toUUID, type)` triple twice,
+/// and a repeated pair whose target cannot read more than one role.
+///
+/// NEAT-AI's TypeScript loader keys synapses by that triple, so only one copy
 /// survives the load; this crate resolves each synapse independently and would
 /// apply — and sum — all of them. The same JSON then scores differently under
 /// the two engines (Issue #556: `rust_scorer` 0.356183 against
@@ -618,22 +655,51 @@ pub fn validate_creature_width(creature: &CreatureExport) -> Result<(), Creature
 /// Which copy TypeScript keeps falls out of its map insertion order, so there
 /// is no value this crate could reproduce and no safe way to dedupe. The rule
 /// is therefore to fail closed with [`CreatureError::DuplicateSynapse`],
-/// naming the first pair that repeats in declaration order.
+/// naming the first triple that repeats in declaration order.
 ///
-/// The ordered pair is the whole key — the synapse **role** plays no part in
-/// it. Many synapses may carry the same role into one neuron as long as their
-/// sources differ; only an exact repeat of `(fromUUID, toUUID)` is rejected
-/// (Issue #572).
+/// **The role is part of the key, and only an `IF` target may use it**
+/// (Issue #577). An `IF` neuron keeps a sum per role, so one source may feed
+/// two of its branches — the contribution that must apply whichever way the
+/// node branches, which used to need an IDENTITY relay purely to be a second
+/// distinct source. Every other squash sums its inward synapses regardless of
+/// role, so two synapses from one source there are exactly one with the summed
+/// weight: that is [`CreatureError::TypedDuplicateSynapse`], a distinct
+/// variant so a caller can tell "you repeated yourself" from "that target
+/// cannot mean what you wrote". A target naming no listed neuron is not an
+/// `IF` neuron and is read as such — [`compile_creature`] reports the dangling
+/// reference itself.
+///
+/// Many synapses may still carry the same role into one neuron as long as
+/// their sources differ (Issue #572).
 ///
 /// [`compile_creature`] calls this before building the network. Consumers that
 /// assemble a [`CreatureExport`] in Rust, or feed one straight into their own
 /// scorer, should call it at their own boundary.
 pub fn validate_no_duplicate_synapses(creature: &CreatureExport) -> Result<(), CreatureError> {
-    let mut seen: HashSet<(&str, &str)> = HashSet::with_capacity(creature.synapses.len());
+    let if_targets: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|neuron| is_if_squash(neuron.squash.as_deref()))
+        .map(|neuron| neuron.uuid.as_str())
+        .collect();
+
+    let mut seen: HashSet<(&str, &str, SynapseType)> =
+        HashSet::with_capacity(creature.synapses.len());
+    let mut pairs: HashSet<(&str, &str)> = HashSet::with_capacity(creature.synapses.len());
+
     for synapse in &creature.synapses {
-        let pair = (synapse.from_uuid.as_str(), synapse.to_uuid.as_str());
-        if !seen.insert(pair) {
+        let from = synapse.from_uuid.as_str();
+        let to = synapse.to_uuid.as_str();
+        let role = parse_synapse_type(synapse.synapse_type.as_deref());
+
+        if !seen.insert((from, to, role)) {
             return Err(CreatureError::DuplicateSynapse {
+                from_uuid: synapse.from_uuid.clone(),
+                to_uuid: synapse.to_uuid.clone(),
+            });
+        }
+        if !pairs.insert((from, to)) && !if_targets.contains(to) {
+            return Err(CreatureError::TypedDuplicateSynapse {
                 from_uuid: synapse.from_uuid.clone(),
                 to_uuid: synapse.to_uuid.clone(),
             });
@@ -690,9 +756,9 @@ pub fn creature_to_json_pretty(creature: &CreatureExport) -> Result<String, Crea
 /// The observation-width contract ([`validate_creature_width`]) is checked
 /// before anything else, so a hand-built `CreatureExport { input: 0, .. }`
 /// fails exactly as loudly as one that came through [`parse_creature_json`]
-/// (Issue #550). A repeated `(fromUUID, toUUID)` pair is then rejected by
-/// [`validate_no_duplicate_synapses`] rather than summed, because TypeScript
-/// keeps only one copy of it (Issue #556).
+/// (Issue #550). A repeated `(fromUUID, toUUID, type)` triple is then rejected
+/// by [`validate_no_duplicate_synapses`] rather than summed, because TypeScript
+/// keeps only one copy of it (Issues #556, #577).
 pub fn compile_creature(creature: &CreatureExport) -> Result<CompiledNetwork, CreatureError> {
     validate_creature_width(creature)?;
     validate_no_duplicate_synapses(creature)?;

--- a/neat-core/src/creature_validate.rs
+++ b/neat-core/src/creature_validate.rs
@@ -71,8 +71,9 @@
 //! | 22 | counted outputs match the declared `output` | `Topology` / `INVALID_STATE` |
 //! | 23 | no synapse points at an input neuron | `Topology` / `INVALID_CONNECTION` |
 //! | 24 | no self connection (when `forward_only`) | `Validation` / `SELF_CONNECTION` |
-//! | 25 | synapses sorted by `(from, to)` | `Topology` / `SORT_FAILURE` |
-//! | 26 | no duplicate `(from, to)` pair | `Topology` / `INVALID_CONNECTION` |
+//! | 25 | synapses sorted by `(from, to, type)` | `Topology` / `SORT_FAILURE` |
+//! | 26 | no duplicate `(from, to, type)` triple | `Topology` / `INVALID_CONNECTION` |
+//! | 26b | a pair repeats only into an `IF` target | `Validation` / `DUPLICATE_SYNAPSE` |
 //! | 27 | no `from > to` when recursion is disallowed | `Validation` / `RECURSIVE_SYNAPSE` |
 //! | 28 | expected connection count (when set) | `Validation` / `OTHER` |
 //! | 29 | forward-only creatures are sorted, self-loop free and acyclic | `Topology` / `INVALID_CONNECTION` |
@@ -80,13 +81,24 @@
 //! | 31 | memetic biases / weights resolve to real neurons and synapses | `Validation` / `MEMETIC` |
 //!
 //! Rule 26 is the same notion of "duplicate" as
-//! [`crate::creature::validate_no_duplicate_synapses`] (Issue #556) — one
-//! ordered `(from, to)` pair, at most once — reported here under the
-//! TypeScript's own class and reason (`TopologyError` / `INVALID_CONNECTION`,
-//! *not* `DUPLICATE_SYNAPSE`, which `creatureValidate` never raises). The
-//! synapse **role** plays no part in either rule: rule 12 wants one edge of
-//! each role and rule 26 wants each pair once, so an `IF` neuron fed two
-//! `positive` edges from two different sources breaks neither (Issue #572).
+//! [`crate::creature::validate_no_duplicate_synapses`] (Issues #556, #577) —
+//! one ordered `(from, to, type)` triple, at most once — reported here under
+//! the TypeScript's own class and reason (`TopologyError` /
+//! `INVALID_CONNECTION`).
+//!
+//! The **role** widens that key only where a target reads it. An `IF` neuron
+//! keeps a sum per role, so one source may feed two of its branches — the
+//! contribution that must apply whichever way the node branches, which used to
+//! need an IDENTITY relay purely to be a second distinct source. Every other
+//! squash sums its inward synapses regardless of role, so a repeated pair there
+//! is redundancy with no meaning: rule 26b, `ValidationError` /
+//! `DUPLICATE_SYNAPSE`, the one place `creatureValidate` raises that reason.
+//! The two codes are deliberately distinct — a caller can tell "you repeated
+//! yourself" from "that target cannot mean what you wrote".
+//!
+//! Rule 12 is unaffected: it wants one edge of each role, so an `IF` neuron fed
+//! two `positive` edges from two different sources still breaks nothing
+//! (Issue #572).
 //!
 //! # Input format
 //!
@@ -222,9 +234,11 @@
 //!
 //! Rule 26 only catches duplicates that are *adjacent* after sorting, which is
 //! sufficient here but not for the same reason as Issue #556: a duplicate that
-//! is separated by another pair necessarily creates the sort regression rule 25
-//! stops on first, so the creature is still rejected — under `SORT_FAILURE`
-//! rather than `INVALID_CONNECTION`. Nothing slips through either path;
+//! is separated by another triple necessarily creates the sort regression rule
+//! 25 stops on first, so the creature is still rejected — under `SORT_FAILURE`
+//! rather than `INVALID_CONNECTION`. Sorting by `(from, to, type)` is what
+//! keeps that argument true once one pair may appear once per role
+//! (Issue #577). Nothing slips through either path;
 //! [`crate::validate_no_duplicate_synapses`] is order-independent and rejects
 //! it too.
 //!
@@ -251,7 +265,7 @@ use std::fmt;
 
 use crate::creature::{
     CreatureExport, MemeticExport, MemeticWeightExport, MemeticWeightRowExport, MemeticWeights,
-    parse_squash_name, parse_synapse_type,
+    is_if_squash, parse_squash_name, parse_synapse_type, synapse_type_name_from,
 };
 use crate::synapse_type::SynapseType;
 use crate::topology_invariants::{
@@ -259,7 +273,7 @@ use crate::topology_invariants::{
 };
 use crate::topology_ops::{
     STRUCTURAL_VALID, VALID, detect_cycles, structural_error_message, topology_error_message,
-    validate_structural_integrity, validate_topology,
+    validate_structural_integrity, validate_topology_typed,
 };
 
 /// Largest neuron id NEAT-AI accepts — `int32` max, mirroring
@@ -293,8 +307,9 @@ pub mod reason {
     pub const RECURSIVE_SYNAPSE: &str = "RECURSIVE_SYNAPSE";
     /// A self connection (`from == to`) in a forward-only creature.
     pub const SELF_CONNECTION: &str = "SELF_CONNECTION";
-    /// Union member kept verbatim; `creatureValidate` reports a repeated
-    /// `(from, to)` pair as [`INVALID_CONNECTION`] instead.
+    /// A `(from, to)` pair repeated into a target that reads no roles — rule
+    /// 26b (Issue #577). An exact repeat of the `(from, to, type)` triple is
+    /// [`INVALID_CONNECTION`] instead, as `creatureValidate` reports it.
     pub const DUPLICATE_SYNAPSE: &str = "DUPLICATE_SYNAPSE";
     /// A memetic bias or weight does not resolve to a neuron or synapse.
     pub const MEMETIC: &str = "MEMETIC";
@@ -312,7 +327,8 @@ pub mod reason {
     pub const INVALID_SYNAPSE_REFERENCE: &str = "INVALID_SYNAPSE_REFERENCE";
     /// A neuron that requires a squash has none.
     pub const MISSING_SQUASH: &str = "MISSING_SQUASH";
-    /// A synapse is wired somewhere it may not be — including a duplicate pair.
+    /// A synapse is wired somewhere it may not be — including a duplicate
+    /// `(from, to, type)` triple.
     pub const INVALID_CONNECTION: &str = "INVALID_CONNECTION";
     /// The creature's own bookkeeping disagrees with its neurons.
     pub const INVALID_STATE: &str = "INVALID_STATE";
@@ -322,7 +338,7 @@ pub mod reason {
     pub const MISSING_NEURON: &str = "MISSING_NEURON";
     /// A neuron has no UUID.
     pub const MISSING_NEURON_UUID: &str = "MISSING_NEURON_UUID";
-    /// Synapses are not sorted by `(from, to)`.
+    /// Synapses are not sorted by `(from, to, type)`.
     pub const SORT_FAILURE: &str = "SORT_FAILURE";
     /// Too many errors to keep reporting.
     pub const EXCESSIVE_ERRORS: &str = "EXCESSIVE_ERRORS";
@@ -1356,13 +1372,34 @@ fn synapse_walk(
     views: &[NeuronView<'_>],
     from_indices: &[u32],
     to_indices: &[u32],
+    synapse_types: &[SynapseType],
     options: &ValidateOptions,
     stats: &mut ValidationStats,
 ) -> Result<(), ValidationFailure> {
+    // Every request shape builds the three buffers together, so a mismatch is a
+    // caller bug rather than a creature defect — reported rather than walked
+    // around, because a short role buffer would silently unkey rule 26.
+    if synapse_types.len() != from_indices.len() {
+        return Err(ValidationFailure::topology(
+            reason::INVALID_STATE,
+            format!(
+                "Expected {} synapse types found: {}",
+                from_indices.len(),
+                synapse_types.len()
+            ),
+        ));
+    }
+
     let mut last_from: i64 = -1;
     let mut last_to: i64 = -1;
+    let mut last_type = SynapseType::Standard;
 
-    for (index, (&from_index, &to_index)) in from_indices.iter().zip(to_indices).enumerate() {
+    for (index, ((&from_index, &to_index), &role)) in from_indices
+        .iter()
+        .zip(to_indices)
+        .zip(synapse_types)
+        .enumerate()
+    {
         stats.connections += 1;
         let synapse_index = index as u32;
         let label = |at: u32| views[at as usize].wire_label(at as usize);
@@ -1408,15 +1445,44 @@ fn synapse_walk(
                 )
                 .at_synapse(synapse_index));
             } else if to == last_to {
-                // Issue #556 — the same "one ordered (from, to) pair, at most
-                // once" invariant as `validate_no_duplicate_synapses`, reported
-                // under the TypeScript's own class and reason.
+                // Rule 25's third leg (Issue #577): the role completes the sort
+                // key, so a pair that repeats does so in ascending role order.
+                if role < last_type {
+                    return Err(ValidationFailure::topology(
+                        reason::SORT_FAILURE,
+                        format!(
+                            "{index}) synapses not sorted {from}->{to} type: {} last type: {}",
+                            role_label(role),
+                            role_label(last_type)
+                        ),
+                    )
+                    .at_synapse(synapse_index));
+                }
                 let (from_label, to_label) = (label(from_index), label(to_index));
-                return Err(ValidationFailure::topology(
-                    reason::INVALID_CONNECTION,
-                    format!("{index}) duplicate synapse {from_label} -> {to_label}"),
-                )
-                .at_synapse(synapse_index));
+                if role == last_type {
+                    // Issues #556, #577 — the same "one ordered
+                    // (from, to, type) triple, at most once" invariant as
+                    // `validate_no_duplicate_synapses`, reported under the
+                    // TypeScript's own class and reason.
+                    return Err(ValidationFailure::topology(
+                        reason::INVALID_CONNECTION,
+                        format!("{index}) duplicate synapse {from_label} -> {to_label}"),
+                    )
+                    .at_synapse(synapse_index));
+                }
+                // Rule 26's second leg: a second role from one source only
+                // means anything where the roles are read separately, which is
+                // an `IF` neuron and nothing else. Its own reason, so a caller
+                // can tell it from the repeat above.
+                if !is_if_squash(views[to_index as usize].squash) {
+                    return Err(ValidationFailure::validation(
+                        reason::DUPLICATE_SYNAPSE,
+                        format!(
+                            "{index}) synapse {from_label} -> {to_label} repeats a source into a non-'IF' neuron"
+                        ),
+                    )
+                    .at_synapse(synapse_index));
+                }
             }
         }
 
@@ -1431,9 +1497,20 @@ fn synapse_walk(
 
         last_from = from;
         last_to = to;
+        // Only read when the next synapse repeats this pair, so it is simply
+        // the previous role rather than something reset per `from` or `to`.
+        last_type = role;
     }
 
     Ok(())
+}
+
+/// The wire name of a synapse role, as a sort-order message spells it.
+///
+/// [`crate::creature::synapse_type_name_from`] omits the untyped role, which is
+/// what the JSON does; a message has to name it, so it is spelled `standard`.
+fn role_label(role: SynapseType) -> &'static str {
+    synapse_type_name_from(role).unwrap_or("standard")
 }
 
 /// Rules 29–30: the extra leg a forward-only creature runs, delegating to
@@ -1451,7 +1528,12 @@ fn forward_only_rules(
     input: usize,
     output: usize,
 ) -> Result<(), ValidationFailure> {
-    let topology = validate_topology(from_indices, to_indices);
+    let synapse_types: Vec<u8> = synapse_types.iter().map(|kind| *kind as u8).collect();
+
+    // Typed, because a creature keys its synapses by `(from, to, type)`
+    // (Issue #577): the untyped gate would report the second role into an `IF`
+    // neuron as a duplicate connection.
+    let topology = validate_topology_typed(from_indices, to_indices, &synapse_types);
     if topology[0] != VALID {
         return Err(ValidationFailure::topology(
             reason::INVALID_CONNECTION,
@@ -1483,7 +1565,6 @@ fn forward_only_rules(
                 .map_or(u8::MAX, |squash| squash as u8)
         })
         .collect();
-    let synapse_types: Vec<u8> = synapse_types.iter().map(|kind| *kind as u8).collect();
 
     let structural = validate_structural_integrity(
         from_indices,
@@ -1976,7 +2057,14 @@ fn synapse_half(
     memetic: Option<&MemeticView<'_>>,
     stats: &mut ValidationStats,
 ) -> Result<(), ValidationFailure> {
-    synapse_walk(views, from_indices, to_indices, options, stats)?;
+    synapse_walk(
+        views,
+        from_indices,
+        to_indices,
+        synapse_types,
+        options,
+        stats,
+    )?;
 
     if let Some(expected) = options.expected_connections()
         && from_indices.len() != expected
@@ -3029,7 +3117,7 @@ mod synapse_half_tests {
     /// topology check above rather than slipping through unreported.
     #[test]
     fn a_cycle_never_reaches_the_cycle_check_unreported() {
-        assert_eq!(validate_topology(&[0, 1], &[1, 2])[0], VALID);
+        assert_eq!(validate_topology_typed(&[0, 1], &[1, 2], &[0, 0])[0], VALID);
         assert_eq!(
             detect_cycles(&[0, 1], &[1, 2], 3, 1),
             0,
@@ -3057,6 +3145,7 @@ mod synapse_half_tests {
             &views(),
             &[0, 1, 1],
             &[1, 2, 2],
+            &[SynapseType::Standard; 3],
             &ValidateOptions::default(),
             &mut stats,
         )

--- a/neat-core/src/decision_tree.rs
+++ b/neat-core/src/decision_tree.rs
@@ -191,7 +191,7 @@ fn edge(from: &str, to: &str, weight: f64, role: SynapseType) -> SynapseExport {
     }
 }
 
-/// Leave a fixture's synapse list in the canonical `(from, to)` order
+/// Leave a fixture's synapse list in the canonical `(from, to, type)` order
 /// [`crate::creature_validate()`] rule 25 requires.
 ///
 /// Each fixture is declared node by node so it reads as the tree it describes;

--- a/neat-core/src/if_graft.rs
+++ b/neat-core/src/if_graft.rs
@@ -19,7 +19,8 @@
 //! What comes back is a creature the shared validator accepts, not merely one
 //! that compiles: the constants a graft introduces are listed ahead of every
 //! hidden neuron and the whole synapse list is left in canonical
-//! `(from, to)` order, which are [`crate::creature_validate()`] rules 11 and 25.
+//! `(from, to, type)` order, which are [`crate::creature_validate()`] rules 11
+//! and 25.
 //!
 //! ```mermaid
 //! flowchart LR
@@ -28,7 +29,7 @@
 //!     B -- yes --> C{"placement:<br/>after every source,<br/>before every target"}
 //!     C -- impossible --> E
 //!     C -- ok --> D["build creature"]
-//!     D --> F{"validate_topology +<br/>validate_structural_integrity"}
+//!     D --> F{"validate_topology_typed +<br/>validate_structural_integrity +<br/>validate_no_duplicate_synapses"}
 //!     F -- fails --> E
 //!     F -- passes --> G["Ok(CreatureExport)"]
 //! ```
@@ -36,12 +37,20 @@
 //! ## Why a grafted node brings its own constant neurons
 //!
 //! An `IF` condition of the form `x > threshold` needs a constant `1.0` source
-//! to carry `-threshold`, and each leaf value needs one too. A creature may not
-//! hold two synapses between the same ordered pair of neurons, so the three
-//! roles cannot share one constant: [`IfCorrectionSpec`] therefore introduces
-//! three (`<uuid>-condition-one`, `<uuid>-positive-one`, `<uuid>-negative-one`),
-//! each with bias [`GRAFT_CONSTANT_BIAS`], leaving the thresholds and leaf
-//! values in the trainable **weights**.
+//! to carry `-threshold`, and each leaf value needs one too.
+//! [`IfCorrectionSpec`] gives each role its own constant
+//! (`<uuid>-condition-one`, `<uuid>-positive-one`, `<uuid>-negative-one`), each
+//! with bias [`GRAFT_CONSTANT_BIAS`], leaving the thresholds and leaf values in
+//! the trainable **weights**.
+//!
+//! ## One source, two roles (Issue #577)
+//!
+//! A creature keys its synapses by `(from, to, type)`, and an `IF` neuron keeps
+//! a sum per role, so **one source may feed two branches of an `IF` target**
+//! directly. What is still refused is a repeat that says nothing new: the same
+//! source in the same role ([`GraftError::DuplicateEdge`]), and two roles into
+//! a destination that sums every inward synapse regardless of role
+//! ([`GraftError::TypedDuplicateEdge`]).
 //!
 //! ## Whole trees, and corrections that enter both branches
 //!
@@ -53,23 +62,24 @@
 //!   may leave its outward edge to a later node in the same batch, and only the
 //!   assembled creature is validated. It is still all or nothing — the first
 //!   rejection returns a [`GraftError`] and no partial creature escapes.
-//! * a correction entering **both branches of an `IF` destination**. An untyped
-//!   edge into an `IF` neuron feeds one branch, so the node takes the other with
-//!   a typed outward edge ([`IfNodeSpec::with_target_role`]); the second, equal
-//!   edge comes through an IDENTITY [`RelaySpec`] ([`graft_relay_node`]),
-//!   because a creature may not carry two synapses between the same ordered
-//!   pair of neurons.
+//! * a correction entering **both branches of an `IF` destination**. The node
+//!   lists that destination twice, once per role
+//!   ([`IfNodeSpec::with_target_role`]), and both edges leave the node itself —
+//!   the IDENTITY [`RelaySpec`] ([`graft_relay_node`]) that used to supply the
+//!   second distinct source is no longer needed for it, and remains only for a
+//!   caller that genuinely wants a relay neuron.
 
 use std::collections::{HashMap, HashSet};
 
 use crate::creature::{
-    CreatureError, CreatureExport, NeuronExport, SynapseExport, parse_squash_name,
+    CreatureError, CreatureExport, NeuronExport, SynapseExport, is_if_squash, parse_squash_name,
     parse_synapse_type, squash_name_from, synapse_type_name_from, validate_creature_width,
+    validate_no_duplicate_synapses,
 };
 use crate::squash::SquashType;
 use crate::synapse_type::SynapseType;
 use crate::topology_ops::{
-    STRUCTURAL_VALID, VALID, validate_structural_integrity, validate_topology,
+    STRUCTURAL_VALID, VALID, validate_structural_integrity, validate_topology_typed,
 };
 
 /// Bias of every constant neuron a graft introduces.
@@ -236,11 +246,11 @@ impl IfNodeSpec {
 /// Description of an **IDENTITY relay** to graft onto a creature: a hidden
 /// neuron that passes its inbound sum on unchanged.
 ///
-/// A creature may not carry two synapses between the same ordered pair of
-/// neurons, so a node whose value must reach *two* branches of one `IF`
-/// destination needs a second source. The relay is that source: the node feeds
-/// one branch directly and the relay carries the same value into the other
-/// (NEAT-AI-Forests #48).
+/// Reaching two branches of one `IF` destination no longer needs one: a node
+/// may carry a typed outward edge per role into the same target (Issue #577).
+/// The relay remains for a caller that wants the neuron for its own sake — a
+/// shared sum several targets read, say — rather than as a way around the
+/// duplicate rule (NEAT-AI-Forests #48).
 #[derive(Debug, Clone, PartialEq)]
 pub struct RelaySpec {
     /// UUID for the new relay; must not already exist in the creature.
@@ -389,11 +399,24 @@ pub enum GraftError {
         /// The target that forced the earliest possible position.
         target: String,
     },
-    /// Two synapses would connect the same ordered pair of neurons.
+    /// Two synapses would connect the same ordered pair of neurons **in the
+    /// same role** — one synapse with the summed weight says the same thing.
     DuplicateEdge {
         /// Source neuron UUID.
         from: String,
         /// Destination neuron UUID.
+        to: String,
+    },
+    /// Two synapses would connect the same ordered pair in **different roles**,
+    /// and the destination is not an `IF` neuron (Issue #577).
+    ///
+    /// Only an `IF` neuron keeps a sum per role; every other squash sums its
+    /// inward synapses regardless of role, so the second edge would be
+    /// redundancy the destination cannot read.
+    TypedDuplicateEdge {
+        /// Source neuron UUID.
+        from: String,
+        /// Destination neuron UUID — the non-`IF` end.
         to: String,
     },
     /// A weight was `NaN` or infinite.
@@ -418,7 +441,7 @@ pub enum GraftError {
         /// The target that forced the earliest possible position.
         target: String,
     },
-    /// The creature failed [`validate_topology`]; `code` is one of the
+    /// The creature failed [`validate_topology_typed`]; `code` is one of the
     /// `topology_ops` topology codes.
     ///
     /// The creature synapse list carries no ordering contract (compilation
@@ -478,6 +501,10 @@ impl std::fmt::Display for GraftError {
             GraftError::DuplicateEdge { from, to } => {
                 write!(f, "Duplicate synapse from {from} to {to}")
             }
+            GraftError::TypedDuplicateEdge { from, to } => write!(
+                f,
+                "Synapses from {from} to {to} carry different roles, but {to} is not an 'IF' neuron"
+            ),
             GraftError::NonFiniteWeight { from, to, weight } => {
                 write!(f, "Non-finite weight {weight} from {from} to {to}")
             }
@@ -545,9 +572,13 @@ fn index_map(creature: &CreatureExport) -> HashMap<String, usize> {
 
 /// Run the fleet's shared width, topology and structural gates over a creature.
 ///
-/// Reuses [`validate_creature_width`], [`validate_topology`] and
-/// [`validate_structural_integrity`] rather than restating their rules, so a
-/// creature that passes here is one the compiler and the WASM consumers accept.
+/// Reuses [`validate_creature_width`], [`validate_topology_typed`],
+/// [`validate_structural_integrity`] and [`validate_no_duplicate_synapses`]
+/// rather than restating their rules, so a creature that passes here is one the
+/// compiler and the WASM consumers accept. The last of those is the order
+/// independent leg: it is what knows a repeated pair is only meaningful into an
+/// `IF` target (Issue #577), which the index gates are not told the squashes to
+/// answer.
 ///
 /// The ordering gate only runs for `forwardOnly` creatures: a recurrent creature
 /// legitimately carries backward edges, which that gate rejects by design.
@@ -589,7 +620,10 @@ pub fn validate_creature_topology(creature: &CreatureExport) -> Result<(), Graft
     let synapse_types: Vec<u8> = edges.iter().map(|e| e.2).collect();
 
     if creature.forward_only {
-        let codes = validate_topology(&from_indices, &to_indices);
+        // Typed, because a creature keys its synapses by `(from, to, type)`
+        // (Issue #577) and the untyped gate would call the second role into an
+        // `IF` neuron a duplicate connection.
+        let codes = validate_topology_typed(&from_indices, &to_indices, &synapse_types);
         if codes[0] != VALID {
             return Err(GraftError::MalformedTopology {
                 code: codes[0],
@@ -614,6 +648,13 @@ pub fn validate_creature_topology(creature: &CreatureExport) -> Result<(), Graft
             index: codes[1],
         });
     }
+
+    // The index gates read a sorted edge list; the UUID rule is order
+    // independent and is the one that knows what a *target* may mean, so it is
+    // what rejects a pair repeated into a neuron that reads no roles
+    // (Issue #577). Reused rather than restated — it is the single home of the
+    // rule.
+    validate_no_duplicate_synapses(creature)?;
 
     Ok(())
 }
@@ -733,10 +774,15 @@ fn place_and_build(
     }
 
     // Earliest position that still leaves every source before the new node.
+    // A source may be listed under more than one branch of an `IF` node — the
+    // node reads each role separately, so the second edge is not redundancy
+    // (Issue #577) — but never twice under the same branch.
+    let node_reads_roles = plan.squash == SquashType::If;
     let mut earliest = 0usize;
     let mut latest_source: Option<&str> = None;
-    let mut seen_sources: HashSet<&str> = HashSet::new();
-    for (edge, _) in &plan.inbound {
+    let mut seen_sources: HashSet<(&str, SynapseType)> = HashSet::new();
+    let mut source_uuids: HashSet<&str> = HashSet::new();
+    for (edge, role) in &plan.inbound {
         if edge.role != SynapseType::Standard {
             return Err(GraftError::InboundEdgeHasRole {
                 from: edge.uuid.clone(),
@@ -753,8 +799,14 @@ fn place_and_build(
                 weight: edge.weight,
             });
         }
-        if !seen_sources.insert(edge.uuid.as_str()) {
+        if !seen_sources.insert((edge.uuid.as_str(), *role)) {
             return Err(GraftError::DuplicateEdge {
+                from: edge.uuid.clone(),
+                to: plan.uuid.to_string(),
+            });
+        }
+        if !source_uuids.insert(edge.uuid.as_str()) && !node_reads_roles {
+            return Err(GraftError::TypedDuplicateEdge {
                 from: edge.uuid.clone(),
                 to: plan.uuid.to_string(),
             });
@@ -775,7 +827,8 @@ fn place_and_build(
     // Latest position that still leaves every target after the new node.
     let mut latest = creature.neurons.len();
     let mut earliest_target: Option<&str> = None;
-    let mut seen_targets: HashSet<&str> = HashSet::new();
+    let mut seen_targets: HashSet<(&str, SynapseType)> = HashSet::new();
+    let mut target_uuids: HashSet<&str> = HashSet::new();
     for edge in plan.targets {
         if edge.uuid == plan.uuid {
             return Err(GraftError::SelfEdge(plan.uuid.to_string()));
@@ -787,7 +840,7 @@ fn place_and_build(
                 weight: edge.weight,
             });
         }
-        if !seen_targets.insert(edge.uuid.as_str()) {
+        if !seen_targets.insert((edge.uuid.as_str(), edge.role)) {
             return Err(GraftError::DuplicateEdge {
                 from: plan.uuid.to_string(),
                 to: edge.uuid.clone(),
@@ -805,6 +858,19 @@ fn place_and_build(
         let position = index - creature.input;
         if creature.neurons[position].neuron_type == "constant" {
             return Err(GraftError::TargetIsConstant(edge.uuid.clone()));
+        }
+        // The node's value may enter two branches of one `IF` destination
+        // directly (Issue #577) — the IDENTITY relay that used to supply the
+        // second distinct source is no longer needed for that. Any other
+        // destination sums both edges into one number, so a second edge there
+        // is redundancy it cannot read.
+        if !target_uuids.insert(edge.uuid.as_str())
+            && !is_if_squash(creature.neurons[position].squash.as_deref())
+        {
+            return Err(GraftError::TypedDuplicateEdge {
+                from: plan.uuid.to_string(),
+                to: edge.uuid.clone(),
+            });
         }
         if position < latest {
             latest = position;
@@ -866,7 +932,7 @@ fn validated(grafted: CreatureExport) -> Result<CreatureExport, GraftError> {
 /// so the node is evaluated after every source and before every target, which
 /// preserves the `forwardOnly` reading order the compiled forward pass relies
 /// on; any constants the spec declares are listed ahead of every hidden neuron,
-/// and the synapse list comes back in canonical `(from, to)` order, so the
+/// and the synapse list comes back in canonical `(from, to, type)` order, so the
 /// result satisfies [`crate::creature_validate()`] as well. The creature is put
 /// through [`validate_creature_topology`] before it is returned, so a malformed
 /// creature is never emitted.
@@ -888,10 +954,10 @@ pub fn graft_if_node(
 
 /// Graft an IDENTITY relay — a hidden neuron that passes its inbound sum on.
 ///
-/// The way to reach a second branch of a destination the source already feeds:
-/// a creature may not carry two synapses between the same ordered pair, so the
-/// relay supplies the second, distinct source (NEAT-AI-Forests #48). Same
-/// placement, ordering and validation contract as [`graft_if_node`].
+/// A relay is no longer how a source reaches a second branch of an `IF`
+/// destination — a typed outward edge per role does that directly (Issue #577)
+/// — so this is for a caller that wants the relayed sum itself. Same placement,
+/// ordering and validation contract as [`graft_if_node`].
 ///
 /// # Errors
 ///
@@ -951,7 +1017,7 @@ pub fn graft_if_nodes(
 
 /// Assemble the grafted creature: the constants ahead of every hidden neuron,
 /// the node at `position`, and the whole synapse list left in canonical
-/// `(from, to)` order.
+/// `(from, to, type)` order.
 ///
 /// Both placements are what [`crate::creature_validate()`] requires of a valid
 /// creature — neurons listed `input, constant, hidden, output` (rule 11) and
@@ -1025,21 +1091,29 @@ fn build_grafted(
 }
 
 /// Leave a creature's synapse list in canonical wire order — ascending by
-/// `(from index, to index)`, the order [`crate::creature_validate()`] rule 25
-/// requires.
+/// `(from index, to index, type)`, the order [`crate::creature_validate()`]
+/// rule 25 requires.
+///
+/// The role is part of the key (Issue #577), so one source feeding two branches
+/// of an `IF` neuron still lands in a total order rather than in whichever
+/// order the graft happened to append the two edges.
 ///
 /// Appending a graft's synapses to the base creature's list leaves them out of
 /// order, so the assembled creature is re-sorted rather than emitted piecemeal.
 /// An endpoint naming no neuron sorts last (`u32::MAX`) instead of being
 /// dropped, so the validator still reports it rather than the graft quietly
-/// reordering a broken creature. The sort is stable, so synapses sharing a pair
-/// keep their relative order and remain reportable as duplicates.
+/// reordering a broken creature. The sort is stable, so synapses sharing a
+/// triple keep their relative order and remain reportable as duplicates.
 pub(crate) fn sort_synapses_canonically(creature: &mut CreatureExport) {
     let map = index_map(creature);
     let resolve = |uuid: &str| -> usize { map.get(uuid).copied().unwrap_or(usize::MAX) };
-    creature
-        .synapses
-        .sort_by_key(|s| (resolve(&s.from_uuid), resolve(&s.to_uuid)));
+    creature.synapses.sort_by_key(|s| {
+        (
+            resolve(&s.from_uuid),
+            resolve(&s.to_uuid),
+            parse_synapse_type(s.synapse_type.as_deref()) as u8,
+        )
+    });
 }
 
 /// Graft a sequence of `IF` nodes, each able to reference the ones before it.

--- a/neat-core/src/lib.rs
+++ b/neat-core/src/lib.rs
@@ -135,12 +135,13 @@ pub use topological_backprop::{
 pub use topology_export::{NodeKind, squash_name, synapse_type_name, to_dot, to_topology_json};
 pub use topology_ops::{
     BACKWARD_CONNECTION, DUPLICATE_CONNECTION, SELF_CONNECTION, SORT_ERROR_FROM, SORT_ERROR_TO,
-    STRUCTURAL_BIAS_NOT_FINITE, STRUCTURAL_CONSTANT_HAS_INWARD, STRUCTURAL_HIDDEN_NO_INWARD,
-    STRUCTURAL_HIDDEN_NO_OUTWARD, STRUCTURAL_IF_MISSING_CONDITION, STRUCTURAL_IF_MISSING_NEGATIVE,
-    STRUCTURAL_IF_MISSING_POSITIVE, STRUCTURAL_IF_TOO_FEW_INWARD, STRUCTURAL_SYNAPSE_TARGETS_INPUT,
-    STRUCTURAL_VALID, VALID, compute_reverse_topological_order, detect_cycles,
-    scan_available_connections, structural_error_message, topology_error_message,
+    SORT_ERROR_TYPE, STRUCTURAL_BIAS_NOT_FINITE, STRUCTURAL_CONSTANT_HAS_INWARD,
+    STRUCTURAL_HIDDEN_NO_INWARD, STRUCTURAL_HIDDEN_NO_OUTWARD, STRUCTURAL_IF_MISSING_CONDITION,
+    STRUCTURAL_IF_MISSING_NEGATIVE, STRUCTURAL_IF_MISSING_POSITIVE, STRUCTURAL_IF_TOO_FEW_INWARD,
+    STRUCTURAL_SYNAPSE_TARGETS_INPUT, STRUCTURAL_VALID, VALID, compute_reverse_topological_order,
+    detect_cycles, scan_available_connections, structural_error_message, topology_error_message,
     validate_structural_integrity, validate_topology, validate_topology_batch,
+    validate_topology_typed,
 };
 pub use training_state::{
     accumulate_bias_persistent_4way, accumulate_bias_persistent_8way,

--- a/neat-core/src/synapse_type.rs
+++ b/neat-core/src/synapse_type.rs
@@ -5,8 +5,12 @@
 
 /// Synapse type identifiers for aggregate functions (Issue #1125)
 /// These are used by IF squash function to categorise inputs
+///
+/// The role is part of a synapse's identity: a creature keys its synapses by
+/// `(from, to, type)` and sorts them the same way (Issue #577), so the enum is
+/// hashable and totally ordered by its discriminant.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SynapseType {
     /// Standard synapse (no special type) - also used as "positive" for IF
     Standard = 0,

--- a/neat-core/src/topology_ops.rs
+++ b/neat-core/src/topology_ops.rs
@@ -41,7 +41,7 @@ pub const BACKWARD_CONNECTION: i32 = 2;
 pub const SORT_ERROR_FROM: i32 = 3;
 /// `to` indices not strictly increasing within the same `from`.
 pub const SORT_ERROR_TO: i32 = 4;
-/// Duplicate `(from, to)` connection.
+/// Duplicate `(from, to, type)` connection.
 pub const DUPLICATE_CONNECTION: i32 = 5;
 /// Input buffers are malformed — length mismatch, index out of range
 /// relative to `num_neurons`, or `num_neurons` itself implausibly large.
@@ -49,6 +49,11 @@ pub const DUPLICATE_CONNECTION: i32 = 5;
 /// a defined error code rather than a WASM `memory access out of bounds`
 /// trap when an evolved creature emits a pathological edge list.
 pub const MALFORMED_BUFFER: i32 = 6;
+/// Synapse roles not ascending within the same `(from, to)` pair — Issue #577.
+///
+/// Only [`validate_topology_typed`] can report it: the untyped
+/// [`validate_topology`] never sees a role.
+pub const SORT_ERROR_TYPE: i32 = 7;
 
 // ===========================================================================
 // Structural integrity error codes.
@@ -95,6 +100,7 @@ pub fn topology_error_message(error_code: i32) -> String {
         SORT_ERROR_TO => "To indices not sorted".to_string(),
         DUPLICATE_CONNECTION => "Duplicate connection".to_string(),
         MALFORMED_BUFFER => "Malformed input buffers".to_string(),
+        SORT_ERROR_TYPE => "Synapse types not sorted".to_string(),
         other => format!("unrecognised topology error code {other}"),
     }
 }
@@ -141,6 +147,11 @@ const SYN_POSITIVE: u8 = SynapseType::Positive as u8;
 /// within the same `from`), contain no self-connections, and contain no
 /// backward connections (`from > to`).
 ///
+/// Every synapse is read as carrying the **same** role, so a repeated
+/// `(from, to)` pair is a [`DUPLICATE_CONNECTION`] whatever the roles say.
+/// A caller holding the roles wants [`validate_topology_typed`], which keys
+/// the pair by role as a creature does (Issue #577).
+///
 /// # Arguments
 /// * `from_indices` - source neuron index per synapse
 /// * `to_indices` - destination neuron index per synapse
@@ -149,6 +160,51 @@ const SYN_POSITIVE: u8 = SynapseType::Positive as u8;
 /// A two-element vector `[error_code, synapse_index]`.
 #[cfg_attr(target_family = "wasm", wasm_bindgen)]
 pub fn validate_topology(from_indices: &[u32], to_indices: &[u32]) -> Vec<i32> {
+    topology_scan(from_indices, to_indices, None)
+}
+
+/// [`validate_topology`] with the synapse roles, which complete the sort key.
+///
+/// A creature keys its synapses by `(from, to, type)` (Issue #577), so an
+/// ordered pair may appear once **per role** — how one source feeds both
+/// branches of an `IF` neuron without an IDENTITY relay in between. Within a
+/// repeated pair the roles must still ascend ([`SORT_ERROR_TYPE`]), and an
+/// exact repeat of the triple is still a [`DUPLICATE_CONNECTION`].
+///
+/// Whether the *target* may read more than one role is a question about its
+/// squash, which this gate is not given: `creature_validate` rule 26 and
+/// [`crate::creature::validate_no_duplicate_synapses`] are where a repeated
+/// pair into a non-`IF` neuron is rejected.
+///
+/// # Arguments
+/// * `from_indices` - source neuron index per synapse
+/// * `to_indices` - destination neuron index per synapse
+/// * `synapse_types` - [`SynapseType`] code per synapse, same length as both
+///
+/// # Returns
+/// A two-element vector `[error_code, synapse_index]`; a `synapse_types`
+/// length that does not match reports [`MALFORMED_BUFFER`].
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
+pub fn validate_topology_typed(
+    from_indices: &[u32],
+    to_indices: &[u32],
+    synapse_types: &[u8],
+) -> Vec<i32> {
+    if synapse_types.len() != from_indices.len() {
+        return vec![MALFORMED_BUFFER, 0];
+    }
+    topology_scan(from_indices, to_indices, Some(synapse_types))
+}
+
+/// The one ordering walk both gates run — with roles when the caller has them.
+///
+/// `None` reads every synapse as the same role, which is exactly the untyped
+/// `(from, to)` rule [`validate_topology`] has always applied.
+fn topology_scan(
+    from_indices: &[u32],
+    to_indices: &[u32],
+    synapse_types: Option<&[u8]>,
+) -> Vec<i32> {
     let len = from_indices.len();
     if len != to_indices.len() {
         // Issue NEAT-AI #2659 — length mismatch now reports a dedicated
@@ -158,12 +214,16 @@ pub fn validate_topology(from_indices: &[u32], to_indices: &[u32]) -> Vec<i32> {
         return vec![MALFORMED_BUFFER, 0];
     }
 
+    let role_at = |i: usize| synapse_types.map_or(0u8, |types| types[i]);
+
     let mut last_from: i64 = -1;
     let mut last_to: i64 = -1;
+    let mut last_type: u8 = 0;
 
     for i in 0..len {
         let from = from_indices[i] as i64;
         let to = to_indices[i] as i64;
+        let role = role_at(i);
 
         if from == to {
             return vec![SELF_CONNECTION, i as i32];
@@ -183,12 +243,20 @@ pub fn validate_topology(from_indices: &[u32], to_indices: &[u32]) -> Vec<i32> {
             if to < last_to {
                 return vec![SORT_ERROR_TO, i as i32];
             } else if to == last_to {
-                return vec![DUPLICATE_CONNECTION, i as i32];
+                if role < last_type {
+                    return vec![SORT_ERROR_TYPE, i as i32];
+                }
+                if role == last_type {
+                    return vec![DUPLICATE_CONNECTION, i as i32];
+                }
             }
         }
 
         last_from = from;
         last_to = to;
+        // Read only when the next synapse repeats this pair, so it is simply
+        // the previous role.
+        last_type = role;
     }
 
     vec![VALID, 0]
@@ -925,6 +993,66 @@ mod tests {
         let to: [u32; 0] = [];
         let result = validate_topology(&from, &to);
         assert_eq!(result[0], VALID);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #577 — the role completes the sort key.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn typed_gate_accepts_one_pair_once_per_role() {
+        let from = [0u32, 0, 0];
+        let to = [2u32, 2, 2];
+        let types = [SYN_CONDITION, SYN_NEGATIVE, SYN_POSITIVE];
+        let result = validate_topology_typed(&from, &to, &types);
+        assert_eq!(result[0], VALID, "one synapse per role is not a duplicate");
+
+        // The untyped gate reads the same list as a repeated pair, which is
+        // exactly why the forward-only leg has to pass the roles.
+        assert_eq!(validate_topology(&from, &to)[0], DUPLICATE_CONNECTION);
+    }
+
+    #[test]
+    fn typed_gate_still_rejects_a_repeated_role() {
+        let from = [0u32, 0];
+        let to = [2u32, 2];
+        let types = [SYN_POSITIVE, SYN_POSITIVE];
+        let result = validate_topology_typed(&from, &to, &types);
+        assert_eq!(result[0], DUPLICATE_CONNECTION);
+        assert_eq!(result[1], 1);
+    }
+
+    #[test]
+    fn typed_gate_rejects_roles_out_of_order_within_a_pair() {
+        let from = [0u32, 0];
+        let to = [2u32, 2];
+        let types = [SYN_POSITIVE, SYN_CONDITION];
+        let result = validate_topology_typed(&from, &to, &types);
+        assert_eq!(result[0], SORT_ERROR_TYPE);
+        assert_eq!(result[1], 1);
+        assert_eq!(
+            topology_error_message(SORT_ERROR_TYPE),
+            "Synapse types not sorted"
+        );
+    }
+
+    #[test]
+    fn typed_gate_resets_the_role_when_the_pair_advances() {
+        // `0->2 positive` then `0->3 condition`: a new pair starts its role
+        // ordering afresh, so the descending code is not a sort failure.
+        let from = [0u32, 0];
+        let to = [2u32, 3];
+        let types = [SYN_POSITIVE, SYN_CONDITION];
+        assert_eq!(validate_topology_typed(&from, &to, &types)[0], VALID);
+    }
+
+    #[test]
+    fn typed_gate_reports_a_short_role_buffer_as_malformed() {
+        let from = [0u32, 0];
+        let to = [2u32, 3];
+        let types = [SYN_STANDARD];
+        let result = validate_topology_typed(&from, &to, &types);
+        assert_eq!(result[0], MALFORMED_BUFFER);
     }
 
     #[test]

--- a/neat-core/tests/creature_duplicate_synapses.rs
+++ b/neat-core/tests/creature_duplicate_synapses.rs
@@ -1,15 +1,23 @@
-//! Duplicate `(fromUUID, toUUID)` synapse rejection (Issue #556).
+//! Duplicate synapse rejection, keyed by `(fromUUID, toUUID, type)`
+//! (Issues #556, #577).
 //!
-//! NEAT-AI's TypeScript loader keys synapses by the `(from, to)` pair, so a
-//! creature carrying the same pair twice loses every copy but one before it is
-//! ever scored. `compile_creature` used to accept all copies and **sum** them,
-//! so the same JSON scored differently under the two engines — observed in
+//! NEAT-AI's TypeScript loader keys synapses by that triple, so a creature
+//! carrying the same triple twice loses every copy but one before it is ever
+//! scored. `compile_creature` used to accept all copies and **sum** them, so
+//! the same JSON scored differently under the two engines — observed in
 //! production as `rust_scorer` 0.356183 against `Creature.scoreDir` 0.353147.
 //!
 //! Which copy TypeScript keeps is an artefact of its map insertion order, so
 //! there is no safe value for Rust to reproduce. The contract is therefore to
-//! **fail closed**: a repeated pair is a typed
+//! **fail closed**: a repeated triple is a typed
 //! [`CreatureError::DuplicateSynapse`], never a silent divergence.
+//!
+//! The **role** is part of the key only where it changes the answer: an `IF`
+//! neuron keeps a separate sum per role, so one source may feed two of its
+//! branches. Every other squash sums its inward synapses regardless of role, so
+//! two synapses from one source are exactly one with the summed weight —
+//! meaningless redundancy, rejected as
+//! [`CreatureError::TypedDuplicateSynapse`] (Issue #577).
 
 use std::error::Error;
 
@@ -37,12 +45,14 @@ fn neuron(neuron_type: &str, uuid: &str, bias: f64, squash: &str) -> NeuronExpor
     }
 }
 
-/// The issue's minimal repro: one constant neuron feeding an `IF` neuron three
-/// times — condition, positive and negative — so all three synapses share the
-/// pair `("c", "if-0")`.
+/// One constant neuron feeding an `IF` neuron three times — condition,
+/// positive and negative — so all three synapses share the pair
+/// `("c", "if-0")` and differ only in their role.
 ///
-/// Rust summed all three branches; TypeScript kept one. Neither number is
-/// trustworthy, so the creature must not compile.
+/// Issue #556 rejected this shape because the key was the pair alone; under
+/// `(from, to, type)` keying (Issue #577) it is the canonical way to build an
+/// `IF` node without a constant per branch, so it compiles and each role lands
+/// in its own sum.
 fn if_triple_from_one_constant() -> CreatureExport {
     CreatureExport {
         memetic: None,
@@ -64,19 +74,62 @@ fn if_triple_from_one_constant() -> CreatureExport {
     }
 }
 
+/// The same creature with its `condition` edge written twice: an exact repeat
+/// of `("c", "if-0", condition)`, which no keying makes meaningful.
+fn repeated_condition_role() -> CreatureExport {
+    let mut creature = if_triple_from_one_constant();
+    creature
+        .synapses
+        .insert(1, synapse("c", "if-0", 4.0, Some("condition")));
+    creature
+}
+
 // ---------------------------------------------------------------------------
 // Rejection
 // ---------------------------------------------------------------------------
 
 #[test]
-fn compile_rejects_an_if_neuron_fed_three_times_by_one_constant() {
-    match compile_creature(&if_triple_from_one_constant()) {
+fn compile_rejects_a_repeated_role_from_one_source() {
+    match compile_creature(&repeated_condition_role()) {
         Err(CreatureError::DuplicateSynapse { from_uuid, to_uuid }) => {
             assert_eq!(from_uuid, "c");
             assert_eq!(to_uuid, "if-0");
         }
         Err(other) => panic!("expected DuplicateSynapse, got {other:?}"),
-        Ok(_) => panic!("a repeated (from, to) pair must not compile"),
+        Ok(_) => panic!("a repeated (from, to, type) triple must not compile"),
+    }
+}
+
+/// The other half of the Issue #577 rule: two roles from one source are only
+/// meaningful into an `IF` target. An IDENTITY neuron sums every inward synapse
+/// regardless of role, so the pair is redundancy with no meaning — and carries
+/// a **distinct** error, so a caller can tell "you repeated yourself" from
+/// "that target cannot mean what you wrote".
+#[test]
+fn compile_rejects_two_roles_from_one_source_into_a_non_if_target() {
+    let creature = CreatureExport {
+        memetic: None,
+        input: 1,
+        output: 1,
+        neurons: vec![
+            neuron("hidden", "h", 0.0, "IDENTITY"),
+            neuron("output", "output-0", 0.0, "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "h", 1.0, Some("positive")),
+            synapse("input-0", "h", 2.0, Some("negative")),
+            synapse("h", "output-0", 1.0, None),
+        ],
+        semantic_version: None,
+        forward_only: true,
+    };
+    match compile_creature(&creature) {
+        Err(CreatureError::TypedDuplicateSynapse { from_uuid, to_uuid }) => {
+            assert_eq!(from_uuid, "input-0");
+            assert_eq!(to_uuid, "h");
+        }
+        Err(other) => panic!("expected TypedDuplicateSynapse, got {other:?}"),
+        Ok(_) => panic!("only an IF target may carry two roles from one source"),
     }
 }
 
@@ -108,9 +161,9 @@ fn compile_rejects_a_repeated_pair_with_identical_weight_and_type() {
 
 #[test]
 fn duplicate_error_display_names_both_endpoints() {
-    let err = compile_creature(&if_triple_from_one_constant())
+    let err = compile_creature(&repeated_condition_role())
         .err()
-        .expect("a repeated (from, to) pair must not compile");
+        .expect("a repeated (from, to, type) triple must not compile");
     let text = err.to_string();
     assert!(text.contains('c'), "message must name the source: {text}");
     assert!(
@@ -142,9 +195,10 @@ fn compile_reports_the_first_repeated_pair_in_declaration_order() {
     }
 }
 
-/// What repeats is the **pair**, not the role: two `positive` synapses from the
-/// same constant are still `("c", "if-0")` twice, and are rejected for exactly
-/// the reason a mixed-role repeat is.
+/// A repeat of one role is a repeat whatever the target is: two `positive`
+/// synapses from the same constant are `("c", "if-0", positive)` twice, and an
+/// `IF` neuron sums them into the one branch it would have summed a single
+/// synapse into.
 #[test]
 fn compile_rejects_a_repeated_pair_that_shares_one_role() {
     let mut creature = if_triple_from_one_constant();
@@ -166,6 +220,48 @@ fn compile_rejects_a_repeated_pair_that_shares_one_role() {
 // ---------------------------------------------------------------------------
 // Acceptance — the rule must not reject legitimate topologies
 // ---------------------------------------------------------------------------
+
+/// The Issue #577 payoff: one constant carries all three roles into an `IF`
+/// neuron, so the node needs neither three constants nor an IDENTITY relay to
+/// reach a second branch.
+#[test]
+fn compile_accepts_an_if_neuron_fed_three_times_by_one_constant() {
+    let creature = if_triple_from_one_constant();
+    assert!(
+        validate_no_duplicate_synapses(&creature).is_ok(),
+        "one source per role is one synapse per (from, to, type) key"
+    );
+    let mut network = compile_creature(&creature).expect("an IF target may repeat a source");
+
+    // `c` activates at its bias of 1.0, so condition = 1.0 * 1.0 > 0 and the
+    // positive branch is taken: 1.0 * 2.0 + bias 0.0 = 2.0, passed through
+    // `output-0` unchanged.
+    let output = network.activate(&[0.0], 1);
+    assert!(
+        (output[0] - 2.0).abs() < 1e-5,
+        "expected 2.0, got {}",
+        output[0]
+    );
+}
+
+/// The negative branch of the same creature, so the second role is proven to
+/// land in its own sum rather than being folded into the first.
+#[test]
+fn a_repeated_source_keeps_one_sum_per_role() {
+    let mut creature = if_triple_from_one_constant();
+    // Flip the condition weight so the condition sum is -1.0, not 1.0.
+    creature.synapses[0].weight = -1.0;
+    let mut network = compile_creature(&creature).expect("an IF target may repeat a source");
+
+    // condition = 1.0 * -1.0 <= 0, so the negative branch is taken:
+    // 1.0 * -3.0 + bias 0.0 = -3.0.
+    let output = network.activate(&[0.0], 1);
+    assert!(
+        (output[0] + 3.0).abs() < 1e-5,
+        "expected -3.0, got {}",
+        output[0]
+    );
+}
 
 #[test]
 fn compile_accepts_distinct_pairs_that_share_one_endpoint() {
@@ -234,9 +330,9 @@ fn compile_accepts_an_if_neuron_fed_by_three_distinct_constants() {
 }
 
 /// A **repeated role** into one neuron is legal as long as the sources differ:
-/// the rule keys on the ordered `(from, to)` pair alone and never reads the
-/// role. Two `positive` synapses into the same `IF` neuron therefore compile,
-/// and both contribute to the branch they name.
+/// the key is `(from, to, type)`, so distinct sources make distinct keys
+/// whatever the roles say. Two `positive` synapses into the same `IF` neuron
+/// therefore compile, and both contribute to the branch they name.
 #[test]
 fn compile_accepts_repeated_roles_into_one_neuron_when_the_sources_differ() {
     let creature = CreatureExport {
@@ -305,7 +401,7 @@ fn compile_accepts_a_creature_with_no_synapses_at_all() {
 fn validate_no_duplicate_synapses_answers_for_a_hand_built_creature() {
     // Consumers that build a `CreatureExport` in Rust — never touching
     // `parse_creature_json` — can apply the same rule at their own boundary.
-    let duplicated = if_triple_from_one_constant();
+    let duplicated = repeated_condition_role();
     match validate_no_duplicate_synapses(&duplicated) {
         Err(CreatureError::DuplicateSynapse { from_uuid, to_uuid }) => {
             assert_eq!(from_uuid, "c");

--- a/neat-core/tests/creature_validate_packed_conformance.rs
+++ b/neat-core/tests/creature_validate_packed_conformance.rs
@@ -202,3 +202,66 @@ fn the_corpus_reaches_both_answers_through_the_packed_shape() {
     assert!(healthy >= 5, "only {healthy} corpus creatures passed");
     assert!(broken >= 20, "only {broken} corpus creatures were rejected");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #577 — the role is part of the key in every request shape.
+// ---------------------------------------------------------------------------
+
+/// One constant feeding an `IF` neuron under all three roles, written in the
+/// runtime shape: three synapses sharing the pair `(1, 2)`.
+///
+/// The corpus predates the rule, so this is the case that proves the role
+/// buffer really is threaded through the packed layout and the runtime one —
+/// under `(from, to)` keying every shape would call the second synapse a
+/// duplicate.
+fn shared_source_if_case(target_squash: &str) -> Case {
+    Case {
+        name: format!("shared-source-if-{target_squash}"),
+        creature: json!({
+            "input": 1,
+            "output": 1,
+            "neurons": [
+                { "type": "input", "id": 0, "uuid": "input-0", "bias": 0.0 },
+                { "type": "constant", "id": 1, "uuid": "k", "bias": 1.0 },
+                { "type": "hidden", "id": 2, "uuid": "if-0", "bias": 0.0, "squash": target_squash },
+                { "type": "output", "id": -1, "uuid": "o", "bias": 0.0, "squash": "IDENTITY" }
+            ],
+            "synapses": [
+                { "from": 0, "to": 2, "weight": 1.0, "type": "condition" },
+                { "from": 1, "to": 2, "weight": 1.0, "type": "condition" },
+                { "from": 1, "to": 2, "weight": 2.0, "type": "negative" },
+                { "from": 1, "to": 2, "weight": 3.0, "type": "positive" },
+                { "from": 2, "to": 3, "weight": 1.0 }
+            ]
+        }),
+        options: None,
+    }
+}
+
+#[test]
+fn one_source_carries_every_role_into_an_if_target_through_both_shapes() {
+    let case = shared_source_if_case("IF");
+
+    let json = json_answer(&case);
+    assert!(json.ok, "the JSON shape rejected it: {:?}", json.failure);
+    let packed = packed_answer(&case);
+    assert!(packed.ok, "the packed shape disagreed with the JSON shape");
+    assert_eq!(
+        packed.stats, json.stats,
+        "the two shapes counted differently"
+    );
+}
+
+#[test]
+fn the_same_wiring_into_a_non_if_target_is_rejected_through_both_shapes() {
+    let case = shared_source_if_case("IDENTITY");
+
+    let json = json_answer(&case);
+    assert!(!json.ok, "a non-IF target reads no roles");
+    let failure = json.failure.expect("a rejected creature carries a failure");
+    assert_eq!(failure.reason, "DUPLICATE_SYNAPSE");
+
+    let packed = packed_answer(&case);
+    assert!(!packed.ok, "the packed shape disagreed with the JSON shape");
+    assert_eq!(packed.detail_required, Some(true));
+}

--- a/neat-core/tests/creature_validate_synapse_rules.rs
+++ b/neat-core/tests/creature_validate_synapse_rules.rs
@@ -323,6 +323,108 @@ fn repeating_one_pair_of_that_creature_is_still_a_duplicate() {
 }
 
 // ---------------------------------------------------------------------------
+// Rules 25 and 26 — the role completes the key, and only an `IF` target may
+// use it (Issue #577).
+// ---------------------------------------------------------------------------
+
+/// `k` (a constant) feeds `if-0` under all three roles, and `if-0` feeds the
+/// output: one source, three branches, no relay neuron and no constant per
+/// branch. Sorted by `(from, to, type)`, which is condition, negative,
+/// positive.
+fn shared_source_if_creature() -> CreatureExport {
+    let mut if_neuron = neuron("hidden", "if-0", 2);
+    if_neuron.squash = Some("IF".to_string());
+    CreatureExport {
+        input: 1,
+        output: 1,
+        neurons: vec![constant("k", 1), if_neuron, neuron("output", "o", -1)],
+        synapses: vec![
+            role_edge("k", "if-0", "condition"),
+            role_edge("k", "if-0", "negative"),
+            role_edge("k", "if-0", "positive"),
+            edge("if-0", "o"),
+        ],
+        semantic_version: None,
+        forward_only: true,
+        memetic: None,
+    }
+}
+
+#[test]
+fn one_source_may_carry_every_role_into_an_if_target() {
+    let creature = shared_source_if_creature();
+    let stats = run(&creature, &ValidateOptions::default());
+    assert_eq!(stats.connections, 4, "one tally per synapse walked");
+
+    // The whole entry point agrees, forward-only leg included: the index-level
+    // topology gate has to key the pair by role too, or it would call the
+    // second edge a duplicate connection.
+    let options = ValidateOptions {
+        forward_only: true,
+        ..ValidateOptions::default()
+    };
+    creature_validate(&creature, &options).expect("a forward-only creature is valid too");
+    assert!(
+        validate_no_duplicate_synapses(&creature).is_ok(),
+        "and so does the order-independent pair rule"
+    );
+}
+
+#[test]
+fn a_repeated_role_into_an_if_target_is_still_an_invalid_connection() {
+    let mut creature = shared_source_if_creature();
+    creature
+        .synapses
+        .insert(1, role_edge("k", "if-0", "condition"));
+
+    let failure = run_err(&creature, &ValidateOptions::default());
+
+    assert_eq!(failure.class, FailureClass::Topology);
+    assert_eq!(failure.reason, reason::INVALID_CONNECTION);
+    assert_eq!(failure.message, "1) duplicate synapse k -> if-0");
+    assert_eq!(failure.synapse_index, Some(1));
+}
+
+/// Rule 25's third leg: within a repeated pair the roles ascend, so the total
+/// order stays total.
+#[test]
+fn roles_out_of_order_within_one_pair_are_a_sort_failure() {
+    let mut creature = shared_source_if_creature();
+    creature.synapses.swap(0, 1);
+
+    let failure = run_err(&creature, &ValidateOptions::default());
+
+    assert_eq!(failure.class, FailureClass::Topology);
+    assert_eq!(failure.reason, reason::SORT_FAILURE);
+    assert_eq!(
+        failure.message,
+        "1) synapses not sorted 1->2 type: condition last type: negative"
+    );
+    assert_eq!(failure.synapse_index, Some(1));
+}
+
+/// The distinct code the issue asks for: "that target cannot mean what you
+/// wrote" is a `ValidationError` / `DUPLICATE_SYNAPSE`, not the
+/// `TopologyError` / `INVALID_CONNECTION` a plain repeat carries.
+#[test]
+fn two_roles_into_a_non_if_target_are_a_duplicate_synapse() {
+    let mut creature = shared_source_if_creature();
+    // The same wiring, but the target sums every inward synapse regardless of
+    // role, so the second edge says nothing the first does not.
+    creature.neurons[1].squash = Some("IDENTITY".to_string());
+
+    let failure = run_err(&creature, &ValidateOptions::default());
+
+    assert_eq!(failure.class, FailureClass::Validation);
+    assert_eq!(failure.reason, reason::DUPLICATE_SYNAPSE);
+    assert_eq!(
+        failure.message,
+        "1) synapse k -> if-0 repeats a source into a non-'IF' neuron"
+    );
+    assert_eq!(failure.synapse_index, Some(1));
+}
+
+// ---------------------------------------------------------------------------
 // Rule 27 — recursive synapse, `feedback_loop` tri-state.
 // ---------------------------------------------------------------------------
 

--- a/neat-core/tests/if_graft.rs
+++ b/neat-core/tests/if_graft.rs
@@ -350,11 +350,38 @@ fn rejects_a_node_with_no_outward_connection() {
     assert!(matches!(reject(spec), GraftError::NoTargets));
 }
 
+/// Issue #577 changed this case: one source feeding two **branches** of the
+/// grafted `IF` node is now a legal creature, because the node keeps a sum per
+/// role. What is still refused is a repeat of one role, below.
 #[test]
-fn rejects_two_synapses_between_the_same_pair() {
+fn accepts_one_source_under_two_branches_of_the_if_node() {
     let spec = IfNodeSpec::new("if-1", 0.0)
         .with_condition("input-0", 1.0)
-        .with_positive("input-0", 1.0)
+        .with_positive("input-0", 2.0)
+        .with_negative("input-1", 3.0)
+        .with_target("output-0", 1.0);
+    let grafted = graft_if_node(&base_creature(), &spec).expect("an IF node may repeat a source");
+
+    // `input-0 = 0.5` makes the condition sum 0.5 > 0, so the positive branch
+    // fires with the *same* source: 0.5 * 2.0 = 1.0 added to the base output.
+    let base = base_creature();
+    let above = [0.5f32, 0.0];
+    assert!((activate(&grafted, &above) - (activate(&base, &above) + 1.0)).abs() <= TOL);
+
+    // Below the split the negative branch reads `input-1` instead.
+    let below = [-0.5f32, 2.0];
+    assert!((activate(&grafted, &below) - (activate(&base, &below) + 6.0)).abs() <= TOL);
+
+    creature_validate(&grafted, &validate_options(&grafted))
+        .expect("and the shared validator accepts it");
+}
+
+#[test]
+fn rejects_two_synapses_between_the_same_pair_in_one_role() {
+    let spec = IfNodeSpec::new("if-1", 0.0)
+        .with_condition("input-0", 1.0)
+        .with_condition("input-0", 2.0)
+        .with_positive("input-1", 1.0)
         .with_negative("input-1", 1.0)
         .with_target("output-0", 1.0);
     assert!(matches!(
@@ -968,6 +995,84 @@ fn a_relay_carries_a_second_typed_edge_into_the_same_target() {
             correction_value(&record)
         );
     }
+}
+
+/// The Issue #577 payoff: the same correction reaches **both** branches of the
+/// `IF` output from the node itself, so the relay neuron the case above needs
+/// is not created at all. Same behaviour, one fewer neuron and one fewer
+/// synapse.
+#[test]
+fn a_node_reaches_both_branches_of_an_if_target_without_a_relay() {
+    let base = if_output_creature();
+    let spec = correction_spec(SynapseType::Positive).with_target_role(
+        "output-0",
+        1.0,
+        SynapseType::Negative,
+    );
+    let grafted = graft_if_node(&base, &spec).expect("both roles into one IF target");
+    assert_valid(&grafted, "a node wired into both branches of an IF output");
+
+    let roles: Vec<Option<&str>> = grafted
+        .synapses
+        .iter()
+        .filter(|s| s.from_uuid == "corr" && s.to_uuid == "output-0")
+        .map(|s| s.synapse_type.as_deref())
+        .collect();
+    assert_eq!(
+        roles,
+        vec![Some("negative"), Some("positive")],
+        "both roles are emitted, in canonical (from, to, type) order"
+    );
+
+    // Behaviour identical to the relay version, whichever branch the output
+    // takes.
+    for record in [[1.0f32, 1.0, 1.0], [-1.0, 1.0, 1.0], [-1.0, 0.0, 0.0]] {
+        let delta = activate(&grafted, &record) - activate(&base, &record);
+        assert!(
+            (delta - correction_value(&record)).abs() <= TOL,
+            "record {record:?}: delta {delta} vs expected {}",
+            correction_value(&record)
+        );
+    }
+
+    // The relay-free creature really is the smaller one.
+    let relay = RelaySpec::new("corr-relay", 0.0)
+        .with_source("corr", 1.0)
+        .with_target_role("output-0", 1.0, SynapseType::Negative);
+    let with_relay = graft_relay_node(
+        &graft_if_node(&base, &correction_spec(SynapseType::Positive)).expect("typed graft"),
+        &relay,
+    )
+    .expect("relay graft succeeds");
+    assert_eq!(grafted.neurons.len() + 1, with_relay.neurons.len());
+    assert_eq!(grafted.synapses.len() + 1, with_relay.synapses.len());
+}
+
+/// The other half of the rule: a destination that sums every inward synapse
+/// regardless of role reads two edges from one source as one, so the second is
+/// redundancy — refused under its own variant.
+#[test]
+fn rejects_two_roles_into_a_target_that_is_not_an_if_neuron() {
+    let spec = valid_spec().with_target_role("output-0", 1.0, SynapseType::Negative);
+    assert!(matches!(
+        graft_if_node(&base_creature(), &spec).expect_err("must be rejected"),
+        GraftError::TypedDuplicateEdge { ref from, ref to } if from == "if-1" && to == "output-0"
+    ));
+}
+
+/// And the same source twice in the same role stays a plain duplicate, however
+/// many roles the destination reads.
+#[test]
+fn rejects_one_role_repeated_into_an_if_target() {
+    let spec = correction_spec(SynapseType::Positive).with_target_role(
+        "output-0",
+        2.0,
+        SynapseType::Positive,
+    );
+    assert!(matches!(
+        graft_if_node(&if_output_creature(), &spec).expect_err("must be rejected"),
+        GraftError::DuplicateEdge { ref from, ref to } if from == "corr" && to == "output-0"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
# Key synapses by `(from, to, type)`, relaxed for `IF` targets

## Summary

A synapse into an `IF` neuron carries a role and the kernel keeps one sum per
role, so a contribution that must apply **whichever way the node branches**
needs two synapses from the same source. Keying synapses by the ordered
`(from, to)` pair forbade that, and the workaround was an IDENTITY relay neuron
existing only to be a second distinct source — 455 of them had accumulated on a
production creature, and removing 415 was worth +4.96e-5 of score for behaviour
identical to 1.5e-9.

Uniqueness is now the `(from, to, type)` **triple**, and only an `IF` target may
carry more than one role from one source: every other squash sums its inward
synapses regardless of role, so two synapses from one source there are exactly
one with the summed weight — redundancy with no meaning. Canonical sort order
becomes `(from, to, type)` so it stays total. The wire format is unchanged
(`type` is already in the JSON) and every currently valid creature stays valid.

The two rejections carry **distinct codes**, as the issue asks, so a caller can
tell "you repeated yourself" from "that target cannot mean what you wrote":

| Creature | Export rule | Validator rule |
|----------|-------------|----------------|
| same `(from, to, type)` twice | `CreatureError::DuplicateSynapse` | `Topology` / `INVALID_CONNECTION` |
| pair repeated into a non-`IF` target | `CreatureError::TypedDuplicateSynapse` | `Validation` / `DUPLICATE_SYNAPSE` |

What changed, file by file:

- **`creature.rs`** — `validate_no_duplicate_synapses` keys the triple and looks
  up the target's squash through the new `is_if_squash` helper (which reads the
  name through `parse_squash_name` rather than comparing to a literal).
- **`creature_validate.rs`** — rule 25 sorts by `(from, to, type)`, rule 26 is
  the exact-triple repeat, and rule 26b is the pair repeated into a target that
  reads no roles. `synapse_walk` now takes the role buffer and fails loud on a
  length that does not match rather than silently unkeying the rule.
- **`topology_ops.rs`** — `validate_topology_typed` keys the index-level gate by
  role, with the new `SORT_ERROR_TYPE` code for roles out of order inside a
  repeated pair. The existing `validate_topology` is untouched for callers that
  hold no roles; both share one walk, so the two cannot drift.
- **`if_graft.rs`** — a node reaches **both** branches of an `IF` target from
  its own outward edges, so no relay neuron is created for that; the same source
  in the same role is still `DuplicateEdge`, and two roles into a non-`IF`
  target are the new `TypedDuplicateEdge`. `validate_creature_topology` now also
  runs `validate_no_duplicate_synapses`, which is the order-independent leg that
  knows what a *target* may mean.
- **`synapse_type.rs`** — `SynapseType` derives `Eq`, `Hash`, `PartialOrd` and
  `Ord`, since the role is now part of a key and of a sort order.

Closes #577.

## Evidence

Backend/CLI change with no web interface, so the evidence is the test suite and
`./quality.sh` — no screenshot applies.

```mermaid
flowchart LR
    S["synapse (from, to, type)"] --> K{"triple seen<br/>before?"}
    K -- yes --> D["Err(DuplicateSynapse)<br/>INVALID_CONNECTION"]
    K -- no --> P{"pair seen<br/>before?"}
    P -- no --> OK["accepted"]
    P -- yes --> T{"target is<br/>an IF neuron?"}
    T -- yes --> OK
    T -- no --> R["Err(TypedDuplicateSynapse)<br/>DUPLICATE_SYNAPSE"]
```

The relay this removes, and what replaces it:

```mermaid
flowchart LR
    subgraph before["before — a relay per correction"]
        C1["corr"] -- positive --> O1["IF output"]
        C1 --> RLY["corr-relay<br/>IDENTITY"]
        RLY -- negative --> O1
    end
    subgraph after["after — Issue #577"]
        C2["corr"] -- positive --> O2["IF output"]
        C2 -- negative --> O2
    end
```

`./quality.sh` passes clean: fmt, clippy `-D warnings`, `cargo check`, 60 test
binaries, doctests, `cargo doc -D warnings`, `cargo deny`, Mermaid and
markdownlint gates.

Behaviour is proven, not just accepted:
`a_node_reaches_both_branches_of_an_if_target_without_a_relay` asserts the
relay-free creature produces the **same** correction for every record as the
relay version, with one fewer neuron and one fewer synapse.

## Test Plan

Existing tests that changed, because the rule they pinned changed — documented
here as required:

- `neat-core/tests/creature_duplicate_synapses.rs` —
  `compile_rejects_an_if_neuron_fed_three_times_by_one_constant` asserted the
  Issue #556 rule that one constant may not feed an `IF` neuron three times.
  That shape is exactly what Issue #577 legalises, so it is now
  `compile_accepts_an_if_neuron_fed_three_times_by_one_constant` and asserts the
  activation. The rejection it used to cover is kept by
  `compile_rejects_a_repeated_role_from_one_source` (an exact triple repeat),
  and the display / consumer-boundary tests now build their duplicate from that
  fixture instead.
- `neat-core/tests/if_graft.rs` —
  `rejects_two_synapses_between_the_same_pair` listed one source under two
  branches of the grafted `IF` node, which is now legal. Split into
  `accepts_one_source_under_two_branches_of_the_if_node` (asserting both
  branches' activations and the shared validator's verdict) and
  `rejects_two_synapses_between_the_same_pair_in_one_role`.

Added:

- `neat-core/tests/creature_duplicate_synapses.rs` —
  `a_repeated_source_keeps_one_sum_per_role` (the negative branch of the shared
  source), `compile_rejects_two_roles_from_one_source_into_a_non_if_target`.
- `neat-core/tests/creature_validate_synapse_rules.rs` —
  `one_source_may_carry_every_role_into_an_if_target` (half, whole entry point
  and forward-only leg), `a_repeated_role_into_an_if_target_is_still_an_invalid_connection`,
  `roles_out_of_order_within_one_pair_are_a_sort_failure`,
  `two_roles_into_a_non_if_target_are_a_duplicate_synapse` — each asserting the
  class, `reason`, message text and synapse index verbatim.
- `neat-core/tests/if_graft.rs` —
  `a_node_reaches_both_branches_of_an_if_target_without_a_relay`,
  `rejects_two_roles_into_a_target_that_is_not_an_if_neuron`,
  `rejects_one_role_repeated_into_an_if_target`.
- `neat-core/tests/creature_validate_packed_conformance.rs` —
  `one_source_carries_every_role_into_an_if_target_through_both_shapes` and
  `the_same_wiring_into_a_non_if_target_is_rejected_through_both_shapes`, so the
  role buffer is proven to reach the rules through the runtime **and** packed
  request shapes, not only the export form.
- `neat-core/src/topology_ops.rs` unit tests — the typed gate accepts one pair
  once per role (and the untyped gate still calls it a duplicate, which is why
  the forward-only leg had to pass roles), still rejects a repeated role,
  reports `SORT_ERROR_TYPE` for descending roles, resets the role when the pair
  advances, and reports a short role buffer as `MALFORMED_BUFFER`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt6ojn02-78f40a`<!-- vibe-worker-issue-577 -->